### PR TITLE
streamingccl: integrate ingestion processors to use partitioned stream client

### DIFF
--- a/pkg/ccl/streamingccl/BUILD.bazel
+++ b/pkg/ccl/streamingccl/BUILD.bazel
@@ -4,14 +4,17 @@ go_library(
     name = "streamingccl",
     srcs = [
         "addresses.go",
+        "errors.go",
         "event.go",
         "settings.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/streamingccl/streampb",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/streaming",
         "//pkg/util/hlc",
     ],
 )

--- a/pkg/ccl/streamingccl/errors.go
+++ b/pkg/ccl/streamingccl/errors.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamingccl
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streampb"
+	"github.com/cockroachdb/cockroach/pkg/streaming"
+)
+
+// StreamStatusErr is an error that encapsulate a replication stream's inactive status.
+type StreamStatusErr struct {
+	StreamID     streaming.StreamID
+	StreamStatus streampb.StreamReplicationStatus_StreamStatus
+}
+
+// NewStreamStatusErr creates a new StreamStatusErr.
+func NewStreamStatusErr(
+	streamID streaming.StreamID, streamStatus streampb.StreamReplicationStatus_StreamStatus,
+) StreamStatusErr {
+	return StreamStatusErr{
+		StreamID:     streamID,
+		StreamStatus: streamStatus,
+	}
+}
+
+// Error implements the error interface.
+func (e StreamStatusErr) Error() string {
+	return fmt.Sprintf("replication stream %d is not running, status is %s", e.StreamID, e.StreamStatus)
+}

--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -31,3 +31,25 @@ var StreamReplicationJobLivenessTimeout = settings.RegisterDurationSetting(
 	"controls how long we wait for to kill an inactive producer job",
 	time.Minute,
 )
+
+// StreamReplicationConsumerHeartbeatFrequency controls frequency the stream replication
+// destination cluster sends heartbeat to the source cluster to keep the stream alive.
+var StreamReplicationConsumerHeartbeatFrequency = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"stream_replication.consumer_heartbeat_frequency",
+	"controls frequency the stream replication destination cluster sends heartbeat "+
+		"to the source cluster to keep the stream alive",
+	30*time.Second,
+	settings.NonNegativeDuration,
+)
+
+// StreamReplicationMinCheckpointFrequency controls the minimum frequency the stream replication
+// source cluster sends checkpoints to destination cluster.
+var StreamReplicationMinCheckpointFrequency = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"stream_replication.min_checkpoint_frequency",
+	"controls minimum frequency the stream replication source cluster sends checkpoints "+
+		"to the destination cluster.",
+	10*time.Second,
+	settings.NonNegativeDuration,
+)

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -113,8 +113,7 @@ type Subscription interface {
 	Err() error
 }
 
-// NewStreamClient creates a new stream client based on the stream
-// address.
+// NewStreamClient creates a new stream client based on the stream address.
 func NewStreamClient(streamAddress streamingccl.StreamAddress) (Client, error) {
 	var streamClient Client
 	streamURL, err := streamAddress.URL()
@@ -126,7 +125,7 @@ func NewStreamClient(streamAddress streamingccl.StreamAddress) (Client, error) {
 	case "postgres", "postgresql":
 		// The canonical PostgreSQL URL scheme is "postgresql", however our
 		// own client commands also accept "postgres".
-		return newPGWireReplicationClient(streamURL)
+		return newPartitionedStreamClient(streamURL)
 	case RandomGenScheme:
 		streamClient, err = newRandomStreamClient(streamURL)
 		if err != nil {

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/ccl/storageccl",
         "//pkg/ccl/streamingccl",
         "//pkg/ccl/streamingccl/streamclient",
+        "//pkg/ccl/streamingccl/streampb",
         "//pkg/ccl/utilccl",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
@@ -65,6 +66,7 @@ go_test(
         "stream_ingestion_job_test.go",
         "stream_ingestion_processor_test.go",
         "stream_ingestion_test.go",
+        "stream_replication_e2e_test.go",
     ],
     embed = [":streamingest"],
     deps = [

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -176,6 +176,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 			var frontierSpec execinfrapb.StreamIngestionFrontierSpec
 			pa1Key := roachpb.Key(pa1)
 			pa2Key := roachpb.Key(pa2)
+			frontierSpec.StreamAddress = spec.StreamAddress
 			frontierSpec.TrackedSpans = []roachpb.Span{{Key: pa1Key, EndKey: pa1Key.Next()}, {Key: pa2Key,
 				EndKey: pa2Key.Next()}}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -41,46 +41,48 @@ func ingest(
 	if err != nil {
 		return err
 	}
+	ingestWithClient := func() error {
+		// TODO(dt): if there is an existing stream ID, reconnect to it.
+		streamID, err := client.Create(ctx, tenantID)
+		if err != nil {
+			return err
+		}
 
-	// TODO(dt): if there is an existing stream ID, reconnect to it.
-	id, err := client.Create(ctx, tenantID)
-	if err != nil {
-		return err
+		topology, err := client.Plan(ctx, streamID)
+		if err != nil {
+			return err
+		}
+
+		// TODO(adityamaru): If the job is being resumed it is possible that it has
+		// check-pointed a resolved ts up to which all of its processors had ingested
+		// KVs. We can skip to ingesting after this resolved ts. Plumb the
+		// initialHighwatermark to the ingestion processor spec based on what we read
+		// from the job progress.
+		initialHighWater := startTime
+		if h := progress.GetHighWater(); h != nil && !h.IsEmpty() {
+			initialHighWater = *h
+		}
+
+		evalCtx := execCtx.ExtendedEvalContext()
+		dsp := execCtx.DistSQLPlanner()
+
+		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+		if err != nil {
+			return err
+		}
+
+		// Construct stream ingestion processor specs.
+		streamIngestionSpecs, streamIngestionFrontierSpec, err := distStreamIngestionPlanSpecs(
+			streamAddress, topology, sqlInstanceIDs, initialHighWater, jobID, streamID)
+		if err != nil {
+			return err
+		}
+
+		// Plan and run the DistSQL flow.
+		return distStreamIngest(ctx, execCtx, sqlInstanceIDs, jobID, planCtx, dsp, streamIngestionSpecs,
+			streamIngestionFrontierSpec)
 	}
-
-	topology, err := client.Plan(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	// TODO(adityamaru): If the job is being resumed it is possible that it has
-	// check-pointed a resolved ts up to which all of its processors had ingested
-	// KVs. We can skip to ingesting after this resolved ts. Plumb the
-	// initialHighwatermark to the ingestion processor spec based on what we read
-	// from the job progress.
-	initialHighWater := startTime
-	if h := progress.GetHighWater(); h != nil && !h.IsEmpty() {
-		initialHighWater = *h
-	}
-
-	evalCtx := execCtx.ExtendedEvalContext()
-	dsp := execCtx.DistSQLPlanner()
-
-	planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
-	if err != nil {
-		return err
-	}
-
-	// Construct stream ingestion processor specs.
-	streamIngestionSpecs, streamIngestionFrontierSpec, err := distStreamIngestionPlanSpecs(
-		streamAddress, topology, sqlInstanceIDs, initialHighWater, jobID)
-	if err != nil {
-		return err
-	}
-
-	// Plan and run the DistSQL flow.
-	return distStreamIngest(ctx, execCtx, sqlInstanceIDs, jobID, planCtx, dsp, streamIngestionSpecs,
-		streamIngestionFrontierSpec)
+	return errors.CombineErrors(ingestWithClient(), client.Close())
 }
 
 // Resume is part of the jobs.Resumer interface.
@@ -99,6 +101,7 @@ func (s *streamIngestionResumer) Resume(resumeCtx context.Context, execCtx inter
 	// processors shut down gracefully, i.e stopped ingesting any additional
 	// events from the replication stream. At this point it is safe to revert to
 	// the cutoff time to leave the cluster in a consistent state.
+	// TODO: after this, we need to complete the producer job into "replication complete state" in the future.
 	return s.revertToCutoverTimestamp(resumeCtx, execCtx)
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -70,7 +70,8 @@ func TestTenantStreaming(t *testing.T) {
 	_, err := sourceDB.Exec(`
 SET CLUSTER SETTING kv.rangefeed.enabled = true;
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
-SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'
+SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
+SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
 `)
 	require.NoError(t, err)
 
@@ -81,6 +82,7 @@ SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms'
 	// job.
 	destSQL := hDest.SysDB
 	destSQL.Exec(t, `
+SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '2s';
 SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '5us';
 SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
 SET enable_experimental_stream_replication = true;

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -88,6 +88,9 @@ type streamIngestionProcessor struct {
 	// client is a streaming client which provides a stream of events from a given
 	// address.
 	forceClientForTests streamclient.Client
+	// streamPartitionClients are a collection of streamclient.Client created for
+	// consuming multiple partitions from a stream.
+	streamPartitionClients []streamclient.Client
 
 	// Checkpoint events may need to be buffered if they arrive within the same
 	// minimumFlushInterval.
@@ -220,6 +223,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	// Initialize the event streams.
 	subscriptions := make(map[string]streamclient.Subscription)
 	sip.cg = ctxgroup.WithContext(ctx)
+	sip.streamPartitionClients = make([]streamclient.Client, 0)
 	for i := range sip.spec.PartitionIds {
 		id := sip.spec.PartitionIds[i]
 		spec := streamclient.SubscriptionToken(sip.spec.PartitionSpecs[i])
@@ -229,11 +233,16 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 			streamClient = sip.forceClientForTests
 			log.Infof(ctx, "using testing client")
 		} else {
-			streamClient, err = streamclient.NewStreamClient(streamingccl.StreamAddress(addr))
 			if err != nil {
-				sip.MoveToDraining(errors.Wrapf(err, "creating client for parition spec %q from %q", spec, addr))
+				sip.MoveToDraining(errors.Wrapf(err, "creating client for partition spec %q from %q", spec, addr))
 				return
 			}
+			streamClient, err = streamclient.NewStreamClient(streamingccl.StreamAddress(addr))
+			if err != nil {
+				sip.MoveToDraining(errors.Wrapf(err, "creating client for partition spec %q from %q", spec, addr))
+				return
+			}
+			sip.streamPartitionClients = append(sip.streamPartitionClients, streamClient)
 		}
 
 		sub, err := streamClient.Subscribe(ctx, streaming.StreamID(sip.spec.StreamID), spec, sip.spec.StartTime)
@@ -291,6 +300,11 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 	return nil, sip.DrainHelper()
 }
 
+// MustBeStreaming implements the Processor interface.
+func (sip *streamIngestionProcessor) MustBeStreaming() bool {
+	return true
+}
+
 // ConsumerClosed is part of the RowSource interface.
 func (sip *streamIngestionProcessor) ConsumerClosed() {
 	sip.close()
@@ -301,6 +315,9 @@ func (sip *streamIngestionProcessor) close() {
 		return
 	}
 
+	for _, client := range sip.streamPartitionClients {
+		_ = client.Close()
+	}
 	if sip.batcher != nil {
 		sip.batcher.Close()
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/streaming"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -34,6 +35,7 @@ func distStreamIngestionPlanSpecs(
 	sqlInstanceIDs []base.SQLInstanceID,
 	initialHighWater hlc.Timestamp,
 	jobID jobspb.JobID,
+	streamID streaming.StreamID,
 ) ([]*execinfrapb.StreamIngestionDataSpec, *execinfrapb.StreamIngestionFrontierSpec, error) {
 
 	// For each stream partition in the topology, assign it to a node.
@@ -46,6 +48,7 @@ func distStreamIngestionPlanSpecs(
 		// the partition addresses.
 		if i < len(sqlInstanceIDs) {
 			spec := &execinfrapb.StreamIngestionDataSpec{
+				StreamID:           uint64(streamID),
 				JobID:              int64(jobID),
 				StartTime:          initialHighWater,
 				StreamAddress:      string(streamAddress),
@@ -72,7 +75,11 @@ func distStreamIngestionPlanSpecs(
 	// Create a spec for the StreamIngestionFrontier processor on the coordinator
 	// node.
 	streamIngestionFrontierSpec := &execinfrapb.StreamIngestionFrontierSpec{
-		HighWaterAtStart: initialHighWater, TrackedSpans: trackedSpans, JobID: int64(jobID),
+		HighWaterAtStart: initialHighWater,
+		TrackedSpans:     trackedSpans,
+		JobID:            int64(jobID),
+		StreamID:         uint64(streamID),
+		StreamAddress:    string(streamAddress),
 	}
 
 	return streamIngestionSpecs, streamIngestionFrontierSpec, nil
@@ -174,19 +181,16 @@ func (s *streamIngestionResultWriter) AddRow(ctx context.Context, row tree.Datum
 		return errors.New("streamIngestionResultWriter expects non-nil row entry")
 	}
 
-	job, err := s.registry.LoadJob(ctx, s.jobID)
-	if err != nil {
-		return err
+	// Decode the row, write the ts into job record, and send a heartbeat to source cluster.
+	var ingestedHighWatermark hlc.Timestamp
+	if err := protoutil.Unmarshal([]byte(*row[0].(*tree.DBytes)),
+		&ingestedHighWatermark); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, `unmarshalling resolved timestamp`)
 	}
-	return job.Update(s.ctx, nil /* txn */, func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-		// Decode the row and write the ts.
-		var ingestedHighWatermark hlc.Timestamp
-		if err := protoutil.Unmarshal([]byte(*row[0].(*tree.DBytes)),
-			&ingestedHighWatermark); err != nil {
-			return errors.NewAssertionErrorWithWrappedErrf(err, `unmarshalling resolved timestamp`)
-		}
-		return jobs.UpdateHighwaterProgressed(ingestedHighWatermark, md, ju)
-	})
+	return s.registry.UpdateJobWithTxn(ctx, s.jobID, nil /* txn */, false, /* useReadLock */
+		func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			return jobs.UpdateHighwaterProgressed(ingestedHighWatermark, md, ju)
+		})
 }
 
 // IncrementRowsAffected implements the sql.rowResultWriter interface.

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -1,0 +1,159 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamingest
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func startTestClusterWithTenant(
+	ctx context.Context,
+	t *testing.T,
+	serverArgs base.TestServerArgs,
+	tenantID roachpb.TenantID,
+	numNodes int,
+) (serverutils.TestClusterInterface, *gosql.DB, *gosql.DB, func()) {
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+	c := testcluster.StartTestCluster(t, numNodes, params)
+	// TODO(casper): support adding splits when we have multiple nodes.
+	_, tenantConn := serverutils.StartTenant(t, c.Server(0), base.TestTenantArgs{TenantID: tenantID})
+	return c, c.ServerConn(0), tenantConn, func() {
+		tenantConn.Close()
+		c.Stopper().Stop(ctx)
+	}
+}
+
+func compareResult(t *testing.T, src *sqlutils.SQLRunner, dest *sqlutils.SQLRunner, query string) {
+	sourceData := src.QueryStr(t, query)
+	destData := dest.QueryStr(t, query)
+	require.Equal(t, sourceData, destData)
+}
+
+func TestPartitionedTenantStreamingEndToEnd(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "slow under race")
+	skip.UnderStress(t, "slow under stress")
+
+	ctx := context.Background()
+	args := base.TestServerArgs{Knobs: base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	}
+
+	// Start the source cluster.
+	tenantID := serverutils.TestTenantID()
+	sc, sourceSysDB, sourceTenantDB, srcCleanup := startTestClusterWithTenant(ctx, t, args, tenantID, 3)
+	defer srcCleanup()
+	sourceSysSQL, sourceTenantSQL := sqlutils.MakeSQLRunner(sourceSysDB), sqlutils.MakeSQLRunner(sourceTenantDB)
+
+	sourceSysSQL.Exec(t, `
+	SET CLUSTER SETTING kv.rangefeed.enabled = true;
+	SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
+	SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
+  SET CLUSTER SETTING stream_replication.job_liveness_timeout = '3s';
+  SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';
+  SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
+  `)
+
+	// Start the destination cluster.
+	_, destSysDB, destTenantDB, destCleanup := startTestClusterWithTenant(ctx, t, args, tenantID, 2)
+	defer destCleanup()
+	destSysSQL, destTenantSQL := sqlutils.MakeSQLRunner(destSysDB), sqlutils.MakeSQLRunner(destTenantDB)
+
+	destSysSQL.Exec(t, `
+	SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '100ms';
+	SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '10ms';
+	SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
+	SET enable_experimental_stream_replication = true;
+	`)
+
+	pgURL, cleanupSinkCert := sqlutils.PGUrl(t, sc.Server(0).ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanupSinkCert()
+
+	var startTime string
+	sourceSysSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
+	var ingestionJobID, streamProducerJobID int
+	destSysSQL.QueryRow(t,
+		`RESTORE TENANT `+tenantID.String()+` FROM REPLICATION STREAM FROM $1 AS OF SYSTEM TIME `+startTime,
+		pgURL.String(),
+	).Scan(&ingestionJobID)
+	sourceSysSQL.CheckQueryResultsRetry(t,
+		"SELECT count(*) FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'", [][]string{{"1"}})
+	sourceSysSQL.QueryRow(t, "SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'STREAM REPLICATION'").
+		Scan(&streamProducerJobID)
+
+	sourceTenantSQL.Exec(t, `
+	CREATE DATABASE d;
+	CREATE TABLE d.t1(i int primary key, a string, b string);
+	CREATE TABLE d.t2(i int primary key);
+	INSERT INTO d.t1 (i) VALUES (42);
+	INSERT INTO d.t2 VALUES (2);
+	UPDATE d.t1 SET b = 'world' WHERE i = 42;
+	`)
+
+	sourceTenantSQL.Exec(t, `
+	ALTER TABLE d.t1 DROP COLUMN b;
+	`)
+
+	// Pick a cutover time, then wait for the job to reach that time.
+	cutoverTime := timeutil.Now().Round(time.Microsecond)
+	testutils.SucceedsSoon(t, func() error {
+		progress := jobutils.GetJobProgress(t, destSysSQL, jobspb.JobID(ingestionJobID))
+		if progress.GetHighWater() == nil {
+			return errors.Newf("stream ingestion has not recorded any progress yet, waiting to advance pos %s",
+				cutoverTime.String())
+		}
+		highwater := timeutil.Unix(0, progress.GetHighWater().WallTime)
+		if highwater.Before(cutoverTime) {
+			return errors.Newf("waiting for stream ingestion job progress %s to advance beyond %s",
+				highwater.String(), cutoverTime.String())
+		}
+		return nil
+	})
+
+	compareResult(t, sourceTenantSQL, destTenantSQL, "SELECT * FROM d.t1")
+	compareResult(t, sourceTenantSQL, destTenantSQL, "SELECT * FROM d.t2")
+
+	// Cut over the ingestion job and the job will stop eventually.
+	destSysSQL.Exec(t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJobID, cutoverTime)
+	jobutils.WaitForJob(t, destSysSQL, jobspb.JobID(ingestionJobID))
+	// TODO(casper): Make producer job exit normally in the cutover scenario.
+	sourceSysSQL.CheckQueryResultsRetry(t,
+		fmt.Sprintf("SELECT status, error FROM [SHOW JOBS] WHERE job_id = %d", streamProducerJobID),
+		[][]string{{"failed", fmt.Sprintf("replication stream %d timed out", streamProducerJobID)}})
+
+	// After cutover, changes to source won't be streamed into destination cluster.
+	sourceTenantSQL.Exec(t, `
+	INSERT INTO d.t2 VALUES (3);
+	`)
+	require.Equal(t, [][]string{{"2"}}, destTenantSQL.QueryStr(t, "SELECT * FROM d.t2"))
+}

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -394,7 +394,7 @@ func (s *eventStream) streamLoop(ctx context.Context, frontier *span.Frontier) e
 
 func setConfigDefaults(cfg *streampb.StreamPartitionSpec_ExecutionConfig) {
 	const defaultInitialScanParallelism = 16
-	const defaultMinCheckpointFrequency = time.Minute
+	const defaultMinCheckpointFrequency = 10 * time.Second
 	const defaultBatchSize = 1 << 20
 
 	if cfg.InitialScanParallelism <= 0 {

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeeddist"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streampb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -254,7 +255,9 @@ func getReplicationStreamSpec(
 			Locality:   nodeInfo.Locality,
 			PartitionSpec: &streampb.StreamPartitionSpec{
 				Spans: sp.Spans,
-				// Use default ExecutionConfig for now
+				Config: streampb.StreamPartitionSpec_ExecutionConfig{
+					MinCheckpointFrequency: streamingccl.StreamReplicationMinCheckpointFrequency.Get(&evalCtx.Settings.SV),
+				},
 			},
 		})
 	}

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -205,6 +205,11 @@ message StreamIngestionFrontierSpec {
   repeated roachpb.Span tracked_spans = 2 [(gogoproto.nullable) = false];
   // JobID is the job ID of the stream ingestion job.
   optional int64 job_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID"];
+
+  // StreamID is the ID of the stream.
+  optional uint64 stream_id = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "StreamID"];
+  // StreamAddress locate the stream so that a stream client can be initialized.
+  optional string stream_address = 5 [(gogoproto.nullable) = false];
 }
 
 message BackupDataSpec {


### PR DESCRIPTION
Make ingestion processor to use partitioned stream client to consume 
stream partitions that belong to that processor and make ingestion frontier 
processor to use the client to send heartbeats into the source cluster.

Release note: none.