### PR TITLE
release-21.2: cmd/roachtest: skip clearrange/zfs/* tests

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -44,6 +44,7 @@ func registerClearRange(r registry.Registry) {
 		// and may need to be tweaked.
 		r.Add(registry.TestSpec{
 			Name:  fmt.Sprintf(`clearrange/zfs/checks=%t`, checks),
+			Skip:  "Consistently failing. See #70306 and #68420 for context.",
 			Owner: registry.OwnerStorage,
 			// 5h for import, 120 for the test. The import should take closer
 			// to <3:30h but it varies.


### PR DESCRIPTION
The clearrange tests consistently fail when run with a ZFS filesystem.
Given that wider ZFS support is minimal, disable these tests until time
can be devoted to investigating the cause of the failures.

Release note: None.

Release justification: