### PR TITLE
security,*: extend CheckPasswordHashValidity to return a GH issue number (scram 1/10)

### DIFF
--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -154,31 +154,38 @@ func isMD5Hash(hashedPassword []byte) bool {
 // Return values:
 // - isPreHashed indicates whether the password is already hashed.
 // - supportedScheme indicates whether the scheme is currently supported
-//   for authentication.
+//   for authentication. If false, issueNum indicates which github
+//   issue to report in the error message.
 // - schemeName is the name of the hashing scheme, for inclusion
 //   in error messages (no guarantee is made of stability of this string).
 // - hashedPassword is a translated version from the input,
 //   suitable for storage in the password database.
 func CheckPasswordHashValidity(
 	ctx context.Context, inputPassword []byte,
-) (isPreHashed, supportedScheme bool, schemeName string, hashedPassword []byte, err error) {
+) (
+	isPreHashed, supportedScheme bool,
+	issueNum int,
+	schemeName string,
+	hashedPassword []byte,
+	err error,
+) {
 	if isBcryptHash(inputPassword) {
 		// Trim the "CRDB-BCRYPT" prefix. We trim this because previous version
 		// CockroachDB nodes do not understand the prefix when stored.
 		hashedPassword = inputPassword[len(crdbBcryptPrefix):]
 		// The bcrypt.Cost() function parses the hash and checks its syntax.
 		_, err = bcrypt.Cost(hashedPassword)
-		return true, true, "crdb-bcrypt", hashedPassword, err
+		return true, true, 0, "crdb-bcrypt", hashedPassword, err
 	}
 	if isSCRAMHash(inputPassword) {
-		return true, false /* unsupported yet */, "scram-sha-256", inputPassword, nil
+		return true, false /* unsupported yet */, 42519 /* issueNum */, "scram-sha-256", inputPassword, nil
 	}
 	if isMD5Hash(inputPassword) {
 		// See: https://github.com/cockroachdb/cockroach/issues/73337
-		return true, false /* not supported */, "md5", inputPassword, nil
+		return true, false /* not supported */, 73337 /* issueNum */, "md5", inputPassword, nil
 	}
 
-	return false, false, "", inputPassword, nil
+	return false, false, 0, "", inputPassword, nil
 }
 
 // MinPasswordLength is the cluster setting that configures the

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -265,13 +265,14 @@ func (p *planner) checkPasswordAndGetHash(
 	if security.AutoDetectPasswordHashes.Get(&st.SV) {
 		var isPreHashed, schemeSupported bool
 		var schemeName string
-		isPreHashed, schemeSupported, schemeName, hashedPassword, err = security.CheckPasswordHashValidity(ctx, []byte(password))
+		var issueNum int
+		isPreHashed, schemeSupported, issueNum, schemeName, hashedPassword, err = security.CheckPasswordHashValidity(ctx, []byte(password))
 		if err != nil {
 			return hashedPassword, pgerror.WithCandidateCode(err, pgcode.Syntax)
 		}
 		if isPreHashed {
 			if !schemeSupported {
-				return hashedPassword, unimplemented.NewWithIssueDetailf(42519, schemeName, "the password hash scheme %q is not supported", schemeName)
+				return hashedPassword, unimplemented.NewWithIssueDetailf(issueNum, schemeName, "the password hash scheme %q is not supported", schemeName)
 			}
 			return hashedPassword, nil
 		}

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1421,15 +1421,15 @@ SELECT 'CRDB-BCRYPT$'||'2a$'||'10$'||'vcmoIBvgeHjgScVHWRMWI.Z3v03WMixAw2bBS6qZih
 statement ok
 CREATE USER hash1 WITH PASSWORD '$bcrypt_pw'
 
-# We don't plan to support md5 ever.
-statement error pgcode 0A000 hash scheme "md5" is not supported
+# Refers to https://github.com/cockroachdb/cockroach/issues/73337
+statement error pgcode 0A000 hash scheme "md5" is not supported.*\nHINT.*\n.*73337
 CREATE USER hash2 WITH PASSWORD 'md5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 let $scram_pw
 SELECT 'SCRAM-SHA-256$'||'4096:B5VaTCvCLDzZxSYL829oVA==$'||'3Ako3mNxNtdsaSOJl0Av3i6vyV2OiSP9Ly7famdFSbw=:d7BfSmrtjwbF74mSoOhQiDSpoIvlakXKdpBNb3Meunc='
 
 # Refers to https://github.com/cockroachdb/cockroach/issues/42519
-statement error pgcode 0A000 hash scheme "scram-sha-256" is not supported
+statement error pgcode 0A000 hash scheme "scram-sha-256" is not supported.*\nHINT.*\n.*42519
 CREATE USER hash3 WITH PASSWORD '$scram_pw'
 
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6338,7 +6338,7 @@ table's zone configuration this will return NULL.`,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				arg := []byte(tree.MustBeDBytes(args[0]))
 				ctx := evalCtx.Ctx()
-				isHashed, _, schemeName, _, err := security.CheckPasswordHashValidity(ctx, arg)
+				isHashed, _, _, schemeName, _, err := security.CheckPasswordHashValidity(ctx, arg)
 				if err != nil {
 					return tree.DNull, pgerror.WithCandidateCode(err, pgcode.Syntax)
 				}


### PR DESCRIPTION
(PR peeled away from #74301; next PR in series: #74842)

This makes it clear what is not supported if the user requires a md5 hash.

Release note: None