### PR TITLE
sql: fix handling of errors on Sync

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -506,11 +506,12 @@ func (ex *connExecutor) execStmtInOpenState(
 			filter(ctx, ex.sessionData(), ast.String(), execErr)
 		}
 
-		// Do the auto-commit, if necessary.
+		// Do the auto-commit, if necessary. In the extended protocol, the
+		// auto-commit happens when the Sync message is handled.
 		if retEv != nil || retErr != nil {
 			return
 		}
-		if canAutoCommit {
+		if canAutoCommit && !isExtendedProtocol {
 			retEv, retPayload = ex.handleAutoCommit(ctx, ast)
 			return
 		}
@@ -709,7 +710,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.stmt = stmt
 	p.cancelChecker.Reset(ctx)
 
-	p.autoCommit = canAutoCommit && !ex.server.cfg.TestingKnobs.DisableAutoCommit
+	p.autoCommit = canAutoCommit && !ex.server.cfg.TestingKnobs.DisableAutoCommitDuringExec
 
 	var stmtThresholdSpan *tracing.Span
 	alreadyRecording := ex.transitionCtx.sessionTracing.Enabled()

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1315,14 +1315,14 @@ type ExecutorTestingKnobs struct {
 	// BeforeRestart is called before a transaction restarts.
 	BeforeRestart func(ctx context.Context, reason error)
 
-	// DisableAutoCommit, if set, disables the auto-commit functionality of some
-	// SQL statements. That functionality allows some statements to commit
+	// DisableAutoCommitDuringExec, if set, disables the auto-commit functionality
+	// of some SQL statements. That functionality allows some statements to commit
 	// directly when they're executed in an implicit SQL txn, without waiting for
 	// the Executor to commit the implicit txn.
 	// This has to be set in tests that need to abort such statements using a
-	// StatementFilter; otherwise, the statement commits immediately after
+	// StatementFilter; otherwise, the statement commits at the same time as
 	// execution so there'll be nothing left to abort by the time the filter runs.
-	DisableAutoCommit bool
+	DisableAutoCommitDuringExec bool
 
 	// BeforeAutoCommit is called when the Executor is about to commit the KV
 	// transaction after running a statement in an implicit transaction, allowing

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -119,7 +119,12 @@ func (r *commandResult) Close(ctx context.Context, t sql.TransactionStatusIndica
 	r.conn.writerState.fi.registerCmd(r.pos)
 	if r.err != nil {
 		r.conn.bufferErr(ctx, r.err)
-		return
+		// Sync is the only client message that results in ReadyForQuery, and it
+		// must *always* result in ReadyForQuery, even if there are errors during
+		// Sync.
+		if r.typ != readyForQuery {
+			return
+		}
 	}
 
 	for _, notice := range r.buffer.notices {

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -28,11 +28,11 @@ go_test(
     name = "tests_test",
     size = "large",
     srcs = [
+        "autocommit_extended_protocol_test.go",
         "bank_test.go",
         "enum_test.go",
         "hash_sharded_test.go",
         "impure_builtin_test.go",
-        "insert_fast_path_test.go",
         "inverted_index_test.go",
         "kv_test.go",
         "main_test.go",

--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -13,12 +13,16 @@ package tests
 import (
 	"context"
 	gosql "database/sql"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,4 +74,50 @@ func TestInsertFastPathExtendedProtocol(t *testing.T) {
 	err = db.QueryRow("SELECT count(*) FROM fast_path_test").Scan(&c)
 	require.NoError(t, err)
 	require.Equal(t, 1, c, "expected 1 row, got %d", c)
+}
+
+// TestErrorDuringExtendedProtocolCommit verifies that the results are correct
+// when there's an error during the COMMIT of an extended protocol statement
+// in an implicit transaction.
+func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	var db *gosql.DB
+
+	var shouldErrorOnAutoCommit syncutil.AtomicBool
+	params, _ := CreateTestServerParams()
+	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+		DisableAutoCommitDuringExec: true,
+		BeforeExecute: func(ctx context.Context, stmt string) {
+			if strings.Contains(stmt, "SELECT 'cat'") {
+				shouldErrorOnAutoCommit.Set(true)
+			}
+		},
+		BeforeAutoCommit: func(ctx context.Context, stmt string) error {
+			if shouldErrorOnAutoCommit.Get() {
+				shouldErrorOnAutoCommit.Set(false)
+				return errors.New("injected error")
+			}
+			return nil
+		},
+	}
+	params.Settings = cluster.MakeTestingClusterSettings()
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: params})
+	defer tc.Stopper().Stop(ctx)
+	db = tc.ServerConn(0)
+
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	var i int
+	var s string
+	// Use placeholders to force usage of extended protocol.
+	err = conn.QueryRowContext(ctx, "SELECT 'cat', $1::int8", 1).Scan(&s, &i)
+	require.EqualError(t, err, "pq: injected error")
+	// Check that the error was handled correctly, and another statement
+	// doesn't confuse the server.
+	err = conn.QueryRowContext(ctx, "SELECT 'dog', $1::int8", 2).Scan(&s, &i)
+	require.NoError(t, err)
+	require.Equal(t, 2, i)
 }

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -374,8 +374,8 @@ func (ta *TxnAborter) executorKnobs() base.ModuleTestingKnobs {
 	return &sql.ExecutorTestingKnobs{
 		// We're going to abort txns using a TxnAborter, and that's incompatible
 		// with AutoCommit.
-		DisableAutoCommit: true,
-		StatementFilter:   ta.statementFilter,
+		DisableAutoCommitDuringExec: true,
+		StatementFilter:             ta.statementFilter,
 	}
 }
 


### PR DESCRIPTION
In #74242 we've changed the conn_executor to sometimes commit
transactions on a Sync protocol message. Errors coming from such commits
have to be handled differently from any other errors because they don't
require us to skip further messages until another Sync. However, the
code was not giving them any special treatment, and so we were skipping
whatever the client was sending next. This causes the client to get
descynchronized and deadlock. This patch fixes it by manipulating the
session advancing instructions on Sync.

Release note: None