### PR TITLE
sql: don't create a tracing span for every pgwire cmd 

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -62,7 +62,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"golang.org/x/net/trace"
@@ -1702,17 +1701,6 @@ func (ex *connExecutor) execCmd() error {
 	if err != nil {
 		return err // err could be io.EOF
 	}
-
-	// Ensure that every statement has a tracing span set up.
-	ctx, sp := tracing.EnsureChildSpan(
-		ctx, ex.server.cfg.AmbientCtx.Tracer,
-		// We print the type of command, not the String() which includes long
-		// statements.
-		cmd.command())
-	defer sp.Finish()
-	// We expect that the span is not used directly, so we'll overwrite the
-	// local variable.
-	sp = nil
 
 	if log.ExpensiveLogEnabled(ctx, 2) || ex.eventLog != nil {
 		ex.sessionEventf(ctx, "[%s pos:%d] executing %s",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1545,7 +1545,7 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) err
 		ex.extraTxnState.savepoints.clear()
 		ex.onTxnFinish(ctx, ev)
 	case txnRestart:
-		ex.onTxnRestart()
+		ex.onTxnRestart(ctx)
 		ex.state.mu.Lock()
 		defer ex.state.mu.Unlock()
 		ex.state.mu.stmtCount = 0
@@ -2416,7 +2416,7 @@ func (ex *connExecutor) makeErrEvent(err error, stmt tree.Statement) (fsm.Event,
 
 // setTransactionModes implements the txnModesSetter interface.
 func (ex *connExecutor) setTransactionModes(
-	modes tree.TransactionModes, asOfTs hlc.Timestamp,
+	ctx context.Context, modes tree.TransactionModes, asOfTs hlc.Timestamp,
 ) error {
 	// This method cheats and manipulates ex.state directly, not through an event.
 	// The alternative would be to create a special event, but it's unclear how
@@ -2439,7 +2439,7 @@ func (ex *connExecutor) setTransactionModes(
 		return errors.AssertionFailedf("expected an evaluated AS OF timestamp")
 	}
 	if !asOfTs.IsEmpty() {
-		if err := ex.state.setHistoricalTimestamp(ex.Ctx(), asOfTs); err != nil {
+		if err := ex.state.setHistoricalTimestamp(ctx, asOfTs); err != nil {
 			return err
 		}
 		ex.state.sqlTimestamp = asOfTs.GoTime()
@@ -2673,7 +2673,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 	// the completion of those schema changes first.
 	if p, ok := payload.(payloadWithError); ok {
 		if descID := scerrors.ConcurrentSchemaChangeDescID(p.errorCause()); descID != descpb.InvalidID {
-			if err := ex.handleWaitingForConcurrentSchemaChanges(descID); err != nil {
+			if err := ex.handleWaitingForConcurrentSchemaChanges(ex.Ctx(), descID); err != nil {
 				return advanceInfo{}, err
 			}
 		}
@@ -2786,9 +2786,11 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 	return advInfo, nil
 }
 
-func (ex *connExecutor) handleWaitingForConcurrentSchemaChanges(descID descpb.ID) error {
+func (ex *connExecutor) handleWaitingForConcurrentSchemaChanges(
+	ctx context.Context, descID descpb.ID,
+) error {
 	if err := ex.planner.WaitForDescriptorSchemaChanges(
-		ex.Ctx(), descID, ex.extraTxnState.schemaChangerState,
+		ctx, descID, ex.extraTxnState.schemaChangerState,
 	); err != nil {
 		return err
 	}
@@ -2796,7 +2798,7 @@ func (ex *connExecutor) handleWaitingForConcurrentSchemaChanges(descID descpb.ID
 	ex.state.mu.Lock()
 	defer ex.state.mu.Unlock()
 	userPriority := ex.state.mu.txn.UserPriority()
-	ex.state.mu.txn = kv.NewTxnWithSteppingEnabled(ex.Ctx(), ex.transitionCtx.db, ex.transitionCtx.nodeIDOrZero)
+	ex.state.mu.txn = kv.NewTxnWithSteppingEnabled(ctx, ex.transitionCtx.db, ex.transitionCtx.nodeIDOrZero)
 	return ex.state.mu.txn.SetUserPriority(userPriority)
 }
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1673,7 +1673,7 @@ func (ex *connExecutor) run(
 		}
 
 		var err error
-		if err = ex.execCmd(ex.Ctx()); err != nil {
+		if err = ex.execCmd(); err != nil {
 			if errors.IsAny(err, io.EOF, errDrainingComplete) {
 				return nil
 			}
@@ -1696,7 +1696,8 @@ var errDrainingComplete = fmt.Errorf("draining done. this is a good time to fini
 // Returns drainingComplete if the session should finish because draining is
 // complete (i.e. we received a DrainRequest - possibly previously - and the
 // connection is found to be idle).
-func (ex *connExecutor) execCmd(ctx context.Context) error {
+func (ex *connExecutor) execCmd() error {
+	ctx := ex.Ctx()
 	cmd, pos, err := ex.stmtBuf.CurCmd()
 	if err != nil {
 		return err // err could be io.EOF
@@ -1929,6 +1930,7 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
 		// Massage the advancing for Sync, which is special.
 		if _, ok := cmd.(Sync); ok {
 			switch advInfo.code {
@@ -1949,6 +1951,11 @@ func (ex *connExecutor) execCmd(ctx context.Context) error {
 				return errors.AssertionFailedf("unexpected advance code stayInPlace when processing Sync")
 			}
 		}
+
+		// If a txn just started, we henceforth want to run in the context of the
+		// transaction. Similarly, if a txn just ended, we don't want to run in its
+		// context any more.
+		ctx = ex.Ctx()
 	} else {
 		// If no event was generated synthesize an advance code.
 		advInfo = advanceInfo{code: advanceOne}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // execStmt executes one statement by dispatching according to the current
@@ -262,6 +263,10 @@ func (ex *connExecutor) execStmtInOpenState(
 	res RestrictedCommandResult,
 	canAutoCommit bool,
 ) (retEv fsm.Event, retPayload fsm.EventPayload, retErr error) {
+	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "sql query")
+	// TODO(andrei): Consider adding the placeholders as tags too.
+	sp.SetTag("statement", attribute.StringValue(parserStmt.SQL))
+	defer sp.Finish()
 	ast := parserStmt.AST
 	ctx = withStatement(ctx, ast)
 
@@ -813,12 +818,10 @@ func (ex *connExecutor) checkDescriptorTwoVersionInvariant(ctx context.Context) 
 // transaction. commitFn is passed as a separate function, so that we avoid
 // executing transactional logic when handling COMMIT in the CommitWait state.
 func (ex *connExecutor) commitSQLTransaction(
-	ctx context.Context,
-	ast tree.Statement,
-	commitFn func(ctx context.Context, ast tree.Statement) error,
+	ctx context.Context, ast tree.Statement, commitFn func(ctx context.Context) error,
 ) (fsm.Event, fsm.EventPayload) {
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionStartTransactionCommit, timeutil.Now())
-	if err := commitFn(ctx, ast); err != nil {
+	if err := commitFn(ctx); err != nil {
 		return ex.makeErrEvent(err, ast)
 	}
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionEndTransactionCommit, timeutil.Now())
@@ -868,9 +871,10 @@ func (ex *connExecutor) reportSessionDataChanges(fn func() error) error {
 	return nil
 }
 
-func (ex *connExecutor) commitSQLTransactionInternal(
-	ctx context.Context, ast tree.Statement,
-) error {
+func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error {
+	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "commit sql txn")
+	defer sp.Finish()
+
 	if err := ex.createJobs(ctx); err != nil {
 		return err
 	}
@@ -1603,7 +1607,7 @@ func (ex *connExecutor) execStmtInCommitWaitState(
 		return ex.commitSQLTransaction(
 			ctx,
 			ast,
-			func(ctx context.Context, ast tree.Statement) error {
+			func(ctx context.Context) error {
 				// COMMIT while in the CommitWait state is a no-op.
 				return nil
 			},

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1944,7 +1944,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
 	}
 }
 
-func (ex *connExecutor) onTxnRestart() {
+func (ex *connExecutor) onTxnRestart(ctx context.Context) {
 	if ex.extraTxnState.shouldExecuteOnTxnRestart {
 		ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionMostRecentStartExecTransaction, timeutil.Now())
 		ex.extraTxnState.transactionStatementFingerprintIDs = nil
@@ -1958,7 +1958,7 @@ func (ex *connExecutor) onTxnRestart() {
 		ex.extraTxnState.rowsWritten = 0
 
 		if ex.server.cfg.TestingKnobs.BeforeRestart != nil {
-			ex.server.cfg.TestingKnobs.BeforeRestart(ex.Ctx(), ex.extraTxnState.autoRetryReason)
+			ex.server.cfg.TestingKnobs.BeforeRestart(ctx, ex.extraTxnState.autoRetryReason)
 		}
 	}
 }

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -30,6 +31,8 @@ import (
 func (ex *connExecutor) execPrepare(
 	ctx context.Context, parseCmd PrepareStmt,
 ) (fsm.Event, fsm.EventPayload) {
+	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "prepare stmt")
+	defer sp.Finish()
 
 	retErr := func(err error) (fsm.Event, fsm.EventPayload) {
 		return ex.makeErrEvent(err, parseCmd.AST)

--- a/pkg/sql/conn_executor_savepoints.go
+++ b/pkg/sql/conn_executor_savepoints.go
@@ -145,7 +145,7 @@ func (ex *connExecutor) execRelease(
 
 	if entry.commitOnRelease {
 		res.ResetStmtType((*tree.CommitTransaction)(nil))
-		err := ex.commitSQLTransactionInternal(ctx, s)
+		err := ex.commitSQLTransactionInternal(ctx)
 		if err == nil {
 			return eventTxnReleased{}, nil
 		}

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -20,24 +20,23 @@ FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
 0   === SPAN START: session recording ===                session recording
-1   === SPAN START: exec stmt ===                        exec stmt
-1   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  exec stmt
-2   === SPAN START: sql txn ===                          sql txn
-3   === SPAN START: exec stmt ===                        exec stmt
-3   [Open pos:?] executing ExecStmt: SELECT 1            exec stmt
-4   === SPAN START: consuming rows ===                   consuming rows
-5   === SPAN START: flow ===                             flow
-6   === SPAN START: exec stmt ===                        exec stmt
-6   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  exec stmt
-7   === SPAN START: exec stmt ===                        exec stmt
-7   [NoTxn pos:?] executing ExecStmt: SELECT 2           exec stmt
-8   === SPAN START: sql txn ===                          sql txn
-9   === SPAN START: exec stmt ===                        exec stmt
-9   [Open pos:?] executing ExecStmt: SELECT 2            exec stmt
-10  === SPAN START: consuming rows ===                   consuming rows
-11  === SPAN START: flow ===                             flow
-12  === SPAN START: exec stmt ===                        exec stmt
-12  [NoTxn pos:?] executing ExecStmt: SET TRACING = off  exec stmt
+0   [NoTxn pos:?] executing ExecStmt: BEGIN TRANSACTION  session recording
+1   === SPAN START: sql txn ===                          sql txn
+1   [Open pos:?] executing ExecStmt: SELECT 1            sql txn
+2   === SPAN START: sql query ===                        sql query
+3   === SPAN START: consuming rows ===                   consuming rows
+4   === SPAN START: flow ===                             flow
+1   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
+5   === SPAN START: sql query ===                        sql query
+6   === SPAN START: commit sql txn ===                   commit sql txn
+0   [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
+7   === SPAN START: sql txn ===                          sql txn
+7   [Open pos:?] executing ExecStmt: SELECT 2            sql txn
+8   === SPAN START: sql query ===                        sql query
+9   === SPAN START: consuming rows ===                   consuming rows
+10  === SPAN START: flow ===                             flow
+11  === SPAN START: commit sql txn ===                   commit sql txn
+0   [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
 
 statement ok
 CREATE TABLE num_ref (a INT PRIMARY KEY, xx INT, b INT, c INT, INDEX bc (b,c))

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace_nonmetamorphic
@@ -21,7 +21,7 @@ batch flow coordinator  CPut /NamespaceTable/30/1/56/0/"public"/4/1 -> 57
 batch flow coordinator  CPut /Table/3/1/57/2/1 -> schema:<name:"public" id:57 state:PUBLIC offline_reason:"" modification_time:<> version:1 parent_id:56 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:516 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"admin" version:2 > >
 batch flow coordinator  CPut /NamespaceTable/30/1/0/0/"t"/4/1 -> 56
 batch flow coordinator  CPut /Table/3/1/56/2/1 -> database:<name:"t" id:56 modification_time:<> version:1 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:2048 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > schemas:<key:"public" value:<id:57 dropped:false > > state:PUBLIC offline_reason:"" default_privileges:<type:DATABASE > >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 
 # More KV operations.
@@ -41,7 +41,7 @@ WHERE message NOT LIKE '%Z/%'
 ----
 batch flow coordinator  CPut /NamespaceTable/30/1/56/57/"kv"/4/1 -> 58
 batch flow coordinator  CPut /Table/3/1/58/2/1 -> table:<name:"kv" id:58 version:1 modification_time:<> parent_id:56 unexposed_parent_schema_id:57 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:0 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false new_schema_change_job_id:0 drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<> temporary:false partition_all_by:false >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -67,7 +67,7 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND operation != 'dist sender send'
 ----
 batch flow coordinator  Put /Table/3/1/58/2/1 -> table:<name:"kv" id:58 version:2 modification_time:<> parent_id:56 unexposed_parent_schema_id:57 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:0 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > mutations:<index:<name:"woo" id:2 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false mutationJobs:<...> new_schema_change_job_id:0 drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -79,7 +79,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 batch flow coordinator  CPut /Table/58/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/58/2/2/0 -> /BYTES/0x89
 batch flow coordinator  fast path completed
-exec stmt               rows affected: 1
+sql query               rows affected: 1
 
 
 statement error duplicate key value
@@ -92,7 +92,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 batch flow coordinator  CPut /Table/58/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/58/2/2/0 -> /BYTES/0x89
-exec stmt               execution failed after 0 rows: duplicate key value violates unique constraint "kv_pkey"
+sql query               execution failed after 0 rows: duplicate key value violates unique constraint "kv_pkey"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -104,7 +104,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 batch flow coordinator  CPut /Table/58/1/2/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/58/2/2/0 -> /BYTES/0x8a
-exec stmt               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
+sql query               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv; SET tracing = off
@@ -122,7 +122,7 @@ WHERE message NOT LIKE '%Z/%'
 ----
 batch flow coordinator  CPut /NamespaceTable/30/1/56/57/"kv2"/4/1 -> 59
 batch flow coordinator  CPut /Table/3/1/59/2/1 -> table:<name:"kv2" id:59 version:1 modification_time:<> parent_id:56 unexposed_parent_schema_id:57 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false default_expr:"unique_rowid()" hidden:true inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"kv2_pkey" id:1 unique:true version:4 key_column_names:"rowid" key_column_directions:ASC store_column_names:"k" store_column_names:"v" key_column_ids:3 store_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:0 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:ADD offline_reason:"" view_query:"" is_materialized_view:false new_schema_change_job_id:0 drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<> temporary:false partition_all_by:false >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2; SET tracing = off
@@ -141,7 +141,7 @@ colbatchscan            Scan /Table/59/{1-2}
 colbatchscan            fetched: /kv2/kv2_pkey/-9222809086901354496/k/v -> /1/2
 batch flow coordinator  Put /Table/59/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 batch flow coordinator  fast path completed
-exec stmt               rows affected: 1
+sql query               rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -152,7 +152,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
 batch flow coordinator  DelRange /Table/59/1 - /Table/59/2
 batch flow coordinator  fast path completed
-exec stmt               rows affected: 1
+sql query               rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2; SET tracing = off
@@ -171,7 +171,7 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
 ----
 batch flow coordinator  Del /NamespaceTable/30/1/56/57/"kv2"/4/1
 batch flow coordinator  Put /Table/3/1/59/2/1 -> table:<name:"kv2" id:59 version:3 modification_time:<> parent_id:56 unexposed_parent_schema_id:57 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false default_expr:"unique_rowid()" hidden:true inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"kv2_pkey" id:1 unique:true version:4 key_column_names:"rowid" key_column_directions:ASC store_column_names:"k" store_column_names:"v" key_column_ids:3 store_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:0 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:DROP offline_reason:"" view_query:"" is_materialized_view:false new_schema_change_job_id:0 drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv; SET tracing = off
@@ -185,7 +185,7 @@ colbatchscan            fetched: /kv/kv_pkey/1/v -> /2
 batch flow coordinator  Del /Table/58/2/2/0
 batch flow coordinator  Del /Table/58/1/1/0
 batch flow coordinator  fast path completed
-exec stmt               rows affected: 1
+sql query               rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE; SET tracing = off
@@ -205,7 +205,7 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
   AND operation != 'dist sender send'
 ----
 batch flow coordinator  Put /Table/3/1/58/2/1 -> table:<name:"kv" id:58 version:5 modification_time:<> parent_id:56 unexposed_parent_schema_id:57 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:0 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > mutations:<index:<name:"woo" id:2 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false mutationJobs:<...> new_schema_change_job_id:0 drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv; SET tracing = off
@@ -223,7 +223,7 @@ WHERE message NOT LIKE '%Z/%' AND message NOT LIKE 'querying next range at%'
 ----
 batch flow coordinator  Del /NamespaceTable/30/1/56/57/"kv"/4/1
 batch flow coordinator  Put /Table/3/1/58/2/1 -> table:<name:"kv" id:58 version:8 modification_time:<> parent_id:56 unexposed_parent_schema_id:57 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false > next_index_id:3 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:0 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:3 format_version:3 state:DROP offline_reason:"" view_query:"" is_materialized_view:false new_schema_change_job_id:0 drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false >
-exec stmt               rows affected: 0
+sql query               rows affected: 0
 
 # Check that session tracing does not inhibit the fast path for inserts &
 # friends (the path resulting in 1PC transactions).

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_nonmetamorphic
@@ -42,7 +42,7 @@ colbatchscan            Scan /Table/59/1/2/0
 batch flow coordinator  CPut /Table/59/1/2/0 -> /TUPLE/2:2:Int/3
 batch flow coordinator  InitPut /Table/59/2/3/0 -> /BYTES/0x8a
 batch flow coordinator  fast path completed
-exec stmt               rows affected: 1
+sql query               rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -55,7 +55,7 @@ colbatchscan            Scan /Table/59/1/1/0
 batch flow coordinator  CPut /Table/59/1/1/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  InitPut /Table/59/2/2/0 -> /BYTES/0x89
 batch flow coordinator  fast path completed
-exec stmt               rows affected: 1
+sql query               rows affected: 1
 
 statement error duplicate key value
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -70,7 +70,7 @@ colbatchscan            fetched: /kv/kv_pkey/2/v -> /3
 batch flow coordinator  Put /Table/59/1/2/0 -> /TUPLE/2:2:Int/2
 batch flow coordinator  Del /Table/59/2/3/0
 batch flow coordinator  CPut /Table/59/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-exec stmt               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
+sql query               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 # ---------------------------------------------------------
 # Index With Delete Preserving Encoding

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -812,7 +812,7 @@ type txnModesSetter interface {
 	// setTransactionModes updates some characteristics of the current
 	// transaction.
 	// asOfTs, if not empty, is the evaluation of modes.AsOf.
-	setTransactionModes(modes tree.TransactionModes, asOfTs hlc.Timestamp) error
+	setTransactionModes(ctx context.Context, modes tree.TransactionModes, asOfTs hlc.Timestamp) error
 }
 
 // validateDescriptor is a convenience function for validating

--- a/pkg/sql/set_transaction.go
+++ b/pkg/sql/set_transaction.go
@@ -34,7 +34,7 @@ func (p *planner) SetTransaction(ctx context.Context, n *tree.SetTransaction) (p
 		return nil, unimplemented.NewWithIssue(53432, "DEFERRABLE transactions")
 	}
 
-	if err := p.extendedEvalCtx.TxnModesSetter.setTransactionModes(n.Modes, asOfTs); err != nil {
+	if err := p.extendedEvalCtx.TxnModesSetter.setTransactionModes(ctx, n.Modes, asOfTs); err != nil {
 		return nil, err
 	}
 	return newZeroNode(nil /* columns */), nil

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -77,7 +77,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"exec stmt",
+				"sql query",
 				"flow",
 				"session recording",
 				"sql txn",
@@ -86,6 +86,7 @@ func TestTrace(t *testing.T) {
 				"txn coordinator send",
 				"dist sender send",
 				"/cockroach.roachpb.Internal/Batch",
+				"commit sql txn",
 			},
 		},
 		{
@@ -137,13 +138,14 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
-				"exec stmt",
+				"sql query",
 				"flow",
 				"table reader",
 				"consuming rows",
 				"txn coordinator send",
 				"dist sender send",
 				"/cockroach.roachpb.Internal/Batch",
+				"commit sql txn",
 			},
 			// Depending on whether the data is local or not, we may not see these
 			// spans.
@@ -172,7 +174,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"exec stmt",
+				"sql query",
 				"flow",
 				"session recording",
 				"sql txn",
@@ -181,6 +183,7 @@ func TestTrace(t *testing.T) {
 				"txn coordinator send",
 				"dist sender send",
 				"/cockroach.roachpb.Internal/Batch",
+				"commit sql txn",
 			},
 		},
 		{
@@ -205,13 +208,14 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
-				"exec stmt",
+				"sql query",
 				"flow",
 				"table reader",
 				"consuming rows",
 				"txn coordinator send",
 				"dist sender send",
 				"/cockroach.roachpb.Internal/Batch",
+				"commit sql txn",
 			},
 			// Depending on whether the data is local or not, we may not see these
 			// spans.
@@ -239,7 +243,7 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
-				"exec stmt",
+				"sql query",
 				"flow",
 				"batch flow coordinator",
 				"colbatchscan",
@@ -247,6 +251,7 @@ func TestTrace(t *testing.T) {
 				"txn coordinator send",
 				"dist sender send",
 				"/cockroach.roachpb.Internal/Batch",
+				"commit sql txn",
 			},
 		},
 	}


### PR DESCRIPTION
Before this patch, processing each pgwire cmd was getting its own span
(when tracing is enabled). This span was not nice because it was
outliving its parent - something that's technically permitted, but not
generally encouraged.

Besides being funky, these spans are too costly for too little
benefit. Generally, executing a query takes a few commands:
bind,describe,exec,sync. If the query is executed as an implicit txn,
the "exec" command is generally twice (once superficially in the
"no-txn" state and once in the "open" state). For simple queries, these
spans end up being about half of the total spans created for the query.
I've never looked at a span for anything other than the "exec", and
there only at the one in the "open" state. So this patch gets rid of
creating spans mechanically for every pgwire command. Instead, we create
spans only for preparing statements, and for executing a query in the
"open" state. I've also added a span for auto-commits, particularly
since those can happen in the context of a Sync command.

This patch also adds the SQL statement as a tag to the span representing
query execution.

Release note: None