### PR TITLE
colexechash: fix an internal error with distinct mode

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -518,6 +518,7 @@ func (ht *HashTable) checkCols(probeVecs []coldata.Vec, nToCheck uint64, probeSe
 
 // checkColsForDistinctTuples performs a column by column check to find distinct
 // tuples in the probe table that are not present in the build table.
+// NOTE: It assumes that probeSel has already been populated and it is not nil.
 func (ht *HashTable) checkColsForDistinctTuples(
 	probeVecs []coldata.Vec, nToCheck uint64, probeSel []int,
 ) {

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -57,60 +57,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -121,59 +116,54 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -186,59 +176,54 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -249,58 +234,53 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -315,58 +295,53 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -377,57 +352,52 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -440,57 +410,52 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -501,56 +466,51 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -580,52 +540,47 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -636,51 +591,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -693,51 +643,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -748,50 +693,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -806,50 +746,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -860,49 +795,44 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -915,49 +845,44 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -968,48 +893,43 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1039,52 +959,47 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1095,51 +1010,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1152,51 +1062,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1207,50 +1112,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1265,50 +1165,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1319,49 +1214,44 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1374,49 +1264,44 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1427,48 +1312,43 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1496,63 +1376,58 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1563,62 +1438,57 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1631,62 +1501,57 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1697,61 +1562,56 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1766,61 +1626,56 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1831,60 +1686,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1897,60 +1747,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -1961,59 +1806,54 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2038,63 +1878,58 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2105,62 +1940,57 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2173,62 +2003,57 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2239,61 +2064,56 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2308,61 +2128,56 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2373,60 +2188,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2439,60 +2249,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2503,59 +2308,54 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2582,63 +2382,58 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2649,62 +2444,57 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2717,62 +2507,57 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2783,61 +2568,56 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2852,61 +2632,56 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -2917,60 +2692,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2983,60 +2753,55 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3047,59 +2812,54 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3129,71 +2889,66 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3204,70 +2959,65 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3280,70 +3030,65 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3354,69 +3099,64 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3431,69 +3171,64 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3504,68 +3239,63 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3578,68 +3308,63 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3650,67 +3375,62 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3740,59 +3460,54 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3803,58 +3518,53 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3867,58 +3577,53 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -3929,57 +3634,52 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3994,57 +3694,52 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4055,56 +3750,51 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4117,56 +3807,51 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4177,55 +3862,50 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4255,52 +3935,47 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4311,51 +3986,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4368,51 +4038,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4423,50 +4088,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4481,50 +4141,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4535,49 +4190,44 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4590,49 +4240,44 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4643,48 +4288,43 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4714,58 +4354,53 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4776,57 +4411,52 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4839,57 +4469,52 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -4900,56 +4525,51 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4964,56 +4584,51 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -5024,55 +4639,50 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5085,55 +4695,50 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -5144,54 +4749,49 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5221,54 +4821,49 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -5279,53 +4874,48 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5338,53 +4928,48 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -5395,52 +4980,47 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										// The vector is probed against itself, so buildVec has the same
-										// selection vector as probeVec.
-										buildIdx = probeSel[keyID-1]
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									// The vector is probed against itself, so buildVec has the same
+									// selection vector as probeVec.
+									buildIdx = probeSel[keyID-1]
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5455,52 +5035,47 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -5511,51 +5086,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5568,51 +5138,46 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
@@ -5623,50 +5188,45 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = int(toCheck)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -5253,508 +5253,254 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Bool()
 					buildKeys := buildVec.Bool()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}
@@ -5770,444 +5516,222 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Bytes()
 					buildKeys := buildVec.Bytes()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}
@@ -6229,444 +5753,222 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Decimal()
 					buildKeys := buildVec.Decimal()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}
@@ -6680,532 +5982,266 @@ func (ht *HashTable) checkColForDistinctTuples(
 				case 16:
 					probeKeys := probeVec.Int16()
 					buildKeys := buildVec.Int16()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			case types.FloatFamily:
@@ -7222,532 +6258,266 @@ func (ht *HashTable) checkColForDistinctTuples(
 				case 32:
 					probeKeys := probeVec.Int32()
 					buildKeys := buildVec.Int32()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			case types.FloatFamily:
@@ -7766,532 +6536,266 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Int64()
 					buildKeys := buildVec.Int64()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			case types.FloatFamily:
@@ -8316,596 +6820,298 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Float64()
 					buildKeys := buildVec.Float64()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											{
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
+														cmpResult = 0
+													} else {
+														cmpResult = -1
+													}
+												} else {
+													cmpResult = 1
+												}
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
-														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
-													} else {
-														cmpResult = 1
-													}
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			case types.DecimalFamily:
@@ -8924,500 +7130,250 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Timestamp()
 					buildKeys := buildVec.Timestamp()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}
@@ -9433,444 +7389,222 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Interval()
 					buildKeys := buildVec.Interval()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}
@@ -9886,492 +7620,246 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.JSON()
 					buildKeys := buildVec.JSON()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
+											}
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}
@@ -10387,460 +7875,230 @@ func (ht *HashTable) checkColForDistinctTuples(
 				default:
 					probeKeys := probeVec.Datum()
 					buildKeys := buildVec.Datum()
-					if probeSel != nil {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = probeSel[toCheck]
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					} else {
-						if probeVec.MaybeHasNulls() {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+						if buildVec.MaybeHasNulls() {
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
+							var (
+								probeIdx, buildIdx       int
+								probeIsNull, buildIsNull bool
+							)
+							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+								// keyID of 0 is reserved to represent the end of the next chain.
+								keyID := ht.ProbeScratch.GroupID[toCheck]
+								if keyID != 0 {
+									// the build table key (calculated using keys[keyID - 1] = key) is
+									// compared to the corresponding probe table to determine if a match is
+									// found.
 
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
+									probeIdx = probeSel[toCheck]
+									buildIdx = int(keyID - 1)
+									if ht.allowNullEquality {
+										if probeIsNull && buildIsNull {
+											// Both values are NULLs, and since we're allowing null equality, we
+											// proceed to the next value to check.
+											continue
+										} else if probeIsNull {
+											// Only probing value is NULL, so it is different from the build value
+											// (which is non-NULL). We mark it as "different" and proceed to the
+											// next value to check. This behavior is special in case of allowing
+											// null equality because we don't want to reset the GroupID of the
+											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
 									}
-									if keyID == 0 {
+									if probeIsNull {
 										ht.ProbeScratch.distinct[toCheck] = true
+									} else if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+									} else {
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
-							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
-								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
-									keyID := ht.ProbeScratch.GroupID[toCheck]
-									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
-
-										probeIdx = int(toCheck)
-										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
-												continue
-											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.distinct[toCheck] = true
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
-									}
-									if keyID == 0 {
-										ht.ProbeScratch.distinct[toCheck] = true
-									}
+								if keyID == 0 {
+									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
-
 					}
 				}
 			}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -5311,8 +5311,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5372,8 +5371,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5435,8 +5433,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5495,8 +5492,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5566,8 +5562,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5619,8 +5614,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5674,8 +5668,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5726,8 +5719,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5803,8 +5795,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5856,8 +5847,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5911,8 +5901,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -5963,8 +5952,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6043,8 +6031,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6107,8 +6094,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6173,8 +6159,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6236,8 +6221,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6319,8 +6303,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6383,8 +6366,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6449,8 +6431,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6512,8 +6493,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6597,8 +6577,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6661,8 +6640,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6727,8 +6705,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6790,8 +6767,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6889,8 +6865,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -6961,8 +6936,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7035,8 +7009,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7106,8 +7079,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7187,8 +7159,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7247,8 +7218,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7309,8 +7279,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7368,8 +7337,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7439,8 +7407,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7492,8 +7459,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7547,8 +7513,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7599,8 +7564,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7676,8 +7640,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7735,8 +7698,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7796,8 +7758,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7854,8 +7815,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7927,8 +7887,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -7982,8 +7941,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -8039,8 +7997,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
@@ -8093,8 +8050,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
-								}
-								if keyID == 0 {
+								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -30,9 +30,10 @@ var (
 	_ tree.AggType
 )
 
-// checkColAgainstItself is similar to checkCol, but it probes the vector
-// against itself.
-func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel []int) {
+// checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
+// vector against itself for the purposes of finding matches to unordered
+// distinct columns.
+func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint64, sel []int) {
 	probeVec, buildVec, probeSel := vec, vec, sel
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -84,7 +85,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -108,6 +108,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -145,7 +148,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -169,6 +171,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -208,7 +213,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -232,6 +236,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -268,7 +275,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -292,6 +298,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -332,7 +341,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -356,6 +364,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -391,7 +402,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -415,6 +425,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -452,7 +465,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -476,6 +488,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -510,7 +525,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -534,6 +548,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -591,7 +608,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -607,6 +623,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -644,7 +663,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -660,6 +678,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -699,7 +720,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -715,6 +735,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -751,7 +774,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -767,6 +789,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -807,7 +832,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -823,6 +847,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -858,7 +885,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -874,6 +900,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -911,7 +940,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -927,6 +955,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -961,7 +992,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -977,6 +1007,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1034,7 +1067,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1050,6 +1082,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1087,7 +1122,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1103,6 +1137,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1142,7 +1179,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1158,6 +1194,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1194,7 +1233,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1210,6 +1248,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1250,7 +1291,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1266,6 +1306,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1301,7 +1344,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1317,6 +1359,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1354,7 +1399,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1370,6 +1414,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1404,7 +1451,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1420,6 +1466,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1475,7 +1524,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1502,6 +1550,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1539,7 +1590,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1566,6 +1616,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1605,7 +1658,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1632,6 +1684,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1668,7 +1723,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1695,6 +1749,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1735,7 +1792,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1762,6 +1818,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1797,7 +1856,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1824,6 +1882,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1861,7 +1922,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1888,6 +1948,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1922,7 +1985,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1949,6 +2011,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2001,7 +2066,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2028,6 +2092,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2065,7 +2132,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2092,6 +2158,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2131,7 +2200,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2158,6 +2226,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2194,7 +2265,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2221,6 +2291,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2261,7 +2334,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2288,6 +2360,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2323,7 +2398,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2350,6 +2424,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2387,7 +2464,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2414,6 +2490,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2448,7 +2527,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2475,6 +2553,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2529,7 +2610,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2556,6 +2636,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2593,7 +2676,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2620,6 +2702,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2659,7 +2744,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2686,6 +2770,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2722,7 +2809,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2749,6 +2835,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2789,7 +2878,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2816,6 +2904,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2851,7 +2942,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2878,6 +2968,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2915,7 +3008,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2942,6 +3034,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2976,7 +3071,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3003,6 +3097,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3060,7 +3157,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3095,6 +3191,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3132,7 +3231,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3167,6 +3265,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3206,7 +3307,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3241,6 +3341,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3277,7 +3380,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3312,6 +3414,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3352,7 +3457,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3388,6 +3492,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
+									}
 								}
 							} else {
 								var (
@@ -3422,7 +3529,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3457,6 +3563,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3494,7 +3603,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3530,6 +3638,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
+									}
 								}
 							} else {
 								var (
@@ -3563,7 +3674,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3598,6 +3708,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3655,7 +3768,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3678,6 +3790,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3715,7 +3830,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3738,6 +3852,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3777,7 +3894,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3800,6 +3916,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3836,7 +3955,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3859,6 +3977,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3899,7 +4020,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3922,6 +4042,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3957,7 +4080,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3980,6 +4102,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4017,7 +4142,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4040,6 +4164,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4074,7 +4201,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4097,6 +4223,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4154,7 +4283,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4170,6 +4298,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4207,7 +4338,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4223,6 +4353,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4262,7 +4395,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4278,6 +4410,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4314,7 +4449,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4330,6 +4464,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4370,7 +4507,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4386,6 +4522,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4421,7 +4560,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4437,6 +4575,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4474,7 +4615,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4490,6 +4630,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4524,7 +4667,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4540,6 +4682,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4597,7 +4742,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4619,6 +4763,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4656,7 +4803,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4678,6 +4824,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4717,7 +4866,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4739,6 +4887,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4775,7 +4926,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4797,6 +4947,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4837,7 +4990,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4859,6 +5011,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4894,7 +5049,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4916,6 +5070,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4953,7 +5110,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4975,6 +5131,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5009,7 +5168,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5031,6 +5189,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5088,7 +5249,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5106,6 +5266,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5143,7 +5306,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5161,6 +5323,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5200,7 +5365,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5218,6 +5382,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5254,7 +5421,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5272,6 +5438,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5312,7 +5481,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5330,6 +5498,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5365,7 +5536,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5383,6 +5553,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5420,7 +5593,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5438,6 +5610,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5472,7 +5647,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5490,6 +5664,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5552,7 +5729,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5614,7 +5790,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5678,7 +5853,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5739,7 +5913,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5807,7 +5980,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5869,7 +6041,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5933,7 +6104,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5994,7 +6164,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6077,7 +6246,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6131,7 +6299,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6187,7 +6354,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6240,7 +6406,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6300,7 +6465,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6354,7 +6518,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6410,7 +6573,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6463,7 +6625,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6544,7 +6705,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6598,7 +6758,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6654,7 +6813,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6707,7 +6865,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6767,7 +6924,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6821,7 +6977,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6877,7 +7032,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6930,7 +7084,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7003,7 +7156,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7068,7 +7220,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7135,7 +7286,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7199,7 +7349,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7270,7 +7419,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7335,7 +7483,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7402,7 +7549,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7466,7 +7612,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7553,7 +7698,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7618,7 +7762,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7685,7 +7828,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7749,7 +7891,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7820,7 +7961,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7885,7 +8025,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7952,7 +8091,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8016,7 +8154,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8105,7 +8242,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8170,7 +8306,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8237,7 +8372,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8301,7 +8435,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8372,7 +8505,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8437,7 +8569,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8504,7 +8635,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8568,7 +8698,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8663,7 +8792,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8736,7 +8864,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8811,7 +8938,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8883,7 +9009,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8962,7 +9087,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9035,7 +9159,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9110,7 +9233,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9182,7 +9304,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9279,7 +9400,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9340,7 +9460,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9403,7 +9522,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9463,7 +9581,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9530,7 +9647,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9591,7 +9707,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9654,7 +9769,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9714,7 +9828,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9796,7 +9909,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9850,7 +9962,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9906,7 +10017,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9959,7 +10069,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10019,7 +10128,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10073,7 +10181,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10129,7 +10236,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10182,7 +10288,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10257,7 +10362,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10317,7 +10421,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10379,7 +10482,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10438,7 +10540,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10504,7 +10605,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10564,7 +10664,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10626,7 +10725,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10685,7 +10783,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10766,7 +10863,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10822,7 +10918,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10880,7 +10975,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10935,7 +11029,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10997,7 +11090,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11053,7 +11145,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11111,7 +11202,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11166,7 +11256,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11203,7 +11292,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 // in the probe table.
 func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
 	for i := range ht.keyCols {
-		ht.checkColAgainstItself(vecs[i], nToCheck, sel)
+		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
 	nDiffers := uint64(0)
 	toCheckSlice := ht.ProbeScratch.ToCheck
@@ -11212,7 +11301,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 		//gcassert:bce
 		toCheck := toCheckSlice[toCheckPos]
 		if ht.ProbeScratch.distinct[toCheck] {
-			ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.GroupID[toCheck]
+			ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
 			continue
 		}
 		if !ht.ProbeScratch.differs[toCheck] {

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -63,6 +63,13 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 // This is a code snippet that is the main body of checkCol* functions. It
 // takes in the following template "meta" variables that enable/disable certain
 // code paths:
+// _GLOBAL - a string replaced by "$global" (the local template variable
+// referring to the NotEqual overload) before performing the template function
+// call. It is needed because _CHECK_COL_BODY template function is called from
+// two places where the overload is in different template context (in one case
+// it is `.`, and in another it is `.Global`). We work around it by replacing
+// _GLOBAL with the local variable during the initial preprocessing of the
+// template.
 // _PROBE_HAS_NULLS - a boolean as .ProbeHasNulls that determines whether the
 // probe vector might have NULL values.
 // _BUILD_HAS_NULLS - a boolean as .BuildHasNulls that determines whether the
@@ -84,6 +91,7 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 // When it is true, the HashTable uses 'visited' slice to mark previously
 // matched tuples as "deleted" so they won't get matched again.
 func _CHECK_COL_BODY(
+	_GLOBAL interface{},
 	_PROBE_HAS_NULLS bool,
 	_BUILD_HAS_NULLS bool,
 	_SELECT_DISTINCT bool,
@@ -207,20 +215,21 @@ func _CHECK_COL_WITH_NULLS(
 	_DELETING_PROBE_MODE bool,
 ) { // */}}
 	// {{define "checkColWithNulls" -}}
+	// {{$global := .Global}}
 	// {{$selectDistinct := .SelectDistinct}}
 	// {{$probingAgainstItself := .ProbingAgainstItself}}
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	if probeVec.MaybeHasNulls() {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(true, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(_GLOBAL, true, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(true, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(_GLOBAL, true, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	} else {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(false, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(_GLOBAL, false, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(false, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(_GLOBAL, false, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	}
 	// {{end}}
@@ -340,27 +349,6 @@ func (ht *HashTable) checkColDeleting(
 
 // {{end}}
 
-// {{/*
-func _CHECK_COL_FOR_DISTINCT_WITH_NULLS(_USE_PROBE_SEL bool) { // */}}
-	// {{define "checkColForDistinctWithNulls" -}}
-	if probeVec.MaybeHasNulls() {
-		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(true, true, true, _USE_PROBE_SEL, false, false)
-		} else {
-			_CHECK_COL_BODY(true, false, true, _USE_PROBE_SEL, false, false)
-		}
-	} else {
-		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(false, true, true, _USE_PROBE_SEL, false, false)
-		} else {
-			_CHECK_COL_BODY(false, false, true, _USE_PROBE_SEL, false, false)
-		}
-	}
-
-	// {{end}}
-	// {{/*
-} // */}}
-
 // {{if .HashTableMode.IsDistinctBuild}}
 // {{with .Overloads}}
 
@@ -394,10 +382,19 @@ func (ht *HashTable) checkColForDistinctTuples(
 				case _RIGHT_TYPE_WIDTH:
 					probeKeys := probeVec._ProbeType()
 					buildKeys := buildVec._ProbeType()
-					if probeSel != nil {
-						_CHECK_COL_FOR_DISTINCT_WITH_NULLS(true)
+					// {{$global := .}}
+					if probeVec.MaybeHasNulls() {
+						if buildVec.MaybeHasNulls() {
+							_CHECK_COL_BODY(_GLOBAL, true, true, true, true, false, false)
+						} else {
+							_CHECK_COL_BODY(_GLOBAL, true, false, true, true, false, false)
+						}
 					} else {
-						_CHECK_COL_FOR_DISTINCT_WITH_NULLS(false)
+						if buildVec.MaybeHasNulls() {
+							_CHECK_COL_BODY(_GLOBAL, false, true, true, true, false, false)
+						} else {
+							_CHECK_COL_BODY(_GLOBAL, false, false, true, true, false, false)
+						}
 					}
 					// {{end}}
 					// {{end}}

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -195,12 +195,11 @@ func _CHECK_COL_BODY(
 				_ASSIGN_NE(unique, probeVal, buildVal, _, probeKeys, buildKeys)
 				ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 			}
-			// {{if or (not .SelectDistinct) (not .ProbingAgainstItself)}}
-		}
-		// {{end}}
-		// {{if and .SelectDistinct (not .ProbingAgainstItself)}}
-		if keyID == 0 {
+			// {{if and .SelectDistinct (not .ProbingAgainstItself)}}
+		} else {
 			ht.ProbeScratch.distinct[toCheck] = true
+			// {{end}}
+			// {{if or (not .SelectDistinct) (not .ProbingAgainstItself)}}
 		}
 		// {{end}}
 	}

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -68,8 +68,10 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 // _BUILD_HAS_NULLS - a boolean as .BuildHasNulls that determines whether the
 // build vector might have NULL values.
 // _SELECT_DISTINCT - a boolean as .SelectDistinct that determines whether a
-// probe tuple should be marked as "distinct" if its GroupID is zero (meaning
-// that there is no tuple in the hash table with the same hash code).
+// probe tuple should be marked as "distinct" if there is no tuple in the hash
+// table that might be a duplicate of the probe tuple (either because the
+// GroupID of the probe tuple is 0 - meaning no hash matches - or because the
+// probe tuple has a NULL value when NULLs are treated as not equal).
 // _USE_PROBE_SEL - a boolean as .UseProbeSel that determines whether there is
 // a selection vector on the probe vector.
 // _PROBING_AGAINST_ITSELF - a boolean as .ProbingAgainstItself that tells us
@@ -153,20 +155,14 @@ func _CHECK_COL_BODY(
 				}
 			}
 			if probeIsNull {
-				// {{if or (.SelectDistinct) (.ProbingAgainstItself)}}
+				// {{if .SelectDistinct}}
 				// {{/*
 				//     We know that nulls are distinct (because
 				//     allowNullEquality case is handled above) and our probing
 				//     tuple has a NULL value in the current column, so the
-				//     probing tuple is distinct from the build table. Both
-				//     parts of the template condition above are only 'true' if
-				//     the hash table is used for the unordered distinct
-				//     operator, and in that scenario we want to mark the
-				//     current probing tuple as distinct but also set its
-				//     GroupID such that it (the probing tuple) matches itself.
+				//     probing tuple is distinct from the build table.
 				// */}}
 				ht.ProbeScratch.distinct[toCheck] = true
-				ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 				// {{else}}
 				ht.ProbeScratch.GroupID[toCheck] = 0
 				// {{end}}
@@ -191,30 +187,37 @@ func _CHECK_COL_BODY(
 }
 
 func _CHECK_COL_WITH_NULLS(
-	_USE_PROBE_SEL bool, _PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_MODE bool,
+	_SELECT_DISTINCT bool,
+	_USE_PROBE_SEL bool,
+	_PROBING_AGAINST_ITSELF bool,
+	_DELETING_PROBE_MODE bool,
 ) { // */}}
 	// {{define "checkColWithNulls" -}}
+	// {{$selectDistinct := .SelectDistinct}}
 	// {{$probingAgainstItself := .ProbingAgainstItself}}
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	if probeVec.MaybeHasNulls() {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(true, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(true, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(true, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(true, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	} else {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(false, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(false, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(false, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(false, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	}
 	// {{end}}
 	// {{/*
 }
 
-func _CHECK_COL_FUNCTION_TEMPLATE(_PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_MODE bool) { // */}}
+func _CHECK_COL_FUNCTION_TEMPLATE(
+	_SELECT_DISTINCT bool, _PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_MODE bool,
+) { // */}}
 	// {{define "checkColFunctionTemplate" -}}
+	// {{$selectDistinct := .SelectDistinct}}
 	// {{$probingAgainstItself := .ProbingAgainstItself}}
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	// {{with .Global}}
@@ -252,9 +255,9 @@ func _CHECK_COL_FUNCTION_TEMPLATE(_PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_
 					probeKeys := probeVec._ProbeType()
 					buildKeys := buildVec._BuildType()
 					if probeSel != nil {
-						_CHECK_COL_WITH_NULLS(true, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+						_CHECK_COL_WITH_NULLS(_SELECT_DISTINCT, true, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 					} else {
-						_CHECK_COL_WITH_NULLS(false, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+						_CHECK_COL_WITH_NULLS(_SELECT_DISTINCT, false, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 					}
 					// {{end}}
 					// {{end}}
@@ -282,7 +285,7 @@ func (ht *HashTable) checkCol(
 	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
 ) {
 	// {{with .Overloads}}
-	_CHECK_COL_FUNCTION_TEMPLATE(false, false)
+	_CHECK_COL_FUNCTION_TEMPLATE(false, false, false)
 	// {{end}}
 }
 
@@ -290,16 +293,17 @@ func (ht *HashTable) checkCol(
 
 // {{if .HashTableMode.IsDistinctBuild}}
 
-// checkColAgainstItself is similar to checkCol, but it probes the vector
-// against itself.
-func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel []int) {
+// checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
+// vector against itself for the purposes of finding matches to unordered
+// distinct columns.
+func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint64, sel []int) {
 	// {{/*
 	// In order to reuse the same template function as checkCol uses, we use
 	// the same variable names.
 	// */}}
 	probeVec, buildVec, probeSel := vec, vec, sel
 	// {{with .Overloads}}
-	_CHECK_COL_FUNCTION_TEMPLATE(true, false)
+	_CHECK_COL_FUNCTION_TEMPLATE(true, true, false)
 	// {{end}}
 }
 
@@ -316,7 +320,7 @@ func (ht *HashTable) checkColDeleting(
 	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
 ) {
 	// {{with .Overloads}}
-	_CHECK_COL_FUNCTION_TEMPLATE(false, true)
+	_CHECK_COL_FUNCTION_TEMPLATE(false, false, true)
 	// {{end}}
 }
 
@@ -405,7 +409,16 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 		toCheck := toCheckSlice[toCheckPos]
 		// {{if .SelectDistinct}}
 		if ht.ProbeScratch.distinct[toCheck] {
-			ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.GroupID[toCheck]
+			// {{/*
+			//     The hash table is used for the unordered distinct operator.
+			//     This code block is only relevant when we're probing the batch
+			//     against itself in order to separate all tuples in the batch
+			//     into equality buckets (where equality buckets are specified
+			//     by the same HeadID values). In this case we see that the
+			//     probing tuple is distinct (i.e. it is unique in the batch),
+			//     so we want to mark it as equal to itself only.
+			// */}}
+			ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
 			continue
 		}
 		// {{end}}
@@ -514,7 +527,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 // in the probe table.
 func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
 	for i := range ht.keyCols {
-		ht.checkColAgainstItself(vecs[i], nToCheck, sel)
+		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
 	nDiffers := uint64(0)
 	_CHECK_BODY(false, false, true)

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -682,8 +682,8 @@ func RunTestsWithFn(
 					if typs != nil {
 						inputTypes = typs[i]
 					}
-					rng, _ := randutil.NewTestRand()
-					inputSources[i] = newOpTestSelInput(allocator, rng, batchSize, tup, inputTypes)
+					inputSources[i] = newOpTestSelInput(allocator, batchSize, tup, inputTypes)
+					inputSources[i].(*opTestInput).batchLengthRandomizationEnabled = true
 				}
 			} else {
 				for i, tup := range tups {
@@ -691,6 +691,7 @@ func RunTestsWithFn(
 						inputTypes = typs[i]
 					}
 					inputSources[i] = NewOpTestInput(allocator, batchSize, tup, inputTypes)
+					inputSources[i].(*opTestInput).batchLengthRandomizationEnabled = true
 				}
 			}
 			test(t, inputSources)
@@ -835,8 +836,9 @@ type opTestInput struct {
 
 	typs []*types.T
 
-	batchSize int
-	tuples    Tuples
+	batchSize                       int
+	batchLengthRandomizationEnabled bool
+	tuples                          Tuples
 	// initialTuples are tuples passed in into the constructor, and we keep the
 	// reference to them in order to be able to reset the operator.
 	initialTuples Tuples
@@ -875,12 +877,11 @@ func NewOpTestInput(
 }
 
 func newOpTestSelInput(
-	allocator *colmem.Allocator, rng *rand.Rand, batchSize int, tuples Tuples, typs []*types.T,
+	allocator *colmem.Allocator, batchSize int, tuples Tuples, typs []*types.T,
 ) *opTestInput {
 	ret := &opTestInput{
 		allocator:     allocator,
 		useSel:        true,
-		rng:           rng,
 		batchSize:     batchSize,
 		tuples:        tuples,
 		initialTuples: tuples,
@@ -898,7 +899,7 @@ func (s *opTestInput) Init(context.Context) {
 		s.typs = extrapolateTypesFromTuples(s.tuples)
 	}
 	s.batch = s.allocator.NewMemBatchWithMaxCapacity(s.typs)
-
+	s.rng, _ = randutil.NewTestRand()
 	s.selection = make([]int, coldata.BatchSize())
 	for i := range s.selection {
 		s.selection[i] = i
@@ -913,6 +914,13 @@ func (s *opTestInput) Next() coldata.Batch {
 	batchSize := s.batchSize
 	if len(s.tuples) < batchSize {
 		batchSize = len(s.tuples)
+	}
+	if s.batchLengthRandomizationEnabled {
+		// With 50% probability for this particular batch use a random length in
+		// range [1, batchSize].
+		if s.rng.Float64() < 0.5 {
+			batchSize = s.rng.Intn(batchSize) + 1
+		}
 	}
 	tups := s.tuples[:batchSize]
 	s.tuples = s.tuples[batchSize:]

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -298,6 +298,28 @@ var distinctTestCases = []distinctTestCase{
 		errorOnDup:              "\"duplicate\" distinct nulls",
 		noError:                 true,
 	},
+	{
+		distinctCols: []uint32{0, 1},
+		typs:         []*types.T{types.Int, types.Int},
+		// Tuples have been carefully constructed so that all of them have the
+		// same hash, only one tuple among first three is inserted into the hash
+		// table, and the last two tuples are distinct. This is a regression
+		// unit test for #74795.
+		tuples: colexectestutils.Tuples{
+			{1, 2},
+			{1, 2},
+			{1, 2},
+			{nil, 7},
+			{nil, 7},
+		},
+		expected: colexectestutils.Tuples{
+			{1, 2},
+			{nil, 7},
+			{nil, 7},
+		},
+		isOrderedOnDistinctCols: false,
+		nullsAreDistinct:        true,
+	},
 }
 
 func mustParseJSON(s string) json.JSON {

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -81,6 +81,7 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		"_RIGHT_TYPE_WIDTH", typeWidthReplacement,
 		"_ProbeType", "{{.Left.VecMethod}}",
 		"_BuildType", "{{.Right.VecMethod}}",
+		"_SELECT_DISTINCT", "$selectDistinct",
 		"_USE_PROBE_SEL", ".UseProbeSel",
 		"_PROBING_AGAINST_ITSELF", "$probingAgainstItself",
 		"_DELETING_PROBE_MODE", "$deletingProbeMode",
@@ -96,14 +97,14 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		`{{template "checkColBody" buildDict "Global" .Global "ProbeHasNulls" $1 "BuildHasNulls" $2 "SelectDistinct" $3 "UseProbeSel" $4 "ProbingAgainstItself" $5 "DeletingProbeMode" $6}}`,
 	)
 
-	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 3)
+	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 4)
 	s = checkColWithNulls.ReplaceAllString(s,
-		`{{template "checkColWithNulls" buildDict "Global" . "UseProbeSel" $1 "ProbingAgainstItself" $2 "DeletingProbeMode" $3}}`,
+		`{{template "checkColWithNulls" buildDict "Global" . "SelectDistinct" $1 "UseProbeSel" $2 "ProbingAgainstItself" $3 "DeletingProbeMode" $4}}`,
 	)
 
-	checkColFunctionTemplate := makeFunctionRegex("_CHECK_COL_FUNCTION_TEMPLATE", 2)
+	checkColFunctionTemplate := makeFunctionRegex("_CHECK_COL_FUNCTION_TEMPLATE", 3)
 	s = checkColFunctionTemplate.ReplaceAllString(s,
-		`{{template "checkColFunctionTemplate" buildDict "Global" . "ProbingAgainstItself" $1 "DeletingProbeMode" $2}}`,
+		`{{template "checkColFunctionTemplate" buildDict "Global" . "SelectDistinct" $1 "ProbingAgainstItself" $2 "DeletingProbeMode" $3}}`,
 	)
 
 	checkColForDistinctWithNulls := makeFunctionRegex("_CHECK_COL_FOR_DISTINCT_WITH_NULLS", 1)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -81,6 +81,7 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		"_RIGHT_TYPE_WIDTH", typeWidthReplacement,
 		"_ProbeType", "{{.Left.VecMethod}}",
 		"_BuildType", "{{.Right.VecMethod}}",
+		"_GLOBAL", "$global",
 		"_SELECT_DISTINCT", "$selectDistinct",
 		"_USE_PROBE_SEL", ".UseProbeSel",
 		"_PROBING_AGAINST_ITSELF", "$probingAgainstItself",
@@ -92,9 +93,9 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 	assignNeRe := makeFunctionRegex("_ASSIGN_NE", 6)
 	s = assignNeRe.ReplaceAllString(s, makeTemplateFunctionCall("Global.Right.Assign", 6))
 
-	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 6)
+	checkColBody := makeFunctionRegex("_CHECK_COL_BODY", 7)
 	s = checkColBody.ReplaceAllString(s,
-		`{{template "checkColBody" buildDict "Global" .Global "ProbeHasNulls" $1 "BuildHasNulls" $2 "SelectDistinct" $3 "UseProbeSel" $4 "ProbingAgainstItself" $5 "DeletingProbeMode" $6}}`,
+		`{{template "checkColBody" buildDict "Global" $1 "ProbeHasNulls" $2 "BuildHasNulls" $3 "SelectDistinct" $4 "UseProbeSel" $5 "ProbingAgainstItself" $6 "DeletingProbeMode" $7}}`,
 	)
 
 	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 4)
@@ -105,11 +106,6 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 	checkColFunctionTemplate := makeFunctionRegex("_CHECK_COL_FUNCTION_TEMPLATE", 3)
 	s = checkColFunctionTemplate.ReplaceAllString(s,
 		`{{template "checkColFunctionTemplate" buildDict "Global" . "SelectDistinct" $1 "ProbingAgainstItself" $2 "DeletingProbeMode" $3}}`,
-	)
-
-	checkColForDistinctWithNulls := makeFunctionRegex("_CHECK_COL_FOR_DISTINCT_WITH_NULLS", 1)
-	s = checkColForDistinctWithNulls.ReplaceAllString(s,
-		`{{template "checkColForDistinctWithNulls" buildDict "Global" . "UseProbeSel" $1}}`,
 	)
 
 	checkBody := makeFunctionRegex("_CHECK_BODY", 3)

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -788,3 +788,27 @@ SELECT * FROM gen_as_id_seqopt ORDER BY a
 8   5   7
 9   8   11
 10  11  2
+
+# Regression test for hitting an internal error in the vectorized unordered
+# distinct when NULLs are present in the rows being inserted (#74795).
+statement ok
+CREATE TABLE t74795 (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL,
+    deletion_request_id TEXT,
+    UNIQUE INDEX (account_id, deletion_request_id)
+);
+INSERT INTO t74795
+    (account_id)
+VALUES
+    ('foo'),
+    ('foo'),
+    ('foo')
+ON CONFLICT (account_id, deletion_request_id) DO NOTHING;
+
+query TT
+SELECT account_id, deletion_request_id FROM t74795
+----
+foo  NULL
+foo  NULL
+foo  NULL


### PR DESCRIPTION
**colexechash: fix an internal error with distinct mode**

This commit fixes a bug with the hash table when it is used by the
unordered distinct when NULLs are treated as different. This is the case
when UPSERT or INSERT ... ON CONFLICT queries have to perform
`upsert-distinct-on` operation.

The problem was that we were updating some internal state (`GroupID`
slice responsible for tracking what is the current duplicate candidate
for each row being probed) in more cases than necessary. The code path
in question is used for two purposes:
- first, when we're removing the duplicates from within the batch,
without looking at the state of the hash table at all. In this case we
do want the update mentioned above;
- next, when the batch only contains unique rows, we want to remove the
duplicates when comparing against the hash table. In this case we do not
want the update.

The bug is fixed by refactoring the code to not update the internal
state at all; instead, we now rely on the `distinct` flag for each row
to tell us that the row is distinct within the batch, and we then
correctly populate `HeadID` value for it (which was the ultimate goal
all the time, and previously we used `GroupID` value as an
intermediary).

This mistake would not result in incorrect results (because `distinct`
flag is still marked correctly) and could only result in an internal
error due to index out of bounds. In particular, for the error to occur
the last row in the vectorized batch must have a NULL value in any
column (except for the last one) used for the distinctness check.

Fixes: #74795.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when performing UPSERT or INSERT ... ON CONFLICT queries
in some cases when the new rows contained NULL values (either NULLS
explicitly specified or NULLs used since some columns were omitted).

**colexechash: cleanup the previous commit**

The idea behind this commit is to remove some dead code (and actually get
a minor performance improvement) by skipping the check of a conditional
that is always true as well as removing another conditional that is
always false.

We chose to not squash this commit into the previous one because the
latter will be backported, and we want to reduce the amount of code
changes for the backport.

Release note: None

**colexectestutils: increase test coverage by randomizing batch length**

We are already randomizing the max batch size used in a run of our unit
tests; however, previously it would be fixed for a single run. This
commit makes it so that on each batch produced by our test operators we
independently decide what length to use - with 50% chance we keep on
using the maximum while in the remaining cases we'll pick a random
length that doesn't exceed the maximum.

Release note: None

**colexechash: remove some dead code**

This commit takes advantage of the observation that `probeSel` argument
in some templated function calls is never `nil` and removes some code
that was present for the case when it is `nil`.

Release note: None

**colexechash: combine two conditionals into one in distinct mode**

Previously, we had the code of the form
```
if keyID != 0 {
...
}
if keyID == 0 {
...
}
```
being generated for the distinct mode. This commit adjusts the template
to generate
```
if keyID != 0 {
...
} else {
...
}
```
instead.

Release note: None