### PR TITLE
server: Add earliest statement and transaction aggregated ts

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3458,6 +3458,8 @@ tenant pods.
 | last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. | [reserved](#support-status) |
 | internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
 | transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. | [reserved](#support-status) |
+| earliest_statement_aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| earliest_transaction_aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 
 
 
@@ -3551,6 +3553,8 @@ Support status: [reserved](#support-status)
 | last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. | [reserved](#support-status) |
 | internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
 | transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. | [reserved](#support-status) |
+| earliest_statement_aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| earliest_transaction_aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -157,6 +157,7 @@ go_library(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slprovider",
         "//pkg/sql/sqlstats",
+        "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/sqlutil",
         "//pkg/sql/stats",

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1236,6 +1236,8 @@ message StatementsResponse {
   // Transactions is transaction-level statistics for the collection of
   // statements in this response.
   repeated ExtendedCollectedTransactionStatistics transactions = 5 [(gogoproto.nullable) = false];
+  google.protobuf.Timestamp earliest_statement_aggregated_ts = 6 [(gogoproto.nullable) = false,  (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp earliest_transaction_aggregated_ts = 7 [(gogoproto.nullable) = false,  (gogoproto.stdtime) = true];
 }
 
 message CombinedStatementsStatsRequest {

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "persistedsqlstats",
     srcs = [
+        "aggregated_ts_reader.go",
         "appStats.go",
         "cluster_settings.go",
         "combined_iterator.go",
@@ -53,6 +54,7 @@ go_library(
 go_test(
     name = "persistedsqlstats_test",
     srcs = [
+        "aggregated_ts_reader_test.go",
         "bench_test.go",
         "compaction_test.go",
         "controller_test.go",
@@ -80,6 +82,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/systemschema",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats",

--- a/pkg/sql/sqlstats/persistedsqlstats/aggregated_ts_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/aggregated_ts_reader.go
@@ -1,0 +1,95 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package persistedsqlstats
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+)
+
+// GetEarliestStatementAggregatedTs returns the earliest aggregated timestamp
+// among statement statistics
+func (s *PersistedSQLStats) GetEarliestStatementAggregatedTs(
+	ctx context.Context,
+) (time.Time, error) {
+	return s.getEarliestAggregatedTs(ctx, "system.statement_statistics", systemschema.StmtStatsHashColumnName)
+}
+
+// GetEarliestTransactionAggregatedTs returns the earliest aggregated timestamp
+// among transaction statistics
+func (s *PersistedSQLStats) GetEarliestTransactionAggregatedTs(
+	ctx context.Context,
+) (time.Time, error) {
+	return s.getEarliestAggregatedTs(ctx, "system.transaction_statistics", systemschema.TxnStatsHashColumnName)
+}
+
+func (s *PersistedSQLStats) getEarliestAggregatedTs(
+	ctx context.Context, tableName, hashColumnName string,
+) (time.Time, error) {
+	var earliestAggregatedTs time.Time
+
+	for shardIdx := int64(0); shardIdx < systemschema.SQLStatsHashShardBucketCount; shardIdx++ {
+		stmt := s.getStatementForEarliestAggregatedTs(tableName, hashColumnName)
+		row, err := s.cfg.InternalExecutor.QueryRowEx(ctx, "get-earliest-aggregated-ts", nil,
+			sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+			stmt,
+			shardIdx,
+		)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if row != nil {
+			aggregatedTs := tree.MustBeDTimestampTZ(row[0]).Time
+			if !aggregatedTs.IsZero() &&
+				(earliestAggregatedTs.IsZero() || aggregatedTs.Before(earliestAggregatedTs)) {
+				earliestAggregatedTs = aggregatedTs
+			}
+		}
+	}
+
+	if earliestAggregatedTs.IsZero() {
+		// When the table is empty, return what the next aggregatedTs would be.
+		earliestAggregatedTs = s.computeAggregatedTs()
+	}
+
+	return earliestAggregatedTs, nil
+}
+
+func (s *PersistedSQLStats) getStatementForEarliestAggregatedTs(
+	tableName, hashColumnName string,
+) string {
+	// [1]: table name
+	// [2]: AOST clause
+	// [3]: hash column name
+	const stmt = `
+		SELECT aggregated_ts
+		FROM %[1]s %[2]s
+		WHERE %[3]s = $1
+		ORDER BY aggregated_ts
+		LIMIT 1;
+	`
+	followerReadClause := "AS OF SYSTEM TIME follower_read_timestamp()"
+	if s.cfg.Knobs != nil {
+		followerReadClause = s.cfg.Knobs.AOSTClause
+	}
+
+	return fmt.Sprintf(stmt,
+		tableName,
+		followerReadClause,
+		hashColumnName,
+	)
+}

--- a/pkg/sql/sqlstats/persistedsqlstats/aggregated_ts_reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/aggregated_ts_reader_test.go
@@ -1,0 +1,195 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package persistedsqlstats_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+type earliestAggTsTestCase struct {
+	testFn             func(context.Context) (time.Time, error)
+	tableName          string
+	runWithExplicitTxn bool
+}
+
+func TestScanEarliestAggregatedTs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	baseTime := timeutil.Now()
+	aggInterval := time.Hour
+	// Chosen to ensure a different truncated aggTs.
+	advancementInterval := time.Hour * 2
+
+	fakeTime := stubTime{
+		aggInterval: aggInterval,
+	}
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: &sqlstats.TestingKnobs{
+				StubTimeNow: fakeTime.Now,
+			},
+		},
+	})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlConn := sqlutils.MakeSQLRunner(db)
+
+	var earliestAggTsTestCases = []earliestAggTsTestCase{
+		{
+			testFn:             sqlStats.GetEarliestStatementAggregatedTs,
+			tableName:          "system.statement_statistics",
+			runWithExplicitTxn: false,
+		},
+		{
+			testFn:             sqlStats.GetEarliestTransactionAggregatedTs,
+			tableName:          "system.transaction_statistics",
+			runWithExplicitTxn: true,
+		},
+	}
+
+	for _, tc := range earliestAggTsTestCases {
+		sqlConn.Exec(t, "SELECT crdb_internal.reset_sql_stats()")
+
+		fakeTime.setTime(baseTime)
+
+		truncatedBaseTime := baseTime.Truncate(aggInterval)
+
+		t.Run(fmt.Sprintf("%s empty table", tc.tableName), func(t *testing.T) {
+			// Generate un-flushed stats with a distribution of hash shard values.
+			// There should also be un-flushed stats from internal queries.
+			runStatements(t, sqlConn, systemschema.SQLStatsHashShardBucketCount*2, tc.runWithExplicitTxn)
+
+			verifyTableEmpty(t, sqlConn, tc.tableName)
+
+			earliestAggTs, err := tc.testFn(ctx)
+			require.NoError(t, err)
+			require.Equal(t, truncatedBaseTime, earliestAggTs)
+		})
+
+		t.Run(fmt.Sprintf("%s populated table", tc.tableName), func(t *testing.T) {
+			// Flush the stats at baseTime.
+			sqlStats.Flush(ctx)
+
+			// The implementation of the tested function finds the earliest aggregated ts
+			// on per-shard basis.
+			// We want to test that the function does check all shards. One proxy for this
+			// is to set up our test such that the expected earliest aggregated ts is not
+			// found for all shard values.
+			// Thus, run and flush one single statement/transaction at the earliest time.
+			beforeBaseTime := baseTime.Add(-advancementInterval)
+			fakeTime.setTime(beforeBaseTime)
+			truncatedBeforeBaseTime := beforeBaseTime.Truncate(aggInterval)
+			runStatements(t, sqlConn, 1 /* numStatements */, tc.runWithExplicitTxn)
+			sqlStats.Flush(ctx)
+
+			// Run and flush stats at a later time.
+			afterBaseTime := baseTime.Add(advancementInterval)
+			fakeTime.setTime(afterBaseTime)
+			runStatements(t, sqlConn, systemschema.SQLStatsHashShardBucketCount*2, tc.runWithExplicitTxn)
+			sqlStats.Flush(ctx)
+
+			verifyDistinctAggregatedTs(
+				t, sqlConn, tc.tableName, []time.Time{truncatedBeforeBaseTime, truncatedBaseTime, afterBaseTime.Truncate(aggInterval)},
+			)
+			verifyNotAllShardValuesHaveExpectedEarliestAggTs(t, sqlConn, tc.tableName, truncatedBeforeBaseTime)
+
+			earliestAggTs, err := tc.testFn(ctx)
+			require.NoError(t, err)
+			require.Equal(t, truncatedBeforeBaseTime, earliestAggTs)
+		})
+	}
+}
+
+func runStatements(
+	t *testing.T, sqlConn *sqlutils.SQLRunner, numStatements int, withExplicitTxn bool,
+) {
+	for i := 1; i < numStatements+1; i++ {
+		// Generate statements with unique fingerprints,
+		// so that they have different hash shard values
+		var ones []string
+		for j := 0; j < i; j++ {
+			ones = append(ones, "1")
+		}
+		stmt := fmt.Sprintf("SELECT %[1]s", strings.Join(ones, ", "))
+		if withExplicitTxn {
+			stmt = fmt.Sprintf("BEGIN; %[1]s; COMMIT;", stmt)
+		}
+		sqlConn.Exec(t, stmt)
+	}
+}
+
+func verifyTableEmpty(t *testing.T, sqlConn *sqlutils.SQLRunner, tableName string) {
+	stmt := fmt.Sprintf(`SELECT count(*) FROM %[1]s`, tableName)
+	sqlConn.CheckQueryResults(
+		t,
+		stmt,
+		[][]string{{`0`}},
+	)
+}
+
+func verifyDistinctAggregatedTs(
+	t *testing.T,
+	sqlConn *sqlutils.SQLRunner,
+	tableName string,
+	sortedExpectedAggregatedTs []time.Time,
+) {
+	var sortedExpectedAggregatedTsStrings [][]string
+	for _, aggregatedTs := range sortedExpectedAggregatedTs {
+		sortedExpectedAggregatedTsStrings = append(sortedExpectedAggregatedTsStrings,
+			[]string{aggregatedTs.String()})
+	}
+
+	// [1]: table name
+	stmt := fmt.Sprintf(`SELECT DISTINCT aggregated_ts FROM %[1]s ORDER BY aggregated_ts`,
+		tableName,
+	)
+	sqlConn.CheckQueryResults(
+		t,
+		stmt,
+		sortedExpectedAggregatedTsStrings,
+	)
+}
+
+func verifyNotAllShardValuesHaveExpectedEarliestAggTs(
+	t *testing.T, sqlConn *sqlutils.SQLRunner, tableName string, expectedEarliestAggTs time.Time,
+) {
+	// In our setup, we only run one statement/transaction at the earliest time.
+	// This sets up our test such that the expected earliest aggregated ts is not
+	// found for all shard values.
+	// However, due to statistics generated by internal queries there is a risk
+	// generating additional statistics. This function runs a stricter test to
+	// verify that this expectation still holds.
+	stmt := fmt.Sprintf(`SELECT count(*) FROM %[1]s WHERE aggregated_ts = $1::TIMESTAMP`,
+		tableName,
+	)
+	row := sqlConn.QueryRow(t, stmt, expectedEarliestAggTs)
+	var count int
+	row.Scan(&count)
+	require.Less(t, count, systemschema.SQLStatsHashShardBucketCount)
+}


### PR DESCRIPTION
Todo:
- Modify this PR to filter out app internal, and add a test that this matches the real code.
- Move `GetEarliestStatementAggregatedTs` to be on the `sqlstats.Provider` interface

Partially fixes #74519

This commit adds the earliest aggregated ts for statement statistics, and for
transaction statistics, to the combined statement stats endpoint. This is done
in anticipation of future UI changes to surface this to users.

Release note (api change): `earliestStatementAggregatedTs` and
`earliestTransactionAggregatedTs` were added to `_status/statements`, providing
the earliest aggregatedTs for statement and transaction statistics.