### PR TITLE
sql: migrate has_database_privilege from evalPrivilegeCheck to ctx.Planner.HasPrivilege

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -362,7 +362,7 @@ SELECT has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'test
 ----
 true  true  true  true
 
-query error pgcode 3D000 database 'does_not_exist' does not exist
+query error pgcode 3D000 database "does_not_exist" does not exist
 SELECT has_database_privilege('does_not_exist', 'CREATE')
 
 query BBBBB

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -358,28 +358,51 @@ func (p *planner) HasPrivilege(
 func (p *planner) ResolveDescriptorForPrivilegeSpecifier(
 	ctx context.Context, specifier tree.HasPrivilegeSpecifier,
 ) (catalog.Descriptor, error) {
-	if specifier.TableName != nil {
-		tn, err := parser.ParseQualifiedTableName(*specifier.TableName)
-		if err != nil {
-			return nil, err
-		}
-		if _, err := p.ResolveTableName(ctx, tn); err != nil {
-			return nil, err
-		}
-
-		if p.SessionData().Database != "" && p.SessionData().Database != string(tn.CatalogName) {
-			// Postgres does not allow cross-database references in these
-			// functions, so we don't either.
-			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-				"cross-database references are not implemented: %s", tn)
-		}
-		_, table, err := p.Descriptors().GetImmutableTableByName(
-			ctx, p.txn, tn, tree.ObjectLookupFlags{
-				CommonLookupFlags: tree.CommonLookupFlags{
-					Required: true,
-				},
-			},
+	if specifier.DatabaseName != nil {
+		return p.Descriptors().GetImmutableDatabaseByName(
+			ctx, p.txn, *specifier.DatabaseName, tree.DatabaseLookupFlags{Required: true},
 		)
+	} else if specifier.DatabaseOID != nil {
+		_, database, err := p.Descriptors().GetImmutableDatabaseByID(
+			ctx, p.txn, descpb.ID(*specifier.DatabaseOID), tree.DatabaseLookupFlags{Required: true},
+		)
+		return database, err
+	} else if specifier.TableName != nil || specifier.TableOID != nil {
+		var table catalog.TableDescriptor
+		var err error
+		if specifier.TableName != nil {
+			var tn *tree.TableName
+			tn, err = parser.ParseQualifiedTableName(*specifier.TableName)
+			if err != nil {
+				return nil, err
+			}
+			if _, err = p.ResolveTableName(ctx, tn); err != nil {
+				return nil, err
+			}
+
+			if p.SessionData().Database != "" && p.SessionData().Database != string(tn.CatalogName) {
+				// Postgres does not allow cross-database references in these
+				// functions, so we don't either.
+				return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+					"cross-database references are not implemented: %s", tn)
+			}
+			_, table, err = p.Descriptors().GetImmutableTableByName(
+				ctx, p.txn, tn, tree.ObjectLookupFlags{
+					CommonLookupFlags: tree.CommonLookupFlags{
+						Required: true,
+					},
+				},
+			)
+		} else {
+			table, err = p.Descriptors().GetImmutableTableByID(
+				ctx, p.txn, descpb.ID(*specifier.TableOID),
+				tree.ObjectLookupFlags{
+					CommonLookupFlags: tree.CommonLookupFlags{
+						Required: true,
+					},
+				},
+			)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -391,27 +414,7 @@ func (p *planner) ResolveDescriptorForPrivilegeSpecifier(
 		}
 		return table, nil
 	}
-	if specifier.TableOID == nil {
-		return nil, errors.AssertionFailedf("no table name or oid found")
-	}
-	table, err := p.Descriptors().GetImmutableTableByID(
-		ctx, p.txn, descpb.ID(*specifier.TableOID),
-		tree.ObjectLookupFlags{
-			CommonLookupFlags: tree.CommonLookupFlags{
-				Required: true,
-			},
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateColumnForHasPrivilegeSpecifier(
-		table,
-		specifier,
-	); err != nil {
-		return nil, err
-	}
-	return table, nil
+	return nil, errors.AssertionFailedf("invalid HasPrivilegeSpecifier")
 }
 
 func validateColumnForHasPrivilegeSpecifier(

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1460,7 +1460,8 @@ SELECT description
 				return nil, err
 			}
 			return runPrivilegeChecks(privs, func(priv privilege.Privilege) (tree.Datum, error) {
-				return hasPrivilege(ctx, specifier, user, priv)
+				ret, err := ctx.Planner.HasPrivilege(ctx.Context, specifier, user, priv)
+				return handleTableHasPrivilegeError(specifier, ret, err)
 			})
 		},
 	),
@@ -1470,23 +1471,10 @@ SELECT description
 		argTypeOpts{{"table", strOrOidTypes}, {"column", []*types.T{types.String, types.Int}}},
 		func(ctx *tree.EvalContext, args tree.Datums, user security.SQLUsername) (tree.Datum, error) {
 			tableArg := tree.UnwrapDatum(ctx, args[0])
-			specifier, err := tableHasPrivilegeSpecifier(tableArg)
+			colArg := tree.UnwrapDatum(ctx, args[1])
+			specifier, err := columnHasPrivilegeSpecifier(tableArg, colArg)
 			if err != nil {
 				return nil, err
-			}
-			// Note that we only verify the column exists for has_column_privilege.
-			colArg := tree.UnwrapDatum(ctx, args[1])
-			switch t := colArg.(type) {
-			case *tree.DString:
-				// When colArg is a string, it specifies the attribute name.
-				n := tree.Name(*t)
-				specifier.ColumnName = &n
-			case *tree.DInt:
-				// When colArg is an integer, it specifies the attribute number.
-				attNum := uint32(*t)
-				specifier.ColumnAttNum = &attNum
-			default:
-				return nil, errors.AssertionFailedf("unexpected arg type %T", t)
 			}
 
 			privs, err := parsePrivilegeStr(args[2], privMap{
@@ -1503,7 +1491,8 @@ SELECT description
 				return nil, err
 			}
 			return runPrivilegeChecks(privs, func(priv privilege.Privilege) (tree.Datum, error) {
-				return hasPrivilege(ctx, specifier, user, priv)
+				ret, err := ctx.Planner.HasPrivilege(ctx.Context, specifier, user, priv)
+				return handleTableHasPrivilegeError(specifier, ret, err)
 			})
 		},
 	),
@@ -1512,22 +1501,11 @@ SELECT description
 		"database",
 		argTypeOpts{{"database", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user security.SQLUsername) (tree.Datum, error) {
-			dbArg := tree.UnwrapDatum(ctx, args[0])
-			db, err := getNameForArg(ctx, dbArg, "pg_database", "datname")
+
+			databaseArg := tree.UnwrapDatum(ctx, args[0])
+			specifier, err := databaseHasPrivilegeSpecifier(databaseArg)
 			if err != nil {
 				return nil, err
-			}
-			retNull := false
-			if db == "" {
-				switch dbArg.(type) {
-				case *tree.DString:
-					return nil, pgerror.Newf(pgcode.InvalidCatalogName,
-						"database %s does not exist", dbArg)
-				case *tree.DOid:
-					// Postgres returns NULL if no matching language is found
-					// when given an OID.
-					retNull = true
-				}
 			}
 
 			privs, err := parsePrivilegeStr(args[1], privMap{
@@ -1543,13 +1521,10 @@ SELECT description
 			if err != nil {
 				return nil, err
 			}
-			if retNull {
-				return tree.DNull, nil
-			}
-			databasePrivilegePred := fmt.Sprintf("database_name = '%s'", db)
+
 			return runPrivilegeChecks(privs, func(priv privilege.Privilege) (tree.Datum, error) {
-				return evalPrivilegeCheck(ctx, `"".crdb_internal`, "cluster_database_privileges",
-					user, databasePrivilegePred, priv.Kind)
+				ret, err := ctx.Planner.HasPrivilege(ctx.Context, specifier, user, priv)
+				return handleDatabaseHasPrivilegeError(specifier, ret, err)
 			})
 		},
 	),
@@ -1854,7 +1829,8 @@ SELECT description
 				return nil, err
 			}
 			return runPrivilegeChecks(privs, func(priv privilege.Privilege) (tree.Datum, error) {
-				return hasPrivilege(ctx, specifier, user, priv)
+				ret, err := ctx.Planner.HasPrivilege(ctx.Context, specifier, user, priv)
+				return handleTableHasPrivilegeError(specifier, ret, err)
 			})
 		},
 	),
@@ -2414,27 +2390,19 @@ SELECT description
 	return r[0], nil
 }
 
-// hasPrivilege returns whether the given specifier has the given privilege.
-func hasPrivilege(
-	ctx *tree.EvalContext,
-	specifier tree.HasPrivilegeSpecifier,
-	user security.SQLUsername,
-	priv privilege.Privilege,
-) (tree.Datum, error) {
-	ret, err := ctx.Planner.HasPrivilege(
-		ctx.Context,
-		specifier,
-		user,
-		priv,
-	)
-	if err != nil {
-		// When an OID is specified and the relation is not found, we return NULL.
-		if specifier.TableOID != nil && sqlerrors.IsUndefinedRelationError(err) {
-			return tree.DNull, nil
-		}
-		return nil, err
+func databaseHasPrivilegeSpecifier(databaseArg tree.Datum) (tree.HasPrivilegeSpecifier, error) {
+	var specifier tree.HasPrivilegeSpecifier
+	switch t := databaseArg.(type) {
+	case *tree.DString:
+		s := string(*t)
+		specifier.DatabaseName = &s
+	case *tree.DOid:
+		oid := oid.Oid(t.DInt)
+		specifier.DatabaseOID = &oid
+	default:
+		return specifier, errors.AssertionFailedf("unknown privilege specifier: %#v", databaseArg)
 	}
-	return tree.MakeDBool(tree.DBool(ret)), nil
+	return specifier, nil
 }
 
 // tableHasPrivilegeSpecifier returns the HasPrivilegeSpecifier for
@@ -2452,6 +2420,53 @@ func tableHasPrivilegeSpecifier(tableArg tree.Datum) (tree.HasPrivilegeSpecifier
 		return specifier, errors.AssertionFailedf("unknown privilege specifier: %#v", tableArg)
 	}
 	return specifier, nil
+}
+
+// Note that we only verify the column exists for has_column_privilege.
+func columnHasPrivilegeSpecifier(
+	tableArg tree.Datum, colArg tree.Datum,
+) (tree.HasPrivilegeSpecifier, error) {
+	specifier, err := tableHasPrivilegeSpecifier(tableArg)
+	if err != nil {
+		return specifier, err
+	}
+	switch t := colArg.(type) {
+	case *tree.DString:
+		n := tree.Name(*t)
+		specifier.ColumnName = &n
+	case *tree.DInt:
+		attNum := uint32(*t)
+		specifier.ColumnAttNum = &attNum
+	default:
+		return specifier, errors.AssertionFailedf("unexpected arg type %T", t)
+	}
+	return specifier, nil
+}
+
+func handleDatabaseHasPrivilegeError(
+	specifier tree.HasPrivilegeSpecifier, ret bool, err error,
+) (tree.Datum, error) {
+	if err != nil {
+		// When a DatabaseOID is specified and the relation is not found, we return NULL.
+		if specifier.DatabaseOID != nil && sqlerrors.IsUndefinedDatabaseError(err) {
+			return tree.DNull, nil
+		}
+		return nil, err
+	}
+	return tree.MakeDBool(tree.DBool(ret)), nil
+}
+
+func handleTableHasPrivilegeError(
+	specifier tree.HasPrivilegeSpecifier, ret bool, err error,
+) (tree.Datum, error) {
+	if err != nil {
+		// When a TableOID is specified and the relation is not found, we return NULL.
+		if specifier.TableOID != nil && sqlerrors.IsUndefinedRelationError(err) {
+			return tree.DNull, nil
+		}
+		return nil, err
+	}
+	return tree.MakeDBool(tree.DBool(ret)), nil
 }
 
 func pgTrueTypImpl(attrField, typField string, retType *types.T) builtinDefinition {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3120,13 +3120,20 @@ type EvalDatabase interface {
 }
 
 // HasPrivilegeSpecifier specifies an object to lookup privilege for.
+// Only one of DatabaseName, DatabaseOID, TableName, TableOID is filled.
 type HasPrivilegeSpecifier struct {
-	// Only one of these is filled.
+
+	// Database privilege
+	DatabaseName *string
+	DatabaseOID  *oid.Oid
+
+	// Table privilege
 	TableName *string
 	TableOID  *oid.Oid
 
-	// Only one of these is filled.
-	// Only used if TableName or TableOID is specified.
+	// Column privilege
+	// Requires TableName or TableOID.
+	// Only one of ColumnName, ColumnAttNum is filled.
 	ColumnName   *Name
 	ColumnAttNum *uint32
 }

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -274,6 +274,11 @@ func IsUndefinedRelationError(err error) bool {
 	return errHasCode(err, pgcode.UndefinedTable)
 }
 
+// IsUndefinedDatabaseError checks whether this is an undefined database error.
+func IsUndefinedDatabaseError(err error) bool {
+	return errHasCode(err, pgcode.UndefinedDatabase)
+}
+
 func errHasCode(err error, code ...pgcode.Code) bool {
 	pgCode := pgerror.GetPGCode(err)
 	for _, c := range code {


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/66173

Migrate has_database_privilege from evalPrivilegeCheck to ctx.Planner.HasPrivilege.

Release note: None

I'm splitting up has_database_privilege, has_schema_privilege, has_sequence_privilege into separate PRs because each of them has some auxiliary work (in this case changing `'` to `"` in a test, but it looks like schema and sequence will have a bit more) to complete them.