### PR TITLE
dev: only build `:go_path` if you're building a `cockroach` binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -263,7 +263,5 @@ go_path(
     mode = "link",
     deps = [
         "//pkg/cmd/cockroach-short",
-        "//pkg/cmd/roachprod",
-        "//pkg/cmd/roachtest",
     ],
 )

--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=3
+DEV_VERSION=4
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
Release note: None