### PR TITLE
kvstreamer: fix potential deadlock

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/budget.go
+++ b/pkg/kv/kvclient/kvstreamer/budget.go
@@ -27,6 +27,8 @@ import (
 // the budget provides blocking (via waitCh) until it gets out of debt.
 type budget struct {
 	mu struct {
+		// If the Streamer's mutex also needs to be locked, the budget's mutex
+		// must be acquired first.
 		syncutil.Mutex
 		// acc represents the current reservation of this budget against the
 		// root memory pool.

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -220,6 +220,8 @@ type Streamer struct {
 	waitForResults chan struct{}
 
 	mu struct {
+		// If the budget's mutex also needs to be locked, the budget's mutex
+		// must be acquired first.
 		syncutil.Mutex
 
 		avgResponseEstimator avgResponseEstimator
@@ -391,13 +393,22 @@ func (s *Streamer) Enqueue(
 	// TODO(yuzefovich): we might want to have more fine-grained lock
 	// acquisitions once pipelining is implemented.
 	s.mu.Lock()
+	locked := true
 	defer func() {
-		if retErr != nil && s.mu.err == nil {
-			// Set the error so that mainLoop of the worker coordinator exits
-			// as soon as possible, without issuing any more requests.
-			s.mu.err = retErr
+		if retErr != nil {
+			if !locked {
+				s.mu.Lock()
+				locked = true
+			}
+			if s.mu.err == nil {
+				// Set the error so that mainLoop of the worker coordinator
+				// exits as soon as possible, without issuing any more requests.
+				s.mu.err = retErr
+			}
 		}
-		s.mu.Unlock()
+		if locked {
+			s.mu.Unlock()
+		}
 	}()
 
 	if enqueueKeys != nil && len(enqueueKeys) != len(reqs) {
@@ -502,6 +513,12 @@ func (s *Streamer) Enqueue(
 			return err
 		}
 	}
+
+	// Release the Streamer's mutex so that there is no overlap with the
+	// budget's mutex - the budget's mutex needs to be acquired first in order
+	// to eliminate a potential deadlock.
+	s.mu.Unlock()
+	locked = false
 
 	// Account for the memory used by all the requests. We allow the budget to
 	// go into debt iff a single request was enqueued. This is needed to support


### PR DESCRIPTION
We have two different locks in the `Streamer` infrastructure: one is for
the `Streamer` itself and another one for the `budget`. Previously,
there was no contract about which mutex needs to be acquired first which
led to the deadlock detector thinking that there is a potential deadlock
situation. This is now fixed by requiring that the `budget`'s mutex is
acquired first and by releasing the `Streamer`'s mutex in `Enqueue`
early in order to not overlap with the interaction with the `budget`.

I believe that it was a false positive (i.e. the deadlock cannot
actually occur) because without the support of pipelining, `Enqueue`
calls and asynchronous requests evaluation never overlap in time.
Still, it's good to fix the order of mutex acquisitions.

Fixes: #74782.
Fixes: #74785.
Fixes: #74787.
Fixes: #74788.
Fixes: #74789.
Fixes: #74790.
Fixes: #74791.

Release note: None