### PR TITLE
ci: bazelize nightly pebble ycsb, write-throughput benchmarks

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# This script runs the Pebble Nightly write-throughput benchmarks.
+#
+# It is run by the Pebble Nightly Write Throughput build
+# configuration.
+
+set -eo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e GOOGLE_EPHEMERAL_CREDENTIALS -e TC_BUILD_BRANCH -e TC_BUILD_ID" \
+                               run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-#
-# This script runs the Pebble Nightly write-throughput benchmarks.
-#
-# It is run by the Pebble Nightly - AWS TeamCity build
-# configuration.
 
 set -eo pipefail
 
@@ -11,7 +6,7 @@ _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Execute the common commands for the benchmark runs and import common
 # variables / constants.
-. "$_dir/teamcity-nightly-pebble-common.sh"
+. "$_dir/pebble_nightly_common.sh"
 
 # Run the write-throughput benchmark.
 #
@@ -28,6 +23,7 @@ if ! timeout -s INT 12h bin/roachtest run \
   --cockroach "true" \
   --workload "true" \
   --artifacts "$artifacts" \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 2 \
   --teamcity \
   --cpu-quota=384 \
@@ -49,3 +45,4 @@ aws s3 sync ./write-throughput s3://pebble-benchmarks/write-throughput
 sync_data_dir
 
 exit "$exit_status"
+

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# This script runs the Pebble Nightly YCSB benchmarks.
+#
+# It is run by the Pebble Nightly YCSB TeamCity build
+# configuration.
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e GOOGLE_EPHEMERAL_CREDENTIALS -e TC_BUILD_BRANCH -e TC_BUILD_ID" \
+                               run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
-#
-# This script runs the Pebble Nightly YCSB benchmarks.
-#
-# It is run by the Pebble Nightly - AWS TeamCity build
-# configuration.
 
 set -eo pipefail
 
 _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Execute the common commands for the benchmark runs.
-. "$_dir/teamcity-nightly-pebble-common.sh"
+. "$_dir/pebble_nightly_common.sh"
 
 # Run the YCSB benchmark.
 #
@@ -27,6 +22,7 @@ if ! timeout -s INT $((1000*60)) bin/roachtest run \
   --cockroach "true" \
   --workload "true" \
   --artifacts "$artifacts" \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 3 \
   --teamcity \
   --cpu-quota=384 \


### PR DESCRIPTION
We still have to take care of the metamorphic nightly.

Part of #67335.

Release note: None