### PR TITLE
pgwire,security: auto-upgrade bcrypt hashes to SCRAM-SHA-256  (scram 10/10)

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2278,6 +2278,26 @@ An event of type `drop_role` is recorded when a role is dropped.
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. Application names starting with a dollar sign (`$`) are not considered sensitive. | depends |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
 
+### `password_hash_converted`
+
+An event of type `password_hash_converted` is recorded when the password credentials
+are automatically converted server-side.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `RoleName` | The name of the user/role whose credentials have been converted. | yes |
+| `OldMethod` | The previous hash method. | no |
+| `NewMethod` | The new hash method. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+
 ## Telemetry events
 
 

--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -75,6 +75,7 @@ server.user_login.password_hashes.default_cost.crdb_bcrypt	integer	10	the hashin
 server.user_login.password_hashes.default_cost.scram_sha_256	integer	119680	the hashing cost to use when storing passwords supplied as cleartext by SQL clients with the hashing method scram-sha-256 (allowed range: 4096-240000000000)
 server.user_login.store_client_pre_hashed_passwords.enabled	boolean	true	whether the server accepts to store passwords pre-hashed by clients
 server.user_login.timeout	duration	10s	timeout after which client authentication times out if some system range is unavailable (0 = no timeout)
+server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled	boolean	true	whether to automatically re-encode stored passwords using crdb-bcrypt to scram-sha-256
 server.web_session.auto_logout.timeout	duration	168h0m0s	the duration that web sessions will survive before being periodically purged, since they were last used
 server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number of old sessions to delete for each purge
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -82,6 +82,7 @@
 <tr><td><code>server.user_login.password_hashes.default_cost.scram_sha_256</code></td><td>integer</td><td><code>119680</code></td><td>the hashing cost to use when storing passwords supplied as cleartext by SQL clients with the hashing method scram-sha-256 (allowed range: 4096-240000000000)</td></tr>
 <tr><td><code>server.user_login.store_client_pre_hashed_passwords.enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the server accepts to store passwords pre-hashed by clients</td></tr>
 <tr><td><code>server.user_login.timeout</code></td><td>duration</td><td><code>10s</code></td><td>timeout after which client authentication times out if some system range is unavailable (0 = no timeout)</td></tr>
+<tr><td><code>server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether to automatically re-encode stored passwords using crdb-bcrypt to scram-sha-256</td></tr>
 <tr><td><code>server.web_session.auto_logout.timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that web sessions will survive before being periodically purged, since they were last used</td></tr>
 <tr><td><code>server.web_session.purge.max_deletions_per_cycle</code></td><td>integer</td><td><code>10</code></td><td>the maximum number of old sessions to delete for each purge</td></tr>
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "certs_test.go",
         "join_token_test.go",
         "main_test.go",
+        "password_test.go",
         "permission_check_test.go",
         "tls_test.go",
         "username_test.go",
@@ -77,6 +78,7 @@ go_test(
         "//pkg/rpc",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/util/envutil",
@@ -87,6 +89,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_exp//rand",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -81,6 +82,8 @@ var SCRAMCost = settings.RegisterIntSetting(
 	// The default value 119680 incurs ~60ms latency on the same hw.
 	// This default was calibrated to incur a similar check latency as the
 	// default value for BCryptCost above.
+	// For further discussion, see the explanation on bcryptCostToSCRAMIterCount
+	// below.
 	//
 	// For reference, value 250000 incurs ~125ms latency on the same hw,
 	// value 1000000 incurs ~500ms.
@@ -418,49 +421,53 @@ func HashPassword(ctx context.Context, sv *settings.Values, password string) ([]
 		return bcrypt.GenerateFromPassword(appendEmptySha256(password), int(BcryptCost.Get(sv)))
 
 	case HashSCRAMSHA256:
-		prepared, err := stringprep.SASLprep.Prepare(password)
-		if err != nil {
-			// Special PostgreSQL case, quoth comment at the top of
-			// auth-scram.c:
-			//
-			// * - If the password isn't valid UTF-8, or contains characters prohibited
-			// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
-			// *	 the raw bytes in calculating the hash.
-			prepared = password
-		}
-
-		// The computation of ServerKey and StoredKey is conveniently provided
-		// to us by xdg/scram in the Client method GetStoredCredentials().
-		// To use it, we need a client.
-		client, err := scram.SHA256.NewClientUnprepped("" /* username: unused */, prepared, "" /* authzID: unused */)
-		if err != nil {
-			return nil, errors.AssertionFailedf("programming error: client construction should never fail")
-		}
-
-		// We also need to generate a random salt ourselves.
-		const scramSaltSize = 16 // postgres: SCRAM_DEFAULT_SALT_LEN.
-		salt := make([]byte, scramSaltSize)
-		if _, err := io.ReadFull(rand.Reader, salt); err != nil {
-			return nil, errors.Wrap(err, "generating random salt")
-		}
-
-		// The computation of the SCRAM hash is expensive. Use the shared
-		// semaphore for it. We reuse the same pattern as the bcrypt case above.
-		sem := getExpensiveHashComputeSem(ctx)
-		alloc, err := sem.Acquire(ctx, 1)
-		if err != nil {
-			return nil, err
-		}
-		defer alloc.Release()
-		// Compute the credentials.
 		cost := int(SCRAMCost.Get(sv))
-		creds := client.GetStoredCredentials(scram.KeyFactors{Iters: cost, Salt: string(salt)})
-		// Encode them in our standard hash format.
-		return encodeScramHash(salt, creds), nil
+		return hashPasswordUsingSCRAM(ctx, cost, password)
 
 	default:
 		return nil, errors.Newf("unsupported hash method: %v", method)
 	}
+}
+
+func hashPasswordUsingSCRAM(ctx context.Context, cost int, cleartext string) ([]byte, error) {
+	prepared, err := stringprep.SASLprep.Prepare(cleartext)
+	if err != nil {
+		// Special PostgreSQL case, quoth comment at the top of
+		// auth-scram.c:
+		//
+		// * - If the password isn't valid UTF-8, or contains characters prohibited
+		// *	 by the SASLprep profile, we skip the SASLprep pre-processing and use
+		// *	 the raw bytes in calculating the hash.
+		prepared = cleartext
+	}
+
+	// The computation of ServerKey and StoredKey is conveniently provided
+	// to us by xdg/scram in the Client method GetStoredCredentials().
+	// To use it, we need a client.
+	client, err := scram.SHA256.NewClientUnprepped("" /* username: unused */, prepared, "" /* authzID: unused */)
+	if err != nil {
+		return nil, errors.AssertionFailedf("programming error: client construction should never fail")
+	}
+
+	// We also need to generate a random salt ourselves.
+	const scramSaltSize = 16 // postgres: SCRAM_DEFAULT_SALT_LEN.
+	salt := make([]byte, scramSaltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, errors.Wrap(err, "generating random salt")
+	}
+
+	// The computation of the SCRAM hash is expensive. Use the shared
+	// semaphore for it. We reuse the same pattern as the bcrypt case above.
+	sem := getExpensiveHashComputeSem(ctx)
+	alloc, err := sem.Acquire(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+	defer alloc.Release()
+	// Compute the credentials.
+	creds := client.GetStoredCredentials(scram.KeyFactors{Iters: cost, Salt: string(salt)})
+	// Encode them in our standard hash format.
+	return encodeScramHash(salt, creds), nil
 }
 
 // encodeScramHash encodes the provided SCRAM credentials using the
@@ -720,4 +727,183 @@ func getExpensiveHashComputeSem(ctx context.Context) *quotapool.IntPool {
 		expensiveHashComputeSemOnce.sem = quotapool.NewIntPool("password_hashes", uint64(n))
 	})
 	return expensiveHashComputeSemOnce.sem
+}
+
+// bcryptCostToSCRAMIterCount maps the bcrypt cost in a pre-hashed
+// password using the crdb-bcrypt method to an “equivalent” cost
+// (iteration count) for the scram-sha-256 method. This is used to
+// automatically upgrade clusters from crdb-bcrypt to scram-sha-256.
+//
+// This mapping was computed so that given a starting bcrypt cost, the
+// latency of authentication using SCRAM-SHA-256 with an iter count
+// computed by this mapping would be comparable to that when using bcrypt.
+//
+// For example, with bcrypt cost 10, if the authn latency is ~60ms
+// (an actual measurement on current hardware as of this writing),
+// the mapping gives SCRAM authn latency of ~60ms too.
+//
+// The actual values were computed as follows:
+// 1. measure the bcrypt authentication cost for costs 1-19.
+// 2. assuming the bcrypt latency is a_bcrypt*2^c + b_bcrypt, where c
+//    is the bcrypt cost, use statistical regression to derive
+//    a_bcrypt and b_bcrypt. (we found b_bcrypt to be negligible.)
+// 3. measure the SCRAM authn cost for iter counts 4096-1000000,
+//    *on the same hardware*.
+// 4. assuming the SCRAM latency is a_scram*c + b_scram,
+//    where c is the SCRAM iter count, use stat regression
+//    to derive a_scram and b_scram. (we found b_scram to be negligible).
+// 5. for each bcrypt cost, compute scram iter count = a_bcrypt * 2^cost_bcrypt / a_scram.
+//
+// The speed of the CPU used for the measurements is equally
+// represented in a_bcrypt and a_scram, so the formula eliminates any
+// CPU-specific factor.
+//
+// An alternative approach would have been to choose a SCRAM-SHA-256
+// mapping that gives equivalent difficulty at bruteforcing passwords
+// given access to the hashes and access to ASICs/GPUs. If that was
+// the goal, we would derive higher iteration counts by a factor of at
+// least 10x.
+// (From bdarnell's analysis: In 1 second, a CPU can do 1M iterations
+// of hmac-sha256 or 16k iterations of bcrypt, a ratio of 60:1. A GPU
+// can do 2G iterations of hmac-sha256 or 3M iterations of 600:1.)
+//
+// However, this would also increase the user login
+// latency by a factor of 10x, which we consider unacceptable from a
+// usability perspective for a *default* mapping.
+// Instead, for CockroachDB we will recommend in docs that
+// users define passwords with a high complexity, so that
+// the entropy of the password itself compounds with the complexity
+// of the SCRAM hash.
+// As of this writing this is already the approach taken in
+// CockroachCloud, where passwords are auto-generated.
+//
+// Meanwhile, we are also announcing this trade-off in release notes:
+// an operator who lets their end-users select their own passwords,
+// and wishes to prioritize bruteforcing hardness at the
+// expense of login latency, will be free to adjust the setting
+// server.user_login.password_hashes.default_cost.scram_sha_256 and
+// re-encode their passwords.
+var bcryptCostToSCRAMIterCount = []int64{
+	0,            // 0-3 are not valid bcrypt costs.
+	0,            // 0-3 are not valid bcrypt costs.
+	0,            // 0-3 are not valid bcrypt costs.
+	0,            // 0-3 are not valid bcrypt costs.
+	4096,         // 4 - special case to select lowest cost possible. Model would predict 7000.
+	9420,         // 5
+	12977,        // 6
+	20090,        // 7
+	34318,        // 8
+	62772,        // 9
+	119680,       // 10 - common default, 50-100ms login latency on 2021 hardware
+	233497,       // 11
+	461131,       // 12
+	916398,       // 13
+	1826932,      // 14
+	3648001,      // 15
+	7290139,      // 16
+	14574415,     // 17
+	29142967,     // 18
+	58280072,     // 19
+	116554280,    // 20
+	233102696,    // 21
+	466199529,    // 22
+	932393195,    // 23
+	1864780528,   // 24
+	3729555192,   // 25
+	7459104520,   // 26
+	14918203177,  // 27
+	29836400491,  // 28
+	59672795119,  // 29
+	119345584374, // 30
+	238691162884, // 31
+}
+
+var autoUpgradePasswordHashes = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled",
+	"whether to automatically re-encode stored passwords using crdb-bcrypt to scram-sha-256",
+	true,
+).WithPublic()
+
+// MaybeUpgradePasswordHash looks at the cleartext and the hashed
+// password and determines whether the hash can be upgraded from
+// crdb-bcrypt to scram-sha-256. If it can, it computes an equivalent
+// SCRAM hash and returns it.
+//
+// See the documentation on bcryptCostToSCRAMIterCount[] for details.
+func MaybeUpgradePasswordHash(
+	ctx context.Context, sv *settings.Values, cleartext string, hashed PasswordHash,
+) (converted bool, prevHashBytes, newHashBytes []byte, newMethod string, err error) {
+	bh, isBcrypt := hashed.(bcryptHash)
+
+	// Do we want to perform the conversion?
+	//
+	// We stop here in the following cases:
+	// - password not currently hashed using crdb-bcrypt: we can't convert.
+	// - conversion disabled by cluster setting.
+	// - some nodes don't know about SCRAM just yet during an upgrade.
+	//   (checked in GetConfiguredPasswordHashMethod)
+	// - the configured default method is not scram-sha-256.
+	if !isBcrypt || !autoUpgradePasswordHashes.Get(sv) ||
+		GetConfiguredPasswordHashMethod(ctx, sv) != HashSCRAMSHA256 {
+		// Nothing to do.
+		return false, nil, nil, "", nil
+	}
+
+	bcryptCost, err := bcrypt.Cost([]byte(bh))
+	if err != nil {
+		// The caller should only call this function after authentication
+		// has succeeded, so the bcrypt cost should have been validated
+		// already.
+		return false, nil, nil, "", errors.NewAssertionErrorWithWrappedErrf(err, "programming error: authn succeeded but invalid bcrypt hash")
+	}
+	if bcryptCost < 0 || bcryptCost >= len(bcryptCostToSCRAMIterCount) || bcryptCostToSCRAMIterCount[bcryptCost] == 0 {
+		// The bcryptCost was smaller than 4 or greater than 31? That's a violation of a bcrypt invariant.
+		// Or perhaps the bcryptCostToSCRAMIterCount was incorrectly modified and there's a hole with value zero.
+		return false, nil, nil, "", errors.AssertionFailedf("unexpected: bcrypt cost %d is out of bounds or has no mapping", bcryptCost)
+	}
+
+	scramIterCount := bcryptCostToSCRAMIterCount[bcryptCost]
+	if scramIterCount > math.MaxInt {
+		// scramIterCount is an int64. However, the SCRAM library we're using (xdg/scram) uses
+		// an int for the iteration count. This is not an issue when this code is running
+		// on a 64-bit platform, where sizeof(int) == sizeof(int64). However, when running
+		// on 32-bit, we can't allow a conversion to proceed because it would potentially
+		// truncate the iter count to a low value.
+		// However, this situation is not an error. The hash could still be converted later
+		// when the system is upgraded to 64-bit.
+		return false, nil, nil, "", nil
+	}
+
+	if bcryptCost > 10 {
+		// Tell the logs that we're doing a conversion. This is important
+		// if the new cost is high and the operation takes a long time, so
+		// the operator knows what's up.
+		//
+		// Note: this is an informational message for troubleshooting
+		// purposes, and therefore is best sent to the DEV channel. The
+		// structured event that reports that the conversion has completed
+		// (and the new credentials were stored) is sent by the SQL code
+		// that also owns the storing of the new credentials.
+		log.Infof(ctx, "hash conversion: computing a SCRAM hash with iteration count %d (from bcrypt cost %d)", scramIterCount, bcryptCost)
+	}
+
+	rawHash, err := hashPasswordUsingSCRAM(ctx, int(scramIterCount), cleartext)
+	if err != nil {
+		// This call only fail with hard errors.
+		return false, nil, nil, "", err
+	}
+
+	// Check the raw hash can be decoded using our decoder.
+	// This checks that we're able to re-parse what we just generated,
+	// which is a safety mechanism to ensure the result is valid.
+	expectedMethod := HashSCRAMSHA256
+	newHash := LoadPasswordHash(ctx, rawHash)
+	if newHash.Method() != expectedMethod {
+		// The conversion failed? That is very strange.
+		log.Errorf(ctx, "unexpected hash contents during bcrypt->scram conversion: %T %+v -> %T %+v", hashed, hashed, newHash, newHash)
+		// In contrast to logs, we don't want the details of the hash in the error with %+v.
+		return false, nil, nil, "", errors.AssertionFailedf("programming error: re-hash failed to produce SCRAM hash, produced %T instead", newHash)
+	}
+	return true, []byte(bh), rawHash, expectedMethod.String(), nil
 }

--- a/pkg/security/password_test.go
+++ b/pkg/security/password_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package security
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestBCryptCostToSCRAMIterCountTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// This test mainly checks that the conversion table properly starts
+	// at bcrypt.MinCost, and that no lines are accidentally added or removed.
+	require.Equal(t, bcrypt.MaxCost+1, len(bcryptCostToSCRAMIterCount))
+	for i := 0; i < bcrypt.MinCost; i++ {
+		require.Equal(t, int64(0), bcryptCostToSCRAMIterCount[i])
+	}
+	require.Equal(t, int64(4096), bcryptCostToSCRAMIterCount[bcrypt.MinCost])
+	require.Equal(t, int64(119680), bcryptCostToSCRAMIterCount[10])
+}
+
+func TestBCryptToSCRAMConversion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s := cluster.MakeTestingClusterSettings()
+
+	const cleartext = "hello"
+
+	ourDefault := int(BcryptCost.Get(&s.SV))
+
+	// Don't iterate all the way to 31: the larger values
+	// incur incredibly large hashing times.
+	for i := bcrypt.MinCost; i < ourDefault+3; i++ {
+		t.Run(fmt.Sprintf("bcrypt=%d", i), func(t *testing.T) {
+			bcryptRaw, err := bcrypt.GenerateFromPassword(appendEmptySha256(cleartext), i)
+			require.NoError(t, err)
+			bh := LoadPasswordHash(ctx, bcryptRaw)
+			require.Equal(t, HashBCrypt, bh.Method())
+
+			// Check conversion succeeds.
+			converted, prevHash, newHashBytes, hashMethod, err := MaybeUpgradePasswordHash(ctx, &s.SV, cleartext, bh)
+			require.NoError(t, err)
+			require.True(t, converted)
+			require.Equal(t, "SCRAM-SHA-256", string(newHashBytes)[:13])
+			require.Equal(t, HashSCRAMSHA256.String(), hashMethod)
+			require.Equal(t, bcryptRaw, prevHash)
+
+			newHash := LoadPasswordHash(ctx, newHashBytes)
+			ok, creds := GetSCRAMStoredCredentials(newHash)
+			require.True(t, ok)
+			require.Equal(t, bcryptCostToSCRAMIterCount[i], int64(creds.Iters))
+
+			// Check that converted hash can't be converted further.
+			ec, _, _, _, err := MaybeUpgradePasswordHash(ctx, &s.SV, cleartext, newHash)
+			require.NoError(t, err)
+			require.False(t, ec)
+		})
+	}
+}

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -442,6 +442,19 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 	}
 
 	ok, err := security.CompareHashAndCleartextPassword(ctx, hashedPassword, password)
+	if ok && err == nil {
+		// Password authentication succeeded using cleartext.  If the
+		// stored hash was encoded using crdb-bcrypt, we might want to
+		// upgrade it to SCRAM instead.
+		//
+		// This auto-conversion is a CockroachDB-specific feature, which
+		// pushes clusters upgraded from a previous version into using
+		// SCRAM-SHA-256.
+		sql.MaybeUpgradeStoredPasswordHash(ctx,
+			s.server.sqlServer.execCfg,
+			username,
+			password, hashedPassword)
+	}
 	return ok, false, err
 }
 

--- a/pkg/sql/pgwire/testdata/auth/password_change
+++ b/pkg/sql/pgwire/testdata/auth/password_change
@@ -4,6 +4,13 @@
 config secure
 ----
 
+
+sql
+-- prevent auto-converting passwords, so that each sub-test exercises its own hash method.
+SET CLUSTER SETTING server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled = false;
+----
+ok
+
 subtest regular_user
 
 subtest regular_user/bcrypt

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -2,6 +2,8 @@ config secure
 ----
 
 sql
+-- prevent auto-converting passwords, so that each sub-test exercises its own hash method.
+SET CLUSTER SETTING server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled = false;
 -- Explicit hash.
 CREATE USER abc WITH PASSWORD 'SCRAM-SHA-256$4096:pAlYy62NTdETKb291V/Wow==$OXMAj9oD53QucEYVMBcdhRnjg2/S/iZY/88ShZnputA=:r8l4c1pk9bmDi+8an059l/nt9Bg1zb1ikkg+DeRv4UQ=';
 -- Automatic hashes.
@@ -253,6 +255,64 @@ authlog 4
 80 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
 81 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
 82 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
+
+subtest end
+
+subtest hash_conversion
+
+sql
+-- enable auto-conversion of passwords.
+SET CLUSTER SETTING server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled = true;
+----
+ok
+
+# Verify the hash is still bcrypt at this point.
+sql
+SELECT crdb_internal.force_error('11111', substr(encode("hashedPassword",'escape'), 1, 4)) FROM system.users WHERE username='foo'
+----
+ERROR: $2a$ (SQLSTATE 11111)
+
+# The first time after conversion is enabled, a bcrypt-using account still uses bcrypt.
+connect user=foo password=abc
+----
+ok defaultdb
+
+# Assert the conn used a cleartext handshake.
+authlog 7
+.*client_connection_end
+----
+83 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+84 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+85 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+86 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+87 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+88 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+89 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
+# Verify the stored hash has been converted now.
+sql
+SELECT crdb_internal.force_error('11111', substr(encode("hashedPassword",'escape'), 1, 13)) FROM system.users WHERE username='foo'
+----
+ERROR: SCRAM-SHA-256 (SQLSTATE 11111)
+
+# So the next login uses SCRAM.
+connect user=foo password=abc
+----
+ok defaultdb
+
+# Assert the conn used a SCRAM handshake.
+authlog 7
+.*client_connection_end
+----
+90 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+91 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+92 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+93 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+94 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+95 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+96 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","Timestamp":"XXX"}
+
 
 
 subtest end

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -83,28 +85,14 @@ func GetUserSessionInitInfo(
 	pwRetrieveFn func(ctx context.Context) (expired bool, hashedPassword security.PasswordHash, err error),
 	err error,
 ) {
-	// We may be operating with a timeout.
-	timeout := userLoginTimeout.Get(&ie.s.cfg.Settings.SV)
-	// We don't like long timeouts for root.
-	// (4.5 seconds to not exceed the default 5s timeout configured in many clients.)
-	const maxRootTimeout = 4*time.Second + 500*time.Millisecond
-	if username.IsRootUser() && (timeout == 0 || timeout > maxRootTimeout) {
-		timeout = maxRootTimeout
-	}
-
-	runFn := func(fn func(ctx context.Context) error) error { return fn(ctx) }
-	if timeout != 0 {
-		runFn = func(fn func(ctx context.Context) error) error {
-			return contextutil.RunWithTimeout(ctx, "get-user-timeout", timeout, fn)
-		}
-	}
+	runFn := getUserInfoRunFn(execCfg, username, "get-user-timeout")
 
 	if username.IsRootUser() {
 		// As explained above, for root we report that the user exists
 		// immediately, and delay retrieving the password until strictly
 		// necessary.
 		rootFn := func(ctx context.Context) (expired bool, ret security.PasswordHash, err error) {
-			err = runFn(func(ctx context.Context) error {
+			err = runFn(ctx, func(ctx context.Context) error {
 				authInfo, _, err := retrieveSessionInitInfoWithCache(ctx, execCfg, ie, username, databaseName)
 				if err != nil {
 					return err
@@ -127,7 +115,7 @@ func GetUserSessionInitInfo(
 	var authInfo sessioninit.AuthInfo
 	var settingsEntries []sessioninit.SettingsCacheEntry
 
-	if err = runFn(func(ctx context.Context) error {
+	if err = runFn(ctx, func(ctx context.Context) error {
 		// Other users must reach for system.users no matter what, because
 		// only that contains the truth about whether the user exists.
 		authInfo, settingsEntries, err = retrieveSessionInitInfoWithCache(
@@ -186,6 +174,27 @@ func GetUserSessionInitInfo(
 			return expired, ret, nil
 		},
 		err
+}
+
+func getUserInfoRunFn(
+	execCfg *ExecutorConfig, username security.SQLUsername, opName string,
+) func(context.Context, func(context.Context) error) error {
+	// We may be operating with a timeout.
+	timeout := userLoginTimeout.Get(&execCfg.Settings.SV)
+	// We don't like long timeouts for root.
+	// (4.5 seconds to not exceed the default 5s timeout configured in many clients.)
+	const maxRootTimeout = 4*time.Second + 500*time.Millisecond
+	if username.IsRootUser() && (timeout == 0 || timeout > maxRootTimeout) {
+		timeout = maxRootTimeout
+	}
+
+	runFn := func(ctx context.Context, fn func(ctx context.Context) error) error { return fn(ctx) }
+	if timeout != 0 {
+		runFn = func(ctx context.Context, fn func(ctx context.Context) error) error {
+			return contextutil.RunWithTimeout(ctx, opName, timeout, fn)
+		}
+	}
+	return runFn
 }
 
 func retrieveSessionInitInfoWithCache(
@@ -607,4 +616,111 @@ func (p *planner) checkCanBecomeUser(ctx context.Context, becomeUser security.SQ
 		)
 	}
 	return nil
+}
+
+// MaybeUpgradeStoredPasswordHash attempts to convert a stored hash
+// that was encoded using crdb-bcrypt, to the SCRAM-SHA-256 format.
+//
+// This auto-conversion is a CockroachDB-specific feature, which
+// pushes clusters upgraded from a previous version into using
+// SCRAM-SHA-256.
+//
+// The caller is responsible for ensuring this function is only called
+// after a successful authentication, that is, the provided cleartext
+// password is known to match the previously-encoded prevHash.
+func MaybeUpgradeStoredPasswordHash(
+	ctx context.Context,
+	execCfg *ExecutorConfig,
+	username security.SQLUsername,
+	cleartext string,
+	currentHash security.PasswordHash,
+) {
+	// This call also checks whether the conversion has been disabled by
+	// configuration.
+	converted, prevHash, newHash, newMethod, err := security.MaybeUpgradePasswordHash(ctx, &execCfg.Settings.SV, cleartext, currentHash)
+	if err != nil {
+		// We're not returning an error: clients should not be refused a
+		// session just because a password conversion failed.
+		//
+		// Simply explain what happened in logs for troubleshooting.
+		log.Warningf(ctx, "password hash conversion failed: %+v", err)
+		return
+	} else if !converted {
+		// No conversion happening. Nothing to do.
+		return
+	}
+
+	// The password hash was successfully converted. Store the new hash.
+	if err := updateUserPasswordHash(ctx, execCfg, username, prevHash, newHash); err != nil {
+		// Again, we don't want to fail with an error, because at this
+		// point authentication succeeded.
+		//
+		// Simply explain what happened in logs for troubleshooting.
+		log.Warningf(ctx, "storing the new password hash after conversion failed: %+v", err)
+	} else {
+		// Inform the security audit log that the hash was upgraded.
+		log.StructuredEvent(ctx, &eventpb.PasswordHashConverted{
+			RoleName:  username.Normalized(),
+			OldMethod: currentHash.Method().String(),
+			NewMethod: newMethod,
+		})
+	}
+}
+
+func updateUserPasswordHash(
+	ctx context.Context,
+	execCfg *ExecutorConfig,
+	username security.SQLUsername,
+	prevHash, newHash []byte,
+) error {
+	runFn := getUserInfoRunFn(execCfg, username, "set-hash-timeout")
+
+	return runFn(ctx, func(ctx context.Context) error {
+		return DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, d *descs.Collection) error {
+			// NB: we cannot use ALTER USER ... WITH PASSWORD here,
+			// because it is not guaranteed to recognize the hash in the
+			// WITH PASSWORD clause.
+			// (The detection could be disabled via cluster setting
+			// server.user_login.store_client_pre_hashed_passwords.enabled)
+			//
+			// So instead we write to system.users and bump the version to
+			// invalidate the cache manually.
+			//
+			// The motivation for the "WHERE hashedPassword = prevHash"
+			// clause and the check for rowsAffected is to protect against
+			// two hazards:
+			//
+			// - a race condition where an ALTER USER WITH PASSWORD is
+			//   executed by an administrator concurrently with a user
+			//   login. Without WHERE, this could mistakenly override the
+			//   new password.
+			//
+			// - multiple concurrent logins by the same user, triggering
+			//   the same password upgrade for all of them. Without WHERE,
+			//   we'd be writing to system.users for all of them and queue
+			//   potentially many schema updates, creating a bottleneck.
+			//
+			rowsAffected, err := execCfg.InternalExecutor.Exec(
+				ctx,
+				"set-password-hash",
+				txn,
+				`UPDATE system.users SET "hashedPassword" = $3 WHERE username = $1 AND "hashedPassword" = $2`,
+				username.Normalized(),
+				prevHash,
+				newHash,
+			)
+			if err != nil || rowsAffected == 0 {
+				// Error, or no update took place.
+				return err
+			}
+			usersTable, err := d.GetMutableTableByID(
+				ctx, txn, keys.UsersTableID, tree.ObjectLookupFlagsWithRequired(),
+			)
+			if err != nil {
+				return err
+			}
+			// WriteDesc will internally bump the version.
+			return d.WriteDesc(ctx, false /* kvTrace */, usersTable, txn)
+		})
+	})
 }

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -264,6 +264,9 @@ func (m *CreateRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_
 func (m *DropRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_ADMIN }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *PasswordHashConverted) LoggingChannel() logpb.Channel { return logpb.Channel_USER_ADMIN }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SampledQuery) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -2545,6 +2545,46 @@ func (m *NodeRestart) AppendJSONFields(printComma bool, b redact.RedactableBytes
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *PasswordHashConverted) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if m.RoleName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RoleName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.RoleName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.OldMethod != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"OldMethod\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.OldMethod)))
+		b = append(b, '"')
+	}
+
+	if m.NewMethod != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NewMethod\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.NewMethod)))
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *QueryExecute) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/role_events.proto
+++ b/pkg/util/log/eventpb/role_events.proto
@@ -55,3 +55,15 @@ message AlterRole {
   // The options set on the user/role.
   repeated string options = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
+
+// PasswordHashConverted is recorded when the password credentials
+// are automatically converted server-side.
+message PasswordHashConverted {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The name of the user/role whose credentials have been converted.
+  string role_name = 3 [(gogoproto.jsontag) = ",omitempty"];
+  // The previous hash method.
+  string old_method = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The new hash method.
+  string new_method = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}


### PR DESCRIPTION
(PR peeled away from #74301; previous PR in series #74849)
Epic CRDB-5349

Release note (security update): In order to promote a transition
to SCRAM-SHA-256 for password authentication, CockroachDB now
automatically attempts to convert stored password hashes
after a cleartext password authentication
succeeds to SCRAM-SHA-256, if the target hash method configured via
`server.user_login.password_encryption` is `scram-sha-256`.

This auto-conversion can happen either during SQL logins
or HTTP logins that use passwords, whichever happens first.

When it happens, a structured event of type `password_hash_converted`
is logged to the SESSIONS channel.

The PKBDF2 iteration count on the hash is chosen in order to preserve
the latency of client logins, to remain similar to the latency
incurred from the starting bcrypt cost.
(For example, the default configuration of bcrypt cost 10 is converted
to a SCRAM iteration count of 119680.)

This choice, however, lowers the cost of bruteforcing passwords for an
attacker with access to the encoded password hashes, if they have
access to ASICs or GPUs, by a factor of ~10. For example, if it would
previously cost them $1M to bruteforce a `crdb-bcrypt` hash, it would
now cost them "just" $100k to bruteforce the `scram-sha-256` hash that
results from this conversion.

If an operator wishes to compensate for this, three options are
available:

1. they can set up their infrastructure such that only passwords with
   a high entropy can be used. This can be achieved by e.g. disabling
   the ability of end-users to select their own passwords and
   auto-generating passwords for them, or enforce some entropy checks
   during password selection. This way, the entropy of the password
   itself compensates for the lower hash complexity.

2. they can manually select a higher SCRAM iteration count.  This can
   be done either by pre-computing SCRAM hashes client-side and providing
   the precomputed hash using ALTER USER WITH PASSWORD; or adjusting the
   cluster setting
   `server.user_login.password_hashes.default_cost.scram_sha_256` and
   asking CockroachDB to recompute the hash.

3. they can disable the auto-conversion of `crdb-bcrypt` hashes to
   `scram-sha-256` altogether, using the new cluster setting
   `server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled`.
   This approach is discouraged however, as it removes the other
   security protections offered by SCRAM authentication.

NB: the conversion also only happens if the target configured method
via `server.user_login.password_encryption` is `scram-sha-256`,
because the goal of the conversion is to move clusters towards that
configuration. This acknowledges cases when the operator had a
legitimate reason to select another value and future versions of of
CockroachDB that may use a new authentication method.

Release note (sql change): After a cluster upgrade, the first time a
SQL client logs in using password authentication, the password will be
converted to a new format (`scram-sha-256`) if it was encoded with
`crdb-bcrypt` previously.

This conversion will increase the latency of that initial login by a
factor of ~2x, but it will be reduced again after the conversion
completes.

When login latency is a concern, operators are invited to perform the
password conversion ahead of time, by computing new SCRAM hashes for
the clients via ALTER USER/ROLE WITH PASSWORD.

This conversion can also be disabled via the new cluster setting
`server.user_login.upgrade_bcrypt_stored_passwords_to_scram.enabled`.