### PR TITLE
ui: add ability to cancel statement diagnostics to the frontend

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3687,7 +3687,7 @@ Support status: [reserved](#support-status)
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| statement_fingerprint | [string](#cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest-string) |  |  | [reserved](#support-status) |
+| request_id | [int64](#cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest-int64) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1286,7 +1286,7 @@ message CreateStatementDiagnosticsReportResponse {
 }
 
 message CancelStatementDiagnosticsReportRequest {
-  string statement_fingerprint = 1;
+  int64 request_id = 1 [(gogoproto.customname) = "RequestID"];
 }
 
 message CancelStatementDiagnosticsReportResponse {

--- a/pkg/server/statement_diagnostics_requests.go
+++ b/pkg/server/statement_diagnostics_requests.go
@@ -106,7 +106,7 @@ func (s *statusServer) CancelStatementDiagnosticsReport(
 	}
 
 	var response serverpb.CancelStatementDiagnosticsReportResponse
-	err := s.stmtDiagnosticsRequester.CancelRequest(ctx, req.StatementFingerprint)
+	err := s.stmtDiagnosticsRequester.CancelRequest(ctx, req.RequestID)
 	if err != nil {
 		response.Canceled = false
 		response.Error = err.Error()

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -396,7 +396,7 @@ type StmtDiagnosticsRequester interface {
 	// CancelRequest updates an entry in system.statement_diagnostics_requests
 	// for tracing a query with the given fingerprint to be expired (thus,
 	// canceling any new tracing for it).
-	CancelRequest(ctx context.Context, stmtFingerprint string) error
+	CancelRequest(ctx context.Context, requestID int64) error
 }
 
 // newStatusServer allocates and returns a statusServer.

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -380,7 +380,7 @@ func (r *Registry) insertRequestInternal(
 }
 
 // CancelRequest is part of the server.StmtDiagnosticsRequester interface.
-func (r *Registry) CancelRequest(ctx context.Context, stmtFingerprint string) error {
+func (r *Registry) CancelRequest(ctx context.Context, requestID int64) error {
 	g, err := r.gossip.OptionalErr(48274)
 	if err != nil {
 		return err
@@ -402,19 +402,21 @@ func (r *Registry) CancelRequest(ctx context.Context, stmtFingerprint string) er
 		// request as "expired" by setting `expires_at` into the past. This will
 		// allow any queries that are currently being traced for this request to
 		// write their collected bundles.
-		fmt.Sprintf("UPDATE system.statement_diagnostics_requests SET expires_at = '1970-01-01' "+
-			"WHERE completed = false AND statement_fingerprint = '%s' "+
-			"AND (expires_at IS NULL OR expires_at > now()) RETURNING id;", stmtFingerprint),
+		"UPDATE system.statement_diagnostics_requests SET expires_at = '1970-01-01' "+
+			"WHERE completed = false AND id = $1 "+
+			"AND (expires_at IS NULL OR expires_at > now()) RETURNING id;",
+		requestID,
 	)
 	if err != nil {
 		return err
 	}
+
 	if row == nil {
 		// There is no pending diagnostics request with the given fingerprint.
-		return errors.Newf("no pending request found for the fingerprint: %s", stmtFingerprint)
+		return errors.Newf("no pending request found for the fingerprint: %s", requestID)
 	}
-	reqID := RequestID(tree.MustBeDInt(row[0]))
 
+	reqID := RequestID(requestID)
 	r.cancelRequest(reqID)
 
 	// Notify all the other nodes that this request has been canceled.

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -202,7 +202,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 	// Verify that an error is returned when attempting to cancel non-existent
 	// request.
 	t.Run("cancel non-existent request", func(t *testing.T) {
-		require.NotNil(t, registry.CancelRequest(ctx, "foo"))
+		require.NotNil(t, registry.CancelRequest(ctx, 123456789))
 	})
 
 	// Verify that if a request (either conditional or unconditional, w/ or w/o
@@ -227,7 +227,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 							require.NoError(t, err)
 							checkNotCompleted(reqID)
 
-							err = registry.CancelRequest(ctx, fprint)
+							err = registry.CancelRequest(ctx, reqID)
 							require.NoError(t, err)
 							checkNotCompleted(reqID)
 
@@ -271,7 +271,7 @@ func TestDiagnosticsRequest(t *testing.T) {
 					go func() {
 						defer wg.Done()
 						<-waitCh
-						err := registry.CancelRequest(ctx, fprint)
+						err := registry.CancelRequest(ctx, reqID)
 						require.NoError(t, err)
 					}()
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -13,9 +13,13 @@ import { fetchData } from "src/api";
 
 const STATEMENT_DIAGNOSTICS_PATH = "/_status/stmtdiagreports";
 const CREATE_STATEMENT_DIAGNOSTICS_REPORT_PATH = "/_status/stmtdiagreports";
+const CANCEL_STATEMENT_DIAGNOSTICS_REPORT_PATH =
+  "/_status/stmtdiagreports/cancel";
 
 type CreateStatementDiagnosticsReportRequestMessage = cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
 type CreateStatementDiagnosticsReportResponseMessage = cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse;
+type CancelStatementDiagnosticsReportRequestMessage = cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
+type CancelStatementDiagnosticsReportResponseMessage = cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse;
 
 export function getStatementDiagnosticsReports(): Promise<
   cockroach.server.serverpb.StatementDiagnosticsReportsResponse
@@ -33,6 +37,17 @@ export function createStatementDiagnosticsReport(
     cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse,
     CREATE_STATEMENT_DIAGNOSTICS_REPORT_PATH,
     cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest,
+    req,
+  );
+}
+
+export function cancelStatementDiagnosticsReport(
+  req: CancelStatementDiagnosticsReportRequestMessage,
+): Promise<CancelStatementDiagnosticsReportResponseMessage> {
+  return fetchData(
+    cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse,
+    CANCEL_STATEMENT_DIAGNOSTICS_REPORT_PATH,
+    cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest,
     req,
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -129,5 +129,27 @@ describe("DiagnosticsView", () => {
         .first();
       assert.isFalse(activateButtonComponent.exists());
     });
+
+    it("Cancel request button shows if diagnostics is requested and waiting query", () => {
+      const diagnosticsRequests: IStatementDiagnosticsReport[] = [
+        generateDiagnosticsRequest({ completed: false }),
+        generateDiagnosticsRequest(),
+      ];
+      wrapper = mount(
+        <TestStoreProvider>
+          <DiagnosticsView
+            activateDiagnosticsRef={activateDiagnosticsRef}
+            statementFingerprint={statementFingerprint}
+            hasData={true}
+            diagnosticsReports={diagnosticsRequests}
+            dismissAlertMessage={() => {}}
+          />
+        </TestStoreProvider>,
+      );
+      const cancelButtonComponent = wrapper
+        .findWhere(n => n.prop("children") === "Cancel request")
+        .first();
+      assert.isTrue(cancelButtonComponent.exists());
+    });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -14,6 +14,7 @@ import moment from "moment";
 import classnames from "classnames/bind";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { Button, Icon } from "@cockroachlabs/ui-components";
+import { Button as CancelButton } from "src/button";
 import { Text, TextTypes } from "src/text";
 import { Table, ColumnsConfig } from "src/table";
 import { SummaryCard } from "src/summaryCard";
@@ -43,6 +44,9 @@ export interface DiagnosticsViewStateProps {
 export interface DiagnosticsViewDispatchProps {
   dismissAlertMessage: () => void;
   onDownloadDiagnosticBundleClick?: (statementFingerprint: string) => void;
+  onDiagnosticCancelRequestClick?: (
+    report: IStatementDiagnosticsReport,
+  ) => void;
   onSortingChange?: (
     name: string,
     columnTitle: string,
@@ -145,7 +149,11 @@ export class DiagnosticsView extends React.Component<
       title: "",
       sorter: false,
       width: "160px",
-      render: ((onDownloadDiagnosticBundleClick: (s: string) => void) => {
+      render: (() => {
+        const {
+          onDownloadDiagnosticBundleClick,
+          onDiagnosticCancelRequestClick,
+        } = this.props;
         return (_text: string, record: IStatementDiagnosticsReport) => {
           if (record.completed) {
             return (
@@ -175,9 +183,24 @@ export class DiagnosticsView extends React.Component<
               </div>
             );
           }
-          return null;
+          return (
+            <div
+              className={cx("crl-statements-diagnostics-view__actions-column")}
+            >
+              <CancelButton
+                size="small"
+                type="secondary"
+                onClick={() =>
+                  onDiagnosticCancelRequestClick &&
+                  onDiagnosticCancelRequestClick(record)
+                }
+              >
+                Cancel request
+              </CancelButton>
+            </div>
+          );
         };
-      })(this.props.onDownloadDiagnosticBundleClick),
+      })(),
     },
   ];
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -72,6 +72,7 @@ import {
   ActivateStatementDiagnosticsModal,
 } from "../statementsDiagnostics";
 type IDuration = google.protobuf.IDuration;
+type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const { TabPane } = Tabs;
 
@@ -150,6 +151,7 @@ export interface StatementDetailsDispatchProps {
   onTabChanged?: (tabName: string) => void;
   onDiagnosticsModalOpen?: (statementFingerprint: string) => void;
   onDiagnosticBundleDownload?: (statementFingerprint?: string) => void;
+  onDiagnosticCancelRequest?: (report: IStatementDiagnosticsReport) => void;
   onSortingChange?: (
     name: string,
     columnTitle: string,
@@ -467,6 +469,7 @@ export class StatementDetails extends React.Component<
       diagnosticsReports,
       dismissStatementDiagnosticsAlertMessage,
       onDiagnosticBundleDownload,
+      onDiagnosticCancelRequest,
       nodeRegions,
       isTenant,
       hasViewActivityRedactedRole,
@@ -833,6 +836,7 @@ export class StatementDetails extends React.Component<
               hasData={hasDiagnosticReports}
               statementFingerprint={statement}
               onDownloadDiagnosticBundleClick={onDiagnosticBundleDownload}
+              onDiagnosticCancelRequestClick={onDiagnosticCancelRequest}
               showDiagnosticsViewLink={
                 this.props.uiConfig.showStatementDiagnosticsLink
               }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -41,9 +41,13 @@ import { actions as nodeLivenessActions } from "../store/liveness";
 import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
 type IDuration = google.protobuf.IDuration;
+type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const CreateStatementDiagnosticsReportRequest =
   cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
+
+const CancelStatementDiagnosticsReportRequest =
+  cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -123,6 +127,22 @@ const mapDispatchToProps = (
         action: "Downloaded",
       }),
     ),
+  onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => {
+    dispatch(
+      statementDiagnosticsActions.cancelReport(
+        new CancelStatementDiagnosticsReportRequest({
+          request_id: report.id,
+        }),
+      ),
+    );
+    dispatch(
+      analyticsActions.track({
+        name: "Statement Diagnostics Clicked",
+        page: "Statement Details",
+        action: "Cancelled",
+      }),
+    );
+  },
   onSortingChange: (tableName, columnName) =>
     dispatch(
       analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
@@ -147,9 +147,11 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
                       className={cx("diagnostic__input__min-latency-time")}
                       disabled={!conditional}
                       value={minExecLatency}
-                      onChange={e =>
-                        setMinExecLatency(parseInt(e.target.value))
-                      }
+                      onChange={e => {
+                        if (parseInt(e.target.value) > 0) {
+                          setMinExecLatency(parseInt(e.target.value));
+                        }
+                      }}
                       size="large"
                     />
                     <Select
@@ -179,7 +181,11 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef(
                 className={cx("diagnostic__input__expires-after-time")}
                 disabled={!expires}
                 value={expiresAfter}
-                onChange={e => setExpiresAfter(parseInt(e.target.value))}
+                onChange={e => {
+                  if (parseInt(e.target.value) > 0) {
+                    setExpiresAfter(parseInt(e.target.value));
+                  }
+                }}
               />
               <div className={cx("diagnostic__checkbox-text")}>minutes</div>
             </div>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -803,7 +803,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onActivateStatementDiagnostics: noop,
   onDiagnosticsModalOpen: noop,
   onSearchComplete: noop,
-  onDiagnosticsReportDownload: noop,
+  onSelectDiagnosticsReportDropdownOption: noop,
   onColumnsChange: noop,
   onSortingChange: noop,
   onFilterChange: noop,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -104,7 +104,9 @@ export interface StatementsPageDispatchProps {
     columnTitle: string,
     ascending: boolean,
   ) => void;
-  onDiagnosticsReportDownload?: (report: IStatementDiagnosticsReport) => void;
+  onSelectDiagnosticsReportDropdownOption?: (
+    report: IStatementDiagnosticsReport,
+  ) => void;
   onFilterChange?: (value: Filters) => void;
   onStatementClick?: (statement: string) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
@@ -484,7 +486,7 @@ export class StatementsPage extends React.Component<
     const { pagination, filters, activeFilters } = this.state;
     const {
       statements,
-      onDiagnosticsReportDownload,
+      onSelectDiagnosticsReportDropdownOption,
       onStatementClick,
       columns: userSelectedColumnsToShow,
       onColumnsChange,
@@ -515,7 +517,7 @@ export class StatementsPage extends React.Component<
       hasViewActivityRedactedRole,
       search,
       this.activateDiagnosticsRef,
-      onDiagnosticsReportDownload,
+      onSelectDiagnosticsReportDropdownOption,
       onStatementClick,
     )
       .filter(c => !(c.name === "regionNodes" && regions.length < 2))

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -271,7 +271,9 @@ export function makeStatementsColumns(
   hasViewActivityRedactedRole: boolean,
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
-  onDiagnosticsDownload?: (report: IStatementDiagnosticsReport) => void,
+  onSelectDiagnosticsReportDropdownOption?: (
+    report: IStatementDiagnosticsReport,
+  ) => void,
   onStatementClick?: (statement: string) => void,
 ): ColumnDescriptor<AggregateStatistics>[] {
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
@@ -292,7 +294,7 @@ export function makeStatementsColumns(
       title: statisticsTableTitles.diagnostics(statType),
       cell: StatementTableCell.diagnostics(
         activateDiagnosticsRef,
-        onDiagnosticsDownload,
+        onSelectDiagnosticsReportDropdownOption,
       ),
       sort: stmt => {
         if (stmt.diagnosticsReports?.length > 0) {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -55,7 +55,7 @@
     margin-left: $spacing-base;
   }
 
-  .download-diagnostics-link {
+  .diagnostic-report-dropdown-option {
     color: inherit;
     text-decoration: none;
     &:hover {

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -34,7 +34,7 @@ type SortingEvent = {
 type StatementDiagnosticEvent = {
   name: "Statement Diagnostics Clicked";
   page: Page;
-  action: "Activated" | "Downloaded";
+  action: "Activated" | "Downloaded" | "Cancelled";
 };
 
 type TabChangedEvent = {

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.reducer.ts
@@ -13,6 +13,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DOMAIN_NAME, noopReducer } from "../utils";
 
 type CreateStatementDiagnosticsReportRequest = cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
+type CancelStatementDiagnosticsReportRequest = cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
 type StatementDiagnosticsReportsResponse = cockroach.server.serverpb.StatementDiagnosticsReportsResponse;
 
 export type StatementDiagnosticsState = {
@@ -55,6 +56,12 @@ const statementDiagnosticsSlice = createSlice({
     ) => {},
     createReportCompleted: noopReducer,
     createReportFailed: (_state, _action: PayloadAction<Error>) => {},
+    cancelReport: (
+      _state,
+      _action: PayloadAction<CancelStatementDiagnosticsReportRequest>,
+    ) => {},
+    cancelReportCompleted: noopReducer,
+    cancelReportFailed: (_state, _action: PayloadAction<Error>) => {},
     openNewDiagnosticsModal: (_state, _action: PayloadAction<string>) => {},
   },
 });

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
@@ -17,12 +17,15 @@ import {
   takeLatest,
 } from "redux-saga/effects";
 import {
+  cancelStatementDiagnosticsReport,
   createStatementDiagnosticsReport,
   getStatementDiagnosticsReports,
 } from "src/api/statementDiagnosticsApi";
 import { actions } from "./statementDiagnostics.reducer";
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
 import { rootActions } from "../reducers";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+type CancelStatementDiagnosticsReportResponseMessage = cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse;
 
 export function* createDiagnosticsReportSaga(
   action: ReturnType<typeof actions.createReport>,
@@ -35,6 +38,32 @@ export function* createDiagnosticsReportSaga(
     yield put(actions.request());
   } catch (e) {
     yield put(actions.createReportFailed(e));
+  }
+}
+
+// TODO(#75559): We would like to alert on a resulting success/failure with this saga.
+// However, the alerting component used on CC console lives in the managed
+// service repo (Notification in notification.tsx) and cannot be used in a
+// cluster-ui saga. Issue has been reported to merge the AlertBanner and
+// Notification components from db-console & managed service respectively, to
+// have a single component in cluster-ui to be used by both repos.
+export function* cancelDiagnosticsReportSaga(
+  action: ReturnType<typeof actions.cancelReport>,
+) {
+  try {
+    const response: CancelStatementDiagnosticsReportResponseMessage = yield call(
+      cancelStatementDiagnosticsReport,
+      action.payload,
+    );
+
+    if (response.error !== "") {
+      throw response.error;
+    }
+
+    yield put(actions.cancelReportCompleted());
+    yield put(actions.request());
+  } catch (e) {
+    yield put(actions.cancelReportFailed(e));
   }
 }
 
@@ -68,6 +97,7 @@ export function* statementsDiagnosticsSagas(
     ),
     takeLatest(actions.request, requestStatementsDiagnosticsSaga),
     takeEvery(actions.createReport, createDiagnosticsReportSaga),
+    takeEvery(actions.cancelReport, cancelDiagnosticsReportSaga),
     takeLatest(actions.received, receivedStatementsDiagnosticsSaga, delayMs),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -365,6 +365,58 @@ export const createStatementDiagnosticsAlertSelector = createSelector(
   },
 );
 
+type CancelStatementDiagnosticsAlertPayload = {
+  show: boolean;
+  status?: "SUCCESS" | "FAILED";
+};
+
+export const cancelStatementDiagnosticsAlertLocalSetting = new LocalSetting<
+  AdminUIState,
+  CancelStatementDiagnosticsAlertPayload
+>("cancel_stmnt_diagnostics_alert", localSettingsSelector, { show: false });
+
+export const cancelStatementDiagnosticsAlertSelector = createSelector(
+  cancelStatementDiagnosticsAlertLocalSetting.selector,
+  (cancelStatementDiagnosticsAlert): Alert => {
+    if (
+      !cancelStatementDiagnosticsAlert ||
+      !cancelStatementDiagnosticsAlert.show
+    ) {
+      return undefined;
+    }
+    const { status } = cancelStatementDiagnosticsAlert;
+
+    if (status === "FAILED") {
+      return {
+        level: AlertLevel.CRITICAL,
+        title: "There was an error cancelling statement diagnostics",
+        text:
+          "Please try cancelling the statement diagnostic again. If the problem continues please reach out to customer support.",
+        showAsAlert: true,
+        dismiss: (dispatch: Dispatch<Action>) => {
+          dispatch(
+            cancelStatementDiagnosticsAlertLocalSetting.set({ show: false }),
+          );
+          return Promise.resolve();
+        },
+      };
+    }
+    return {
+      level: AlertLevel.SUCCESS,
+      title: "Statement diagnostics were successfully cancelled",
+      showAsAlert: true,
+      autoClose: true,
+      closable: false,
+      dismiss: (dispatch: Dispatch<Action>) => {
+        dispatch(
+          cancelStatementDiagnosticsAlertLocalSetting.set({ show: false }),
+        );
+        return Promise.resolve();
+      },
+    };
+  },
+);
+
 type TerminateSessionAlertPayload = {
   show: boolean;
   status?: "SUCCESS" | "FAILED";
@@ -478,6 +530,7 @@ export const bannerAlertsSelector = createSelector(
   disconnectedAlertSelector,
   emailSubscriptionAlertSelector,
   createStatementDiagnosticsAlertSelector,
+  cancelStatementDiagnosticsAlertSelector,
   terminateSessionAlertSelector,
   terminateQueryAlertSelector,
   (...alerts: Alert[]): Alert[] => {

--- a/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
@@ -17,6 +17,8 @@ export const TRACK_STATEMENTS_PAGINATION =
 export const TRACK_TABLE_SORT = "cockroachui/analytics/TRACK_TABLE_SORT";
 export const TRACK_DOWNLOAD_DIAGNOSTIC_BUNDLE =
   "cockroachui/analytics/TRACK_DOWNLOAD_DIAGNOSTIC_BUNDLE";
+export const TRACK_CANCEL_DIAGNOSTIC_BUNDLE =
+  "cockroachui/analytics/TRACK_CANCEL_DIAGNOSTIC_BUNDLE";
 export const TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION =
   "cockroachui/analytics/TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION";
 
@@ -64,6 +66,15 @@ export function trackDownloadDiagnosticsBundleAction(
 ): PayloadAction<string> {
   return {
     type: TRACK_DOWNLOAD_DIAGNOSTIC_BUNDLE,
+    payload: statementFingerprint,
+  };
+}
+
+export function trackCancelDiagnosticsBundleAction(
+  statementFingerprint: string,
+): PayloadAction<string> {
+  return {
+    type: TRACK_CANCEL_DIAGNOSTIC_BUNDLE,
     payload: statementFingerprint,
   };
 }

--- a/pkg/ui/workspaces/db-console/src/redux/analyticsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/analyticsSagas.ts
@@ -31,7 +31,9 @@ import {
   TableSortActionPayload,
   TRACK_DOWNLOAD_DIAGNOSTIC_BUNDLE,
   TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION,
+  TRACK_CANCEL_DIAGNOSTIC_BUNDLE,
 } from "./analyticsActions";
+import trackCancelDiagnosticsBundle from "src/util/analytics/trackCancelDiagnosticsBundle";
 
 export function* trackActivateStatementsDiagnostics(
   action: PayloadAction<DiagnosticsReportPayload>,
@@ -68,6 +70,12 @@ export function* trackDownloadDiagnosticBundleSaga(
   yield call(trackDownloadDiagnosticsBundle, action.payload);
 }
 
+export function* trackCancelDiagnosticBundleSaga(
+  action: PayloadAction<string>,
+) {
+  yield call(trackCancelDiagnosticsBundle, action.payload);
+}
+
 export function* trackStatementDetailsSubnavSelectionSaga(
   action: PayloadAction<string>,
 ) {
@@ -88,6 +96,7 @@ export function* analyticsSaga() {
       TRACK_DOWNLOAD_DIAGNOSTIC_BUNDLE,
       trackDownloadDiagnosticBundleSaga,
     ),
+    takeEvery(TRACK_CANCEL_DIAGNOSTIC_BUNDLE, trackCancelDiagnosticBundleSaga),
     takeEvery(
       TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION,
       trackStatementDetailsSubnavSelectionSaga,

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
@@ -22,6 +22,12 @@ export const CREATE_STATEMENT_DIAGNOSTICS_FAILED =
   "cockroachui/statements/CREATE_STATEMENT_DIAGNOSTICS_FAILED";
 export const OPEN_STATEMENT_DIAGNOSTICS_MODAL =
   "cockroachui/statements/OPEN_STATEMENT_DIAGNOSTICS_MODAL";
+export const CANCEL_STATEMENT_DIAGNOSTICS_REPORT =
+  "cockroachui/statements/CANCEL_STATEMENT_DIAGNOSTICS_REPORT";
+export const CANCEL_STATEMENT_DIAGNOSTICS_COMPLETE =
+  "cockroachui/statements/CANCEL_STATEMENT_DIAGNOSTICS_COMPLETE";
+export const CANCEL_STATEMENT_DIAGNOSTICS_FAILED =
+  "cockroachui/statements/CANCEL_STATEMENT_DIAGNOSTICS_FAILED";
 
 export type DiagnosticsReportPayload = {
   statementFingerprint: string;
@@ -57,6 +63,33 @@ export function createStatementDiagnosticsReportCompleteAction(): Action {
 export function createStatementDiagnosticsReportFailedAction(): Action {
   return {
     type: CREATE_STATEMENT_DIAGNOSTICS_FAILED,
+  };
+}
+
+export type CancelStatementDiagnosticsReportPayload = {
+  requestID: Long;
+};
+
+export function cancelStatementDiagnosticsReportAction(
+  requestID: Long,
+): PayloadAction<CancelStatementDiagnosticsReportPayload> {
+  return {
+    type: CANCEL_STATEMENT_DIAGNOSTICS_REPORT,
+    payload: {
+      requestID,
+    },
+  };
+}
+
+export function cancelStatementDiagnosticsReportCompleteAction(): Action {
+  return {
+    type: CANCEL_STATEMENT_DIAGNOSTICS_COMPLETE,
+  };
+}
+
+export function cancelStatementDiagnosticsReportFailedAction(): Action {
+  return {
+    type: CANCEL_STATEMENT_DIAGNOSTICS_FAILED,
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackCancelDiagnosticsBundle.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackCancelDiagnosticsBundle.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { get, isString } from "lodash";
+import { assert } from "chai";
+import { createSandbox } from "sinon";
+import { track } from "./trackCancelDiagnosticsBundle";
+
+const sandbox = createSandbox();
+
+describe("trackCancelDiagnosticsBundle", () => {
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  it("should only call track once", () => {
+    const spy = sandbox.spy();
+    track(spy)("some statement");
+    assert.isTrue(spy.calledOnce);
+  });
+
+  it("should send the right event", () => {
+    const spy = sandbox.spy();
+    const expected = "Diagnostics Bundle Cancellation";
+
+    track(spy)("whatever");
+
+    const sent = spy.getCall(0).args[0];
+    const event = get(sent, "event");
+
+    assert.isTrue(isString(event));
+    assert.isTrue(event === expected);
+  });
+
+  it("should send the correct payload", () => {
+    const spy = sandbox.spy();
+    const statement = "SELECT blah from blah-blah";
+
+    track(spy)(statement);
+
+    const sent = spy.getCall(0).args[0];
+    const fingerprint = get(sent, "properties.fingerprint");
+
+    assert.isTrue(isString(fingerprint));
+    assert.isTrue(fingerprint === statement);
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/util/analytics/trackCancelDiagnosticsBundle.ts
+++ b/pkg/ui/workspaces/db-console/src/util/analytics/trackCancelDiagnosticsBundle.ts
@@ -1,0 +1,25 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { analytics } from "src/redux/analytics";
+
+export const track = (fn: Function) => (statement: string) => {
+  fn({
+    event: "Diagnostics Bundle Cancellation",
+    properties: {
+      fingerprint: statement,
+    },
+  });
+};
+
+export default function trackCancelDiagnosticsBundle(statement: string) {
+  const boundTrack = analytics.track.bind(analytics);
+  track(boundTrack)(statement);
+}

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -131,6 +131,9 @@ export type StatementDiagnosticsReportsResponseMessage = protos.cockroach.server
 export type CreateStatementDiagnosticsReportRequestMessage = protos.cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
 export type CreateStatementDiagnosticsReportResponseMessage = protos.cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse;
 
+export type CancelStatementDiagnosticsReportRequestMessage = protos.cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
+export type CancelStatementDiagnosticsReportResponseMessage = protos.cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse;
+
 export type StatementDiagnosticsRequestMessage = protos.cockroach.server.serverpb.StatementDiagnosticsRequest;
 export type StatementDiagnosticsResponseMessage = protos.cockroach.server.serverpb.StatementDiagnosticsResponse;
 
@@ -717,6 +720,18 @@ export function createStatementDiagnosticsReport(
   return timeoutFetch(
     serverpb.CreateStatementDiagnosticsReportResponse,
     `${STATUS_PREFIX}/stmtdiagreports`,
+    req as any,
+    timeout,
+  );
+}
+
+export function cancelStatementDiagnosticsReport(
+  req: CancelStatementDiagnosticsReportRequestMessage,
+  timeout?: moment.Duration,
+): Promise<CancelStatementDiagnosticsReportResponseMessage> {
+  return timeoutFetch(
+    serverpb.CancelStatementDiagnosticsReportResponse,
+    `${STATUS_PREFIX}/stmtdiagreports/cancel`,
     req as any,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -47,6 +47,8 @@ import {
   SortSetting,
   ColumnDescriptor,
 } from "@cockroachlabs/cluster-ui";
+import { cancelStatementDiagnosticsReportAction } from "src/redux/statements";
+import { trackCancelDiagnosticsBundleAction } from "src/redux/analyticsActions";
 
 type StatementDiagnosticsHistoryViewProps = MapStateToProps &
   MapDispatchToProps;
@@ -164,7 +166,19 @@ class StatementDiagnosticsHistoryView extends React.Component<
             </div>
           );
         }
-        return null;
+        return (
+          <div className="crl-statements-diagnostics-view__actions-column cell--show-on-hover nodes-table__link">
+            <Button
+              size="small"
+              type="secondary"
+              onClick={() => {
+                this.props.onDiagnosticCancelRequest(record);
+              }}
+            >
+              Cancel request
+            </Button>
+          </div>
+        );
       },
     },
   ];
@@ -266,6 +280,7 @@ interface MapStateToProps {
 }
 
 interface MapDispatchToProps {
+  onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => void;
   refresh: () => void;
 }
 
@@ -277,6 +292,10 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
 });
 
 const mapDispatchToProps = (dispatch: AppDispatch): MapDispatchToProps => ({
+  onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => {
+    dispatch(cancelStatementDiagnosticsReportAction(report.id));
+    dispatch(trackCancelDiagnosticsBundleAction(report.statement_fingerprint));
+  },
   refresh: () => {
     dispatch(invalidateStatementDiagnosticsRequests());
     dispatch(refreshStatementDiagnosticsRequests());

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -24,7 +24,7 @@ import {
   nodeDisplayNameByIDSelector,
   nodeRegionsByIDSelector,
 } from "src/redux/nodes";
-import { AdminUIState } from "src/redux/state";
+import { AdminUIState, AppDispatch } from "src/redux/state";
 import {
   aggregatedTsAttr,
   aggregationIntervalAttr,
@@ -43,14 +43,20 @@ import {
   AggregateStatistics,
   util,
 } from "@cockroachlabs/cluster-ui";
-import { createStatementDiagnosticsReportAction } from "src/redux/statements";
+import {
+  cancelStatementDiagnosticsReportAction,
+  createStatementDiagnosticsReportAction,
+} from "src/redux/statements";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
 import { statementsTimeScaleLocalSetting } from "src/redux/statementsTimeScale";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
 import {
+  trackCancelDiagnosticsBundleAction,
   trackDownloadDiagnosticsBundleAction,
   trackStatementDetailsSubnavSelectionAction,
 } from "src/redux/analyticsActions";
+import * as protos from "src/js/protos";
+type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const { combineStatementStats, flattenStatementStats, statementKey } = util;
 type ExecutionStatistics = util.ExecutionStatistics;
@@ -248,6 +254,14 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
   createStatementDiagnosticsReport: createStatementDiagnosticsReportAction,
   onTabChanged: trackStatementDetailsSubnavSelectionAction,
   onDiagnosticBundleDownload: trackDownloadDiagnosticsBundleAction,
+  onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => {
+    return (dispatch: AppDispatch) => {
+      dispatch(cancelStatementDiagnosticsReportAction(report.id));
+      dispatch(
+        trackCancelDiagnosticsBundleAction(report.statement_fingerprint),
+      );
+    };
+  },
   refreshNodes: refreshNodes,
   refreshNodesLiveness: refreshLiveness,
   refreshUserSQLRoles: refreshUserSQLRoles,


### PR DESCRIPTION
**Note**: This PR was split into two PRs: #75733, #75732.

Previously, there did not exist an option to cancel a running request
for statement diagnostics, this change provides a cancellation option.

The statements page now has an ellipsis dropdown button where the
download bundle links used to appear. The dropdown contains a
cancellation button (if there is a currently waiting diagnostic request)
and the download links to previously completed diagnostic requests.

The statement details page now has a "Cancel request" button while a
diagnostic request is not completed (i.e. in the "Waiting" status).

The statement diagnostics history page on db-console also has a "Cancel
Request" button while a diagnostic request is not completed (i.e. in the
"Waiting" status).

Added a small code change to the cancel statement diagnostics request
API on the backend. Previously, the frontend passed a statement
fingerprint to the API to update the corresponding statement diagnostic
request to an expired state. Now we pass the statement diagnostic ID
directly. This resolves a SQL parsing error that occurs when a statement
fingerprint contains single-quotes (i.e. when a statement fingerprint
contains placeholders).

Added a small code change in the statement diagnostic "Activate" modal.
The expiry time picker allowed for values that were <1, the code change
fixes this bug.

Note: Follow up [issue](https://github.com/cockroachdb/cockroach/issues/75559) regarding alerts & notifications in db-console and managed-service.

**DB Console Changes**:
https://www.loom.com/share/f76694148f6f4fcdb129665eb519eb4b

**CC Console Changes - this is using intrusion & console with fake backends**
https://www.loom.com/share/06bdc2455b5c49d6ba0d23cc53c7b460

Release note (ui change): Added an option to cancel a running request
for statement diagnostics.