### PR TITLE
sql: use a view to join persistent and in-mem stmt stats

### DIFF
--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -96,6 +96,7 @@ const (
 	CrdbInternalClusterTransactionsTableID
 	CrdbInternalClusterSessionsTableID
 	CrdbInternalClusterSettingsTableID
+	CrdbInternalClusterStmtStatsTableID
 	CrdbInternalCreateSchemaStmtsTableID
 	CrdbInternalCreateStmtsTableID
 	CrdbInternalCreateTypeStmtsTableID


### PR DESCRIPTION
We've got some stats that are in-memory on each of the nodes
and we've got some which are on disk. Scanning all the ones on
disk when trying to use a predicate is unjustifiable and negates
the purpose of the indexes. However, scanning the in-memory data
is ~fine. Sadly the only way that the data was previously exposed
was via a single virtual table which enumerated all of the on-disk
data every time. This is not acceptable. Fortunately, we've got
a great technology in virtual views that allows us to leverage
the indexes on disk for the on disk data and combine it with the
in-memory data.

This commit shows how to do that for statement statistics. It can
also be used for transaction statistics.

I suspect we can backport this approach.

```
> EXPLAIN SELECT * FROM crdb_internal.statement_statistics WHERE fingerprint_id = decode('e85be2acda52c191', 'hex');
                                                            info
-----------------------------------------------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • union all
  │
  ├── • filter
  │   │ filter: fingerprint_id = '\xe85be2acda52c191'
  │   │
  │   └── • virtual table
  │         table: cluster_statement_statistics@primary
  │
  └── • index join
      │ table: statement_statistics@primary
      │
      └── • scan
            missing stats
            table: statement_statistics@fingerprint_stats_idx
            spans: [/'\xe85be2acda52c191' - /'\xe85be2acda52c191']
```

Touches https://github.com/cockroachdb/cockroach/issues/71245. 

Release note: None