### PR TITLE
pgwire,sqlproxyccl: base support for a SCRAM authentication flow  (scram 2/10)

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -170,4 +170,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-44	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-46	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -177,6 +177,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-44</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-46</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux_amd64": [
             "//pkg/ccl/utilccl",
             "//pkg/security",
+            "//pkg/settings",
             "//pkg/sql",
             "//pkg/sql/sem/tree",
             "//pkg/sql/pgwire",

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
@@ -113,7 +114,7 @@ func authGSS(
 
 // checkEntry validates that the HBA entry contains exactly one of the
 // include_realm=0 directive or an identity-mapping configuration.
-func checkEntry(entry hba.Entry) error {
+func checkEntry(_ *settings.Values, entry hba.Entry) error {
 	hasInclude0 := false
 	hasMap := false
 	for _, op := range entry.Options {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -242,6 +242,8 @@ const (
 	// ScanWholeRows is the version at which the Header.WholeRowsOfSize parameter
 	// was introduced, preventing limited scans from returning partial rows.
 	ScanWholeRows
+	// SCRAM authentication is available.
+	SCRAMAuthentication
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -365,6 +367,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     ScanWholeRows,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 44},
+	},
+	{
+		Key:     SCRAMAuthentication,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 46},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -31,11 +31,12 @@ func _() {
 	_ = x[EnsureSpanConfigSubscription-20]
 	_ = x[EnableSpanConfigStore-21]
 	_ = x[ScanWholeRows-22]
+	_ = x[SCRAMAuthentication-23]
 }
 
-const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsAlterSystemProtectedTimestampAddColumnEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRows"
+const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsAlterSystemProtectedTimestampAddColumnEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthentication"
 
-var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 463, 493, 521, 542, 555}
+var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 463, 493, 521, 542, 555, 574}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -757,6 +757,15 @@ var logicTestConfigs = []testClusterConfig{
 		localities:        multiregion9node3region3azsLocalities,
 		overrideVectorize: "off",
 	},
+	{
+		name:                "local-mixed-21.2-22.1",
+		numNodes:            1,
+		overrideDistSQLMode: "off",
+		overrideAutoStats:   "false",
+		bootstrapVersion:    roachpb.Version{Major: 21, Minor: 2},
+		binaryVersion:       roachpb.Version{Major: 22, Minor: 1},
+		disableUpgrade:      true,
+	},
 }
 
 // An index in the above slice.

--- a/pkg/sql/logictest/testdata/logic_test/scram_221_upgrade
+++ b/pkg/sql/logictest/testdata/logic_test/scram_221_upgrade
@@ -1,0 +1,5 @@
+# LogicTest: local-mixed-21.2-22.1
+
+# Check that the new HBA syntax is not accepted during the upgrade.
+statement error HBA authentication method "scram-sha-256" requires all nodes to be upgraded to 21.2-
+set cluster setting server.host_based_authentication.configuration = 'host all all all scram-sha-256'

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/col/coldata",
         "//pkg/security",
         "//pkg/server/telemetry",

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
+        "@com_github_xdg_go_scram//:scram",
     ],
 )
 

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -37,6 +37,13 @@ const (
 	// authCleartextPassword is the pgwire auth response code to request
 	// a plaintext password during the connection handshake.
 	authCleartextPassword int32 = 3
+
+	// authReqSASL is the begin request for a SCRAM handshake.
+	authReqSASL int32 = 10
+	// authReqSASLContinue is the continue request for a SCRAM handshake.
+	authReqSASLContinue int32 = 11
+	// authReqSASLFin is the final message for a SCRAM handshake.
+	authReqSASLFin int32 = 12
 )
 
 type authOptions struct {

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -14,18 +14,23 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/xdg-go/scram"
 )
 
 // This file contains the methods that are accepted to perform
@@ -173,10 +178,10 @@ func passwordString(pwdData []byte) (string, error) {
 }
 
 func authScram(
-	_ context.Context,
+	ctx context.Context,
 	c AuthConn,
 	_ tls.ConnectionState,
-	_ *sql.ExecutorConfig,
+	execCfg *sql.ExecutorConfig,
 	_ *hba.Entry,
 	_ *identmap.Conf,
 ) (*AuthBehaviors, error) {
@@ -188,7 +193,122 @@ func authScram(
 		clientConnection bool,
 		pwRetrieveFn PasswordRetrievalFn,
 	) error {
-		return unimplemented.NewWithIssue(42519, "scram auth not yet available")
+		// This scram auth credential was generated on pg with:
+		//      create user abc with password 'abc'
+		// const testPassword = "SCRAM-SHA-256$4096:pAlYy62NTdETKb291V/Wow==$OXMAj9oD53QucEYVMBcdhRnjg2/S/iZY/88ShZnputA=:r8l4c1pk9bmDi+8an059l/nt9Bg1zb1ikkg+DeRv4UQ="
+		salt, err := base64.StdEncoding.DecodeString("pAlYy62NTdETKb291V/Wow==")
+		if err != nil {
+			panic(err)
+		}
+		storedKey, err := base64.StdEncoding.DecodeString("OXMAj9oD53QucEYVMBcdhRnjg2/S/iZY/88ShZnputA=")
+		if err != nil {
+			panic(err)
+		}
+		serverKey, err := base64.StdEncoding.DecodeString("r8l4c1pk9bmDi+8an059l/nt9Bg1zb1ikkg+DeRv4UQ=")
+		if err != nil {
+			panic(err)
+		}
+		scramServer, _ := scram.SHA256.NewServer(func(user string) (scram.StoredCredentials, error) {
+			if user == "abc" {
+				return scram.StoredCredentials{
+					KeyFactors: scram.KeyFactors{
+						Salt:  string(salt),
+						Iters: 4096,
+					},
+					StoredKey: storedKey,
+					ServerKey: serverKey,
+				}, nil
+			}
+			return scram.StoredCredentials{}, errors.New("no scram cookie for you")
+		})
+
+		handshake := scramServer.NewConversation()
+
+		// NB: SCRAM-SHA-256-PLUS is not supported, see
+		// https://github.com/cockroachdb/cockroach/issues/74300
+		// There is one nul byte to terminate the first string,
+		// then another nul byte to terminate the list.
+		const supportedMethods = "SCRAM-SHA-256\x00\x00"
+		if err := c.SendAuthRequest(authReqSASL, []byte(supportedMethods)); err != nil {
+			return err
+		}
+
+		initial := true
+		for {
+			if handshake.Done() {
+				break
+			}
+
+			// Receive a response from the client.
+			resp, err := c.GetPwdData()
+			if err != nil {
+				return err
+			}
+			var input []byte
+			if initial {
+				// Quoth postgres, backend/auth.go:
+				//
+				// The first SASLInitialResponse message is different from the others.
+				// It indicates which SASL mechanism the client selected, and contains
+				// an optional Initial Client Response payload. The subsequent
+				// SASLResponse messages contain just the SASL payload.
+				//
+				rb := pgwirebase.ReadBuffer{Msg: resp}
+				reqMethod, err := rb.GetString()
+				if err != nil {
+					return err
+				}
+				if reqMethod != "SCRAM-SHA-256" {
+					c.LogAuthInfof(ctx, "client requests unknown scram method %q", reqMethod)
+					err := unimplemented.NewWithIssue(74300, "channel binding not supported")
+					// We need to manually report the unimplemented error because it is not
+					// passed through to the client as-is (authn errors are hidden behind
+					// a generic "authn failed" error).
+					sqltelemetry.RecordError(ctx, err, &execCfg.Settings.SV)
+					return err
+				}
+				inputLen, err := rb.GetUint32()
+				if err != nil {
+					return err
+				}
+				// PostgreSQL ignores input from clients that pass -1 as length,
+				// but does not treat it as invalid.
+				if inputLen < math.MaxUint32 {
+					input, err = rb.GetBytes(int(inputLen))
+					if err != nil {
+						return err
+					}
+				}
+				initial = false
+			} else {
+				input = resp
+			}
+
+			// Feed the client message to the state machine.
+			got, err := handshake.Step(string(input))
+			if err != nil {
+				c.LogAuthInfof(ctx, "scram handshake error: %v", err)
+				break
+			}
+			// Decide which response to send to the client.
+			reqType := authReqSASLContinue
+			if handshake.Done() {
+				// This is the last message.
+				reqType = authReqSASLFin
+			}
+			// Send the response to the client.
+			if err := c.SendAuthRequest(reqType, []byte(got)); err != nil {
+				return err
+			}
+		}
+
+		// Was the authentication for the right username?
+
+		// Did authentication succeed?
+		if !handshake.Valid() {
+			return errors.Errorf(security.ErrPasswordUserAuthFailed, systemIdentity)
+		}
+		return nil // auth success!
 	})
 	return b, nil
 }

--- a/pkg/sql/pgwire/testdata/auth/hba_syntax
+++ b/pkg/sql/pgwire/testdata/auth/hba_syntax
@@ -20,7 +20,7 @@ host all all 0.0.0.0/0 invalid
 ERROR: unimplemented: unknown auth method "invalid" (SQLSTATE 0A000)
 HINT: You have attempted to use a feature that is not yet implemented.<STANDARD REFERRAL>
 --
-Supported methods: cert, cert-password, password, reject, trust
+Supported methods: cert, cert-password, cert-scram-sha-256, password, reject, scram-sha-256, trust
 
 
 # CockroachDB does not (yet?) support per-db HBA rules.

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -3,6 +3,7 @@ config secure
 
 sql
 CREATE USER foo WITH PASSWORD 'abc';
+CREATE USER abc WITH PASSWORD 'abc';
 ----
 ok
 
@@ -10,35 +11,66 @@ subtest only_scram
 
 set_hba
 host all foo all scram-sha-256
+host all abc all scram-sha-256
 ----
 # Active authentication configuration on this node:
 # Original configuration:
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all foo all scram-sha-256
+# host all abc all scram-sha-256
 #
 # Interpreted configuration:
 # TYPE DATABASE USER ADDRESS METHOD        OPTIONS
 host   all      root all     cert-password
 host   all      foo  all     scram-sha-256
+host   all      abc  all     scram-sha-256
 
 subtest only_scram/conn_scram
 
+# For now (testing), foo does not have SCRAM credentials.
 connect user=foo password=abc
 ----
-ERROR: unimplemented: scram auth not yet available (SQLSTATE 0A000)
-HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/42519/v22.1
+ERROR: password authentication failed for user foo (SQLSTATE 28000)
 
 authlog 6
 .*client_connection_end
 ----
-4 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
 5 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 6 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-7 {"Detail":"unimplemented: scram auth not yet available","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-8 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-9 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+7 {"EventType":"client_authentication_info","Info":"scram handshake error: no scram cookie for you","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+8 {"Detail":"password authentication failed for user foo","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+9 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+10 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 
+# User abc has SCRAM credentials, but 'mistake' is not its password.
+# Expect authn error.
+connect user=abc password=mistake
+----
+ERROR: password authentication failed for user abc (SQLSTATE 28000)
+
+authlog 6
+.*client_connection_end
+----
+11 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+12 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+13 {"EventType":"client_authentication_info","Info":"scram handshake error: challenge proof invalid","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+14 {"Detail":"password authentication failed for user abc","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+15 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+16 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
+
+connect user=abc password=abc
+----
+ok defaultdb
+
+authlog 5
+.*client_connection_end
+----
+17 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+18 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+19 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+20 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+21 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -73,10 +105,11 @@ subtest scram_cert/scram
 
 connect user=foo password=abc
 ----
-ERROR: unimplemented: scram auth not yet available (SQLSTATE 0A000)
-HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/42519/v22.1
+ERROR: password authentication failed for user foo (SQLSTATE 28000)
 
+connect user=abc password=abc
+----
+ok defaultdb
 
 subtest end
 

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -1,0 +1,83 @@
+config secure
+----
+
+sql
+CREATE USER foo WITH PASSWORD 'abc';
+----
+ok
+
+subtest only_scram
+
+set_hba
+host all foo all scram-sha-256
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all foo all scram-sha-256
+#
+# Interpreted configuration:
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      root all     cert-password
+host   all      foo  all     scram-sha-256
+
+subtest only_scram/conn_scram
+
+connect user=foo password=abc
+----
+ERROR: unimplemented: scram auth not yet available (SQLSTATE 0A000)
+HINT: You have attempted to use a feature that is not yet implemented.
+See: https://go.crdb.dev/issue-v/42519/v22.1
+
+authlog 6
+.*client_connection_end
+----
+4 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+5 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+6 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+7 {"Detail":"unimplemented: scram auth not yet available","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+8 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+9 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
+
+subtest end
+
+subtest end
+
+subtest scram_cert
+
+set_hba
+host all all all cert-scram-sha-256
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all all all cert-scram-sha-256
+#
+# Interpreted configuration:
+# TYPE DATABASE USER ADDRESS METHOD             OPTIONS
+host   all      root all     cert-password
+host   all      all  all     cert-scram-sha-256
+
+subtest scram_cert/cert
+
+# testuser is presenting a valid TLS client cert.
+
+connect user=testuser
+----
+ok defaultdb
+
+subtest end
+
+subtest scram_cert/scram
+
+connect user=foo password=abc
+----
+ERROR: unimplemented: scram auth not yet available (SQLSTATE 0A000)
+HINT: You have attempted to use a feature that is not yet implemented.
+See: https://go.crdb.dev/issue-v/42519/v22.1
+
+
+subtest end
+
+subtest end


### PR DESCRIPTION
(PR peeled away from #74301; previous PR in series #74841; next PR in series: #74843)
Epic CRDB-5349

This commit introduces support for the HBA auth methods
'scram-sha-256' and `'cert-scram-sha-256'. They are gated behind a new
cluster version.

The method callback is merely plumbed in here. There is no
implementation yet (it generates an unsupported error that redirects
to the issue about implementing the feature).

At this time, the implementation in pgwire is merely able to authenticate a fixed user.

We are OK having this imperfect commit in the git history, because
the feature at this point is not enabled by default. A user would
need to opt into it manually by modifying the HBA configuration.
