### PR TITLE
sql: Make Collection.getSchemaByID consistent with Collection.getTableByID

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -277,10 +277,7 @@ func getSchemaByName(
 			AvoidLeased:    avoidLeased,
 			AvoidSynthetic: avoidSynthetic,
 		})
-		// Deal with the fact that ByID retrieval always uses required and the
-		// logic here never returns an error if the descriptor does not exist.
-		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
-			errors.Is(err, catalog.ErrDescriptorDropped) {
+		if errors.Is(err, catalog.ErrDescriptorDropped) {
 			err = nil
 		}
 		return sc != nil, sc, err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -728,9 +728,9 @@ func (p *planner) getQualifiedTableName(
 			AvoidLeased:    true,
 		})
 	switch {
-	case err == nil:
+	case scDesc != nil:
 		schemaName = tree.Name(scDesc.GetName())
-	case desc.IsTemporary() && errors.Is(err, catalog.ErrDescriptorNotFound):
+	case desc.IsTemporary() && scDesc == nil:
 		// We've lost track of the session which owned this schema, but we
 		// can come up with a name that is also going to be unique and
 		// informative and looks like a pg_temp_<session_id> name.


### PR DESCRIPTION
getSchemaByID now respects SchemaLookupFlags.Required and returns
sqlerrors.NewUndefinedSchemaError instead of catalog.ErrDescriptorNotFound

Release note: None

`getTableByID` for reference
```
func (tc *Collection) getTableByID(
	ctx context.Context, txn *kv.Txn, tableID descpb.ID, flags tree.ObjectLookupFlags,
) (catalog.TableDescriptor, error) {
	desc, err := tc.getDescriptorByID(ctx, txn, tableID, flags.CommonLookupFlags)
	if err != nil {
		if errors.Is(err, catalog.ErrDescriptorNotFound) {
			return nil, sqlerrors.NewUndefinedRelationError(
				&tree.TableRef{TableID: int64(tableID)})
		}
		return nil, err
	}
	table, ok := desc.(catalog.TableDescriptor)
	if !ok {
		return nil, sqlerrors.NewUndefinedRelationError(
			&tree.TableRef{TableID: int64(tableID)})
	}
	hydrated, err := tc.hydrateTypesInTableDesc(ctx, txn, table)
	if err != nil {
		return nil, err
	}
	return hydrated, nil
}
```