### PR TITLE
Tag test rules that fail with TestNoLinkForbidden

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "vec_test.go",
     ],
     embed = [":coldata"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldatatestutils",
         "//pkg/sql/colconv",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -138,6 +138,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":with-mocks"],  # keep
+    tags = ["no-remote"],
     deps = [
         "//build/bazelutil:noop",
         "//pkg/base",

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -159,6 +159,7 @@ go_test(
         "version_test.go",
     ],
     embed = [":with-mocks"],  # keep
+    tags = ["no-remote"],
     deps = [
         "//pkg/cli/exit",
         "//pkg/kv/kvserver/concurrency/lock",

--- a/pkg/server/diagnostics/BUILD.bazel
+++ b/pkg/server/diagnostics/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "update_checker_test.go",
     ],
     embed = [":diagnostics"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/base",
         "//pkg/build",

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "table_col_set_test.go",
     ],
     embed = [":catalog"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/dbdesc",

--- a/pkg/sql/colexec/colexecagg/BUILD.bazel
+++ b/pkg/sql/colexec/colexecagg/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     name = "colexecagg_test",
     srcs = ["dep_test.go"],
     embed = [":colexecagg"],
+    tags = ["no-remote"],
     deps = ["//pkg/testutils/buildutil"],
 )
 

--- a/pkg/sql/colexec/colexecargs/BUILD.bazel
+++ b/pkg/sql/colexec/colexecargs/BUILD.bazel
@@ -29,5 +29,6 @@ go_test(
     name = "colexecargs_test",
     srcs = ["dep_test.go"],
     embed = [":colexecargs"],
+    tags = ["no-remote"],
     deps = ["//pkg/testutils/buildutil"],
 )

--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "ordinality_test.go",
         "simple_project_test.go",
     ],
+    tags = ["no-remote"],
     deps = [
         ":colexecbase",
         "//pkg/col/coldata",

--- a/pkg/sql/colexec/colexeccmp/BUILD.bazel
+++ b/pkg/sql/colexec/colexeccmp/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     name = "colexeccmp_test",
     srcs = ["dep_test.go"],
     embed = [":colexeccmp"],
+    tags = ["no-remote"],
     deps = ["//pkg/testutils/buildutil"],
 )
 

--- a/pkg/sql/colexec/colexechash/BUILD.bazel
+++ b/pkg/sql/colexec/colexechash/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "main_test.go",
     ],
     embed = [":colexechash"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "mergejoiner_test.go",
     ],
     embed = [":colexecjoin"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecproj/BUILD.bazel
+++ b/pkg/sql/colexec/colexecproj/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "projection_ops_test.go",
     ],
     embed = [":colexecproj"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecsel/BUILD.bazel
+++ b/pkg/sql/colexec/colexecsel/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "selection_ops_test.go",
     ],
     embed = [":colexecsel"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecspan/BUILD.bazel
+++ b/pkg/sql/colexec/colexecspan/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "span_assembler_test.go",
     ],
     embed = [":colexecspan"],  # keep
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexecutils/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "spilling_queue_test.go",
     ],
     embed = [":colexecutils"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexec/colexecwindow/BUILD.bazel
+++ b/pkg/sql/colexec/colexecwindow/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "window_functions_test.go",
     ],
     embed = [":colexecwindow"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",

--- a/pkg/sql/colexecop/BUILD.bazel
+++ b/pkg/sql/colexecop/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     size = "small",
     srcs = ["dep_test.go"],
     embed = [":colexecop"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/testutils/buildutil",
         "//pkg/util/leaktest",

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "vectorized_panic_propagation_test.go",
     ],
     embed = [":colflow"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/base",
         "//pkg/col/coldata",

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "main_test.go",
     ],
     embed = [":execinfra"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "utils_test.go",
     ],
     embed = [":flowinfra"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/base",
         "//pkg/gossip",

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -133,6 +133,7 @@ go_test(
         "zigzagjoiner_test.go",
     ],
     embed = [":rowexec"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/base",
         "//pkg/gossip",

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "routers_test.go",
     ],
     embed = [":rowflow"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/base",
         "//pkg/keys",

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "statement_diagnostics_test.go",
     ],
     embed = [":stmtdiagnostics"],
+    tags = ["no-remote"],
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
```
--- FAIL: TestNoLinkForbidden (0.01s)
    build.go:56: cannot find package "github.com/cockroachdb/cockroach/pkg/roachpb" in any of:
        	GOROOT/src/github.com/cockroachdb/cockroach/pkg/roachpb (from $GOROOT)
        	/go/src/github.com/cockroachdb/cockroach/pkg/roachpb (from $GOPATH)
```

This is a workaround for #74176.

Release note: None