### PR TITLE
kvstreamer: a couple of optimizations

### DIFF
--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -134,7 +134,7 @@ func (f *TxnKVStreamer) processedScanResponse() {
 }
 
 func (f *TxnKVStreamer) releaseLastResult(ctx context.Context) {
-	f.lastResultState.MemoryTok.Release(ctx)
+	f.lastResultState.Release(ctx)
 	f.lastResultState.Result = kvstreamer.Result{}
 }
 
@@ -207,11 +207,9 @@ func (f *TxnKVStreamer) nextBatch(
 
 // close releases the resources of this TxnKVStreamer.
 func (f *TxnKVStreamer) close(ctx context.Context) {
-	if f.lastResultState.MemoryTok != nil {
-		f.lastResultState.MemoryTok.Release(ctx)
-	}
+	f.lastResultState.Release(ctx)
 	for _, r := range f.results {
-		r.MemoryTok.Release(ctx)
+		r.Release(ctx)
 	}
 	*f = TxnKVStreamer{}
 }

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -50,6 +50,9 @@ type TxnKVStreamer struct {
 	// fully responded to yet.
 	numOutstandingRequests int
 
+	// getResponseScratch is reused to return the result of Get requests.
+	getResponseScratch [1]roachpb.KeyValue
+
 	results         []kvstreamer.Result
 	lastResultState struct {
 		kvstreamer.Result
@@ -107,7 +110,8 @@ func (f *TxnKVStreamer) proceedWithLastResult(
 		origSpan := f.spans[pos]
 		f.lastResultState.numEmitted++
 		f.numOutstandingRequests--
-		return false, []roachpb.KeyValue{{Key: origSpan.Key, Value: *get.Value}}, nil, nil
+		f.getResponseScratch[0] = roachpb.KeyValue{Key: origSpan.Key, Value: *get.Value}
+		return false, f.getResponseScratch[:], nil, nil
 	}
 	scan := result.ScanResp
 	if len(scan.BatchResponses) > 0 {


### PR DESCRIPTION
**sql/row: remove an allocation for Get responses**

```
name                    old time/op    new time/op    delta
IndexJoin/Cockroach-24    8.02ms ± 9%    7.92ms ± 2%    ~     (p=1.000 n=9+10)

name                    old alloc/op   new alloc/op   delta
IndexJoin/Cockroach-24    1.68MB ± 1%    1.62MB ± 1%  -3.83%  (p=0.000 n=10+9)

name                    old allocs/op  new allocs/op  delta
IndexJoin/Cockroach-24     11.1k ± 1%     10.1k ± 0%  -8.85%  (p=0.000 n=9+9)
```

Release note: None

**kvstreamer: refactor memory tokens to reduce allocations**

```
name                    old time/op    new time/op    delta
IndexJoin/Cockroach-24    7.72ms ± 7%    7.51ms ± 3%   -2.75%  (p=0.001 n=10+9)

name                    old alloc/op   new alloc/op   delta
IndexJoin/Cockroach-24    1.61MB ± 1%    1.60MB ± 1%   -0.91%  (p=0.001 n=10+9)

name                    old allocs/op  new allocs/op  delta
IndexJoin/Cockroach-24     10.1k ± 1%      9.1k ± 1%  -10.24%  (p=0.000 n=10+10)
```

Release note: None