### PR TITLE
security: enable plaintext authentication with SCRAM credentials  (scram 5/10)

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//pkg/util/contextutil",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/metric",
@@ -47,6 +46,7 @@ go_library(
         "@com_github_xdg_go_stringprep//:stringprep",
         "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_crypto//ocsp",
+        "@org_golang_x_crypto//pbkdf2",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -13,6 +13,7 @@ package security
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
@@ -24,14 +25,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
 	"github.com/xdg-go/scram"
-	// Reserved import for PR #74301.
-	_ "github.com/xdg-go/stringprep"
+	"github.com/xdg-go/stringprep"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 // BcryptCost is the cost to use when hashing passwords.
@@ -237,12 +237,13 @@ func CompareHashAndCleartextPassword(
 func (b bcryptHash) compareWithCleartextPassword(
 	ctx context.Context, cleartext string,
 ) (ok bool, err error) {
-	sem := getBcryptSem(ctx)
+	sem := getExpensiveHashComputeSem(ctx)
 	alloc, err := sem.Acquire(ctx, 1)
 	if err != nil {
 		return false, err
 	}
 	defer alloc.Release()
+
 	err = bcrypt.CompareHashAndPassword([]byte(b), appendEmptySha256(cleartext))
 	if err != nil {
 		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
@@ -257,12 +258,49 @@ func (b bcryptHash) compareWithCleartextPassword(
 func (s *scramHash) compareWithCleartextPassword(
 	ctx context.Context, cleartext string,
 ) (ok bool, err error) {
-	return false, unimplemented.NewWithIssue(42519, "cleartext comparison for SCRAM not supported yet")
+	sem := getExpensiveHashComputeSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return false, err
+	}
+	defer alloc.Release()
+
+	// Server-side verification of a plaintext password
+	// against a pre-computed stored SCRAM server key.
+	//
+	// Code inspired from pg's scram_verify_plain_password(),
+	// src/backend/libpq/auth-scram.c.
+	//
+	prepared, err := stringprep.SASLprep.Prepare(cleartext)
+	if err != nil {
+		// Special PostgreSQL case, quoth comment at the top of
+		// auth-scram.c:
+		//
+		// * - If the password isn't valid UTF-8, or contains characters prohibited
+		// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
+		// *	 the raw bytes in calculating the hash.
+		prepared = cleartext
+	}
+
+	saltedPassword := pbkdf2.Key([]byte(prepared), []byte(s.decoded.Salt), s.decoded.Iters, sha256.Size, sha256.New)
+	// As per xdg-go/scram and pg's scram_ServerKey().
+	// Note: the string "Server Key" is part of the SCRAM algorithm,
+	// see IETF RFC 5802.
+	serverKey := computeHMAC(scram.SHA256, saltedPassword, []byte("Server Key"))
+	return bytes.Equal(serverKey, s.decoded.ServerKey), nil
+}
+
+// computeHMAC is taken from xdg-go/scram; sadly it is not exported
+// from that package.
+func computeHMAC(hg scram.HashGeneratorFcn, key, data []byte) []byte {
+	mac := hmac.New(hg, key)
+	mac.Write(data)
+	return mac.Sum(nil)
 }
 
 // HashPassword takes a raw password and returns a bcrypt hashed password.
 func HashPassword(ctx context.Context, sv *settings.Values, password string) ([]byte, error) {
-	sem := getBcryptSem(ctx)
+	sem := getExpensiveHashComputeSem(ctx)
 	alloc, err := sem.Acquire(ctx, 1)
 	if err != nil {
 		return nil, err
@@ -458,35 +496,36 @@ var MinPasswordLength = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 ).WithPublic()
 
-// bcryptSemOnce wraps a semaphore that limits the number of concurrent calls
-// to the bcrypt hash functions. This is needed to avoid the risk of a
-// DoS attacks by malicious users or broken client apps that would
-// starve the server of CPU resources just by computing bcrypt hashes.
+// expensiveHashComputeSemOnce wraps a semaphore that limits the
+// number of concurrent calls to the bcrypt and sha256 hash
+// functions. This is needed to avoid the risk of a DoS attacks by
+// malicious users or broken client apps that would starve the server
+// of CPU resources just by computing hashes.
 //
 // We use a sync.Once to delay the creation of the semaphore to the
 // first time the password functions are used. This gives a chance to
 // the server process to update GOMAXPROCS before we compute the
 // maximum amount of concurrency for the semaphore.
-var bcryptSemOnce struct {
+var expensiveHashComputeSemOnce struct {
 	sem  *quotapool.IntPool
 	once sync.Once
 }
 
-// envMaxBcryptConcurrency allows a user to override the semaphore
+// envMaxHashComputeConcurrency allows a user to override the semaphore
 // configuration using an environment variable.
 // If the env var is set to a value >= 1, that value is used.
 // Otherwise, a default is computed from the configure GOMAXPROCS.
-var envMaxBcryptConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_BCRYPT_CONCURRENCY", 0)
+var envMaxHashComputeConcurrency = envutil.EnvOrDefaultInt("COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY", 0)
 
-// getBcryptSem retrieves the bcrypt semaphore.
-func getBcryptSem(ctx context.Context) *quotapool.IntPool {
-	bcryptSemOnce.once.Do(func() {
+// getExpensiveHashComputeSem retrieves the hashing semaphore.
+func getExpensiveHashComputeSem(ctx context.Context) *quotapool.IntPool {
+	expensiveHashComputeSemOnce.once.Do(func() {
 		var n int
-		if envMaxBcryptConcurrency >= 1 {
+		if envMaxHashComputeConcurrency >= 1 {
 			// The operator knows better. Use what they tell us to use.
-			n = envMaxBcryptConcurrency
+			n = envMaxHashComputeConcurrency
 		} else {
-			// We divide by 8 so that the max CPU usage of bcrypt checks
+			// We divide by 8 so that the max CPU usage of hash checks
 			// never exceeds ~10% of total CPU resources allocated to this
 			// process.
 			n = runtime.GOMAXPROCS(-1) / 8
@@ -494,8 +533,8 @@ func getBcryptSem(ctx context.Context) *quotapool.IntPool {
 		if n < 1 {
 			n = 1
 		}
-		log.VInfof(ctx, 1, "configured maximum bcrypt concurrency: %d", n)
-		bcryptSemOnce.sem = quotapool.NewIntPool("bcrypt", uint64(n))
+		log.VInfof(ctx, 1, "configured maximum hashing concurrency: %d", n)
+		expensiveHashComputeSemOnce.sem = quotapool.NewIntPool("password_hashes", uint64(n))
 	})
-	return bcryptSemOnce.sem
+	return expensiveHashComputeSemOnce.sem
 }

--- a/pkg/sql/pgwire/testdata/auth/password_change
+++ b/pkg/sql/pgwire/testdata/auth/password_change
@@ -124,9 +124,7 @@ ok
 # For now, the login using SCRAM is not yet recognized.
 connect user=userhpw password=abc
 ----
-ERROR: unimplemented: cleartext comparison for SCRAM not supported yet (SQLSTATE 0A000)
-HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/42519/v22.1
+ok defaultdb
 
 sql
 ALTER USER userhpw WITH PASSWORD 'SCRAM-SHA-256$119680:RuTd0cF3mxFD/nUyNmH4bA==$PsNXCu6vNpjJmeAnph5NA5FWUYlkqIdKD/tTvHCMwLI=:sS8xL723JQUDVG4pL3uk17yoBeVE3d6ZuWpV7Mp/eNE='
@@ -136,9 +134,7 @@ ok
 # For now, the login using SCRAM is not yet recognized.
 connect user=userhpw password=pass
 ----
-ERROR: unimplemented: cleartext comparison for SCRAM not supported yet (SQLSTATE 0A000)
-HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/42519/v22.1
+ok defaultdb
 
 subtest end
 

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -7,6 +7,56 @@ CREATE USER abc WITH PASSWORD 'abc';
 ----
 ok
 
+subtest conn_plaintext
+
+# This subtest checks that a plaintext password provided by a SQL client
+# can still be used when the stored credentials for the target user
+# use the SCRAM encoding.
+
+set_hba
+host all abc all password
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all abc all password
+#
+# Interpreted configuration:
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      root all     cert-password
+host   all      abc  all     password
+
+# User abc has SCRAM credentials, but 'mistake' is not its password.
+# Expect authn error.
+connect user=abc password=mistake
+----
+ERROR: password authentication failed for user abc (SQLSTATE 28000)
+
+authlog 5
+.*client_connection_end
+----
+5 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+6 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+7 {"Detail":"password authentication failed for user abc","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+8 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+9 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
+connect user=abc password=abc
+----
+ok defaultdb
+
+authlog 5
+.*client_connection_end
+----
+10 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+11 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+12 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+13 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+14 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
+
+subtest end
+
 subtest only_scram
 
 set_hba
@@ -35,12 +85,12 @@ ERROR: password authentication failed for user foo (SQLSTATE 28000)
 authlog 6
 .*client_connection_end
 ----
-5 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-6 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-7 {"EventType":"client_authentication_info","Info":"scram handshake error: no scram cookie for you","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-8 {"Detail":"password authentication failed for user foo","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-9 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-10 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+15 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+16 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+17 {"EventType":"client_authentication_info","Info":"scram handshake error: no scram cookie for you","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+18 {"Detail":"password authentication failed for user foo","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+19 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+20 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 
 # User abc has SCRAM credentials, but 'mistake' is not its password.
 # Expect authn error.
@@ -51,12 +101,12 @@ ERROR: password authentication failed for user abc (SQLSTATE 28000)
 authlog 6
 .*client_connection_end
 ----
-11 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-12 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-13 {"EventType":"client_authentication_info","Info":"scram handshake error: challenge proof invalid","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-14 {"Detail":"password authentication failed for user abc","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-15 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-16 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+21 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+22 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+23 {"EventType":"client_authentication_info","Info":"scram handshake error: challenge proof invalid","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+24 {"Detail":"password authentication failed for user abc","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":6,"RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+25 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+26 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 
 
 connect user=abc password=abc
@@ -66,15 +116,16 @@ ok defaultdb
 authlog 5
 .*client_connection_end
 ----
-17 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-18 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-19 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-20 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
-21 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+27 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+28 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+29 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+30 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+31 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 
 subtest end
 
 subtest end
+
 
 subtest scram_cert
 
@@ -106,6 +157,7 @@ subtest scram_cert/scram
 connect user=foo password=abc
 ----
 ERROR: password authentication failed for user foo (SQLSTATE 28000)
+
 
 connect user=abc password=abc
 ----


### PR DESCRIPTION
(PR peeled away from #74301; previous PR in series #74844; next PR in series: #74846)
Epic CRDB-5349

This commit introduces support for cleartext password authentication
against SCRAM-SHA-256 stored credentials.

This feature is necessary *in addition to* support for the full SCRAM
handshake, because the web UI authn will continue using cleartext
passwords for the foreseeable future, and we want to continue
supporting the `password` and `cert-password` HBA methods for backward
compatibility.

When performing cleartext authn against SCRAM credentials, the hash
must be computed server-side. Like bcrypt, this is meant to be
computationally expensive. Therefore, for the same reason as bcrypt,
we want to restrict CPU usage for this using a semaphore.

This commit achieves this by using the same semaphore as was used for
bcrypt computations. Because we're using the same semaphore, the
commit also renames the semaphore and its configuration env var to
denote the more general usage.

Release note (backward-incompatible change): The environment variable
that controls the max amount of CPU that can be taken by password
hash computations during authentication was renamed from
`COCKROACH_MAX_BCRYPT_CONCURRENCY` to
`COCKROACH_MAX_PW_HASH_COMPUTE_CONCURRENCY`.
Its semantics remain unchanged.

Release note (security update): CockroachDB is now able to
authenticate users via the web UI and through SQL sessions when the
client provides a cleartext password and the stored credentials are
encoded using the SCRAM-SHA-256 algorithm.

(Note: support for a SCRAM authentication flow is a separate
feature and is not the target of this release note.)

In particular, for SQL client sessions it makes it possible
to use the authentication methods `password` (cleartext passwords),
and `cert-password` (TLS client cert or cleartext password) with
either CRDB-BCRYPT or SCRAM-SHA-256 stored credentials. Previously,
only CRDB-BCRYPT stored credentials were supported for cleartext
password authentication.