### PR TITLE
[DNM] schemachanger: refactor ConstraintOrdinal to ConstraintId

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/common_relation.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/common_relation.go
@@ -430,40 +430,42 @@ func decomposeTableDescToElements(
 		panic(err)
 	}
 	// Add any constraints without indexes first.
-	for idx, constraint := range tbl.AllActiveAndInactiveUniqueWithoutIndexConstraints() {
+	for _, constraint := range tbl.AllActiveAndInactiveUniqueWithoutIndexConstraints() {
+		id := b.NextConstraintID(tbl)
 		enqueue(b, targetStatus, &scpb.ConstraintName{
 			TableID:        tbl.GetID(),
 			ConstraintType: scpb.ConstraintType_UniqueWithoutIndex,
-			ConstraintId:   uint32(idx),
+			ConstraintId:   id,
 			Name:           constraint.Name,
 		})
 		enqueue(b, targetStatus, &scpb.UniqueConstraint{
 			TableID:        tbl.GetID(),
 			ConstraintType: scpb.ConstraintType_UniqueWithoutIndex,
-			ConstraintId:   uint32(idx),
+			ConstraintId:   id,
 			IndexID:        0, // Invalid ID
 			ColumnIDs:      constraint.ColumnIDs,
 		})
 	}
 	// Add any check constraints next.
-	for idx, constraint := range tbl.AllActiveAndInactiveChecks() {
+	for _, constraint := range tbl.AllActiveAndInactiveChecks() {
+		id := b.NextConstraintID(tbl)
 		decomposeExprToElements(
 			b,
 			constraint.Expr,
 			exprTypeCheck,
 			tbl.GetID(),
-			uint32(idx),
+			id,
 			targetStatus,
 		)
 		enqueue(b, targetStatus, &scpb.ConstraintName{
 			TableID:        tbl.GetID(),
 			ConstraintType: scpb.ConstraintType_Check,
-			ConstraintId:   uint32(idx),
+			ConstraintId:   id,
 			Name:           constraint.Name,
 		})
 		enqueue(b, targetStatus, &scpb.CheckConstraint{
 			ConstraintType: scpb.ConstraintType_Check,
-			ConstraintId:   uint32(idx),
+			ConstraintId:   id,
 			TableID:        tbl.GetID(),
 			Name:           constraint.Name,
 			Validated:      constraint.Validity == descpb.ConstraintValidity_Validated,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/common_relation.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/common_relation.go
@@ -178,9 +178,9 @@ func decomposeExprToElements(
 				}
 			case exprTypeCheck:
 				typeRef = &scpb.CheckConstraintTypeReference{
-					TableID:           tableID,
-					ConstraintOrdinal: expressionID,
-					TypeID:            typeID,
+					TableID:      tableID,
+					ConstraintId: expressionID,
+					TypeID:       typeID,
 				}
 			}
 			enqueue(b, targetStatus, typeRef)
@@ -432,17 +432,17 @@ func decomposeTableDescToElements(
 	// Add any constraints without indexes first.
 	for idx, constraint := range tbl.AllActiveAndInactiveUniqueWithoutIndexConstraints() {
 		enqueue(b, targetStatus, &scpb.ConstraintName{
-			TableID:           tbl.GetID(),
-			ConstraintType:    scpb.ConstraintType_UniqueWithoutIndex,
-			ConstraintOrdinal: uint32(idx),
-			Name:              constraint.Name,
+			TableID:        tbl.GetID(),
+			ConstraintType: scpb.ConstraintType_UniqueWithoutIndex,
+			ConstraintId:   uint32(idx),
+			Name:           constraint.Name,
 		})
 		enqueue(b, targetStatus, &scpb.UniqueConstraint{
-			TableID:           tbl.GetID(),
-			ConstraintType:    scpb.ConstraintType_UniqueWithoutIndex,
-			ConstraintOrdinal: uint32(idx),
-			IndexID:           0, // Invalid ID
-			ColumnIDs:         constraint.ColumnIDs,
+			TableID:        tbl.GetID(),
+			ConstraintType: scpb.ConstraintType_UniqueWithoutIndex,
+			ConstraintId:   uint32(idx),
+			IndexID:        0, // Invalid ID
+			ColumnIDs:      constraint.ColumnIDs,
 		})
 	}
 	// Add any check constraints next.
@@ -456,19 +456,19 @@ func decomposeTableDescToElements(
 			targetStatus,
 		)
 		enqueue(b, targetStatus, &scpb.ConstraintName{
-			TableID:           tbl.GetID(),
-			ConstraintType:    scpb.ConstraintType_Check,
-			ConstraintOrdinal: uint32(idx),
-			Name:              constraint.Name,
+			TableID:        tbl.GetID(),
+			ConstraintType: scpb.ConstraintType_Check,
+			ConstraintId:   uint32(idx),
+			Name:           constraint.Name,
 		})
 		enqueue(b, targetStatus, &scpb.CheckConstraint{
-			ConstraintType:    scpb.ConstraintType_Check,
-			ConstraintOrdinal: uint32(idx),
-			TableID:           tbl.GetID(),
-			Name:              constraint.Name,
-			Validated:         constraint.Validity == descpb.ConstraintValidity_Validated,
-			ColumnIDs:         constraint.ColumnIDs,
-			Expr:              constraint.Expr,
+			ConstraintType: scpb.ConstraintType_Check,
+			ConstraintId:   uint32(idx),
+			TableID:        tbl.GetID(),
+			Name:           constraint.Name,
+			Validated:      constraint.Validity == descpb.ConstraintValidity_Validated,
+			ColumnIDs:      constraint.ColumnIDs,
+			Expr:           constraint.Expr,
 		})
 	}
 	// Add locality information.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -269,6 +269,11 @@ type TableElementIDGenerator interface {
 	// NextIndexID returns the ID that should be used for any new index added to
 	// this table descriptor.
 	NextIndexID(tbl catalog.TableDescriptor) descpb.IndexID
+
+	// NextConstraintID returns a unique ID for a constraint. These will be
+	// used by both execution and build phases for adding/dropping constraints, b
+	// but are never written into descriptors.
+	NextConstraintID(tbl catalog.TableDescriptor) uint32
 }
 
 // AstFormatter provides interfaces for formatting AST nodes.

--- a/pkg/sql/schemachanger/scbuild/table_element_id_generator.go
+++ b/pkg/sql/schemachanger/scbuild/table_element_id_generator.go
@@ -75,3 +75,21 @@ func (b buildCtx) NextIndexID(tbl catalog.TableDescriptor) descpb.IndexID {
 	}
 	return tbl.GetNextIndexID()
 }
+
+// NextConstraintID implements the scbuildstmt.TableElementIDGenerator interface.
+func (b buildCtx) NextConstraintID(tbl catalog.TableDescriptor) uint32 {
+	maxConstraintId := uint32(0)
+	b.BuilderState.ForEachElementStatus(func(status, targetStatus scpb.Status, elem scpb.Element) {
+		if _, ok := elem.(*scpb.ConstraintName); !ok {
+			return
+		}
+		if screl.GetDescID(elem) != tbl.GetID() {
+			return
+		}
+		constraintId := screl.GetConstraintId(elem)
+		if maxConstraintId < constraintId {
+			maxConstraintId = constraintId
+		}
+	})
+	return maxConstraintId + 1
+}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_table
@@ -1,6 +1,137 @@
 create-table
-CREATE TABLE defaultdb.customers (id INT PRIMARY KEY, email STRING UNIQUE);
+CREATE TABLE defaultdb.customers (id INT PRIMARY KEY CHECK (id < 500), email STRING UNIQUE CHECK (email <> 'blah'));
 ----
+
+build
+DROP TABLE defaultdb.customers CASCADE;
+----
+- [[CheckConstraint:{DescID: 54, ConstraintType: Check, ConstraintOrdinal: 1, Name: check_id}, ABSENT], PUBLIC]
+  details:
+    columnIds:
+    - 1
+    constraintId: 1
+    constraintType: Check
+    expr: id < 500:::INT8
+    name: check_id
+    tableId: 54
+    validated: true
+- [[CheckConstraint:{DescID: 54, ConstraintType: Check, ConstraintOrdinal: 2, Name: check_email}, ABSENT], PUBLIC]
+  details:
+    columnIds:
+    - 2
+    constraintId: 2
+    constraintType: Check
+    expr: email != 'blah':::STRING
+    name: check_email
+    tableId: 54
+    validated: true
+- [[Column:{DescID: 54, ColumnID: 1}, ABSENT], PUBLIC]
+  details:
+    columnId: 1
+    familyName: primary
+    pgAttributeNum: 1
+    tableId: 54
+    type:
+      family: IntFamily
+      oid: 20
+      width: 64
+- [[Column:{DescID: 54, ColumnID: 2}, ABSENT], PUBLIC]
+  details:
+    columnId: 2
+    familyName: primary
+    nullable: true
+    pgAttributeNum: 2
+    tableId: 54
+    type:
+      family: StringFamily
+      oid: 25
+- [[ColumnName:{DescID: 54, ColumnID: 1, Name: id}, ABSENT], PUBLIC]
+  details:
+    columnId: 1
+    name: id
+    tableId: 54
+- [[ColumnName:{DescID: 54, ColumnID: 2, Name: email}, ABSENT], PUBLIC]
+  details:
+    columnId: 2
+    name: email
+    tableId: 54
+- [[ConstraintName:{DescID: 54, ConstraintType: Check, ConstraintOrdinal: 1, Name: check_id}, ABSENT], PUBLIC]
+  details:
+    constraintId: 1
+    constraintType: Check
+    name: check_id
+    tableId: 54
+- [[ConstraintName:{DescID: 54, ConstraintType: Check, ConstraintOrdinal: 2, Name: check_email}, ABSENT], PUBLIC]
+  details:
+    constraintId: 2
+    constraintType: Check
+    name: check_email
+    tableId: 54
+- [[IndexName:{DescID: 54, IndexID: 1, Name: customers_pkey}, ABSENT], PUBLIC]
+  details:
+    indexId: 1
+    name: customers_pkey
+    tableId: 54
+- [[IndexName:{DescID: 54, IndexID: 2, Name: customers_email_key}, ABSENT], PUBLIC]
+  details:
+    indexId: 2
+    name: customers_email_key
+    tableId: 54
+- [[Locality:{DescID: 54}, ABSENT], PUBLIC]
+  details:
+    descriptorId: 54
+- [[Namespace:{DescID: 54, Name: customers}, ABSENT], PUBLIC]
+  details:
+    databaseId: 50
+    descriptorId: 54
+    name: customers
+    schemaId: 51
+- [[Owner:{DescID: 54}, ABSENT], PUBLIC]
+  details:
+    descriptorId: 54
+    owner: root
+- [[PrimaryIndex:{DescID: 54, IndexID: 1}, ABSENT], PUBLIC]
+  details:
+    indexId: 1
+    keyColumnDirection:
+    - ASC
+    keyColumnIds:
+    - 1
+    shardedDescriptor: {}
+    sourceIndexId: 1
+    storingColumnIds:
+    - 2
+    tableId: 54
+    unique: true
+- [[SecondaryIndex:{DescID: 54, IndexID: 2}, ABSENT], PUBLIC]
+  details:
+    indexId: 2
+    keyColumnDirection:
+    - ASC
+    keyColumnIds:
+    - 2
+    keySuffixColumnIds:
+    - 1
+    shardedDescriptor: {}
+    tableId: 54
+    unique: true
+- [[Table:{DescID: 54}, ABSENT], PUBLIC]
+  details:
+    tableId: 54
+- [[UserPrivileges:{DescID: 54, Username: admin}, ABSENT], PUBLIC]
+  details:
+    descriptorId: 54
+    privileges: 2
+    username: admin
+- [[UserPrivileges:{DescID: 54, Username: public}, ABSENT], PUBLIC]
+  details:
+    descriptorId: 54
+    username: public
+- [[UserPrivileges:{DescID: 54, Username: root}, ABSENT], PUBLIC]
+  details:
+    descriptorId: 54
+    privileges: 2
+    username: root
 
 create-table
 CREATE TABLE IF NOT EXISTS defaultdb.orders (

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -140,7 +140,7 @@ message SequenceDependency {
 message UniqueConstraint {
   option (gogoproto.equal) = true;
   ConstraintType constraint_type = 1;
-  uint32 constraint_ordinal = 2;
+  uint32 constraint_id = 2;
   uint32 table_id = 3 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"];
   uint32 index_id = 4 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.IndexID"];
   repeated uint32 column_ids = 5 [(gogoproto.customname) = "ColumnIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ColumnID"];
@@ -149,7 +149,7 @@ message UniqueConstraint {
 message CheckConstraint {
   option (gogoproto.equal) = true;
   ConstraintType constraint_type = 1;
-  uint32 constraint_ordinal = 2;
+  uint32 constraint_id = 2;
   uint32 table_id = 3 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"];
   string name = 4;
   string expr = 5;
@@ -211,7 +211,7 @@ message ColumnTypeReference {
 message CheckConstraintTypeReference {
   option (gogoproto.equal) = true;
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"];
-  uint32 constraint_ordinal = 2;
+  uint32 constraint_id = 2;
   uint32 type_id = 3 [(gogoproto.customname) = "TypeID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"];
 }
 
@@ -338,7 +338,7 @@ message ConstraintName {
   option (gogoproto.equal) = true;
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"];
   ConstraintType constraint_type = 2;
-  uint32 constraint_ordinal = 3;
+  uint32 constraint_id = 3;
   string name = 4;
 }
 

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -59,7 +59,7 @@ SequenceDependency :  Type
 object UniqueConstraint
 
 UniqueConstraint :  ConstraintType
-UniqueConstraint :  ConstraintOrdinal
+UniqueConstraint :  ConstraintId
 UniqueConstraint :  TableID
 UniqueConstraint :  IndexID
 UniqueConstraint : []ColumnIDs
@@ -67,7 +67,7 @@ UniqueConstraint : []ColumnIDs
 object CheckConstraint
 
 CheckConstraint :  ConstraintType
-CheckConstraint :  ConstraintOrdinal
+CheckConstraint :  ConstraintId
 CheckConstraint :  TableID
 CheckConstraint :  Name
 CheckConstraint :  Expr
@@ -185,7 +185,7 @@ object ConstraintName
 
 ConstraintName :  TableID
 ConstraintName :  ConstraintType
-ConstraintName :  ConstraintOrdinal
+ConstraintName :  ConstraintId
 ConstraintName :  Name
 
 object DefaultExprTypeReference
@@ -225,7 +225,7 @@ DatabaseSchemaEntry :  SchemaID
 object CheckConstraintTypeReference
 
 CheckConstraintTypeReference :  TableID
-CheckConstraintTypeReference :  ConstraintOrdinal
+CheckConstraintTypeReference :  ConstraintId
 CheckConstraintTypeReference :  TypeID
 
 Table <|-- Column

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -68,8 +68,8 @@ const (
 	Username
 	// ConstraintType is the ID of a constraint
 	ConstraintType
-	// ConstraintOrdinal is the ordinal of the constraints
-	ConstraintOrdinal
+	// ConstraintId is the ordinal of the constraints
+	ConstraintId
 )
 
 var t = reflect.TypeOf
@@ -106,13 +106,13 @@ var Schema = rel.MustSchema("screl",
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(IndexID, "IndexID"),
 		rel.EntityAttr(ConstraintType, "ConstraintType"),
-		rel.EntityAttr(ConstraintOrdinal, "ConstraintOrdinal"),
+		rel.EntityAttr(ConstraintId, "ConstraintId"),
 	),
 	rel.EntityMapping(t((*scpb.CheckConstraint)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(Name, "Name"),
 		rel.EntityAttr(ConstraintType, "ConstraintType"),
-		rel.EntityAttr(ConstraintOrdinal, "ConstraintOrdinal"),
+		rel.EntityAttr(ConstraintId, "ConstraintId"),
 	),
 	rel.EntityMapping(t((*scpb.Sequence)(nil)),
 		rel.EntityAttr(DescID, "SequenceID"),
@@ -146,7 +146,7 @@ var Schema = rel.MustSchema("screl",
 	),
 	rel.EntityMapping(t((*scpb.CheckConstraintTypeReference)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
-		rel.EntityAttr(ConstraintOrdinal, "ConstraintOrdinal"),
+		rel.EntityAttr(ConstraintId, "ConstraintId"),
 		rel.EntityAttr(ReferencedDescID, "TypeID"),
 	),
 	rel.EntityMapping(t((*scpb.ViewDependsOnType)(nil)),
@@ -215,7 +215,7 @@ var Schema = rel.MustSchema("screl",
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(Name, "Name"),
 		rel.EntityAttr(ConstraintType, "ConstraintType"),
-		rel.EntityAttr(ConstraintOrdinal, "ConstraintOrdinal"),
+		rel.EntityAttr(ConstraintId, "ConstraintId"),
 	),
 	rel.EntityMapping(t((*scpb.DatabaseSchemaEntry)(nil)),
 		rel.EntityAttr(DescID, "DatabaseID"),

--- a/pkg/sql/schemachanger/screl/attr_string.go
+++ b/pkg/sql/schemachanger/screl/attr_string.go
@@ -19,12 +19,12 @@ func _() {
 	_ = x[Target-9]
 	_ = x[Username-10]
 	_ = x[ConstraintType-11]
-	_ = x[ConstraintOrdinal-12]
+	_ = x[ConstraintId-12]
 }
 
-const _Attr_name = "DescIDReferencedDescIDColumnIDNameIndexIDTargetStatusCurrentStatusElementTargetUsernameConstraintTypeConstraintOrdinal"
+const _Attr_name = "DescIDReferencedDescIDColumnIDNameIndexIDTargetStatusCurrentStatusElementTargetUsernameConstraintTypeConstraintId"
 
-var _Attr_index = [...]uint8{0, 6, 22, 30, 34, 41, 53, 66, 73, 79, 87, 101, 118}
+var _Attr_index = [...]uint8{0, 6, 22, 30, 34, 41, 53, 66, 73, 79, 87, 101, 113}
 
 func (i Attr) String() string {
 	i -= 1

--- a/pkg/sql/schemachanger/screl/compare.go
+++ b/pkg/sql/schemachanger/screl/compare.go
@@ -22,7 +22,7 @@ var equalityAttrs = []rel.Attr{
 	ReferencedDescID,
 	ColumnID,
 	ConstraintType,
-	ConstraintOrdinal,
+	ConstraintId,
 	Name,
 	Username,
 	IndexID,

--- a/pkg/sql/schemachanger/screl/scalars.go
+++ b/pkg/sql/schemachanger/screl/scalars.go
@@ -42,3 +42,16 @@ func GetDescIDs(s scpb.TargetState) descpb.IDs {
 	}
 	return descIDSet.Ordered()
 }
+
+// GetConstraintId retrieves the constraint ID from the element.
+func GetConstraintId(e scpb.Element) uint32 {
+	id, err := Schema.GetAttribute(ConstraintId, e)
+	if err != nil {
+		// Note that this is safe because we have a unit test that ensures that
+		// all elements don't panic on this.
+		panic(errors.NewAssertionErrorWithWrappedErrf(
+			err, "failed to retrieve constraint ID for %T", e,
+		))
+	}
+	return id.(uint32)
+}


### PR DESCRIPTION
This PR will refactor the way constraints will be identified inside the declarative schema changer. Previously, for
the table decomposition work, we were storing the ordinal position of constraints, which will be prone to issues when we start adding support for adding/removing constraints. An alternative approach would have been to identify constraints by name, but that causes multiple additions and removals inside a single transaction to be problematic. So instead, we are going to start allocating IDs for constraint elements, which will be only be used for the schemachanger to identify things.