### PR TITLE
sql: support default `default_table_access_method` var value

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4631,6 +4631,7 @@ database                                              test
 datestyle                                             ISO, MDY
 datestyle_enabled                                     off
 default_int_size                                      8
+default_table_access_method                           heap
 default_tablespace                                    ·
 default_transaction_isolation                         serializable
 default_transaction_priority                          normal

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4038,6 +4038,7 @@ database                                              test                NULL  
 datestyle                                             ISO, MDY            NULL      NULL        NULL        string
 datestyle_enabled                                     off                 NULL      NULL        NULL        string
 default_int_size                                      8                   NULL      NULL        NULL        string
+default_table_access_method                           heap                NULL      NULL        NULL        string
 default_tablespace                                    ·                   NULL      NULL        NULL        string
 default_transaction_isolation                         serializable        NULL      NULL        NULL        string
 default_transaction_priority                          normal              NULL      NULL        NULL        string
@@ -4147,6 +4148,7 @@ database                                              test                NULL  
 datestyle                                             ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
 datestyle_enabled                                     off                 NULL  user     NULL      off                 off
 default_int_size                                      8                   NULL  user     NULL      8                   8
+default_table_access_method                           heap                NULL  user     NULL      heap                heap
 default_tablespace                                    ·                   NULL  user     NULL      ·                   ·
 default_transaction_isolation                         serializable        NULL  user     NULL      default             default
 default_transaction_priority                          normal              NULL  user     NULL      normal              normal
@@ -4251,6 +4253,7 @@ database                                              NULL    NULL     NULL     
 datestyle                                             NULL    NULL     NULL     NULL        NULL
 datestyle_enabled                                     NULL    NULL     NULL     NULL        NULL
 default_int_size                                      NULL    NULL     NULL     NULL        NULL
+default_table_access_method                           NULL    NULL     NULL     NULL        NULL
 default_tablespace                                    NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation                         NULL    NULL     NULL     NULL        NULL
 default_transaction_priority                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -530,6 +530,24 @@ SET standard_conforming_strings='true'
 statement ok
 SET standard_conforming_strings='on'
 
+subtest default_table_access_method_test
+
+query T
+SHOW default_table_access_method
+----
+heap
+
+statement ok
+SET default_table_access_method = 'heap'
+
+query T
+SHOW default_table_access_method
+----
+heap
+
+statement error invalid value for parameter "default_table_access_method": "not-heap"
+SET default_table_access_method = 'not-heap'
+
 subtest default_with_oids_test
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -36,6 +36,7 @@ database                                              test
 datestyle                                             ISO, MDY
 datestyle_enabled                                     off
 default_int_size                                      8
+default_table_access_method                           heap
 default_tablespace                                    ·
 default_transaction_isolation                         serializable
 default_transaction_priority                          normal

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1033,6 +1033,9 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// See https://www.postgresql.org/docs/12/runtime-config-client.html.
+	`default_table_access_method`: makeCompatStringVar(`default_table_access_method`, `heap`),
+
 	// See https://www.postgresql.org/docs/13/runtime-config-compatible.html
 	// CockroachDB only supports safe_encoding for now. If `client_encoding` is updated to
 	// allow encodings other than UTF8, then the default value of `backslash_quote` should


### PR DESCRIPTION
Release note (sql change): Support the `default_table_access_method`
session variable, which only takes in `heap` (same as PG).