### PR TITLE
sql: support setting `check_function_bodies`

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2859,6 +2859,10 @@ func (m *sessionDataMutator) SetSafeUpdates(val bool) {
 	m.data.SafeUpdates = val
 }
 
+func (m *sessionDataMutator) SetCheckFunctionBodies(val bool) {
+	m.data.CheckFunctionBodies = val
+}
+
 func (m *sessionDataMutator) SetPreferLookupJoinsForFKs(val bool) {
 	m.data.PreferLookupJoinsForFKs = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4625,6 +4625,7 @@ application_name                                      ·
 avoid_buffering                                       off
 backslash_quote                                       safe_encoding
 bytea_output                                          hex
+check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
 database                                              test

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4032,6 +4032,7 @@ application_name                                      ·                   NULL 
 avoid_buffering                                       off                 NULL      NULL        NULL        string
 backslash_quote                                       safe_encoding       NULL      NULL        NULL        string
 bytea_output                                          hex                 NULL      NULL        NULL        string
+check_function_bodies                                 on                  NULL      NULL        NULL        string
 client_encoding                                       UTF8                NULL      NULL        NULL        string
 client_min_messages                                   notice              NULL      NULL        NULL        string
 database                                              test                NULL      NULL        NULL        string
@@ -4141,6 +4142,7 @@ application_name                                      ·                   NULL 
 avoid_buffering                                       off                 NULL  user     NULL      false               false
 backslash_quote                                       safe_encoding       NULL  user     NULL      safe_encoding       safe_encoding
 bytea_output                                          hex                 NULL  user     NULL      hex                 hex
+check_function_bodies                                 on                  NULL  user     NULL      on                  on
 client_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                   notice              NULL  user     NULL      notice              notice
 database                                              test                NULL  user     NULL      ·                   test
@@ -4244,6 +4246,7 @@ application_name                                      NULL    NULL     NULL     
 avoid_buffering                                       NULL    NULL     NULL     NULL        NULL
 backslash_quote                                       NULL    NULL     NULL     NULL        NULL
 bytea_output                                          NULL    NULL     NULL     NULL        NULL
+check_function_bodies                                 NULL    NULL     NULL     NULL        NULL
 client_encoding                                       NULL    NULL     NULL     NULL        NULL
 client_min_messages                                   NULL    NULL     NULL     NULL        NULL
 crdb_version                                          NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -642,6 +642,24 @@ SET LC_NUMERIC = 'en_US.UTF-8'
 statement error invalid value for parameter "lc_time": "en_US.UTF-8"
 SET LC_TIME = 'en_US.UTF-8'
 
+subtest check_function_bodies_test
+
+statement ok
+SET check_function_bodies = true
+
+query T
+SHOW check_function_bodies
+----
+on
+
+statement ok
+SET check_function_bodies = false
+
+query T
+SHOW check_function_bodies
+----
+off
+
 # Test custom session variables
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -30,6 +30,7 @@ application_name                                      ·
 avoid_buffering                                       off
 backslash_quote                                       safe_encoding
 bytea_output                                          hex
+check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
 database                                              test

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -219,6 +219,9 @@ message LocalOnlySessionData {
   // buffered by conn executor.  This is currently used by replication primitives
   // to ensure the data is flushed to the consumer immediately.
   bool avoid_buffering = 59;
+  // CheckFunctionBodies indicates whether functions are validated during
+  // creation.
+  bool check_function_bodies = 60;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/unsupported_vars.go
+++ b/pkg/sql/unsupported_vars.go
@@ -65,7 +65,7 @@ var UnsupportedVars = func(ss ...string) map[string]struct{} {
 	"array_nulls",
 	"backend_flush_after",
 	// "bytea_output",
-	"check_function_bodies",
+	// "check_function_bodies",
 	// "client_encoding",
 	// "client_min_messages",
 	"commit_delay",

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1085,6 +1085,23 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: globalFalse,
 	},
 
+	// See https://www.postgresql.org/docs/13/runtime-config-client.html.
+	`check_function_bodies`: {
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CheckFunctionBodies), nil
+		},
+		GetStringVal: makePostgresBoolGetStringValFn("check_function_bodies"),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("check_function_bodies", s)
+			if err != nil {
+				return err
+			}
+			m.SetCheckFunctionBodies(b)
+			return nil
+		},
+		GlobalDefault: globalTrue,
+	},
+
 	// CockroachDB extension.
 	`prefer_lookup_joins_for_fks`: {
 		Get: func(evalCtx *extendedEvalContext) (string, error) {


### PR DESCRIPTION
This commonly appears in dumps as noise for the actual problem (CREATE
FUNCTION doesn't work). This commit adds setting the variable, but we
don't do anything with it because we don't support UDFs.

Release note (sql change): Support setting `check_function_bodies`. Note
this doesn't variable doesn't do anything.