### PR TITLE
execgen: remove temporary decimals from the helper

### DIFF
--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -106,14 +106,6 @@ type avg_TYPE_AGGKINDAgg struct {
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
 	curCount int64
-	// {{if .NeedsHelper}}
-	// {{/*
-	// overloadHelper is used only when we perform the summation of integers
-	// and get a decimal result which is the case when NeedsHelper is true. In
-	// all other cases we don't want to wastefully allocate the helper.
-	// */}}
-	overloadHelper execgen.OverloadHelper
-	// {{end}}
 }
 
 var _ AggregateFunc = &avg_TYPE_AGGKINDAgg{}
@@ -129,16 +121,6 @@ func (a *avg_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 func (a *avg_TYPE_AGGKINDAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// {{if .NeedsHelper}}
-	// {{/*
-	// overloadHelper is used only when we perform the summation of integers
-	// and get a decimal result which is the case when NeedsHelper is true. In
-	// all other cases we don't want to wastefully allocate the helper.
-	// */}}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
-	// {{end}}
 	execgen.SETVARIABLESIZE(oldCurSumSize, a.curSum)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
@@ -257,11 +239,6 @@ func (a *avg_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *avg_TYPE_AGGKINDAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
-	// {{if .NeedsHelper}}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
-	// {{end}}
 	execgen.SETVARIABLESIZE(oldCurSumSize, a.curSum)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -76,8 +75,7 @@ type avgInt16HashAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt16HashAgg{}
@@ -85,9 +83,6 @@ var _ AggregateFunc = &avgInt16HashAgg{}
 func (a *avgInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -104,9 +99,9 @@ func (a *avgInt16HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -124,9 +119,9 @@ func (a *avgInt16HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -194,8 +189,7 @@ type avgInt32HashAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt32HashAgg{}
@@ -203,9 +197,6 @@ var _ AggregateFunc = &avgInt32HashAgg{}
 func (a *avgInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -222,9 +213,9 @@ func (a *avgInt32HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -242,9 +233,9 @@ func (a *avgInt32HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -312,8 +303,7 @@ type avgInt64HashAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt64HashAgg{}
@@ -321,9 +311,6 @@ var _ AggregateFunc = &avgInt64HashAgg{}
 func (a *avgInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -340,9 +327,9 @@ func (a *avgInt64HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -360,9 +347,9 @@ func (a *avgInt64HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -75,8 +74,7 @@ type sumInt16HashAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt16HashAgg{}
@@ -84,9 +82,6 @@ var _ AggregateFunc = &sumInt16HashAgg{}
 func (a *sumInt16HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -103,9 +98,9 @@ func (a *sumInt16HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -123,9 +118,9 @@ func (a *sumInt16HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -188,8 +183,7 @@ type sumInt32HashAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt32HashAgg{}
@@ -197,9 +191,6 @@ var _ AggregateFunc = &sumInt32HashAgg{}
 func (a *sumInt32HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -216,9 +207,9 @@ func (a *sumInt32HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -236,9 +227,9 @@ func (a *sumInt32HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -301,8 +292,7 @@ type sumInt64HashAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt64HashAgg{}
@@ -310,9 +300,6 @@ var _ AggregateFunc = &sumInt64HashAgg{}
 func (a *sumInt64HashAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -329,9 +316,9 @@ func (a *sumInt64HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -349,9 +336,9 @@ func (a *sumInt64HashAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -78,8 +77,7 @@ type avgInt16OrderedAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt16OrderedAgg{}
@@ -92,9 +90,6 @@ func (a *avgInt16OrderedAgg) SetOutput(vec coldata.Vec) {
 func (a *avgInt16OrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -138,9 +133,9 @@ func (a *avgInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -180,9 +175,9 @@ func (a *avgInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -223,9 +218,9 @@ func (a *avgInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -263,9 +258,9 @@ func (a *avgInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -340,8 +335,7 @@ type avgInt32OrderedAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt32OrderedAgg{}
@@ -354,9 +348,6 @@ func (a *avgInt32OrderedAgg) SetOutput(vec coldata.Vec) {
 func (a *avgInt32OrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -400,9 +391,9 @@ func (a *avgInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -442,9 +433,9 @@ func (a *avgInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -485,9 +476,9 @@ func (a *avgInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -525,9 +516,9 @@ func (a *avgInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -602,8 +593,7 @@ type avgInt64OrderedAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt64OrderedAgg{}
@@ -616,9 +606,6 @@ func (a *avgInt64OrderedAgg) SetOutput(vec coldata.Vec) {
 func (a *avgInt64OrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -662,9 +649,9 @@ func (a *avgInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -704,9 +691,9 @@ func (a *avgInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -747,9 +734,9 @@ func (a *avgInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -787,9 +774,9 @@ func (a *avgInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -77,8 +76,7 @@ type sumInt16OrderedAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt16OrderedAgg{}
@@ -91,9 +89,6 @@ func (a *sumInt16OrderedAgg) SetOutput(vec coldata.Vec) {
 func (a *sumInt16OrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -134,9 +129,9 @@ func (a *sumInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -172,9 +167,9 @@ func (a *sumInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -212,9 +207,9 @@ func (a *sumInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -248,9 +243,9 @@ func (a *sumInt16OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -320,8 +315,7 @@ type sumInt32OrderedAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt32OrderedAgg{}
@@ -334,9 +328,6 @@ func (a *sumInt32OrderedAgg) SetOutput(vec coldata.Vec) {
 func (a *sumInt32OrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -377,9 +368,9 @@ func (a *sumInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -415,9 +406,9 @@ func (a *sumInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -455,9 +446,9 @@ func (a *sumInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -491,9 +482,9 @@ func (a *sumInt32OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -563,8 +554,7 @@ type sumInt64OrderedAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt64OrderedAgg{}
@@ -577,9 +567,6 @@ func (a *sumInt64OrderedAgg) SetOutput(vec coldata.Vec) {
 func (a *sumInt64OrderedAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -620,9 +607,9 @@ func (a *sumInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -658,9 +645,9 @@ func (a *sumInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -698,9 +685,9 @@ func (a *sumInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -734,9 +721,9 @@ func (a *sumInt64OrderedAgg) Compute(
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(v))
-							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -98,15 +98,6 @@ type sum_SUMKIND_TYPE_AGGKINDAgg struct {
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
 	numNonNull uint64
-	// {{if .NeedsHelper}}
-	// {{/*
-	// overloadHelper is used only when we perform the summation of integers
-	// and get a decimal result which is the case when {{if .NeedsHelper}}
-	// evaluates to true. In all other cases we don't want to wastefully
-	// allocate the helper.
-	// */}}
-	overloadHelper execgen.OverloadHelper
-	// {{end}}
 }
 
 var _ AggregateFunc = &sum_SUMKIND_TYPE_AGGKINDAgg{}
@@ -122,17 +113,6 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAgg) SetOutput(vec coldata.Vec) {
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// {{if .NeedsHelper}}
-	// {{/*
-	// overloadHelper is used only when we perform the summation of integers
-	// and get a decimal result which is the case when {{if .NeedsHelper}}
-	// evaluates to true. In all other cases we don't want to wastefully
-	// allocate the helper.
-	// */}}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
-	// {{end}}
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()
@@ -253,11 +233,6 @@ func (a *sum_SUMKIND_TYPE_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 func (a *sum_SUMKIND_TYPE_AGGKINDAgg) Remove(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
-	// {{if .NeedsHelper}}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
-	// {{end}}
 	execgen.SETVARIABLESIZE(oldCurAggSize, a.curAgg)
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.TemplateType(), vec.Nulls()

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -76,8 +75,7 @@ type avgInt16WindowAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt16WindowAgg{}
@@ -85,9 +83,6 @@ var _ AggregateFunc = &avgInt16WindowAgg{}
 func (a *avgInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -106,9 +101,9 @@ func (a *avgInt16WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -127,9 +122,9 @@ func (a *avgInt16WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -189,9 +184,6 @@ func (a *avgInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *avgInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -207,9 +199,9 @@ func (a *avgInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -228,9 +220,9 @@ func (a *avgInt16WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -253,8 +245,7 @@ type avgInt32WindowAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt32WindowAgg{}
@@ -262,9 +253,6 @@ var _ AggregateFunc = &avgInt32WindowAgg{}
 func (a *avgInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -283,9 +271,9 @@ func (a *avgInt32WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -304,9 +292,9 @@ func (a *avgInt32WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -366,9 +354,6 @@ func (a *avgInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *avgInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -384,9 +369,9 @@ func (a *avgInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -405,9 +390,9 @@ func (a *avgInt32WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -430,8 +415,7 @@ type avgInt64WindowAgg struct {
 	curSum apd.Decimal
 	// curCount keeps track of the number of non-null elements that we've seen
 	// belonging to the current group.
-	curCount       int64
-	overloadHelper execgen.OverloadHelper
+	curCount int64
 }
 
 var _ AggregateFunc = &avgInt64WindowAgg{}
@@ -439,9 +423,6 @@ var _ AggregateFunc = &avgInt64WindowAgg{}
 func (a *avgInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -460,9 +441,9 @@ func (a *avgInt64WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -481,9 +462,9 @@ func (a *avgInt64WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -543,9 +524,6 @@ func (a *avgInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 // Remove implements the slidingWindowAggregateFunc interface (see
 // window_aggregator_tmpl.go).
 func (a *avgInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurSumSize := a.curSum.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -561,9 +539,9 @@ func (a *avgInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -582,9 +560,9 @@ func (a *avgInt64WindowAgg) Remove(vecs []coldata.Vec, inputIdxs []uint32, start
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curSum, &a.curSum, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -75,8 +74,7 @@ type sumInt16WindowAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt16WindowAgg{}
@@ -84,9 +82,6 @@ var _ AggregateFunc = &sumInt16WindowAgg{}
 func (a *sumInt16WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -105,9 +100,9 @@ func (a *sumInt16WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -126,9 +121,9 @@ func (a *sumInt16WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -186,9 +181,6 @@ func (a *sumInt16WindowAggAlloc) newAggFunc() AggregateFunc {
 func (a *sumInt16WindowAgg) Remove(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int16(), vec.Nulls()
@@ -204,9 +196,9 @@ func (a *sumInt16WindowAgg) Remove(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -225,9 +217,9 @@ func (a *sumInt16WindowAgg) Remove(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -249,8 +241,7 @@ type sumInt32WindowAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt32WindowAgg{}
@@ -258,9 +249,6 @@ var _ AggregateFunc = &sumInt32WindowAgg{}
 func (a *sumInt32WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -279,9 +267,9 @@ func (a *sumInt32WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -300,9 +288,9 @@ func (a *sumInt32WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -360,9 +348,6 @@ func (a *sumInt32WindowAggAlloc) newAggFunc() AggregateFunc {
 func (a *sumInt32WindowAgg) Remove(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int32(), vec.Nulls()
@@ -378,9 +363,9 @@ func (a *sumInt32WindowAgg) Remove(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -399,9 +384,9 @@ func (a *sumInt32WindowAgg) Remove(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -423,8 +408,7 @@ type sumInt64WindowAgg struct {
 	curAgg apd.Decimal
 	// numNonNull tracks the number of non-null values we have seen for the group
 	// that is currently being aggregated.
-	numNonNull     uint64
-	overloadHelper execgen.OverloadHelper
+	numNonNull uint64
 }
 
 var _ AggregateFunc = &sumInt64WindowAgg{}
@@ -432,9 +416,6 @@ var _ AggregateFunc = &sumInt64WindowAgg{}
 func (a *sumInt64WindowAgg) Compute(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int, sel []int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -453,9 +434,9 @@ func (a *sumInt64WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -474,9 +455,9 @@ func (a *sumInt64WindowAgg) Compute(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Add(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -534,9 +515,6 @@ func (a *sumInt64WindowAggAlloc) newAggFunc() AggregateFunc {
 func (a *sumInt64WindowAgg) Remove(
 	vecs []coldata.Vec, inputIdxs []uint32, startIdx, endIdx int,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "overloadHelper".
-	_overloadHelper := a.overloadHelper
 	oldCurAggSize := a.curAgg.Size()
 	vec := vecs[inputIdxs[0]]
 	col, nulls := vec.Int64(), vec.Nulls()
@@ -552,9 +530,9 @@ func (a *sumInt64WindowAgg) Remove(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}
@@ -573,9 +551,9 @@ func (a *sumInt64WindowAgg) Remove(
 
 				{
 
-					tmpDec := &_overloadHelper.TmpDec1
+					var tmpDec apd.Decimal //gcassert:noescape
 					tmpDec.SetInt64(int64(v))
-					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, tmpDec); err != nil {
+					if _, err := tree.ExactCtx.Sub(&a.curAgg, &a.curAgg, &tmpDec); err != nil {
 						colexecerror.ExpectedError(err)
 					}
 				}

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -1691,8 +1690,6 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 
 type castDecimalInt2Op struct {
 	castOpBase
-
-	overloadHelper execgen.OverloadHelper
 }
 
 var _ colexecop.ResettableOperator = &castDecimalInt2Op{}
@@ -1704,9 +1701,6 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "execgen.OverloadHelper".
-	_overloadHelper := c.overloadHelper
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
 	outputVec := batch.ColVec(c.outputIdx)
@@ -1736,8 +1730,8 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -1775,8 +1769,8 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -1817,8 +1811,8 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -1856,8 +1850,8 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -1888,8 +1882,6 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 
 type castDecimalInt4Op struct {
 	castOpBase
-
-	overloadHelper execgen.OverloadHelper
 }
 
 var _ colexecop.ResettableOperator = &castDecimalInt4Op{}
@@ -1901,9 +1893,6 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "execgen.OverloadHelper".
-	_overloadHelper := c.overloadHelper
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
 	outputVec := batch.ColVec(c.outputIdx)
@@ -1933,8 +1922,8 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -1972,8 +1961,8 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -2014,8 +2003,8 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -2053,8 +2042,8 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -2085,8 +2074,6 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 
 type castDecimalIntOp struct {
 	castOpBase
-
-	overloadHelper execgen.OverloadHelper
 }
 
 var _ colexecop.ResettableOperator = &castDecimalIntOp{}
@@ -2098,9 +2085,6 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "execgen.OverloadHelper".
-	_overloadHelper := c.overloadHelper
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
 	outputVec := batch.ColVec(c.outputIdx)
@@ -2130,8 +2114,8 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -2163,8 +2147,8 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -2199,8 +2183,8 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -2232,8 +2216,8 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
-								_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &v)
+								var tmpDec apd.Decimal //gcassert:noescape
+								_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &v)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -418,14 +417,6 @@ func setNativeToDatumCast(
 
 type cast_NAMEOp struct {
 	castOpBase
-
-	// {{if and (eq $fromFamily "types.DecimalFamily") (eq $toFamily "types.IntFamily")}}
-	// {{/*
-	// overloadHelper is used only when we perform the cast from decimals to
-	// ints. In all other cases we don't want to wastefully allocate the helper.
-	// */}}
-	overloadHelper execgen.OverloadHelper
-	// {{end}}
 }
 
 var _ colexecop.ResettableOperator = &cast_NAMEOp{}
@@ -437,11 +428,6 @@ func (c *cast_NAMEOp) Next() coldata.Batch {
 	if n == 0 {
 		return coldata.ZeroBatch
 	}
-	// {{if and (eq $fromFamily "types.DecimalFamily") (eq $toFamily "types.IntFamily")}}
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "execgen.OverloadHelper".
-	_overloadHelper := c.overloadHelper
-	// {{end}}
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
 	outputVec := batch.ColVec(c.outputIdx)

--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/json",  # keep
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_apd_v3//:apd",  # keep
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -33,6 +34,7 @@ var (
 	_ = coldataext.Hash
 	_ json.JSON
 	_ tree.Datum
+	_ apd.Context
 )
 
 // rehash takes an element of a key (tuple representing a row of equality
@@ -264,7 +266,7 @@ func rehash(
 
 						// In order for equal decimals to hash to the same value we need to
 						// remove the trailing zeroes if there are any.
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.Reduce(&v)
 						b := []byte(tmpDec.String())
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
@@ -289,7 +291,7 @@ func rehash(
 
 						// In order for equal decimals to hash to the same value we need to
 						// remove the trailing zeroes if there are any.
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.Reduce(&v)
 						b := []byte(tmpDec.String())
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
@@ -315,7 +317,7 @@ func rehash(
 
 						// In order for equal decimals to hash to the same value we need to
 						// remove the trailing zeroes if there are any.
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.Reduce(&v)
 						b := []byte(tmpDec.String())
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
@@ -337,7 +339,7 @@ func rehash(
 
 						// In order for equal decimals to hash to the same value we need to
 						// remove the trailing zeroes if there are any.
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.Reduce(&v)
 						b := []byte(tmpDec.String())
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -22,6 +22,7 @@
 package colexechash
 
 import (
+	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -41,6 +42,7 @@ var (
 	_ = coldataext.Hash
 	_ json.JSON
 	_ tree.Datum
+	_ apd.Context
 )
 
 // {{/*

--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -3229,9 +3229,9 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3249,9 +3249,9 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3273,9 +3273,9 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3290,9 +3290,9 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3359,9 +3359,9 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3379,9 +3379,9 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3403,9 +3403,9 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3420,9 +3420,9 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3489,9 +3489,9 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3509,9 +3509,9 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3533,9 +3533,9 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3550,9 +3550,9 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -4123,9 +4123,9 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4144,9 +4144,9 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4169,9 +4169,9 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4187,9 +4187,9 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4781,9 +4781,9 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4802,9 +4802,9 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4827,9 +4827,9 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4845,9 +4845,9 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5439,9 +5439,9 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5460,9 +5460,9 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5485,9 +5485,9 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5503,9 +5503,9 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6877,9 +6877,9 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -6897,9 +6897,9 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -6921,9 +6921,9 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -6938,9 +6938,9 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7007,9 +7007,9 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7027,9 +7027,9 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7051,9 +7051,9 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7068,9 +7068,9 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7137,9 +7137,9 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7157,9 +7157,9 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7181,9 +7181,9 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7198,9 +7198,9 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7771,9 +7771,9 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -7792,9 +7792,9 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -7817,9 +7817,9 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7835,9 +7835,9 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8429,9 +8429,9 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -8450,9 +8450,9 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -8475,9 +8475,9 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8493,9 +8493,9 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9087,9 +9087,9 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9108,9 +9108,9 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9133,9 +9133,9 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9151,9 +9151,9 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11253,9 +11253,9 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11273,9 +11273,9 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11297,9 +11297,9 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11314,9 +11314,9 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11383,9 +11383,9 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11403,9 +11403,9 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11427,9 +11427,9 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11444,9 +11444,9 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11513,9 +11513,9 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11533,9 +11533,9 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11557,9 +11557,9 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11574,9 +11574,9 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12357,9 +12357,9 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -12378,9 +12378,9 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -12403,9 +12403,9 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -12421,9 +12421,9 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13059,9 +13059,9 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13080,9 +13080,9 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13105,9 +13105,9 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13123,9 +13123,9 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13761,9 +13761,9 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13782,9 +13782,9 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13807,9 +13807,9 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13825,9 +13825,9 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14691,9 +14691,9 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14715,9 +14715,9 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14743,9 +14743,9 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14764,9 +14764,9 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14837,9 +14837,9 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14861,9 +14861,9 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14889,9 +14889,9 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14910,9 +14910,9 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14983,9 +14983,9 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15007,9 +15007,9 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15035,9 +15035,9 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15056,9 +15056,9 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15269,10 +15269,10 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15292,10 +15292,10 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15319,10 +15319,10 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15339,10 +15339,10 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15411,10 +15411,10 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15434,10 +15434,10 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15461,10 +15461,10 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15481,10 +15481,10 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15553,10 +15553,10 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15576,10 +15576,10 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15603,10 +15603,10 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15623,10 +15623,10 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15697,9 +15697,9 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -15722,9 +15722,9 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -15751,9 +15751,9 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -15773,9 +15773,9 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -15845,10 +15845,10 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15868,10 +15868,10 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15895,10 +15895,10 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15915,10 +15915,10 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15987,10 +15987,10 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16010,10 +16010,10 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16037,10 +16037,10 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16057,10 +16057,10 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16129,10 +16129,10 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16152,10 +16152,10 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16179,10 +16179,10 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16199,10 +16199,10 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16273,9 +16273,9 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16298,9 +16298,9 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16327,9 +16327,9 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16349,9 +16349,9 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16421,10 +16421,10 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16444,10 +16444,10 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16471,10 +16471,10 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16491,10 +16491,10 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16563,10 +16563,10 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16586,10 +16586,10 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16613,10 +16613,10 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16633,10 +16633,10 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16705,10 +16705,10 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16728,10 +16728,10 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 							if int64(arg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16755,10 +16755,10 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16775,10 +16775,10 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 						if int64(arg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16849,9 +16849,9 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16874,9 +16874,9 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16903,9 +16903,9 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16925,9 +16925,9 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17349,9 +17349,9 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17373,9 +17373,9 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17401,9 +17401,9 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17422,9 +17422,9 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17495,9 +17495,9 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17519,9 +17519,9 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17547,9 +17547,9 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17568,9 +17568,9 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17641,9 +17641,9 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17665,9 +17665,9 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17693,9 +17693,9 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17714,9 +17714,9 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18295,9 +18295,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18320,9 +18320,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18349,9 +18349,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18371,9 +18371,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18811,9 +18811,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18836,9 +18836,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18865,9 +18865,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18887,9 +18887,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19327,9 +19327,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19352,9 +19352,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19381,9 +19381,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19403,9 +19403,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19607,9 +19607,9 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19631,9 +19631,9 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19659,9 +19659,9 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19680,9 +19680,9 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19753,9 +19753,9 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19777,9 +19777,9 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19805,9 +19805,9 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19826,9 +19826,9 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19899,9 +19899,9 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19923,9 +19923,9 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19951,9 +19951,9 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19972,9 +19972,9 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -20553,9 +20553,9 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20578,9 +20578,9 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20607,9 +20607,9 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20629,9 +20629,9 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21069,9 +21069,9 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21094,9 +21094,9 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21123,9 +21123,9 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21145,9 +21145,9 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21585,9 +21585,9 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21610,9 +21610,9 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21639,9 +21639,9 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21661,9 +21661,9 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21861,9 +21861,9 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21881,9 +21881,9 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21905,9 +21905,9 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21922,9 +21922,9 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21991,9 +21991,9 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22011,9 +22011,9 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22035,9 +22035,9 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22052,9 +22052,9 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22121,9 +22121,9 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22141,9 +22141,9 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22165,9 +22165,9 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22182,9 +22182,9 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22376,10 +22376,10 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22401,10 +22401,10 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22430,10 +22430,10 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22452,10 +22452,10 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22526,10 +22526,10 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22551,10 +22551,10 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22580,10 +22580,10 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22602,10 +22602,10 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22676,10 +22676,10 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22701,10 +22701,10 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22730,10 +22730,10 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22752,10 +22752,10 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22827,9 +22827,9 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22848,9 +22848,9 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22873,9 +22873,9 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22891,9 +22891,9 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22960,10 +22960,10 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22985,10 +22985,10 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23014,10 +23014,10 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23036,10 +23036,10 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23110,10 +23110,10 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23135,10 +23135,10 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23164,10 +23164,10 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23186,10 +23186,10 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23260,10 +23260,10 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23285,10 +23285,10 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23314,10 +23314,10 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23336,10 +23336,10 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23411,9 +23411,9 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -23432,9 +23432,9 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -23457,9 +23457,9 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23475,9 +23475,9 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23544,10 +23544,10 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23569,10 +23569,10 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23598,10 +23598,10 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23620,10 +23620,10 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23694,10 +23694,10 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23719,10 +23719,10 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23748,10 +23748,10 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23770,10 +23770,10 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23844,10 +23844,10 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23869,10 +23869,10 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23898,10 +23898,10 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23920,10 +23920,10 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23995,9 +23995,9 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24016,9 +24016,9 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24041,9 +24041,9 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24059,9 +24059,9 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -3231,9 +3231,9 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3251,9 +3251,9 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3275,9 +3275,9 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3292,9 +3292,9 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3361,9 +3361,9 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3381,9 +3381,9 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3405,9 +3405,9 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3422,9 +3422,9 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3491,9 +3491,9 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3511,9 +3511,9 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3535,9 +3535,9 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3552,9 +3552,9 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -4125,9 +4125,9 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4146,9 +4146,9 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4171,9 +4171,9 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4189,9 +4189,9 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4781,9 +4781,9 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4802,9 +4802,9 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4827,9 +4827,9 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4845,9 +4845,9 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5437,9 +5437,9 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5458,9 +5458,9 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5483,9 +5483,9 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5501,9 +5501,9 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6879,9 +6879,9 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -6899,9 +6899,9 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -6923,9 +6923,9 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -6940,9 +6940,9 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7009,9 +7009,9 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7029,9 +7029,9 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7053,9 +7053,9 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7070,9 +7070,9 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7139,9 +7139,9 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7159,9 +7159,9 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7183,9 +7183,9 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7200,9 +7200,9 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7773,9 +7773,9 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -7794,9 +7794,9 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -7819,9 +7819,9 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7837,9 +7837,9 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8429,9 +8429,9 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -8450,9 +8450,9 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -8475,9 +8475,9 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8493,9 +8493,9 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9085,9 +9085,9 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9106,9 +9106,9 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9131,9 +9131,9 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9149,9 +9149,9 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11261,9 +11261,9 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11281,9 +11281,9 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11305,9 +11305,9 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11322,9 +11322,9 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11391,9 +11391,9 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11411,9 +11411,9 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11435,9 +11435,9 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11452,9 +11452,9 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11521,9 +11521,9 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11541,9 +11541,9 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -11565,9 +11565,9 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -11582,9 +11582,9 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12365,9 +12365,9 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -12386,9 +12386,9 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -12411,9 +12411,9 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -12429,9 +12429,9 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13067,9 +13067,9 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13088,9 +13088,9 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13113,9 +13113,9 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13131,9 +13131,9 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13769,9 +13769,9 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13790,9 +13790,9 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13815,9 +13815,9 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13833,9 +13833,9 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14699,9 +14699,9 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14723,9 +14723,9 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14751,9 +14751,9 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14772,9 +14772,9 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14845,9 +14845,9 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14869,9 +14869,9 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14897,9 +14897,9 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14918,9 +14918,9 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14991,9 +14991,9 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15015,9 +15015,9 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15043,9 +15043,9 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15064,9 +15064,9 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15277,10 +15277,10 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15300,10 +15300,10 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15327,10 +15327,10 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15347,10 +15347,10 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15419,10 +15419,10 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15442,10 +15442,10 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15469,10 +15469,10 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15489,10 +15489,10 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15561,10 +15561,10 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15584,10 +15584,10 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15611,10 +15611,10 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15631,10 +15631,10 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15705,9 +15705,9 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -15730,9 +15730,9 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -15759,9 +15759,9 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -15781,9 +15781,9 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -15853,10 +15853,10 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15876,10 +15876,10 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15903,10 +15903,10 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15923,10 +15923,10 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15995,10 +15995,10 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16018,10 +16018,10 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16045,10 +16045,10 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16065,10 +16065,10 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16137,10 +16137,10 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16160,10 +16160,10 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16187,10 +16187,10 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16207,10 +16207,10 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16281,9 +16281,9 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16306,9 +16306,9 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16335,9 +16335,9 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16357,9 +16357,9 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16429,10 +16429,10 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16452,10 +16452,10 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16479,10 +16479,10 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16499,10 +16499,10 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16571,10 +16571,10 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16594,10 +16594,10 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16621,10 +16621,10 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16641,10 +16641,10 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16713,10 +16713,10 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16736,10 +16736,10 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 							if int64(p.constArg) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16763,10 +16763,10 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16783,10 +16783,10 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 						if int64(p.constArg) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16857,9 +16857,9 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16882,9 +16882,9 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16911,9 +16911,9 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16933,9 +16933,9 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17357,9 +17357,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17381,9 +17381,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17409,9 +17409,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17430,9 +17430,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17503,9 +17503,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17527,9 +17527,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17555,9 +17555,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17576,9 +17576,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17649,9 +17649,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17673,9 +17673,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17701,9 +17701,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17722,9 +17722,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18303,9 +18303,9 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18328,9 +18328,9 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18357,9 +18357,9 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18379,9 +18379,9 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18819,9 +18819,9 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18844,9 +18844,9 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18873,9 +18873,9 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18895,9 +18895,9 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19335,9 +19335,9 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19360,9 +19360,9 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19389,9 +19389,9 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19411,9 +19411,9 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19615,9 +19615,9 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19639,9 +19639,9 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19667,9 +19667,9 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19688,9 +19688,9 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19761,9 +19761,9 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19785,9 +19785,9 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19813,9 +19813,9 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19834,9 +19834,9 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19907,9 +19907,9 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19931,9 +19931,9 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19959,9 +19959,9 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19980,9 +19980,9 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -20561,9 +20561,9 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20586,9 +20586,9 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20615,9 +20615,9 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20637,9 +20637,9 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21077,9 +21077,9 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21102,9 +21102,9 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21131,9 +21131,9 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21153,9 +21153,9 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21593,9 +21593,9 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21618,9 +21618,9 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21647,9 +21647,9 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21669,9 +21669,9 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21869,9 +21869,9 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21889,9 +21889,9 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21913,9 +21913,9 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21930,9 +21930,9 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21999,9 +21999,9 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22019,9 +22019,9 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22043,9 +22043,9 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22060,9 +22060,9 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22129,9 +22129,9 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22149,9 +22149,9 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -22173,9 +22173,9 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22190,9 +22190,9 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -22384,10 +22384,10 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22409,10 +22409,10 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22438,10 +22438,10 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22460,10 +22460,10 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22534,10 +22534,10 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22559,10 +22559,10 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22588,10 +22588,10 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22610,10 +22610,10 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22684,10 +22684,10 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22709,10 +22709,10 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22738,10 +22738,10 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22760,10 +22760,10 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -22835,9 +22835,9 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22856,9 +22856,9 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22881,9 +22881,9 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22899,9 +22899,9 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22968,10 +22968,10 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -22993,10 +22993,10 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23022,10 +23022,10 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23044,10 +23044,10 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23118,10 +23118,10 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23143,10 +23143,10 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23172,10 +23172,10 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23194,10 +23194,10 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23268,10 +23268,10 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23293,10 +23293,10 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23322,10 +23322,10 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23344,10 +23344,10 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23419,9 +23419,9 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -23440,9 +23440,9 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -23465,9 +23465,9 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23483,9 +23483,9 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23552,10 +23552,10 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23577,10 +23577,10 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23606,10 +23606,10 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23628,10 +23628,10 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23702,10 +23702,10 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23727,10 +23727,10 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23756,10 +23756,10 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23778,10 +23778,10 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23852,10 +23852,10 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23877,10 +23877,10 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23906,10 +23906,10 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23928,10 +23928,10 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24003,9 +24003,9 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24024,9 +24024,9 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24049,9 +24049,9 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24067,9 +24067,9 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &p.constArg)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -29527,9 +29527,9 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29550,9 +29550,9 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29577,9 +29577,9 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -29597,9 +29597,9 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -29669,9 +29669,9 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29692,9 +29692,9 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29719,9 +29719,9 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -29739,9 +29739,9 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -29811,9 +29811,9 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29834,9 +29834,9 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29861,9 +29861,9 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -29881,9 +29881,9 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -29953,11 +29953,11 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -29978,11 +29978,11 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -30007,11 +30007,11 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -30029,11 +30029,11 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -30901,9 +30901,9 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -30924,9 +30924,9 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -30951,9 +30951,9 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -30971,9 +30971,9 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31723,9 +31723,9 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31746,9 +31746,9 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31773,9 +31773,9 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31793,9 +31793,9 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -32545,9 +32545,9 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -32568,9 +32568,9 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -32595,9 +32595,9 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -32615,9 +32615,9 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -33463,11 +33463,11 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -33488,11 +33488,11 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -33517,11 +33517,11 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -33539,11 +33539,11 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -34407,9 +34407,9 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34430,9 +34430,9 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34457,9 +34457,9 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34477,9 +34477,9 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34549,9 +34549,9 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34572,9 +34572,9 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34599,9 +34599,9 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34619,9 +34619,9 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34691,9 +34691,9 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34714,9 +34714,9 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34741,9 +34741,9 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34761,9 +34761,9 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34833,11 +34833,11 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34858,11 +34858,11 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -34887,11 +34887,11 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -34909,11 +34909,11 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -35781,9 +35781,9 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -35804,9 +35804,9 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -35831,9 +35831,9 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -35851,9 +35851,9 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36603,9 +36603,9 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36626,9 +36626,9 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36653,9 +36653,9 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36673,9 +36673,9 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -37425,9 +37425,9 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -37448,9 +37448,9 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -37475,9 +37475,9 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -37495,9 +37495,9 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -38343,11 +38343,11 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -38368,11 +38368,11 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -38397,11 +38397,11 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -38419,11 +38419,11 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -39287,9 +39287,9 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39310,9 +39310,9 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39337,9 +39337,9 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39357,9 +39357,9 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39429,9 +39429,9 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39452,9 +39452,9 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39479,9 +39479,9 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39499,9 +39499,9 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39571,9 +39571,9 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39594,9 +39594,9 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39621,9 +39621,9 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39641,9 +39641,9 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39713,11 +39713,11 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39738,11 +39738,11 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -39767,11 +39767,11 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -39789,11 +39789,11 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -40661,9 +40661,9 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -40684,9 +40684,9 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -40711,9 +40711,9 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -40731,9 +40731,9 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41483,9 +41483,9 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41506,9 +41506,9 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41533,9 +41533,9 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41553,9 +41553,9 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -42305,9 +42305,9 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -42328,9 +42328,9 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -42355,9 +42355,9 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -42375,9 +42375,9 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -43223,11 +43223,11 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -43248,11 +43248,11 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -43277,11 +43277,11 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -43299,11 +43299,11 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -44167,9 +44167,9 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44190,9 +44190,9 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44217,9 +44217,9 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44237,9 +44237,9 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44309,9 +44309,9 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44332,9 +44332,9 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44359,9 +44359,9 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44379,9 +44379,9 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44451,9 +44451,9 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44474,9 +44474,9 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44501,9 +44501,9 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44521,9 +44521,9 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44593,11 +44593,11 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44618,11 +44618,11 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -44647,11 +44647,11 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -44669,11 +44669,11 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -45541,9 +45541,9 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -45564,9 +45564,9 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -45591,9 +45591,9 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -45611,9 +45611,9 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -46363,9 +46363,9 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46386,9 +46386,9 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46413,9 +46413,9 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -46433,9 +46433,9 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -47185,9 +47185,9 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -47208,9 +47208,9 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -47235,9 +47235,9 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -47255,9 +47255,9 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -48103,11 +48103,11 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -48128,11 +48128,11 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -48157,11 +48157,11 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -48179,11 +48179,11 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -49047,9 +49047,9 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49070,9 +49070,9 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49097,9 +49097,9 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49117,9 +49117,9 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49189,9 +49189,9 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49212,9 +49212,9 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49239,9 +49239,9 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49259,9 +49259,9 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49331,9 +49331,9 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49354,9 +49354,9 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49381,9 +49381,9 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49401,9 +49401,9 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49473,11 +49473,11 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49498,11 +49498,11 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -49527,11 +49527,11 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -49549,11 +49549,11 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -50421,9 +50421,9 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -50444,9 +50444,9 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -50471,9 +50471,9 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -50491,9 +50491,9 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -51243,9 +51243,9 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -51266,9 +51266,9 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -51293,9 +51293,9 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -51313,9 +51313,9 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52065,9 +52065,9 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -52088,9 +52088,9 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -52115,9 +52115,9 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52135,9 +52135,9 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52983,11 +52983,11 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -53008,11 +53008,11 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -53037,11 +53037,11 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -53059,11 +53059,11 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -53927,9 +53927,9 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -53950,9 +53950,9 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -53977,9 +53977,9 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -53997,9 +53997,9 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -54069,9 +54069,9 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -54092,9 +54092,9 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -54119,9 +54119,9 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -54139,9 +54139,9 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -54211,9 +54211,9 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -54234,9 +54234,9 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(p.constArg))
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -54261,9 +54261,9 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -54281,9 +54281,9 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -54353,11 +54353,11 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -54378,11 +54378,11 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -54407,11 +54407,11 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -54429,11 +54429,11 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -55301,9 +55301,9 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -55324,9 +55324,9 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -55351,9 +55351,9 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -55371,9 +55371,9 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -56123,9 +56123,9 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -56146,9 +56146,9 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -56173,9 +56173,9 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -56193,9 +56193,9 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -56945,9 +56945,9 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -56968,9 +56968,9 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg))
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -56995,9 +56995,9 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57015,9 +57015,9 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57863,11 +57863,11 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57888,11 +57888,11 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+								cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57917,11 +57917,11 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57939,11 +57939,11 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						projCol[i] = cmpResult >= 0

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -40,6 +41,7 @@ var (
 	_ = coldataext.CompareDatum
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
+	_ apd.Context
 )
 
 // projConstOpBase contains all of the fields for projections with a constant,
@@ -3484,9 +3486,9 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3508,9 +3510,9 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3533,9 +3535,9 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3553,9 +3555,9 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3622,9 +3624,9 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3646,9 +3648,9 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3671,9 +3673,9 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3691,9 +3693,9 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3760,9 +3762,9 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3784,9 +3786,9 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -3809,9 +3811,9 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -3829,9 +3831,9 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Add(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -4434,9 +4436,9 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4459,9 +4461,9 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -4485,9 +4487,9 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4506,9 +4508,9 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5130,9 +5132,9 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5155,9 +5157,9 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5181,9 +5183,9 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5202,9 +5204,9 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5826,9 +5828,9 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5851,9 +5853,9 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -5877,9 +5879,9 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5898,9 +5900,9 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Add(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Add(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7348,9 +7350,9 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7372,9 +7374,9 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7397,9 +7399,9 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7417,9 +7419,9 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7486,9 +7488,9 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7510,9 +7512,9 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7535,9 +7537,9 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7555,9 +7557,9 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7624,9 +7626,9 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7648,9 +7650,9 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -7673,9 +7675,9 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -7693,9 +7695,9 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Sub(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -8298,9 +8300,9 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -8323,9 +8325,9 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -8349,9 +8351,9 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8370,9 +8372,9 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8994,9 +8996,9 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9019,9 +9021,9 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9045,9 +9047,9 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9066,9 +9068,9 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9690,9 +9692,9 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9715,9 +9717,9 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9741,9 +9743,9 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9762,9 +9764,9 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Sub(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Sub(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -11982,9 +11984,9 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12006,9 +12008,9 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12031,9 +12033,9 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12051,9 +12053,9 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12120,9 +12122,9 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12144,9 +12146,9 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12169,9 +12171,9 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12189,9 +12191,9 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12258,9 +12260,9 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12282,9 +12284,9 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12307,9 +12309,9 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12327,9 +12329,9 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.ExactCtx.Mul(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13150,9 +13152,9 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13175,9 +13177,9 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13201,9 +13203,9 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13222,9 +13224,9 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13892,9 +13894,9 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13917,9 +13919,9 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13943,9 +13945,9 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13964,9 +13966,9 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14634,9 +14636,9 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -14659,9 +14661,9 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+							_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -14685,9 +14687,9 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14706,9 +14708,9 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.ExactCtx.Mul(&projCol[i], tmpDec, &arg2)
+						_, err := tree.ExactCtx.Mul(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -15636,9 +15638,9 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15664,9 +15666,9 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15693,9 +15695,9 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15717,9 +15719,9 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15790,9 +15792,9 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15818,9 +15820,9 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15847,9 +15849,9 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15871,9 +15873,9 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -15944,9 +15946,9 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -15972,9 +15974,9 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16001,9 +16003,9 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16025,9 +16027,9 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16246,10 +16248,10 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16273,10 +16275,10 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16301,10 +16303,10 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16324,10 +16326,10 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16396,10 +16398,10 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16423,10 +16425,10 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16451,10 +16453,10 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16474,10 +16476,10 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16546,10 +16548,10 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16573,10 +16575,10 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16601,10 +16603,10 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16624,10 +16626,10 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16698,9 +16700,9 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16727,9 +16729,9 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -16757,9 +16759,9 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16782,9 +16784,9 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -16854,10 +16856,10 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16881,10 +16883,10 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -16909,10 +16911,10 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -16932,10 +16934,10 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17004,10 +17006,10 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17031,10 +17033,10 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17059,10 +17061,10 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17082,10 +17084,10 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17154,10 +17156,10 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17181,10 +17183,10 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17209,10 +17211,10 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17232,10 +17234,10 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17306,9 +17308,9 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17335,9 +17337,9 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17365,9 +17367,9 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17390,9 +17392,9 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17462,10 +17464,10 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17489,10 +17491,10 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17517,10 +17519,10 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17540,10 +17542,10 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17612,10 +17614,10 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17639,10 +17641,10 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17667,10 +17669,10 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17690,10 +17692,10 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17762,10 +17764,10 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17789,10 +17791,10 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 							if int64(arg2) == 0 {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17817,10 +17819,10 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17840,10 +17842,10 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 						if int64(arg2) == 0 {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17914,9 +17916,9 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17943,9 +17945,9 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17973,9 +17975,9 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17998,9 +18000,9 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18446,9 +18448,9 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18474,9 +18476,9 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18503,9 +18505,9 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18527,9 +18529,9 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18600,9 +18602,9 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18628,9 +18630,9 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18657,9 +18659,9 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18681,9 +18683,9 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18754,9 +18756,9 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18782,9 +18784,9 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18811,9 +18813,9 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18835,9 +18837,9 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19448,9 +19450,9 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19477,9 +19479,9 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19507,9 +19509,9 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19532,9 +19534,9 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19996,9 +19998,9 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20025,9 +20027,9 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20055,9 +20057,9 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20080,9 +20082,9 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20544,9 +20546,9 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20573,9 +20575,9 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20603,9 +20605,9 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20628,9 +20630,9 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.QuoInteger(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20840,9 +20842,9 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -20868,9 +20870,9 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -20897,9 +20899,9 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -20921,9 +20923,9 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -20994,9 +20996,9 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21022,9 +21024,9 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21051,9 +21053,9 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21075,9 +21077,9 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21148,9 +21150,9 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21176,9 +21178,9 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -21205,9 +21207,9 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21229,9 +21231,9 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.HighPrecisionCtx.Rem(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -21842,9 +21844,9 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21871,9 +21873,9 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -21901,9 +21903,9 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21926,9 +21928,9 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22390,9 +22392,9 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22419,9 +22421,9 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22449,9 +22451,9 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22474,9 +22476,9 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22938,9 +22940,9 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22967,9 +22969,9 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+							_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -22997,9 +22999,9 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23022,9 +23024,9 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], tmpDec, &arg2)
+						_, err := tree.HighPrecisionCtx.Rem(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23230,9 +23232,9 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -23254,9 +23256,9 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -23279,9 +23281,9 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -23299,9 +23301,9 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -23368,9 +23370,9 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -23392,9 +23394,9 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -23417,9 +23419,9 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -23437,9 +23439,9 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -23506,9 +23508,9 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -23530,9 +23532,9 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -23555,9 +23557,9 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -23575,9 +23577,9 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, tmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -23777,10 +23779,10 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23806,10 +23808,10 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23836,10 +23838,10 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23861,10 +23863,10 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -23935,10 +23937,10 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23964,10 +23966,10 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -23994,10 +23996,10 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24019,10 +24021,10 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24093,10 +24095,10 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24122,10 +24124,10 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24152,10 +24154,10 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24177,10 +24179,10 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24252,9 +24254,9 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24277,9 +24279,9 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24303,9 +24305,9 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24324,9 +24326,9 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24393,10 +24395,10 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24422,10 +24424,10 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24452,10 +24454,10 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24477,10 +24479,10 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24551,10 +24553,10 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24580,10 +24582,10 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24610,10 +24612,10 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24635,10 +24637,10 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24709,10 +24711,10 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24738,10 +24740,10 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -24768,10 +24770,10 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24793,10 +24795,10 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -24868,9 +24870,9 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24893,9 +24895,9 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -24919,9 +24921,9 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -24940,9 +24942,9 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25009,10 +25011,10 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -25038,10 +25040,10 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -25068,10 +25070,10 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -25093,10 +25095,10 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -25167,10 +25169,10 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -25196,10 +25198,10 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -25226,10 +25228,10 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -25251,10 +25253,10 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -25325,10 +25327,10 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -25354,10 +25356,10 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						{
-							leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -25384,10 +25386,10 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -25409,10 +25411,10 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					{
-						leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -25484,9 +25486,9 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -25509,9 +25511,9 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 						{
 
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -25535,9 +25537,9 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -25556,9 +25558,9 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 					{
 
-						tmpDec := &_overloadHelper.TmpDec1
+						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], tmpDec, &arg2)
+						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -31296,9 +31298,9 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31323,9 +31325,9 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31351,9 +31353,9 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31374,9 +31376,9 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31446,9 +31448,9 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31473,9 +31475,9 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31501,9 +31503,9 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31524,9 +31526,9 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31596,9 +31598,9 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31623,9 +31625,9 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31651,9 +31653,9 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31674,9 +31676,9 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31746,11 +31748,11 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31775,11 +31777,11 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -31805,11 +31807,11 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -31830,11 +31832,11 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -32742,9 +32744,9 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -32769,9 +32771,9 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -32797,9 +32799,9 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -32820,9 +32822,9 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -33604,9 +33606,9 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -33631,9 +33633,9 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -33659,9 +33661,9 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -33682,9 +33684,9 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -34466,9 +34468,9 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -34493,9 +34495,9 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -34521,9 +34523,9 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -34544,9 +34546,9 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -35424,11 +35426,11 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -35453,11 +35455,11 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult == 0
@@ -35483,11 +35485,11 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -35508,11 +35510,11 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult == 0
@@ -36418,9 +36420,9 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36445,9 +36447,9 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36473,9 +36475,9 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36496,9 +36498,9 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36568,9 +36570,9 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36595,9 +36597,9 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36623,9 +36625,9 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36646,9 +36648,9 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36718,9 +36720,9 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36745,9 +36747,9 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36773,9 +36775,9 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36796,9 +36798,9 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36868,11 +36870,11 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36897,11 +36899,11 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -36927,11 +36929,11 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -36952,11 +36954,11 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -37864,9 +37866,9 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -37891,9 +37893,9 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -37919,9 +37921,9 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -37942,9 +37944,9 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -38726,9 +38728,9 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -38753,9 +38755,9 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -38781,9 +38783,9 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -38804,9 +38806,9 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -39588,9 +39590,9 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -39615,9 +39617,9 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -39643,9 +39645,9 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -39666,9 +39668,9 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -40546,11 +40548,11 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -40575,11 +40577,11 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult != 0
@@ -40605,11 +40607,11 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -40630,11 +40632,11 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult != 0
@@ -41540,9 +41542,9 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41567,9 +41569,9 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41595,9 +41597,9 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41618,9 +41620,9 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41690,9 +41692,9 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41717,9 +41719,9 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41745,9 +41747,9 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41768,9 +41770,9 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41840,9 +41842,9 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41867,9 +41869,9 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -41895,9 +41897,9 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41918,9 +41920,9 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -41990,11 +41992,11 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -42019,11 +42021,11 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -42049,11 +42051,11 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -42074,11 +42076,11 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -42986,9 +42988,9 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -43013,9 +43015,9 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -43041,9 +43043,9 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -43064,9 +43066,9 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -43848,9 +43850,9 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -43875,9 +43877,9 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -43903,9 +43905,9 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -43926,9 +43928,9 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -44710,9 +44712,9 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -44737,9 +44739,9 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -44765,9 +44767,9 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -44788,9 +44790,9 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -45668,11 +45670,11 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -45697,11 +45699,11 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult < 0
@@ -45727,11 +45729,11 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -45752,11 +45754,11 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult < 0
@@ -46662,9 +46664,9 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46689,9 +46691,9 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46717,9 +46719,9 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -46740,9 +46742,9 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -46812,9 +46814,9 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46839,9 +46841,9 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46867,9 +46869,9 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -46890,9 +46892,9 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -46962,9 +46964,9 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -46989,9 +46991,9 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -47017,9 +47019,9 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -47040,9 +47042,9 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -47112,11 +47114,11 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -47141,11 +47143,11 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -47171,11 +47173,11 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -47196,11 +47198,11 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -48108,9 +48110,9 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -48135,9 +48137,9 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -48163,9 +48165,9 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -48186,9 +48188,9 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -48970,9 +48972,9 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -48997,9 +48999,9 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -49025,9 +49027,9 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -49048,9 +49050,9 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -49832,9 +49834,9 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -49859,9 +49861,9 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -49887,9 +49889,9 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -49910,9 +49912,9 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -50790,11 +50792,11 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -50819,11 +50821,11 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult <= 0
@@ -50849,11 +50851,11 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -50874,11 +50876,11 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult <= 0
@@ -51784,9 +51786,9 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -51811,9 +51813,9 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -51839,9 +51841,9 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -51862,9 +51864,9 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -51934,9 +51936,9 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -51961,9 +51963,9 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -51989,9 +51991,9 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52012,9 +52014,9 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52084,9 +52086,9 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -52111,9 +52113,9 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -52139,9 +52141,9 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52162,9 +52164,9 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52234,11 +52236,11 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -52263,11 +52265,11 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -52293,11 +52295,11 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -52318,11 +52320,11 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -53230,9 +53232,9 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -53257,9 +53259,9 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -53285,9 +53287,9 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -53308,9 +53310,9 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -54092,9 +54094,9 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -54119,9 +54121,9 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -54147,9 +54149,9 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -54170,9 +54172,9 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -54954,9 +54956,9 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -54981,9 +54983,9 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -55009,9 +55011,9 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -55032,9 +55034,9 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -55912,11 +55914,11 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -55941,11 +55943,11 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult > 0
@@ -55971,11 +55973,11 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -55996,11 +55998,11 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult > 0
@@ -56906,9 +56908,9 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -56933,9 +56935,9 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -56961,9 +56963,9 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -56984,9 +56986,9 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57056,9 +57058,9 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57083,9 +57085,9 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57111,9 +57113,9 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57134,9 +57136,9 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57206,9 +57208,9 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57233,9 +57235,9 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg2))
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57261,9 +57263,9 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57284,9 +57286,9 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57356,11 +57358,11 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57385,11 +57387,11 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+								cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -57415,11 +57417,11 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -57440,11 +57442,11 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -58352,9 +58354,9 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -58379,9 +58381,9 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -58407,9 +58409,9 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -58430,9 +58432,9 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -59214,9 +59216,9 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -59241,9 +59243,9 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -59269,9 +59271,9 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -59292,9 +59294,9 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -60076,9 +60078,9 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -60103,9 +60105,9 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								tmpDec.SetInt64(int64(arg1))
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -60131,9 +60133,9 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -60154,9 +60156,9 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -61034,11 +61036,11 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -61063,11 +61065,11 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 							var cmpResult int
 
 							{
-								tmpDec := &_overloadHelper.TmpDec1
+								var tmpDec apd.Decimal //gcassert:noescape
 								if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 									colexecerror.ExpectedError(err)
 								}
-								cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+								cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 							}
 
 							projCol[i] = cmpResult >= 0
@@ -61093,11 +61095,11 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0
@@ -61118,11 +61120,11 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						projCol[i] = cmpResult >= 0

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -22,6 +22,7 @@
 package colexecproj
 
 import (
+	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -47,6 +48,7 @@ var (
 	_ = coldataext.CompareDatum
 	_ sqltelemetry.EnumTelemetryType
 	_ telemetry.Counter
+	_ apd.Context
 )
 
 // {{/*

--- a/pkg/sql/colexec/colexecsel/selection_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops.eg.go
@@ -629,9 +629,9 @@ func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -658,9 +658,9 @@ func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -683,9 +683,9 @@ func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -709,9 +709,9 @@ func (p *selEQDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -771,9 +771,9 @@ func (p *selEQDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -803,9 +803,9 @@ func (p *selEQDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -829,9 +829,9 @@ func (p *selEQDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -858,9 +858,9 @@ func (p *selEQDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -917,9 +917,9 @@ func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -946,9 +946,9 @@ func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -971,9 +971,9 @@ func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -997,9 +997,9 @@ func (p *selEQDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1059,9 +1059,9 @@ func (p *selEQDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1091,9 +1091,9 @@ func (p *selEQDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1117,9 +1117,9 @@ func (p *selEQDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1146,9 +1146,9 @@ func (p *selEQDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1205,9 +1205,9 @@ func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1234,9 +1234,9 @@ func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1259,9 +1259,9 @@ func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1285,9 +1285,9 @@ func (p *selEQDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1347,9 +1347,9 @@ func (p *selEQDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1379,9 +1379,9 @@ func (p *selEQDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1405,9 +1405,9 @@ func (p *selEQDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1434,9 +1434,9 @@ func (p *selEQDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1493,11 +1493,11 @@ func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1524,11 +1524,11 @@ func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1551,11 +1551,11 @@ func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1579,11 +1579,11 @@ func (p *selEQDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1643,11 +1643,11 @@ func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1677,11 +1677,11 @@ func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1705,11 +1705,11 @@ func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -1736,11 +1736,11 @@ func (p *selEQDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult == 0
@@ -3413,9 +3413,9 @@ func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -3442,9 +3442,9 @@ func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -3467,9 +3467,9 @@ func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -3493,9 +3493,9 @@ func (p *selEQInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -3555,9 +3555,9 @@ func (p *selEQInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -3587,9 +3587,9 @@ func (p *selEQInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -3613,9 +3613,9 @@ func (p *selEQInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -3642,9 +3642,9 @@ func (p *selEQInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -5077,9 +5077,9 @@ func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -5106,9 +5106,9 @@ func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -5131,9 +5131,9 @@ func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -5157,9 +5157,9 @@ func (p *selEQInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -5219,9 +5219,9 @@ func (p *selEQInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -5251,9 +5251,9 @@ func (p *selEQInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -5277,9 +5277,9 @@ func (p *selEQInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -5306,9 +5306,9 @@ func (p *selEQInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -6741,9 +6741,9 @@ func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -6770,9 +6770,9 @@ func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -6795,9 +6795,9 @@ func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -6821,9 +6821,9 @@ func (p *selEQInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -6883,9 +6883,9 @@ func (p *selEQInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -6915,9 +6915,9 @@ func (p *selEQInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -6941,9 +6941,9 @@ func (p *selEQInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -6970,9 +6970,9 @@ func (p *selEQInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -8597,11 +8597,11 @@ func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -8628,11 +8628,11 @@ func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -8655,11 +8655,11 @@ func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -8683,11 +8683,11 @@ func (p *selEQFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult == 0
@@ -8747,11 +8747,11 @@ func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -8781,11 +8781,11 @@ func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -8809,11 +8809,11 @@ func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -8840,11 +8840,11 @@ func (p *selEQFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult == 0
@@ -10507,9 +10507,9 @@ func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10536,9 +10536,9 @@ func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10561,9 +10561,9 @@ func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10587,9 +10587,9 @@ func (p *selNEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10649,9 +10649,9 @@ func (p *selNEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10681,9 +10681,9 @@ func (p *selNEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10707,9 +10707,9 @@ func (p *selNEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10736,9 +10736,9 @@ func (p *selNEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10795,9 +10795,9 @@ func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10824,9 +10824,9 @@ func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10849,9 +10849,9 @@ func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10875,9 +10875,9 @@ func (p *selNEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10937,9 +10937,9 @@ func (p *selNEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10969,9 +10969,9 @@ func (p *selNEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -10995,9 +10995,9 @@ func (p *selNEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11024,9 +11024,9 @@ func (p *selNEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11083,9 +11083,9 @@ func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11112,9 +11112,9 @@ func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11137,9 +11137,9 @@ func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11163,9 +11163,9 @@ func (p *selNEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11225,9 +11225,9 @@ func (p *selNEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11257,9 +11257,9 @@ func (p *selNEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11283,9 +11283,9 @@ func (p *selNEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11312,9 +11312,9 @@ func (p *selNEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11371,11 +11371,11 @@ func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11402,11 +11402,11 @@ func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11429,11 +11429,11 @@ func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11457,11 +11457,11 @@ func (p *selNEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11521,11 +11521,11 @@ func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11555,11 +11555,11 @@ func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11583,11 +11583,11 @@ func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -11614,11 +11614,11 @@ func (p *selNEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult != 0
@@ -13291,9 +13291,9 @@ func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -13320,9 +13320,9 @@ func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -13345,9 +13345,9 @@ func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -13371,9 +13371,9 @@ func (p *selNEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -13433,9 +13433,9 @@ func (p *selNEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -13465,9 +13465,9 @@ func (p *selNEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -13491,9 +13491,9 @@ func (p *selNEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -13520,9 +13520,9 @@ func (p *selNEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -14955,9 +14955,9 @@ func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -14984,9 +14984,9 @@ func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -15009,9 +15009,9 @@ func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -15035,9 +15035,9 @@ func (p *selNEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -15097,9 +15097,9 @@ func (p *selNEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -15129,9 +15129,9 @@ func (p *selNEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -15155,9 +15155,9 @@ func (p *selNEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -15184,9 +15184,9 @@ func (p *selNEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -16619,9 +16619,9 @@ func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -16648,9 +16648,9 @@ func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -16673,9 +16673,9 @@ func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -16699,9 +16699,9 @@ func (p *selNEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -16761,9 +16761,9 @@ func (p *selNEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -16793,9 +16793,9 @@ func (p *selNEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -16819,9 +16819,9 @@ func (p *selNEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -16848,9 +16848,9 @@ func (p *selNEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -18475,11 +18475,11 @@ func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -18506,11 +18506,11 @@ func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -18533,11 +18533,11 @@ func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -18561,11 +18561,11 @@ func (p *selNEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult != 0
@@ -18625,11 +18625,11 @@ func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -18659,11 +18659,11 @@ func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -18687,11 +18687,11 @@ func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -18718,11 +18718,11 @@ func (p *selNEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult != 0
@@ -20385,9 +20385,9 @@ func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20414,9 +20414,9 @@ func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20439,9 +20439,9 @@ func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20465,9 +20465,9 @@ func (p *selLTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20527,9 +20527,9 @@ func (p *selLTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20559,9 +20559,9 @@ func (p *selLTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20585,9 +20585,9 @@ func (p *selLTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20614,9 +20614,9 @@ func (p *selLTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20673,9 +20673,9 @@ func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20702,9 +20702,9 @@ func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20727,9 +20727,9 @@ func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20753,9 +20753,9 @@ func (p *selLTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20815,9 +20815,9 @@ func (p *selLTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20847,9 +20847,9 @@ func (p *selLTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20873,9 +20873,9 @@ func (p *selLTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20902,9 +20902,9 @@ func (p *selLTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20961,9 +20961,9 @@ func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -20990,9 +20990,9 @@ func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21015,9 +21015,9 @@ func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21041,9 +21041,9 @@ func (p *selLTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21103,9 +21103,9 @@ func (p *selLTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21135,9 +21135,9 @@ func (p *selLTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21161,9 +21161,9 @@ func (p *selLTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21190,9 +21190,9 @@ func (p *selLTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21249,11 +21249,11 @@ func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21280,11 +21280,11 @@ func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21307,11 +21307,11 @@ func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21335,11 +21335,11 @@ func (p *selLTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21399,11 +21399,11 @@ func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21433,11 +21433,11 @@ func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21461,11 +21461,11 @@ func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -21492,11 +21492,11 @@ func (p *selLTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult < 0
@@ -23169,9 +23169,9 @@ func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -23198,9 +23198,9 @@ func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -23223,9 +23223,9 @@ func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -23249,9 +23249,9 @@ func (p *selLTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -23311,9 +23311,9 @@ func (p *selLTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -23343,9 +23343,9 @@ func (p *selLTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -23369,9 +23369,9 @@ func (p *selLTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -23398,9 +23398,9 @@ func (p *selLTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -24833,9 +24833,9 @@ func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -24862,9 +24862,9 @@ func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -24887,9 +24887,9 @@ func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -24913,9 +24913,9 @@ func (p *selLTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -24975,9 +24975,9 @@ func (p *selLTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -25007,9 +25007,9 @@ func (p *selLTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -25033,9 +25033,9 @@ func (p *selLTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -25062,9 +25062,9 @@ func (p *selLTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -26497,9 +26497,9 @@ func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -26526,9 +26526,9 @@ func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -26551,9 +26551,9 @@ func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -26577,9 +26577,9 @@ func (p *selLTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -26639,9 +26639,9 @@ func (p *selLTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -26671,9 +26671,9 @@ func (p *selLTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -26697,9 +26697,9 @@ func (p *selLTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -26726,9 +26726,9 @@ func (p *selLTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -28353,11 +28353,11 @@ func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -28384,11 +28384,11 @@ func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -28411,11 +28411,11 @@ func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -28439,11 +28439,11 @@ func (p *selLTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult < 0
@@ -28503,11 +28503,11 @@ func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -28537,11 +28537,11 @@ func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -28565,11 +28565,11 @@ func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -28596,11 +28596,11 @@ func (p *selLTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult < 0
@@ -30263,9 +30263,9 @@ func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30292,9 +30292,9 @@ func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30317,9 +30317,9 @@ func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30343,9 +30343,9 @@ func (p *selLEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30405,9 +30405,9 @@ func (p *selLEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30437,9 +30437,9 @@ func (p *selLEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30463,9 +30463,9 @@ func (p *selLEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30492,9 +30492,9 @@ func (p *selLEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30551,9 +30551,9 @@ func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30580,9 +30580,9 @@ func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30605,9 +30605,9 @@ func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30631,9 +30631,9 @@ func (p *selLEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30693,9 +30693,9 @@ func (p *selLEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30725,9 +30725,9 @@ func (p *selLEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30751,9 +30751,9 @@ func (p *selLEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30780,9 +30780,9 @@ func (p *selLEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30839,9 +30839,9 @@ func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30868,9 +30868,9 @@ func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30893,9 +30893,9 @@ func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30919,9 +30919,9 @@ func (p *selLEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -30981,9 +30981,9 @@ func (p *selLEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31013,9 +31013,9 @@ func (p *selLEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31039,9 +31039,9 @@ func (p *selLEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31068,9 +31068,9 @@ func (p *selLEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31127,11 +31127,11 @@ func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31158,11 +31158,11 @@ func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31185,11 +31185,11 @@ func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31213,11 +31213,11 @@ func (p *selLEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31277,11 +31277,11 @@ func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31311,11 +31311,11 @@ func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31339,11 +31339,11 @@ func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -31370,11 +31370,11 @@ func (p *selLEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult <= 0
@@ -33047,9 +33047,9 @@ func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -33076,9 +33076,9 @@ func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -33101,9 +33101,9 @@ func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -33127,9 +33127,9 @@ func (p *selLEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -33189,9 +33189,9 @@ func (p *selLEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -33221,9 +33221,9 @@ func (p *selLEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -33247,9 +33247,9 @@ func (p *selLEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -33276,9 +33276,9 @@ func (p *selLEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -34711,9 +34711,9 @@ func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -34740,9 +34740,9 @@ func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -34765,9 +34765,9 @@ func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -34791,9 +34791,9 @@ func (p *selLEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -34853,9 +34853,9 @@ func (p *selLEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -34885,9 +34885,9 @@ func (p *selLEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -34911,9 +34911,9 @@ func (p *selLEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -34940,9 +34940,9 @@ func (p *selLEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -36375,9 +36375,9 @@ func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -36404,9 +36404,9 @@ func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -36429,9 +36429,9 @@ func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -36455,9 +36455,9 @@ func (p *selLEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -36517,9 +36517,9 @@ func (p *selLEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -36549,9 +36549,9 @@ func (p *selLEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -36575,9 +36575,9 @@ func (p *selLEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -36604,9 +36604,9 @@ func (p *selLEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -38231,11 +38231,11 @@ func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -38262,11 +38262,11 @@ func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -38289,11 +38289,11 @@ func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -38317,11 +38317,11 @@ func (p *selLEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult <= 0
@@ -38381,11 +38381,11 @@ func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -38415,11 +38415,11 @@ func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -38443,11 +38443,11 @@ func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -38474,11 +38474,11 @@ func (p *selLEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult <= 0
@@ -40141,9 +40141,9 @@ func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40170,9 +40170,9 @@ func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40195,9 +40195,9 @@ func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40221,9 +40221,9 @@ func (p *selGTDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40283,9 +40283,9 @@ func (p *selGTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40315,9 +40315,9 @@ func (p *selGTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40341,9 +40341,9 @@ func (p *selGTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40370,9 +40370,9 @@ func (p *selGTDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40429,9 +40429,9 @@ func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40458,9 +40458,9 @@ func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40483,9 +40483,9 @@ func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40509,9 +40509,9 @@ func (p *selGTDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40571,9 +40571,9 @@ func (p *selGTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40603,9 +40603,9 @@ func (p *selGTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40629,9 +40629,9 @@ func (p *selGTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40658,9 +40658,9 @@ func (p *selGTDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40717,9 +40717,9 @@ func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40746,9 +40746,9 @@ func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40771,9 +40771,9 @@ func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40797,9 +40797,9 @@ func (p *selGTDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40859,9 +40859,9 @@ func (p *selGTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40891,9 +40891,9 @@ func (p *selGTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40917,9 +40917,9 @@ func (p *selGTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -40946,9 +40946,9 @@ func (p *selGTDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41005,11 +41005,11 @@ func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41036,11 +41036,11 @@ func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41063,11 +41063,11 @@ func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41091,11 +41091,11 @@ func (p *selGTDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41155,11 +41155,11 @@ func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41189,11 +41189,11 @@ func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41217,11 +41217,11 @@ func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -41248,11 +41248,11 @@ func (p *selGTDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult > 0
@@ -42925,9 +42925,9 @@ func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -42954,9 +42954,9 @@ func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -42979,9 +42979,9 @@ func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -43005,9 +43005,9 @@ func (p *selGTInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -43067,9 +43067,9 @@ func (p *selGTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -43099,9 +43099,9 @@ func (p *selGTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -43125,9 +43125,9 @@ func (p *selGTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -43154,9 +43154,9 @@ func (p *selGTInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -44589,9 +44589,9 @@ func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -44618,9 +44618,9 @@ func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -44643,9 +44643,9 @@ func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -44669,9 +44669,9 @@ func (p *selGTInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -44731,9 +44731,9 @@ func (p *selGTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -44763,9 +44763,9 @@ func (p *selGTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -44789,9 +44789,9 @@ func (p *selGTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -44818,9 +44818,9 @@ func (p *selGTInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -46253,9 +46253,9 @@ func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -46282,9 +46282,9 @@ func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -46307,9 +46307,9 @@ func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -46333,9 +46333,9 @@ func (p *selGTInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -46395,9 +46395,9 @@ func (p *selGTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -46427,9 +46427,9 @@ func (p *selGTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -46453,9 +46453,9 @@ func (p *selGTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -46482,9 +46482,9 @@ func (p *selGTInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -48109,11 +48109,11 @@ func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -48140,11 +48140,11 @@ func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -48167,11 +48167,11 @@ func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -48195,11 +48195,11 @@ func (p *selGTFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult > 0
@@ -48259,11 +48259,11 @@ func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -48293,11 +48293,11 @@ func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -48321,11 +48321,11 @@ func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -48352,11 +48352,11 @@ func (p *selGTFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult > 0
@@ -50019,9 +50019,9 @@ func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50048,9 +50048,9 @@ func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50073,9 +50073,9 @@ func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50099,9 +50099,9 @@ func (p *selGEDecimalInt16ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50161,9 +50161,9 @@ func (p *selGEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50193,9 +50193,9 @@ func (p *selGEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50219,9 +50219,9 @@ func (p *selGEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50248,9 +50248,9 @@ func (p *selGEDecimalInt16Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50307,9 +50307,9 @@ func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50336,9 +50336,9 @@ func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50361,9 +50361,9 @@ func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50387,9 +50387,9 @@ func (p *selGEDecimalInt32ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50449,9 +50449,9 @@ func (p *selGEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50481,9 +50481,9 @@ func (p *selGEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50507,9 +50507,9 @@ func (p *selGEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50536,9 +50536,9 @@ func (p *selGEDecimalInt32Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50595,9 +50595,9 @@ func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50624,9 +50624,9 @@ func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50649,9 +50649,9 @@ func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50675,9 +50675,9 @@ func (p *selGEDecimalInt64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50737,9 +50737,9 @@ func (p *selGEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50769,9 +50769,9 @@ func (p *selGEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50795,9 +50795,9 @@ func (p *selGEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50824,9 +50824,9 @@ func (p *selGEDecimalInt64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50883,11 +50883,11 @@ func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50914,11 +50914,11 @@ func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50941,11 +50941,11 @@ func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -50969,11 +50969,11 @@ func (p *selGEDecimalFloat64ConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(p.constArg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -51033,11 +51033,11 @@ func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -51067,11 +51067,11 @@ func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -51095,11 +51095,11 @@ func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -51126,11 +51126,11 @@ func (p *selGEDecimalFloat64Op) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg2)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(&arg1, tmpDec)
+							cmpResult = tree.CompareDecimals(&arg1, &tmpDec)
 						}
 
 						cmp = cmpResult >= 0
@@ -52803,9 +52803,9 @@ func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -52832,9 +52832,9 @@ func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -52857,9 +52857,9 @@ func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -52883,9 +52883,9 @@ func (p *selGEInt16DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -52945,9 +52945,9 @@ func (p *selGEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -52977,9 +52977,9 @@ func (p *selGEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -53003,9 +53003,9 @@ func (p *selGEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -53032,9 +53032,9 @@ func (p *selGEInt16DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -54467,9 +54467,9 @@ func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -54496,9 +54496,9 @@ func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -54521,9 +54521,9 @@ func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -54547,9 +54547,9 @@ func (p *selGEInt32DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -54609,9 +54609,9 @@ func (p *selGEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -54641,9 +54641,9 @@ func (p *selGEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -54667,9 +54667,9 @@ func (p *selGEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -54696,9 +54696,9 @@ func (p *selGEInt32DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -56131,9 +56131,9 @@ func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -56160,9 +56160,9 @@ func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -56185,9 +56185,9 @@ func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -56211,9 +56211,9 @@ func (p *selGEInt64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -56273,9 +56273,9 @@ func (p *selGEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -56305,9 +56305,9 @@ func (p *selGEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -56331,9 +56331,9 @@ func (p *selGEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -56360,9 +56360,9 @@ func (p *selGEInt64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -57987,11 +57987,11 @@ func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -58018,11 +58018,11 @@ func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -58045,11 +58045,11 @@ func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -58073,11 +58073,11 @@ func (p *selGEFloat64DecimalConstOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &p.constArg)
+							cmpResult = tree.CompareDecimals(&tmpDec, &p.constArg)
 						}
 
 						cmp = cmpResult >= 0
@@ -58137,11 +58137,11 @@ func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -58171,11 +58171,11 @@ func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -58199,11 +58199,11 @@ func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0
@@ -58230,11 +58230,11 @@ func (p *selGEFloat64DecimalOp) Next() coldata.Batch {
 						var cmpResult int
 
 						{
-							tmpDec := &_overloadHelper.TmpDec1
+							var tmpDec apd.Decimal //gcassert:noescape
 							if _, err := tmpDec.SetFloat64(float64(arg1)); err != nil {
 								colexecerror.ExpectedError(err)
 							}
-							cmpResult = tree.CompareDecimals(tmpDec, &arg2)
+							cmpResult = tree.CompareDecimals(&tmpDec, &arg2)
 						}
 
 						cmp = cmpResult >= 0

--- a/pkg/sql/colexec/execgen/BUILD.bazel
+++ b/pkg/sql/colexec/execgen/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     deps = [
         "//pkg/sql/colexecerror",
         "//pkg/sql/sem/tree",
-        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_dave_dst//:dst",
         "@com_github_dave_dst//decorator",

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -25,7 +25,6 @@ import (
 
 type avgTmplInfo struct {
 	aggTmplInfoBase
-	NeedsHelper    bool
 	InputVecMethod string
 	RetGoType      string
 	RetGoTypeSlice string
@@ -148,14 +147,12 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 	for _, inputTypeFamily := range []types.Family{types.IntFamily, types.DecimalFamily, types.FloatFamily, types.IntervalFamily} {
 		tmplInfo := avgAggTypeTmplInfo{TypeFamily: toString(inputTypeFamily)}
 		for _, inputTypeWidth := range supportedWidthsByCanonicalTypeFamily[inputTypeFamily] {
-			needsHelper := false
 			// Note that we don't use execinfrapb.GetAggregateInfo because we don't
 			// want to bring in a dependency on that package to reduce the burden
 			// of regenerating execgen code when the protobufs get generated.
 			retTypeFamily, retTypeWidth := inputTypeFamily, inputTypeWidth
 			if inputTypeFamily == types.IntFamily {
 				// Average of integers is a decimal.
-				needsHelper = true
 				retTypeFamily, retTypeWidth = types.DecimalFamily, anyWidth
 			}
 			tmplInfo.WidthOverloads = append(tmplInfo.WidthOverloads, avgAggWidthTmplInfo{
@@ -164,7 +161,6 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 					aggTmplInfoBase: aggTmplInfoBase{
 						canonicalTypeFamily: typeconv.TypeFamilyToCanonicalTypeFamily(retTypeFamily),
 					},
-					NeedsHelper:    needsHelper,
 					InputVecMethod: toVecMethod(inputTypeFamily, inputTypeWidth),
 					RetGoType:      toPhysicalRepresentation(retTypeFamily, retTypeWidth),
 					RetGoTypeSlice: goTypeSliceName(retTypeFamily, retTypeWidth),

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -128,8 +128,8 @@ func getDecimalToIntCastFunc(toIntWidth int32) castFunc {
 		// as well.
 		convStr := `
 		{
-			tmpDec := &_overloadHelper.TmpDec1
-			_, err := tree.DecimalCtx.RoundToIntegralValue(tmpDec, &%[2]s)
+			var tmpDec apd.Decimal //gcassert:noescape
+			_, err := tree.DecimalCtx.RoundToIntegralValue(&tmpDec, &%[2]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -472,10 +472,10 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 				if {{.Right}} == 0 {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
-				leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+				var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 				leftTmpDec.SetInt64(int64({{.Left}}))
 				rightTmpDec.SetInt64(int64({{.Right}}))
-				if _, err := tree.{{.Ctx}}.Quo(&{{.Target}}, leftTmpDec, rightTmpDec); err != nil {
+				if _, err := tree.{{.Ctx}}.Quo(&{{.Target}}, &leftTmpDec, &rightTmpDec); err != nil {
 					colexecerror.ExpectedError(err)
 				}
 			}
@@ -485,10 +485,10 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 
 			t = template.Must(template.New("").Parse(`
 			{
-				leftTmpDec, rightTmpDec := &_overloadHelper.TmpDec1, &_overloadHelper.TmpDec2
+				var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 				leftTmpDec.SetInt64(int64({{.Left}}))
 				rightTmpDec.SetInt64(int64({{.Right}}))
-				if _, err := tree.{{.Ctx}}.Pow(leftTmpDec, leftTmpDec, rightTmpDec); err != nil {
+				if _, err := tree.{{.Ctx}}.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 					colexecerror.ExpectedError(err)
 				}
 				resultInt, err := leftTmpDec.Int64()
@@ -550,9 +550,9 @@ func (c decimalIntCustomizer) getBinOpAssignFunc() assignFunc {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
 				{{end}}
-				tmpDec := &_overloadHelper.TmpDec1
+				var tmpDec apd.Decimal //gcassert:noescape
 				tmpDec.SetInt64(int64({{.Right}}))
-				if _, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, tmpDec); err != nil {
+				if _, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, &tmpDec); err != nil {
 					colexecerror.ExpectedError(err)
 				}
 			}
@@ -583,9 +583,9 @@ func (c intDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
 				{{end}}
-				tmpDec := &_overloadHelper.TmpDec1
+				var tmpDec apd.Decimal //gcassert:noescape
 				tmpDec.SetInt64(int64({{.Left}}))
-				_, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, tmpDec, &{{.Right}})
+				_, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &tmpDec, &{{.Right}})
 				if err != nil {
 					colexecerror.ExpectedError(err)
 				}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_cmp.go
@@ -222,11 +222,11 @@ func (c decimalFloatCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &_overloadHelper.TmpDec1
+				var tmpDec apd.Decimal //gcassert:noescape
 				if _, err := tmpDec.SetFloat64(float64({{.Right}})); err != nil {
 					colexecerror.ExpectedError(err)
 				}
-				{{.Target}} = tree.CompareDecimals(&{{.Left}}, tmpDec)
+				{{.Target}} = tree.CompareDecimals(&{{.Left}}, &tmpDec)
 			}
 		`))
 		if err := t.Execute(&buf, args); err != nil {
@@ -242,9 +242,9 @@ func (c decimalIntCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &_overloadHelper.TmpDec1
+				var tmpDec apd.Decimal //gcassert:noescape
 				tmpDec.SetInt64(int64({{.Right}}))
-				{{.Target}} = tree.CompareDecimals(&{{.Left}}, tmpDec)
+				{{.Target}} = tree.CompareDecimals(&{{.Left}}, &tmpDec)
 			}
 		`))
 		if err := t.Execute(&buf, args); err != nil {
@@ -260,11 +260,11 @@ func (c floatDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &_overloadHelper.TmpDec1
+				var tmpDec apd.Decimal //gcassert:noescape
 				if _, err := tmpDec.SetFloat64(float64({{.Left}})); err != nil {
 					colexecerror.ExpectedError(err)
 				}
-				{{.Target}} = tree.CompareDecimals(tmpDec, &{{.Right}})
+				{{.Target}} = tree.CompareDecimals(&tmpDec, &{{.Right}})
 			}
 		`))
 		if err := t.Execute(&buf, args); err != nil {
@@ -280,9 +280,9 @@ func (c intDecimalCustomizer) getCmpOpCompareFunc() compareFunc {
 		buf := strings.Builder{}
 		t := template.Must(template.New("").Parse(`
 			{
-				tmpDec := &_overloadHelper.TmpDec1
+				var tmpDec apd.Decimal //gcassert:noescape
 				tmpDec.SetInt64(int64({{.Left}}))
-				{{.Target}} = tree.CompareDecimals(tmpDec, &{{.Right}})
+				{{.Target}} = tree.CompareDecimals(&tmpDec, &{{.Right}})
 			}
 		`))
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
@@ -91,7 +91,7 @@ func (decimalCustomizer) getHashAssignFunc() assignFunc {
 		return fmt.Sprintf(`
 			// In order for equal decimals to hash to the same value we need to
 			// remove the trailing zeroes if there are any.
-			tmpDec := &_overloadHelper.TmpDec1
+			var tmpDec apd.Decimal //gcassert:noescape
 			tmpDec.Reduce(&%[1]s)
 			b := []byte(tmpDec.String())`, vElem) +
 			fmt.Sprintf(hashByteSliceString, targetElem, "b")

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -25,7 +25,6 @@ import (
 type sumAggTmplInfo struct {
 	aggTmplInfoBase
 	SumKind        string
-	NeedsHelper    bool
 	InputVecMethod string
 	RetGoType      string
 	RetGoTypeSlice string
@@ -165,7 +164,6 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 			TypeFamily: toString(inputTypeFamily),
 		}
 		for _, inputTypeWidth := range supportedWidthsByCanonicalTypeFamily[inputTypeFamily] {
-			needsHelper := false
 			// Note that we don't use execinfrapb.GetAggregateInfo because we don't
 			// want to bring in a dependency on that package to reduce the burden
 			// of regenerating execgen code when the protobufs get generated.
@@ -174,9 +172,6 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 				if isSumInt {
 					retTypeFamily, retTypeWidth = types.IntFamily, anyWidth
 				} else {
-					// Non-integer summation of integers needs a helper because
-					// the result is a decimal.
-					needsHelper = true
 					retTypeFamily, retTypeWidth = types.DecimalFamily, anyWidth
 				}
 			}
@@ -187,7 +182,6 @@ func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 						canonicalTypeFamily: typeconv.TypeFamilyToCanonicalTypeFamily(retTypeFamily),
 					},
 					SumKind:        sumKind,
-					NeedsHelper:    needsHelper,
 					InputVecMethod: toVecMethod(inputTypeFamily, inputTypeWidth),
 					RetGoType:      toPhysicalRepresentation(retTypeFamily, retTypeWidth),
 					RetGoTypeSlice: goTypeSliceName(retTypeFamily, retTypeWidth),

--- a/pkg/sql/colexec/execgen/overloads_util.go
+++ b/pkg/sql/colexec/execgen/overloads_util.go
@@ -10,24 +10,16 @@
 
 package execgen
 
-import (
-	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-)
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
-// OverloadHelper is a utility struct used for templates that helps us avoid
-// allocations of temporary decimals on every overloaded operation with them as
-// well as plumbs through other useful information.
+// OverloadHelper is a utility struct used for templates that plumbs through
+// miscellaneous useful information.
 //
 // In order for the templates to see it correctly, a local variable named
 // `_overloadHelper` of this type must be declared before the inlined
 // overloaded code.
 type OverloadHelper struct {
-	// TODO(yuzefovich): remove these now that temporary apd.Decimal instances can
-	// be stack-allocated without any indirection to the heap. When doing so, make
-	// sure the stack variables don't escape by using gcassert:noescape.
-	TmpDec1, TmpDec2 apd.Decimal
-	BinFn            tree.TwoArgFn
-	EvalCtx          *tree.EvalContext
-	ByteScratch      []byte
+	BinFn       tree.TwoArgFn
+	EvalCtx     *tree.EvalContext
+	ByteScratch []byte
 }


### PR DESCRIPTION
This commit removes two temporary decimals from `execgen.OverloadHelper`
since after the upgrade of the decimal library it can use
stack-allocated temporary objects without them escaping to the heap.

Release note: None