### PR TITLE
rangefeed: Extend rangefeed client with per span start time.

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5090,7 +5090,6 @@ var crdbInternalActiveRangeFeedsTable = virtualSchemaTable{
 CREATE TABLE crdb_internal.active_range_feeds (
   id INT,
   tags STRING,
-  startTS STRING,
   diff BOOL,
   node_id INT,
   range_id INT,
@@ -5112,7 +5111,6 @@ CREATE TABLE crdb_internal.active_range_feeds (
 				return addRow(
 					tree.NewDInt(tree.DInt(rfCtx.ID)),
 					tree.NewDString(rfCtx.CtxTags),
-					tree.NewDString(rfCtx.StartFrom.AsOfSystemTime()),
 					tree.MakeDBool(tree.DBool(rfCtx.WithDiff)),
 					tree.NewDInt(tree.DInt(rf.NodeID)),
 					tree.NewDInt(tree.DInt(rf.RangeID)),

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -35,7 +35,6 @@ create_statement  create_nofks  alter_statements  validate_statements
 CREATE TABLE crdb_internal.active_range_feeds (
    id INT8 NULL,
    tags STRING NULL,
-   startts STRING NULL,
    diff BOOL NULL,
    node_id INT8 NULL,
    range_id INT8 NULL,
@@ -46,7 +45,6 @@ CREATE TABLE crdb_internal.active_range_feeds (
 )  CREATE TABLE crdb_internal.active_range_feeds (
    id INT8 NULL,
    tags STRING NULL,
-   startts STRING NULL,
    diff BOOL NULL,
    node_id INT8 NULL,
    range_id INT8 NULL,


### PR DESCRIPTION
Extend rangefeed client code to support specifying the list of spans
with different starting times.

It is useful, and more efficient, for the caller to specify the list
of spans to run rangefeed against (as opposed to starting a separate
go routine per span).  However, the callers may need to specify
slightly different start times for some spans (for example, because
the client may be resuming the feed from the checkpoint).

As part of this small refactoring, fix a bug where a failure to resolve
the span address could result in early return prior to waiting for the
context group completion.

In addition, because the set of spans now can have different starting time,
the `crdb_internal.active_range_feeds` table no longer prints startTime.

Release Notes: None