### PR TITLE
bulk,kv: create initial splits in imports and backfills

### DIFF
--- a/pkg/ccl/importccl/import_processor.go
+++ b/pkg/ccl/importccl/import_processor.go
@@ -351,14 +351,15 @@ func ingestKvs(
 	minBufferSize, maxBufferSize, stepSize := importBufferConfigSizes(flowCtx.Cfg.Settings,
 		true /* isPKAdder */)
 	pkIndexAdder, err := flowCtx.Cfg.BulkAdder(ctx, flowCtx.Cfg.DB, writeTS, kvserverbase.BulkAdderOptions{
-		Name:                   "pkAdder",
-		DisallowShadowingBelow: writeTS,
-		SkipDuplicates:         true,
-		MinBufferSize:          minBufferSize,
-		MaxBufferSize:          maxBufferSize,
-		StepBufferSize:         stepSize,
-		SSTSize:                flushSize,
-		WriteAtRequestTime:     writeAtRequestTime,
+		Name:                     "pkAdder",
+		DisallowShadowingBelow:   writeTS,
+		SkipDuplicates:           true,
+		MinBufferSize:            minBufferSize,
+		MaxBufferSize:            maxBufferSize,
+		StepBufferSize:           stepSize,
+		SSTSize:                  flushSize,
+		InitialSplitsIfUnordered: int(spec.InitialSplits),
+		WriteAtRequestTime:       writeAtRequestTime,
 	})
 	if err != nil {
 		return nil, err
@@ -368,14 +369,15 @@ func ingestKvs(
 	minBufferSize, maxBufferSize, stepSize = importBufferConfigSizes(flowCtx.Cfg.Settings,
 		false /* isPKAdder */)
 	indexAdder, err := flowCtx.Cfg.BulkAdder(ctx, flowCtx.Cfg.DB, writeTS, kvserverbase.BulkAdderOptions{
-		Name:                   "indexAdder",
-		DisallowShadowingBelow: writeTS,
-		SkipDuplicates:         true,
-		MinBufferSize:          minBufferSize,
-		MaxBufferSize:          maxBufferSize,
-		StepBufferSize:         stepSize,
-		SSTSize:                flushSize,
-		WriteAtRequestTime:     writeAtRequestTime,
+		Name:                     "indexAdder",
+		DisallowShadowingBelow:   writeTS,
+		SkipDuplicates:           true,
+		MinBufferSize:            minBufferSize,
+		MaxBufferSize:            maxBufferSize,
+		StepBufferSize:           stepSize,
+		SSTSize:                  flushSize,
+		InitialSplitsIfUnordered: int(spec.InitialSplits),
+		WriteAtRequestTime:       writeAtRequestTime,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/importccl/import_processor_planning.go
+++ b/pkg/ccl/importccl/import_processor_planning.go
@@ -264,6 +264,7 @@ func makeImportReaderSpecs(
 				ResumePos:             make(map[int32]int64),
 				UserProto:             user.EncodeProto(),
 				DatabasePrimaryRegion: details.DatabasePrimaryRegion,
+				InitialSplits:         int32(len(sqlInstanceIDs)),
 			}
 			inputSpecs = append(inputSpecs, spec)
 		}

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -668,7 +668,9 @@ func (b *Batch) adminMerge(key interface{}) {
 
 // adminSplit is only exported on DB. It is here for symmetry with the
 // other operations.
-func (b *Batch) adminSplit(splitKeyIn interface{}, expirationTime hlc.Timestamp) {
+func (b *Batch) adminSplit(
+	splitKeyIn interface{}, expirationTime hlc.Timestamp, predicateKeys []roachpb.Key,
+) {
 	splitKey, err := marshalKey(splitKeyIn)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
@@ -680,6 +682,7 @@ func (b *Batch) adminSplit(splitKeyIn interface{}, expirationTime hlc.Timestamp)
 		},
 		SplitKey:       splitKey,
 		ExpirationTime: expirationTime,
+		PredicateKeys:  predicateKeys,
 	}
 	b.appendReqs(req)
 	b.initResult(1, 0, notRaw, nil)

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -13,6 +13,7 @@ package bulk
 import (
 	"context"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
@@ -308,8 +309,14 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 
 	for i := targetSize; i < b.curBuf.Len(); i += targetSize {
 		k := b.curBuf.Key(i)
+		prev := b.curBuf.Key(i - targetSize)
 		log.VEventf(ctx, 1, "splitting at key %d / %d: %s", i, b.curBuf.Len(), k)
-		if err := b.sink.db.SplitAndScatter(ctx, k, hour); err != nil {
+		if err := b.sink.db.SplitAndScatter(ctx, k, hour, prev); err != nil {
+			// TODO(dt): a typed error would be nice here.
+			if strings.Contains(err.Error(), "predicate") {
+				log.VEventf(ctx, 1, "split at %s rejected, had previously split and no longer included %s", k, prev)
+				continue
+			}
 			return err
 		}
 	}

--- a/pkg/kv/bulk/kv_buf.go
+++ b/pkg/kv/bulk/kv_buf.go
@@ -102,6 +102,9 @@ func (b *kvBuf) Swap(i, j int) {
 }
 
 func (b *kvBuf) Reset() {
+	// We could reset sorted to true here but in practice, if we saw any unsorted
+	// keys before, the rest are almost always unsorted as well, so we don't even
+	// bother checking.
 	b.slab = b.slab[:0]
 	b.entries = b.entries[:0]
 	b.MemSize = 0

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -352,7 +352,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 				// NB: Passing 'hour' here is technically illegal until 19.2 is
 				// active, but the value will be ignored before that, and we don't
 				// have access to the cluster version here.
-				if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
+				if err := b.db.SplitAndScatter(ctx, splitAt, hour, nil); err != nil {
 					log.Warningf(ctx, "%v", err)
 				}
 			}
@@ -404,7 +404,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 					// NB: Passing 'hour' here is technically illegal until 19.2 is
 					// active, but the value will be ignored before that, and we don't
 					// have access to the cluster version here.
-					if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
+					if err := b.db.SplitAndScatter(ctx, splitAt, hour, nil); err != nil {
 						log.Warningf(ctx, "failed to split and scatter during ingest: %+v", err)
 					}
 					b.flushCounts.splitWait += timeutil.Since(beforeSplit)
@@ -460,7 +460,9 @@ type SSTSender interface {
 		batchTs hlc.Timestamp,
 	) (hlc.Timestamp, error)
 
-	SplitAndScatter(ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp) error
+	SplitAndScatter(
+		ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp, predicateKeys ...roachpb.Key,
+	) error
 
 	Clock() *hlc.Clock
 }

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -572,20 +572,26 @@ func (db *DB) AdminMerge(ctx context.Context, key interface{}) error {
 //
 // The keys can be either byte slices or a strings.
 func (db *DB) AdminSplit(
-	ctx context.Context, splitKey interface{}, expirationTime hlc.Timestamp,
+	ctx context.Context,
+	splitKey interface{},
+	expirationTime hlc.Timestamp,
+	predicateKeys ...roachpb.Key,
 ) error {
 	b := &Batch{}
-	b.adminSplit(splitKey, expirationTime)
+	b.adminSplit(splitKey, expirationTime, predicateKeys)
 	return getOneErr(db.Run(ctx, b), b)
 }
 
 // SplitAndScatter is a helper that wraps AdminSplit + AdminScatter.
 func (db *DB) SplitAndScatter(
-	ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp,
+	ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp, predicateKeys ...roachpb.Key,
 ) error {
-	if err := db.AdminSplit(ctx, key, expirationTime); err != nil {
+	b := &Batch{}
+	b.adminSplit(key, expirationTime, predicateKeys)
+	if err := getOneErr(db.Run(ctx, b), b); err != nil {
 		return err
 	}
+
 	scatterReq := &roachpb.AdminScatterRequest{
 		RequestHeader:   roachpb.RequestHeaderFromSpan(roachpb.Span{Key: key, EndKey: key.Next()}),
 		RandomizeLeases: true,

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -71,6 +71,15 @@ type BulkAdderOptions struct {
 	// WriteAtRequestTime is used to set the corresponding field when sending
 	// constructed SSTables to AddSSTable. See roachpb.AddSSTableRequest.
 	WriteAtRequestTime bool
+
+	// InitialSplitsIfUnordered specifies a number of splits to make before the
+	// first flush of the buffer if the contents of that buffer were unsorted.
+	// Being unsorted suggests the remaining input is likely unsorted as well and
+	// thus future flushes and flushes on other nodes will overlap, so we want to
+	// pre-split the target span now before we start filling it, using the keys in
+	// the first buffer to pick split points in the hope it is a representative
+	// sample of the overall input.
+	InitialSplitsIfUnordered int
 }
 
 // DisableExplicitSplits can be returned by a SplitAndScatterAfter function to

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -344,6 +344,14 @@ func (r *Replica) adminSplitWithDescriptor(
 			return reply, errors.Errorf("requested split key %s out of bounds of %s", args.SplitKey, r)
 		}
 
+		// If predicate keys are specified, make sure they are contained by this
+		// range as well.
+		for _, k := range args.PredicateKeys {
+			if !kvserverbase.ContainsKey(desc, k) {
+				return reply, errors.Errorf("requested predicate key %s out of bounds of %s", k, r)
+			}
+		}
+
 		var err error
 		splitKey, err = keys.Addr(foundSplitKey)
 		if err != nil {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -763,6 +763,11 @@ message AdminSplitRequest {
   bytes split_key = 2 [(gogoproto.casttype) = "Key"];
   reserved 3;
   util.hlc.Timestamp expiration_time = 4 [(gogoproto.nullable) = false];
+
+  // PredicateKeys specifies keys which if not contained within the range should
+  // cause the split to be rejected. This can be used by a caller to effectively
+  // send a "conditional split" request, i.e. a split if not already split.
+  repeated bytes predicate_keys = 5;
 }
 
 // An AdminSplitResponse is the return value from the AdminSplit()

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -767,7 +767,7 @@ message AdminSplitRequest {
   // PredicateKeys specifies keys which if not contained within the range should
   // cause the split to be rejected. This can be used by a caller to effectively
   // send a "conditional split" request, i.e. a split if not already split.
-  repeated bytes predicate_keys = 5;
+  repeated bytes predicate_keys = 5 [(gogoproto.casttype) = "Key"];
 }
 
 // An AdminSplitResponse is the return value from the AdminSplit()

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -65,6 +65,7 @@ func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
 	for i, sp := range spanPartitions {
 		ib := &execinfrapb.BackfillerSpec{}
 		*ib = spec
+		ib.InitialSplits = int32(len(spanPartitions))
 		ib.Spans = sp.Spans
 
 		proc := physicalplan.Processor{

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -72,6 +72,8 @@ message BackfillerSpec {
   repeated uint32 indexes_to_backfill = 8 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.IndexID"];
 
   reserved 6;
+
+  optional int32 initial_splits = 11 [(gogoproto.nullable) = false];
 }
 
 // JobProgress identifies the job to report progress on. This reporting
@@ -152,7 +154,9 @@ message ReadImportDataSpec {
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb.RegionName"
   ];
 
-  // NEXTID: 18
+  optional int32 initial_splits = 18 [(gogoproto.nullable) = false];
+
+  // NEXTID: 19
 }
 
 message StreamIngestionDataSpec {

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -193,12 +193,13 @@ func (ib *indexBackfiller) ingestIndexEntries(
 	sstSize := func() int64 { return backillerSSTSize.Get(&ib.flowCtx.Cfg.Settings.SV) }
 	stepSize := backfillerBufferIncrementSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	opts := kvserverbase.BulkAdderOptions{
-		SSTSize:        sstSize,
-		MinBufferSize:  minBufferSize,
-		MaxBufferSize:  maxBufferSize,
-		StepBufferSize: stepSize,
-		SkipDuplicates: ib.ContainsInvertedIndex(),
-		BatchTimestamp: ib.spec.ReadAsOf,
+		SSTSize:                  sstSize,
+		MinBufferSize:            minBufferSize,
+		MaxBufferSize:            maxBufferSize,
+		StepBufferSize:           stepSize,
+		SkipDuplicates:           ib.ContainsInvertedIndex(),
+		BatchTimestamp:           ib.spec.ReadAsOf,
+		InitialSplitsIfUnordered: int(ib.spec.InitialSplits),
 	}
 	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.WriteAsOf, opts)
 	if err != nil {


### PR DESCRIPTION
It has been observed that during a backfill or import, the split-as-we-go behavior used by the sst batcher, where it only explicitly splits and scatters after sending some amount of data all to one range, does not send any splits in the steady state when importing out of order data: since it is out of order, after chunking it by destination range, no one chunk is large enough to be considered filling that range enough to cause us to send a split. Of course, the range may fill on its own, as many processors send it small chunks over and over and those add up, but no one processor knows when that happens, so we simply leave it up to the range to split itself when it is full as it would in any other heavy write-rate, non-bulk ingestion case.

However, we've seen this lead to hotspots during bulk ingestion. Until the range becomes full and decides to split, it can be a bottleneck as many processors send it data at once.  Existing mechanisms for kv-driven load-based splitting are not tuned for ingestion workloads. When it does decide to split and rebalance, that is a more expensive operation, as we're now needing to read, move and ingest half of that *full* range that we just spend so much work sending data to and ingesting, all while still being sent more ingestion load.

Ideally, we'd prefer to split the span before we start ingesting, both to spread ingestion load over our available capacity better, and to reduce how much ingested data it will need to shuffle if we waited to split and scatter only once a range filled. By scattering first, we'll just ingest directly to the right place initially. However a challenge in doing this is that in many cases, we don't know what data we'll be ingesting until we start reading input and producing it -- it could be that we're working off of a key-ordered CSV, or it could be that we have a uniform random distribution. In some cases, such as an index backfill, we may be able to use some external information like a SQL statistics or a sampling scan of the table to derive a good partitioning, but in others, like IMPORTs or view materialization, we have no way to know what the data will be until we start producing it.

This change tries to do a bit better than not presplitting at all though, by instead using the first buffer's worth of data, if it was read out of sorted order, as if it is a representative sample of the rest of the data to come and then generating splits from it and splitting and scatter the target spans using those before proceeding to flush. If this buffer turns out not to be a good sample after all, this is no worse than before, where we pre-split not at all. If the input data was sorted, this step is unnecessary as we'll just split as we go, after each range we fill and scatter the empty remainder before moving to fill it, as we already do today.

Release note (performance improvement): IMPORTs and Index Creation attempt to better balance their expected data between nodes before ingesting data.