### PR TITLE
release-21.2: opt: fix corner case with lookup joins and provided orderings

### DIFF
--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -714,7 +714,7 @@ project
       │    │    ├── stats: [rows=478.646617]
       │    │    ├── key: (3,5)
       │    │    ├── fd: ()-->(1,2,4,20,21), (3,5)-->(6,7)
-      │    │    ├── ordering: -3 opt(1,2,4) [actual: -3]
+      │    │    ├── ordering: -3 opt(1,2,4,20,21) [actual: -3]
       │    │    ├── limit hint: 100.00
       │    │    ├── index-join transactiondetails
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null
@@ -862,7 +862,7 @@ project
  │    │         │    │    │    ├── stats: [rows=19000]
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: ()-->(42,43), (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │    │         │    │    │    ├── ordering: +1
+ │    │         │    │    │    ├── ordering: +1 opt(42,43) [actual: +1]
  │    │         │    │    │    ├── select
  │    │         │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │    │         │    │    │    │    ├── immutable

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -718,7 +718,7 @@ project
       │    │    ├── stats: [rows=478.646617]
       │    │    ├── key: (3,5)
       │    │    ├── fd: ()-->(1,2,4,24,25), (3,5)-->(6,7)
-      │    │    ├── ordering: -3 opt(1,2,4) [actual: -3]
+      │    │    ├── ordering: -3 opt(1,2,4,24,25) [actual: -3]
       │    │    ├── limit hint: 100.00
       │    │    ├── index-join transactiondetails
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null
@@ -866,7 +866,7 @@ project
  │    │         │    │    │    ├── stats: [rows=19000]
  │    │         │    │    │    ├── key: (1)
  │    │         │    │    │    ├── fd: ()-->(48,49), (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │    │         │    │    │    ├── ordering: +1
+ │    │         │    │    │    ├── ordering: +1 opt(48,49) [actual: +1]
  │    │         │    │    │    ├── select
  │    │         │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │    │         │    │    │    │    ├── immutable

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2351,7 +2351,7 @@ distinct-on
       ├── project
       │    ├── columns: "lookup_join_const_col_@9":14!null a:1!null b:5!null
       │    ├── fd: ()-->(14), (1)==(5), (5)==(1)
-      │    ├── ordering: +(1|5) [actual: +1]
+      │    ├── ordering: +(1|5) opt(14) [actual: +1]
       │    ├── inner-join (lookup t44469_b@secondary)
       │    │    ├── columns: a:1!null b:5!null
       │    │    ├── flags: force lookup join (into right side)
@@ -2401,3 +2401,113 @@ project
  │              └── k:1 > 0 [outer=(1)]
  └── projections
       └── 1 [as="?column?":6]
+
+# Regression test for #73968. Lookup join needs to simplify the ordering
+# required of its child.
+exec-ddl
+CREATE TABLE t73968 (
+  k INT PRIMARY KEY,
+  name STRING,
+  x STRING AS (CAST(k AS STRING)) VIRTUAL,
+  y STRING AS (lower(name)) VIRTUAL,
+  UNIQUE (y),
+  UNIQUE (x)
+);
+----
+
+exec-ddl
+ALTER TABLE t73968 INJECT STATISTICS e'[
+  {
+    "columns": ["k"],
+    "created_at": "2000-01-01 00:00:00+00:00",
+    "distinct_count": 1000000,
+    "name": "__auto__",
+    "null_count": 0,
+    "row_count": 1000000000
+  }
+]';
+----
+
+opt
+SELECT
+  t2.crdb_internal_mvcc_timestamp
+FROM
+  t73968 AS t1 JOIN t73968 AS t2 ON t1.name = t2.name
+      AND t1.y = t2.y
+      AND t1.x = t2.y
+      AND t1.k = t2.k
+      AND t1.x = t2.x
+ORDER BY
+  t2.x, t2.k
+LIMIT
+  56
+----
+project
+ ├── columns: crdb_internal_mvcc_timestamp:11  [hidden: k:7!null x:9!null]
+ ├── cardinality: [0 - 56]
+ ├── immutable
+ ├── key: (7)
+ ├── fd: (7)-->(9,11)
+ ├── ordering: +9,+7 [actual: +9]
+ └── limit
+      ├── columns: k:1!null name:2!null x:3!null k:7!null name:8!null x:9!null crdb_internal_mvcc_timestamp:11
+      ├── internal-ordering: +(3|9),+(1|7)
+      ├── cardinality: [0 - 56]
+      ├── immutable
+      ├── key: (7)
+      ├── fd: (1)-->(2,3), (7)-->(8,9,11), (2)==(8), (8)==(2), (1)==(7), (7)==(1), (3)==(9), (9)==(3)
+      ├── ordering: +(3|9),+(1|7) [actual: +3]
+      ├── inner-join (lookup t73968)
+      │    ├── columns: k:1!null name:2!null x:3!null k:7!null name:8!null x:9!null crdb_internal_mvcc_timestamp:11
+      │    ├── key columns: [7] = [7]
+      │    ├── lookup columns are key
+      │    ├── immutable
+      │    ├── key: (7)
+      │    ├── fd: (1)-->(2,3), (7)-->(8,9,11), (2)==(8), (8)==(2), (1)==(7), (7)==(1), (3)==(9), (9)==(3)
+      │    ├── ordering: +(3|9),+(1|7) [actual: +3]
+      │    ├── limit hint: 56.00
+      │    ├── inner-join (lookup t73968@secondary)
+      │    │    ├── columns: k:1!null name:2 x:3!null k:7!null x:9!null
+      │    │    ├── key columns: [3] = [9]
+      │    │    ├── lookup columns are key
+      │    │    ├── immutable
+      │    │    ├── key: (7)
+      │    │    ├── fd: (1)-->(2,3), (7)-->(9), (9)-->(7), (1)==(7), (7)==(1), (3)==(9), (9)==(3)
+      │    │    ├── ordering: +(3|9) [actual: +3]
+      │    │    ├── limit hint: 200.00
+      │    │    ├── sort
+      │    │    │    ├── columns: k:1!null name:2 x:3!null
+      │    │    │    ├── immutable
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2,3)
+      │    │    │    ├── ordering: +3
+      │    │    │    ├── limit hint: 2100.00
+      │    │    │    └── project
+      │    │    │         ├── columns: x:3!null k:1!null name:2
+      │    │    │         ├── immutable
+      │    │    │         ├── key: (1)
+      │    │    │         ├── fd: (1)-->(2,3)
+      │    │    │         ├── select
+      │    │    │         │    ├── columns: k:1!null name:2
+      │    │    │         │    ├── immutable
+      │    │    │         │    ├── key: (1)
+      │    │    │         │    ├── fd: (1)-->(2)
+      │    │    │         │    ├── scan t73968
+      │    │    │         │    │    ├── columns: k:1!null name:2
+      │    │    │         │    │    ├── computed column expressions
+      │    │    │         │    │    │    ├── x:3
+      │    │    │         │    │    │    │    └── k:1::STRING
+      │    │    │         │    │    │    └── y:4
+      │    │    │         │    │    │         └── lower(name:2)
+      │    │    │         │    │    ├── key: (1)
+      │    │    │         │    │    └── fd: (1)-->(2)
+      │    │    │         │    └── filters
+      │    │    │         │         └── k:1::STRING = lower(name:2) [outer=(1,2), immutable]
+      │    │    │         └── projections
+      │    │    │              └── k:1::STRING [as=x:3, outer=(1), immutable]
+      │    │    └── filters
+      │    │         └── k:1 = k:7 [outer=(1,7), fd=(1)==(7), (7)==(1)]
+      │    └── filters
+      │         ├── name:2 = name:8 [outer=(2,8), fd=(2)==(8), (8)==(2)]
+      │         └── k:7::STRING = lower(name:8) [outer=(7,8), immutable]
+      └── 56

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1757,14 +1757,14 @@ memo (optimized, ~27KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G10: (filters G19)
  ├── G11: (filters)
  ├── G12: (project G8 G20 x)
- │    ├── [ordering: +1]
+ │    ├── [ordering: +1 opt(14)]
  │    │    ├── best: (project G8="[ordering: +1]" G20 x)
  │    │    └── cost: 1074.34
  │    └── []
  │         ├── best: (project G8 G20 x)
  │         └── cost: 1074.34
  ├── G13: (project G8 G20 x)
- │    ├── [ordering: +1]
+ │    ├── [ordering: +1 opt(15)]
  │    │    ├── best: (project G8="[ordering: +1]" G20 x)
  │    │    └── cost: 1074.34
  │    └── []


### PR DESCRIPTION
Backport 1/1 commits from #74700. Backport justification: to avoid hitting this again in sqlsmtith on 21.2; also, this check was added because we rely on a certain invariant; I don't have all the details paged in but it's possible there are rare cases in which this causes an incorrect ordering somewhere causing errors or incorrect query results.

/cc @cockroachdb/release

---

This commit fixes a case where the lookup join was passing through a
provided ordering with unnecessary columns. This was caused by
imperfect FDs at the join level such that the ordering cannot be
simplified at the join level but it can be simplified at the level of
its input.

Note that the case causes an internal error in test builds but there
are no known examples of user-visible problems in non-test builds
(hence no release note).

Fixes #73968.

Release note: None
