### PR TITLE
pgwire: improve tracing span tags

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/util/timetz",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
@@ -69,6 +70,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
         "@com_github_xdg_go_scram//:scram",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -43,9 +43,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ring"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/lib/pq/oid"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // conn implements a pgwire network connection (version 3 of the protocol,
@@ -249,6 +251,7 @@ func (c *conn) serveImpl(
 	} else {
 		ctx = logtags.AddTag(ctx, "user", c.sessionArgs.User)
 	}
+	tracing.SpanFromContext(ctx).SetTag("user", attribute.StringValue(c.sessionArgs.User.Normalized()))
 
 	inTestWithoutSQL := sqlServer == nil
 	if !inTestWithoutSQL {

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -47,9 +47,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // ATTENTION: After changing this value in a unit test, you probably want to
@@ -650,7 +652,8 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 	if clientErr != nil {
 		return s.sendErr(ctx, conn, clientErr)
 	}
-	ctx = logtags.AddTag(ctx, connType.String(), nil)
+	sp := tracing.SpanFromContext(ctx)
+	sp.SetTag("conn_type", attribute.StringValue(connType.String()))
 
 	// What does the client want to do?
 	switch version {
@@ -691,10 +694,11 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 
 	// Populate the client address field in the context tags and the
 	// shared struct for structured logging.
-	// Only know do we know the remote client address for sure (it may have
+	// Only now do we know the remote client address for sure (it may have
 	// been overridden by a status parameter).
 	connDetails.RemoteAddress = sArgs.RemoteAddr.String()
 	ctx = logtags.AddTag(ctx, "client", connDetails.RemoteAddress)
+	sp.SetTag("client", attribute.StringValue(connDetails.RemoteAddress))
 
 	// If a test is hooking in some authentication option, load it.
 	var testingAuthHook func(context.Context) error


### PR DESCRIPTION
This patch adds the connection type, user, and remote address as span
tags on the "pgwire-serve" spans corresponding to connections. Before,
these were context logging tags. Being span tags, they'll show up when
one looks at spans, and I'm trying to make looking at spans much more
common.
The user and remote address remain as logging tags too. The connection
type (ssl, nossl, etc.) is no longer a logging tag because it seems too
noisy and, I imagine, very rarely interesting. These log tags don't stay
confined to the pgwire goroutine dealing with the network connection;
they are propagated also to the connExecutor goroutine that executes
queries, so they infect most code. This propagation doesn't necessarily
need to be the case, so if we really wanted we could keep the connection
type as a log tag for the pgwire goroutine; I didn't feel the need for
doing that, though.

This patch came to be because I'm working on the UI for exploring the
registry of active spans, and I'm trying to rationalize and clean up the
information people see associated with different spans.

Release note: None