### PR TITLE
colexec: batch allocate datums for projectTupleOp

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3662,6 +3662,11 @@ func NewDTupleWithLen(typ *types.T, l int) *DTuple {
 	return &DTuple{D: make(Datums, l), typ: typ}
 }
 
+// MakeDTuple creates a DTuple with the provided datums. See NewDTuple.
+func MakeDTuple(typ *types.T, d ...Datum) DTuple {
+	return DTuple{D: d, typ: typ}
+}
+
 // AsDTuple attempts to retrieve a *DTuple from an Expr, returning a *DTuple and
 // a flag signifying whether the assertion was successful. The function should
 // be used instead of direct type assertions wherever a *DTuple wrapped by a


### PR DESCRIPTION
This has a profound impact on the amound of garbage generated by the delivery
query in TPC-C.

```
name                    old time/op    new time/op    delta
TPCC/mix=delivery=1-16    38.0ms ± 2%    35.8ms ± 1%   -5.76%  (p=0.000 n=9+8)

name                    old alloc/op   new alloc/op   delta
TPCC/mix=delivery=1-16    8.17MB ± 1%    7.97MB ± 1%   -2.36%  (p=0.000 n=9+10)

name                    old allocs/op  new allocs/op  delta
TPCC/mix=delivery=1-16     80.2k ± 0%     20.3k ± 1%  -74.65%  (p=0.000 n=10+9)
```

Leveraged https://github.com/cockroachdb/cockroach/pull/74443 to find this.

Release note: None