### PR TITLE
sql,pgwire,server: factor the password expiry code  (scram 6/10)

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -255,7 +254,7 @@ func (s *authenticationServer) UserLoginFromSSO(
 	// without further normalization.
 	username, _ := security.MakeSQLUsernameFromUserInput(reqUsername, security.UsernameValidation)
 
-	exists, _, canLoginDBConsole, _, _, _, _, err := sql.GetUserSessionInitInfo(
+	exists, _, canLoginDBConsole, _, _, _, err := sql.GetUserSessionInitInfo(
 		ctx,
 		s.server.sqlServer.execCfg,
 		s.server.sqlServer.execCfg.InternalExecutor,
@@ -420,7 +419,7 @@ WHERE id = $1`
 func (s *authenticationServer) verifyPasswordDBConsole(
 	ctx context.Context, username security.SQLUsername, password string,
 ) (valid bool, expired bool, err error) {
-	exists, _, canLoginDBConsole, _, validUntil, _, pwRetrieveFn, err := sql.GetUserSessionInitInfo(
+	exists, _, canLoginDBConsole, _, _, pwRetrieveFn, err := sql.GetUserSessionInitInfo(
 		ctx,
 		s.server.sqlServer.execCfg,
 		s.server.sqlServer.execCfg.InternalExecutor,
@@ -433,15 +432,13 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 	if !exists || !canLoginDBConsole {
 		return false, false, nil
 	}
-	hashedPassword, err := pwRetrieveFn(ctx)
+	expired, hashedPassword, err := pwRetrieveFn(ctx)
 	if err != nil {
 		return false, false, err
 	}
 
-	if validUntil != nil {
-		if validUntil.Time.Sub(timeutil.Now()) < 0 {
-			return false, true, nil
-		}
+	if expired {
+		return false, true, nil
 	}
 
 	ok, err := security.CompareHashAndCleartextPassword(ctx, hashedPassword, password)

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/xdg-go/scram"
 )
@@ -123,7 +122,7 @@ func authPassword(
 		// Note: if this fails, we can't return the error right away,
 		// because we need to consume the client response first. This
 		// will be handled below.
-		hashedPassword, pwValidUntil, pwRetrievalErr := pwRetrieveFn(ctx)
+		expired, hashedPassword, pwRetrievalErr := pwRetrieveFn(ctx)
 
 		// Wait for the password response from the client.
 		pwdData, err := c.GetPwdData()
@@ -146,19 +145,20 @@ func authPassword(
 			c.LogAuthFailed(ctx, eventpb.AuthFailReason_PRE_HOOK_ERROR, err)
 			return err
 		}
-		// Inform operators looking at logs if there's something amiss.
-		if hashedPassword.Method() == security.HashMissingPassword {
+
+		// Expiration check.
+		//
+		// NB: This check is advisory and could be omitted; the retrieval
+		// function ensures that the returned hashedPassword is
+		// security.MissingPasswordHash when the credentials have expired,
+		// so the credential check below would fail anyway.
+		if expired {
+			c.LogAuthFailed(ctx, eventpb.AuthFailReason_CREDENTIALS_EXPIRED, nil)
+			return errExpiredPassword
+		} else if hashedPassword.Method() == security.HashMissingPassword {
 			c.LogAuthInfof(ctx, "user has no password defined")
 			// NB: the failure reason will be automatically handled by the fallback
 			// in auth.go (and report CREDENTIALS_INVALID).
-		}
-
-		// Expiration check.
-		if pwValidUntil != nil {
-			if pwValidUntil.Sub(timeutil.Now()) < 0 {
-				c.LogAuthFailed(ctx, eventpb.AuthFailReason_CREDENTIALS_EXPIRED, nil)
-				return errors.New("password is expired")
-			}
 		}
 
 		// Now check the cleartext password against the retrieved credentials.
@@ -168,6 +168,8 @@ func authPassword(
 	})
 	return b, nil
 }
+
+var errExpiredPassword = errors.New("password is expired")
 
 func passwordString(pwdData []byte) (string, error) {
 	// Make a string out of the byte array.

--- a/pkg/sql/pgwire/authenticator.go
+++ b/pkg/sql/pgwire/authenticator.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 // Authenticator is a component of an AuthMethod that determines if the
@@ -31,7 +30,7 @@ type Authenticator = func(
 // and expiration time for a user logging in with password-based
 // authentication.
 type PasswordRetrievalFn = func(context.Context) (
+	expired bool,
 	pwHash security.PasswordHash,
-	pwExpiration *tree.DTimestamp,
 	_ error,
 )


### PR DESCRIPTION
(PR peeled away from #74301; previous PR in series #74845; next PR in series: #74847)
Epic CRDB-5349

To understand this commit, it is perhaps useful to remember that
password credentials, in Postgres's SQL dialect, have their own
expiration timestamp, set via the VALID UNTIL role option.  The
timestamp is attached to the password, not the user account, such that
a user can still log in using a separate authentication method even
when their password is expired.

Additionally, it is perhaps useful to understand that throughout the
authentication stack, we distinguish the phase where we determine
whether a principal *exists* and is allowed to log in (i.e. it has the
LOGIN privilege); and the phase where we load its password credentials
from storage (or from an in-RAM cache). In particular, we are keen to
skip the loading of the password credentials in the case where the
client is authenticating using another method than passwords (for
example TLS client certs, which is still pretty common).

In this context, this commit performs two changes.

The first change is an API cleanup.

Prior to this commit, we were loading the password expiration
timestamp in the first phase (checking that the principal exists),
rather than the second phase (loading the credentials). This was a
misdesign because, as explained above, the expiry timestamp is a
property of the password, and thus needs not be looked at when
passwords are not used.

We fix this in this commit by making the expiration timestamp part of
the second phase, as it should have been from the start.

The second change in this commit is a reduction of security risk.

Prior to this commit, the password expiration timestamp was checked
(compared to the current time) again and again in each of the call
points for the password retrieval function. It was the responsibility
of each caller to perform this check. This constituted a security risk
because a new caller could forget to add the expiry check and bypass
the expiration mechanism entirely.

We fix this by performing the expiry validation in a central location,
in the common function that retrieves the credentials from storage (or
cache). If the password is expired, the function also hides the
password hash by returning the new "password missing" pseudo-hash, so
that the caller cannot any more mistakenly attempt to validate a
password despite the expiration.

Release note: None