### PR TITLE
roachtest: fix sequelize nightly

### DIFF
--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -23,7 +23,7 @@ import (
 )
 
 var sequelizeCockroachDBReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var supportedSequelizeCockroachDBRelease = "v6.0.3"
+var supportedSequelizeCockroachDBRelease = "v6.0.5"
 
 // This test runs sequelize's full test suite against a single cockroach node.
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/74057

Upstream changed how imports are done, so this library had to be
updated.

Release note: None