### PR TITLE
backupccl: add libgeos to BUILD.bazel

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -160,7 +160,7 @@ go_test(
         "split_and_scatter_processor_test.go",
         "system_schema_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = glob(["testdata/**"]) + ["@cockroach//c-deps:libgeos"],
     embed = [":backupccl"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
This is required when using randgen so that libgeos can be initialized
when a geometric type is generated.

Fixes #73895

Release note: None