### PR TITLE
sql: Make Collection.getSchemaByID consistent with Collection.getTableByID

### DIFF
--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -800,7 +800,7 @@ func getPublicSchemaDescForDatabase(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) error {
 		publicSchemaID := db.GetSchemaID(tree.PublicSchema)
-		scDesc, err = descriptors.GetImmutableSchemaByID(ctx, txn, publicSchemaID, tree.SchemaLookupFlags{})
+		scDesc, err = descriptors.GetImmutableSchemaByID(ctx, txn, publicSchemaID, tree.SchemaLookupFlags{Required: true})
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -613,7 +613,7 @@ func (p *planner) canCreateOnSchema(
 	checkPublicSchema shouldCheckPublicSchema,
 ) error {
 	scDesc, err := p.Descriptors().GetImmutableSchemaByID(
-		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{})
+		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{Required: true})
 	if err != nil {
 		return err
 	}
@@ -738,7 +738,7 @@ func (p *planner) HasOwnershipOnSchema(
 		return p.User().IsNodeUser(), nil
 	}
 	scDesc, err := p.Descriptors().GetImmutableSchemaByID(
-		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{},
+		ctx, p.Txn(), schemaID, tree.SchemaLookupFlags{Required: true},
 	)
 	if err != nil {
 		return false, err

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -284,10 +284,7 @@ func getSchemaByName(
 			AvoidLeased:    avoidLeased,
 			AvoidSynthetic: avoidSynthetic,
 		})
-		// Deal with the fact that ByID retrieval always uses required and the
-		// logic here never returns an error if the descriptor does not exist.
-		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
-			errors.Is(err, catalog.ErrDescriptorDropped) {
+		if errors.Is(err, catalog.ErrDescriptorDropped) {
 			err = nil
 		}
 		return sc != nil, sc, err

--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -56,6 +56,7 @@ func (tc *Collection) hydrateTypesInTableDesc(
 			sc, err := tc.getSchemaByID(
 				ctx, txn, desc.ParentSchemaID,
 				tree.SchemaLookupFlags{
+					Required:       true,
 					IncludeOffline: true,
 					RequireMutable: true,
 				},
@@ -89,7 +90,7 @@ func (tc *Collection) hydrateTypesInTableDesc(
 				return tree.TypeName{}, nil, err
 			}
 			sc, err := tc.GetImmutableSchemaByID(
-				ctx, txn, desc.GetParentSchemaID(), tree.SchemaLookupFlags{})
+				ctx, txn, desc.GetParentSchemaID(), tree.SchemaLookupFlags{Required: true})
 			if err != nil {
 				return tree.TypeName{}, nil, err
 			}

--- a/pkg/sql/catalog/descs/schema.go
+++ b/pkg/sql/catalog/descs/schema.go
@@ -12,16 +12,16 @@ package descs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/errors"
 )
 
 // GetMutableSchemaByName resolves the schema and, if applicable, returns a
@@ -128,7 +128,15 @@ func (tc *Collection) getSchemaByID(
 	}
 	if sc, err := tc.virtual.getSchemaByID(
 		ctx, schemaID, flags.RequireMutable,
-	); sc != nil || err != nil {
+	); err != nil {
+		if errors.Is(err, catalog.ErrDescriptorNotFound) {
+			if flags.Required {
+				return nil, sqlerrors.NewUndefinedSchemaError(fmt.Sprintf("[%d]", schemaID))
+			}
+			return nil, nil
+		}
+		return nil, err
+	} else if sc != nil {
 		return sc, err
 	}
 
@@ -141,13 +149,17 @@ func (tc *Collection) getSchemaByID(
 	// Otherwise, fall back to looking up the descriptor with the desired ID.
 	desc, err := tc.getDescriptorByID(ctx, txn, schemaID, flags)
 	if err != nil {
+		if errors.Is(err, catalog.ErrDescriptorNotFound) {
+			if flags.Required {
+				return nil, sqlerrors.NewUndefinedSchemaError(fmt.Sprintf("[%d]", schemaID))
+			}
+			return nil, nil
+		}
 		return nil, err
 	}
-
 	schemaDesc, ok := desc.(catalog.SchemaDescriptor)
 	if !ok {
-		return nil, pgerror.Newf(pgcode.WrongObjectType,
-			"descriptor %d was not a schema", schemaID)
+		return nil, sqlerrors.NewUndefinedSchemaError(fmt.Sprintf("[%d]", schemaID))
 	}
 
 	return schemaDesc, nil

--- a/pkg/sql/comment_on_constraint.go
+++ b/pkg/sql/comment_on_constraint.go
@@ -31,8 +31,8 @@ type commentOnConstraintNode struct {
 	metadataUpdater scexec.DescriptorMetadataUpdater
 }
 
-//CommentOnConstraint add comment on a constraint
-//Privileges: CREATE on table
+// CommentOnConstraint add comment on a constraint
+// Privileges: CREATE on table
 func (p *planner) CommentOnConstraint(
 	ctx context.Context, n *tree.CommentOnConstraint,
 ) (planNode, error) {
@@ -70,7 +70,7 @@ func (n *commentOnConstraintNode) startExec(params runParams) error {
 		return err
 	}
 	schema, err := params.p.Descriptors().GetImmutableSchemaByID(
-		params.ctx, params.extendedEvalCtx.Txn, n.tableDesc.GetParentSchemaID(), tree.SchemaLookupFlags{},
+		params.ctx, params.extendedEvalCtx.Txn, n.tableDesc.GetParentSchemaID(), tree.SchemaLookupFlags{Required: true},
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/comment_on_schema.go
+++ b/pkg/sql/comment_on_schema.go
@@ -54,7 +54,7 @@ func (p *planner) CommentOnSchema(ctx context.Context, n *tree.CommentOnSchema) 
 	}
 
 	schemaDesc, err := p.Descriptors().GetImmutableSchemaByID(ctx, p.txn,
-		db.GetSchemaID(string(n.Name)), tree.DatabaseLookupFlags{Required: true})
+		db.GetSchemaID(string(n.Name)), tree.SchemaLookupFlags{Required: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -77,7 +77,7 @@ type RewriteEvTypes string
 
 const evTypeSelect RewriteEvTypes = "1"
 
-//PGShDependType is an enumeration that lists pg_shdepend deptype column values
+// PGShDependType is an enumeration that lists pg_shdepend deptype column values
 type PGShDependType string
 
 const (
@@ -1423,13 +1423,13 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 				objID := h.rewriteOid(table.GetID(), dep.ID)
 				for _, colID := range dep.ColumnIDs {
 					if err := addRow(
-						pgRewriteTableOid,              //classid
-						objID,                          //objid
-						zeroVal,                        //objsubid
-						pgClassTableOid,                //refclassid
-						refObjOid,                      //refobjid
-						tree.NewDInt(tree.DInt(colID)), //refobjsubid
-						depTypeNormal,                  //deptype
+						pgRewriteTableOid,              // classid
+						objID,                          // objid
+						zeroVal,                        // objsubid
+						pgClassTableOid,                // refclassid
+						refObjOid,                      // refobjid
+						tree.NewDInt(tree.DInt(colID)), // refobjsubid
+						depTypeNormal,                  // deptype
 					); err != nil {
 						return err
 					}
@@ -2851,7 +2851,7 @@ func getSchemaAndTypeByTypeID(
 		ctx,
 		p.txn,
 		typDesc.GetParentSchemaID(),
-		tree.SchemaLookupFlags{},
+		tree.SchemaLookupFlags{Required: true},
 	)
 	if err != nil {
 		return "", nil, err
@@ -2962,7 +2962,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 						ctx,
 						p.txn,
 						table.GetParentSchemaID(),
-						tree.SchemaLookupFlags{},
+						tree.SchemaLookupFlags{Required: true},
 					)
 					if err != nil {
 						return false, err
@@ -4378,7 +4378,7 @@ func stringOid(s string) *tree.DOid {
 	return h.getOid()
 }
 
-//MakeConstraintOidBuilder constructs an OID builder.
+// MakeConstraintOidBuilder constructs an OID builder.
 func MakeConstraintOidBuilder() descmetadata.ConstraintOidBuilder {
 	return makeOidHasher()
 }

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -484,7 +484,7 @@ func (p *planner) GetTypeDescriptor(
 		return tree.TypeName{}, nil, err
 	}
 	sc, err := p.Descriptors().GetImmutableSchemaByID(
-		ctx, p.txn, desc.GetParentSchemaID(), tree.SchemaLookupFlags{})
+		ctx, p.txn, desc.GetParentSchemaID(), tree.SchemaLookupFlags{Required: true})
 	if err != nil {
 		return tree.TypeName{}, nil, err
 	}
@@ -760,9 +760,9 @@ func (p *planner) getQualifiedTableName(
 			AvoidLeased:    true,
 		})
 	switch {
-	case err == nil:
+	case scDesc != nil:
 		schemaName = tree.Name(scDesc.GetName())
-	case desc.IsTemporary() && errors.Is(err, catalog.ErrDescriptorNotFound):
+	case desc.IsTemporary() && scDesc == nil:
 		// We've lost track of the session which owned this schema, but we
 		// can come up with a name that is also going to be unique and
 		// informative and looks like a pg_temp_<session_id> name.
@@ -838,7 +838,7 @@ func (p *planner) getQualifiedTypeName(
 
 	schemaID := desc.GetParentSchemaID()
 	scDesc, err := p.Descriptors().GetImmutableSchemaByID(
-		ctx, p.txn, schemaID, tree.SchemaLookupFlags{},
+		ctx, p.txn, schemaID, tree.SchemaLookupFlags{Required: true},
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1177,7 +1177,7 @@ func (t *typeSchemaChanger) canRemoveEnumValueFromArrayUsages(
 		if len(rows) > 0 {
 			// Use an FQN in the error message.
 			parentSchema, err := descsCol.GetImmutableSchemaByID(
-				ctx, txn, desc.GetParentSchemaID(), tree.SchemaLookupFlags{})
+				ctx, txn, desc.GetParentSchemaID(), tree.SchemaLookupFlags{Required: true})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
getSchemaByID now respects SchemaLookupFlags.Required and returns
sqlerrors.NewUndefinedSchemaError instead of catalog.ErrDescriptorNotFound

Release note: None

`getTableByID` for reference
```
func (tc *Collection) getTableByID(
	ctx context.Context, txn *kv.Txn, tableID descpb.ID, flags tree.ObjectLookupFlags,
) (catalog.TableDescriptor, error) {
	desc, err := tc.getDescriptorByID(ctx, txn, tableID, flags.CommonLookupFlags)
	if err != nil {
		if errors.Is(err, catalog.ErrDescriptorNotFound) {
			return nil, sqlerrors.NewUndefinedRelationError(
				&tree.TableRef{TableID: int64(tableID)})
		}
		return nil, err
	}
	table, ok := desc.(catalog.TableDescriptor)
	if !ok {
		return nil, sqlerrors.NewUndefinedRelationError(
			&tree.TableRef{TableID: int64(tableID)})
	}
	hydrated, err := tc.hydrateTypesInTableDesc(ctx, txn, table)
	if err != nil {
		return nil, err
	}
	return hydrated, nil
}
```