### PR TITLE
sql,security: support storing SCRAM hashes in ALTER/CREATE USER/ROLE  (scram 3/10)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1428,8 +1428,7 @@ CREATE USER hash2 WITH PASSWORD 'md5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 let $scram_pw
 SELECT 'SCRAM-SHA-256$'||'4096:B5VaTCvCLDzZxSYL829oVA==$'||'3Ako3mNxNtdsaSOJl0Av3i6vyV2OiSP9Ly7famdFSbw=:d7BfSmrtjwbF74mSoOhQiDSpoIvlakXKdpBNb3Meunc='
 
-# Refers to https://github.com/cockroachdb/cockroach/issues/42519
-statement error pgcode 0A000 hash scheme "scram-sha-256" is not supported.*\nHINT.*\n.*42519
+statement ok
 CREATE USER hash3 WITH PASSWORD '$scram_pw'
 
 
@@ -1452,6 +1451,7 @@ query TTB
 SELECT username, substr("hashedPassword", 1, 7), 'CRDB-BCRYPT'||"hashedPassword" = '$bcrypt_pw' FROM system.users WHERE username LIKE 'hash%' ORDER BY 1
 ----
 hash1  $2a$10$  true
+hash3  SCRAM-S  false
 hash4  $2a$10$  false
 hash5  $2a$10$  false
 hash6  $2a$10$  false

--- a/pkg/sql/pgwire/testdata/auth/password_change
+++ b/pkg/sql/pgwire/testdata/auth/password_change
@@ -57,6 +57,8 @@ subtest end
 
 subtest precomputed_hash
 
+subtest precomputed_hash/bcrypt
+
 sql
 CREATE USER userhpw WITH PASSWORD 'CRDB-BCRYPT$3a$10$vcmoIBvgeHjgScVHWRMWI.Z3v03WMixAw2bBS6qZihljSUuwi88Yq'
 ----
@@ -89,6 +91,52 @@ ok
 connect user=userhpw password=abc
 ----
 ok defaultdb
+
+sql
+DROP USER userhpw
+----
+ok
+
+subtest end
+
+subtest precomputed_hash/scram
+
+sql
+CREATE USER userhpw WITH PASSWORD 'SCRAM-SHA-256$9999999999999999999999999999999:Hw/dhibRaBVbObr6bATlqw==$BTFlXuZT2ZNxA3DxogkGgK0wVlOyNtxGoqDI62hyLUo=:3eZMZdAossPInncABj7/N/jkGtRZEUrz7uGkkNibHps='
+----
+ERROR: invalid scram-sha-256 iteration count: strconv.ParseInt: parsing "9999999999999999999999999999999": value out of range (SQLSTATE 42601)
+
+sql
+CREATE USER userhpw WITH PASSWORD 'SCRAM-SHA-256$990000000000:Hw/dhibRaBVbObr6bATlqw==$BTFlXuZT2ZNxA3DxogkGgK0wVlOyNtxGoqDI62hyLUo=:3eZMZdAossPInncABj7/N/jkGtRZEUrz7uGkkNibHps='
+----
+ERROR: scram-sha-256 iteration count not in allowed range (4096,240000000000) (SQLSTATE 42601)
+
+sql
+CREATE USER userhpw WITH PASSWORD 'SCRAM-SHA-256$3000:Hw/dhibRaBVbObr6bATlqw==$BTFlXuZT2ZNxA3DxogkGgK0wVlOyNtxGoqDI62hyLUo=:3eZMZdAossPInncABj7/N/jkGtRZEUrz7uGkkNibHps='
+----
+ERROR: scram-sha-256 iteration count not in allowed range (4096,240000000000) (SQLSTATE 42601)
+
+sql
+CREATE USER userhpw WITH PASSWORD 'SCRAM-SHA-256$119680:Hw/dhibRaBVbObr6bATlqw==$BTFlXuZT2ZNxA3DxogkGgK0wVlOyNtxGoqDI62hyLUo=:3eZMZdAossPInncABj7/N/jkGtRZEUrz7uGkkNibHps='
+----
+ok
+
+# For now, the login using SCRAM is not yet recognized.
+connect user=userhpw password=abc
+----
+ERROR: password authentication failed for user userhpw (SQLSTATE 28000)
+
+sql
+ALTER USER userhpw WITH PASSWORD 'SCRAM-SHA-256$119680:RuTd0cF3mxFD/nUyNmH4bA==$PsNXCu6vNpjJmeAnph5NA5FWUYlkqIdKD/tTvHCMwLI=:sS8xL723JQUDVG4pL3uk17yoBeVE3d6ZuWpV7Mp/eNE='
+----
+ok
+
+# For now, the login using SCRAM is not yet recognized.
+connect user=userhpw password=pass
+----
+ERROR: password authentication failed for user userhpw (SQLSTATE 28000)
+
+subtest end
 
 subtest end
 


### PR DESCRIPTION
(PR peeled away from #74301; previous PR in series #74842; next PR in series: #74844)
Epic CRDB-5349

This commit introduces the ability to *store* SCRAM hashes.
Note: in this commit they are not yet used to authenticate
SQL clients. Authentication will fail if a SCRAM hash is the only
credential available to a user account.

Release note (sql change): The `CREATE ROLE` and `ALTER ROLE`
statements now accept password hashes computed using the SCRAM-SHA-256
method, for example: `CREATE USER foo WITH PASSWORD
'SCRAM-SHA-256$4096:B5VaT...'`.

As for other types of pre-hashed passwords, this auto-detection can be
disabled by changing the cluster setting
`server.user_login.store_client_pre_hashed_passwords.enabled` to
`false`.

To ascertain whether a SCRAM-SHA-256 password hash will be recognized
as such, orchestration code can use the built-in function
`crdb_internal.check_password_hash_format()` that had been previously introduced.

The encoding of the SCRAM-SHA-256 password should be performed as
follows:

1. take the cleartext password string.
2. generate a salt, iteration count, stored key and server key as per
   [RFC 5802](datatracker.ietf.org/doc/html/rfc5802).
3. encode the hash into the format recognized by CockroachDB: the
   string `SCRAM-SHA-256$`, followed by the iteration count,
   followed by `:`, followed by the base64-encoded salt, followed
   by `$`, followed by the base-64 stored key, followed by `:`,
   followed by the base-64 server key.