### PR TITLE
colexechash: minor improvements and cleanup

### DIFF
--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/col/coldataext",  # keep
         "//pkg/col/typeconv",  # keep
         "//pkg/sql/colexec/colexecutils",
-        "//pkg/sql/colexec/execgen",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",
         "//pkg/sql/colmem",
@@ -44,7 +43,6 @@ go_test(
         "//pkg/col/coldataext",
         "//pkg/settings/cluster",
         "//pkg/sql/colexec/colexecutils",
-        "//pkg/sql/colexec/execgen",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -46,12 +45,8 @@ func rehash(
 	nKeys int,
 	sel []int,
 	cancelChecker colexecutils.CancelChecker,
-	overloadHelper *execgen.OverloadHelper,
 	datumAlloc *tree.DatumAlloc,
 ) {
-	// In order to inline the templated code of overloads, we need to have a
-	// "_overloadHelper" local variable of type "execgen.OverloadHelper".
-	_overloadHelper := overloadHelper
 	switch col.CanonicalTypeFamily() {
 	case types.BoolFamily:
 		switch col.Type().Width() {
@@ -927,16 +922,12 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
 
-						scratch := _overloadHelper.ByteScratch[:0]
-						_b, _err := json.EncodeJSON(scratch, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
-						}
-						_overloadHelper.ByteScratch = _b
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
@@ -954,16 +945,12 @@ func rehash(
 						if nulls.NullAt(selIdx) {
 							continue
 						}
-						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
 
-						scratch := _overloadHelper.ByteScratch[:0]
-						_b, _err := json.EncodeJSON(scratch, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
-						}
-						_overloadHelper.ByteScratch = _b
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
@@ -982,16 +969,12 @@ func rehash(
 					for i := 0; i < nKeys; i++ {
 						//gcassert:bce
 						selIdx = sel[i]
-						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
 
-						scratch := _overloadHelper.ByteScratch[:0]
-						_b, _err := json.EncodeJSON(scratch, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
-						}
-						_overloadHelper.ByteScratch = _b
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
@@ -1006,16 +989,12 @@ func rehash(
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
-						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
 
-						scratch := _overloadHelper.ByteScratch[:0]
-						_b, _err := json.EncodeJSON(scratch, v)
-						if _err != nil {
-							colexecerror.ExpectedError(_err)
-						}
-						_overloadHelper.ByteScratch = _b
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
 
 						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
 						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -78,16 +78,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -101,7 +102,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -125,13 +125,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -145,7 +146,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -176,7 +176,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -196,7 +195,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -217,7 +215,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -234,7 +231,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -270,16 +266,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -295,7 +292,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -321,13 +317,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -343,7 +340,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -374,16 +370,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -395,7 +392,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -417,13 +413,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -435,7 +432,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		case 32:
@@ -463,16 +459,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -484,7 +481,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -506,13 +502,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -524,7 +521,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		case -1:
@@ -553,16 +549,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -574,7 +571,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -596,13 +592,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -614,7 +611,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -648,16 +644,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -671,7 +668,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -695,13 +691,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -715,7 +712,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -746,16 +742,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -766,7 +763,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -787,13 +783,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -804,7 +801,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -837,16 +833,17 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
 						if nulls.NullAt(selIdx) {
 							continue
 						}
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -859,7 +856,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -882,13 +878,14 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
 					var selIdx int
 					for i := 0; i < nKeys; i++ {
 						selIdx = i
+						//gcassert:bce
 						v := keys.Get(selIdx)
 						//gcassert:bce
 						p := uintptr(buckets[i])
@@ -901,7 +898,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -935,7 +931,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -958,7 +953,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -982,7 +976,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -1002,7 +995,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
@@ -1033,7 +1025,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -1053,7 +1044,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			} else {
 				if sel != nil {
@@ -1074,7 +1064,6 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				} else {
 					// Early bounds checks.
 					_ = buckets[nKeys-1]
@@ -1091,11 +1080,11 @@ func rehash(
 						//gcassert:bce
 						buckets[i] = uint64(p)
 					}
-					cancelChecker.CheckEveryCall()
 				}
 			}
 		}
 	default:
 		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", col.Type()))
 	}
+	cancelChecker.CheckEveryCall()
 }

--- a/pkg/sql/colexec/colexechash/hash_utils.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -117,9 +116,8 @@ type TupleHashDistributor struct {
 	selections [][]int
 	// cancelChecker is used during the hashing of the rows to distribute to
 	// check for query cancellation.
-	cancelChecker  colexecutils.CancelChecker
-	overloadHelper execgen.OverloadHelper
-	datumAlloc     tree.DatumAlloc
+	cancelChecker colexecutils.CancelChecker
+	datumAlloc    tree.DatumAlloc
 }
 
 // NewTupleHashDistributor returns a new TupleHashDistributor.
@@ -157,7 +155,7 @@ func (d *TupleHashDistributor) Distribute(b coldata.Batch, hashCols []uint32) []
 	}
 
 	for _, i := range hashCols {
-		rehash(d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, &d.overloadHelper, &d.datumAlloc)
+		rehash(d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, &d.datumAlloc)
 	}
 
 	finalizeHash(d.buckets, n, uint64(len(d.selections)))

--- a/pkg/sql/colexec/colexechash/hash_utils_test.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -41,9 +40,8 @@ func TestHashFunctionFamily(t *testing.T) {
 	}
 	numBuckets := uint64(16)
 	var (
-		cancelChecker     colexecutils.CancelChecker
-		overloadHelperVar execgen.OverloadHelper
-		datumAlloc        tree.DatumAlloc
+		cancelChecker colexecutils.CancelChecker
+		datumAlloc    tree.DatumAlloc
 	)
 	cancelChecker.Init(context.Background())
 
@@ -51,7 +49,7 @@ func TestHashFunctionFamily(t *testing.T) {
 		// We need +1 here because 0 is not a valid initial hash value.
 		initHash(buckets, nKeys, uint64(initHashValue+1))
 		for _, keysCol := range keys {
-			rehash(buckets, keysCol, nKeys, nil /* sel */, cancelChecker, &overloadHelperVar, &datumAlloc)
+			rehash(buckets, keysCol, nKeys, nil /* sel */, cancelChecker, &datumAlloc)
 		}
 		finalizeHash(buckets, nKeys, numBuckets)
 	}

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -78,7 +78,7 @@ func _REHASH_BODY(
 	_ = buckets[nKeys-1]
 	// {{if .HasSel}}
 	_ = sel[nKeys-1]
-	// {{else if .Sliceable}}
+	// {{else if .Global.Sliceable}}
 	_ = keys.Get(nKeys - 1)
 	// {{end}}
 	var selIdx int
@@ -99,7 +99,7 @@ func _REHASH_BODY(
 		//     No need to decode the JSON value (which is done in Get) since
 		//     we'll be operating directly on the underlying []byte.
 		// */}}
-		// {{if .Sliceable}}
+		// {{if and (not .HasSel) .Global.Sliceable}}
 		//gcassert:bce
 		// {{end}}
 		v := keys.Get(selIdx)
@@ -110,7 +110,6 @@ func _REHASH_BODY(
 		//gcassert:bce
 		buckets[i] = uint64(p)
 	}
-	cancelChecker.CheckEveryCall()
 	// {{end}}
 
 	// {{/*
@@ -155,4 +154,5 @@ func rehash(
 	default:
 		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", col.Type()))
 	}
+	cancelChecker.CheckEveryCall()
 }

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -182,9 +181,8 @@ type HashTable struct {
 	// each other.
 	allowNullEquality bool
 
-	overloadHelper execgen.OverloadHelper
-	datumAlloc     tree.DatumAlloc
-	cancelChecker  colexecutils.CancelChecker
+	datumAlloc    tree.DatumAlloc
+	cancelChecker colexecutils.CancelChecker
 
 	BuildMode HashTableBuildMode
 	probeMode HashTableProbeMode
@@ -552,7 +550,7 @@ func (ht *HashTable) ComputeBuckets(buckets []uint64, keys []coldata.Vec, nKeys 
 	}
 
 	for i := range ht.keyCols {
-		rehash(buckets, keys[i], nKeys, sel, ht.cancelChecker, &ht.overloadHelper, &ht.datumAlloc)
+		rehash(buckets, keys[i], nKeys, sel, ht.cancelChecker, &ht.datumAlloc)
 	}
 
 	finalizeHash(buckets, nKeys, ht.numBuckets)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -29,7 +29,7 @@ func genHashUtils(inputFileContents string, wr io.Writer) error {
 	s := r.Replace(inputFileContents)
 
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 4)
-	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.UnaryAssign", 4))
+	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignHash", 4))
 
 	rehash := makeFunctionRegex("_REHASH_BODY", 7)
 	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $6 "HasNulls" $7}}`)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_hash.go
@@ -34,8 +34,6 @@ func populateHashOverloads() {
 		ov := newLastArgTypeOverload(hashOverloadBase, family)
 		for _, width := range widths {
 			// Note that we pass in types.Bool as the return type just to make
-			//
-			// Note that we pass in types.Bool as the return type just to make
 			// overloads initialization happy. We don't actually care about the
 			// return type since we know that it will be represented physically
 			// as uint64.
@@ -43,7 +41,7 @@ func populateHashOverloads() {
 			sameTypeCustomizer := typeCustomizers[typePair{family, width, family, width}]
 			if sameTypeCustomizer != nil {
 				if b, ok := sameTypeCustomizer.(hashTypeCustomizer); ok {
-					lawo.AssignFunc = b.getHashAssignFunc()
+					lawo.HashFunc = b.getHashFunc()
 				}
 			}
 		}
@@ -56,11 +54,11 @@ func populateHashOverloads() {
 // hashTypeCustomizer is a type customizer that changes how the templater
 // produces hash output for a particular type.
 type hashTypeCustomizer interface {
-	getHashAssignFunc() assignFunc
+	getHashFunc() hashFunc
 }
 
-func (boolCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (boolCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		return fmt.Sprintf(`
 			x := 0
 			if %[2]s {
@@ -80,14 +78,14 @@ const hashByteSliceString = `
 			%[1]s = memhash(unsafe.Pointer(sh.Data), %[1]s, uintptr(len(%[2]s)))
 `
 
-func (bytesCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (bytesCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		return fmt.Sprintf(hashByteSliceString, targetElem, vElem)
 	}
 }
 
-func (decimalCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (decimalCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		return fmt.Sprintf(`
 			// In order for equal decimals to hash to the same value we need to
 			// remove the trailing zeroes if there are any.
@@ -98,8 +96,8 @@ func (decimalCustomizer) getHashAssignFunc() assignFunc {
 	}
 }
 
-func (c floatCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (c floatCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		// TODO(yuzefovich): think through whether this is appropriate way to hash
 		// NaNs.
 		return fmt.Sprintf(
@@ -113,8 +111,8 @@ func (c floatCustomizer) getHashAssignFunc() assignFunc {
 	}
 }
 
-func (c intCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (c intCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		return fmt.Sprintf(`
 				// In order for integers with different widths but of the same value to
 				// to hash to the same value, we upcast all of them to int64.
@@ -124,8 +122,8 @@ func (c intCustomizer) getHashAssignFunc() assignFunc {
 	}
 }
 
-func (c timestampCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (c timestampCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		return fmt.Sprintf(`
 		  s := %[2]s.UnixNano()
 		  %[1]s = memhash64(noescape(unsafe.Pointer(&s)), %[1]s)
@@ -133,8 +131,8 @@ func (c timestampCustomizer) getHashAssignFunc() assignFunc {
 	}
 }
 
-func (c intervalCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (c intervalCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		return fmt.Sprintf(`
 		  months, days, nanos := %[2]s.Months, %[2]s.Days, %[2]s.Nanos()
 		  %[1]s = memhash64(noescape(unsafe.Pointer(&months)), %[1]s)
@@ -144,25 +142,18 @@ func (c intervalCustomizer) getHashAssignFunc() assignFunc {
 	}
 }
 
-func (c jsonCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
-		// TODO(yuzefovich): consider refactoring this to avoid decoding-encoding of
-		// JSON altogether. This will require changing `assignFunc` to also have an
-		// access to the index of the current element and then some trickery to get
-		// to the bytes underlying the JSON.
+func (c jsonCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, _, vVec, vIdx string) string {
 		return fmt.Sprintf(`
-        scratch := _overloadHelper.ByteScratch[:0]
-        _b, _err := json.EncodeJSON(scratch, %[2]s)
-        if _err != nil {
-          colexecerror.ExpectedError(_err)
-        }
-        _overloadHelper.ByteScratch = _b
-        %[1]s`, fmt.Sprintf(hashByteSliceString, targetElem, "_b"), vElem)
+        // Access the underlying []byte directly which allows us to skip
+        // decoding-encoding of the JSON object.
+        _b := %[2]s.Bytes.Get(%[3]s)
+        %[1]s`, fmt.Sprintf(hashByteSliceString, targetElem, "_b"), vVec, vIdx)
 	}
 }
 
-func (c datumCustomizer) getHashAssignFunc() assignFunc {
-	return func(op *lastArgWidthOverload, targetElem, vElem, _, _, _, _ string) string {
+func (c datumCustomizer) getHashFunc() hashFunc {
+	return func(targetElem, vElem, _, _ string) string {
 		// Note that this overload assumes that there exists
 		//   var datumAlloc *tree.DatumAlloc.
 		// in the scope.

--- a/pkg/sql/colexec/execgen/overloads_util.go
+++ b/pkg/sql/colexec/execgen/overloads_util.go
@@ -19,7 +19,6 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 // `_overloadHelper` of this type must be declared before the inlined
 // overloaded code.
 type OverloadHelper struct {
-	BinFn       tree.TwoArgFn
-	EvalCtx     *tree.EvalContext
-	ByteScratch []byte
+	BinFn   tree.TwoArgFn
+	EvalCtx *tree.EvalContext
 }

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -39,17 +39,22 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 54
+const Version execinfrapb.DistSQLVersion = 55
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 52
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 55
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+- Version: 55 (MinAcceptedVersion: 55)
+  - The computation of the hash of JSONs in the vectorized engine has changed.
+    As a result, the hash routing can be now done in a different manner, so we
+    have to bump both versions.
 
 - Version: 54 (MinAcceptedVersion: 52)
   - Field NeededColumns has been removed from the TableReaderSpec. It was being


### PR DESCRIPTION
**execgen: skip encoding/decoding JSON when hashing it**

Previously, in order to hash a JSON object we would encode and decode it
(due to the behavior of `coldata.JSONs.Get` and the setup of the
execgen). This commit refactors how the hash functions are handled in
the execgen which allows us to peek inside of `coldata.Bytes` (that is
under the `coldata.JSONs`) in order to get direct access to the
underlying `[]byte`. This should be a minor performance improvement but
also allows us to remove the need for the overload helper in the hashing
context.

It is possible (although I'm not certain) that the hash computation is
now different, so this commit bumps the DistSQL versions to be safe.

Release note: None

**colexechash: fix BCEs in some cases**

Previously, we were not getting (and not asserting) some of the bounds
check eliminations in `rehash` function because we were accessing
`.Sliceable` property in the wrong context. This is now fixed (by
accessing it via `.Global`) as well as assertions are added correctly.
Additionally, this commit pulls out the call to the cancel checker out
of the templated block to reduce the amount of code duplication.

Release note: None