### PR TITLE
kvcoord: break dependency on localtestcluster

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -129,6 +129,7 @@ go_test(
         "txn_coord_sender_server_test.go",
         "txn_coord_sender_test.go",
         "txn_correctness_test.go",
+        "txn_intercepter_pipeliner_client_test.go",
         "txn_interceptor_committer_test.go",
         "txn_interceptor_heartbeater_test.go",
         "txn_interceptor_pipeliner_test.go",

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -172,6 +172,8 @@ var rangeDescriptorCacheSize = settings.RegisterIntSetting(
 	1e6,
 )
 
+// senderConcurrencyLimit controls the maximum number of asynchronous send
+// requests.
 var senderConcurrencyLimit = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"kv.dist_sender.concurrency_limit",

--- a/pkg/kv/kvclient/kvcoord/helpers_test.go
+++ b/pkg/kv/kvclient/kvcoord/helpers_test.go
@@ -26,3 +26,32 @@ func (s *condensableSpanSet) asSortedSlice() []roachpb.Span {
 	sort.Sort(cpy)
 	return cpy
 }
+
+// TestingSenderConcurrencyLimit exports the cluster setting for testing
+// purposes.
+var TestingSenderConcurrencyLimit = senderConcurrencyLimit
+
+// TestingGetLockFootprint returns the internal lock footprint for testing
+// purposes.
+func (tc *TxnCoordSender) TestingGetLockFootprint(mergeAndSort bool) []roachpb.Span {
+	if mergeAndSort {
+		tc.interceptorAlloc.txnPipeliner.lockFootprint.mergeAndSort()
+	}
+	return tc.interceptorAlloc.txnPipeliner.lockFootprint.asSlice()
+}
+
+// TestingGetRefreshFootprint returns the internal refresh footprint for testing
+// purposes.
+func (tc *TxnCoordSender) TestingGetRefreshFootprint() []roachpb.Span {
+	return tc.interceptorAlloc.txnSpanRefresher.refreshFootprint.asSlice()
+}
+
+// TestingSetLinearizable allows tests to enable linearizable behavior.
+func (tcf *TxnCoordSenderFactory) TestingSetLinearizable(linearizable bool) {
+	tcf.linearizable = linearizable
+}
+
+// TestingSetMetrics allows tests to override the factory's metrics struct.
+func (tcf *TxnCoordSenderFactory) TestingSetMetrics(metrics TxnMetrics) {
+	tcf.metrics = metrics
+}

--- a/pkg/kv/kvclient/kvcoord/range_iter_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter_test.go
@@ -46,7 +46,7 @@ func init() {
 		lastKey = key
 	}
 	alphaRangeDescriptorDB = mockRangeDescriptorDBForDescs(
-		append(alphaRangeDescriptors, testMetaRangeDescriptor)...,
+		append(alphaRangeDescriptors, TestMetaRangeDescriptor)...,
 	)
 }
 

--- a/pkg/kv/kvclient/kvcoord/split_test.go
+++ b/pkg/kv/kvclient/kvcoord/split_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvcoord
+package kvcoord_test
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -188,7 +189,7 @@ func TestRangeSplitsWithWritePressure(t *testing.T) {
 			DisableScanner: true,
 		},
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseContext(), kvcoord.InitFactoryForLocalTestCluster)
 
 	// This is purely to silence log spam.
 	config.TestingSetupZoneConfigHook(s.Stopper())

--- a/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvcoord
+package kvcoord_test
 
 import (
 	"bytes"
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -836,7 +837,7 @@ func checkConcurrency(name string, txns []string, verify *verifier, t *testing.T
 			},
 		},
 	}
-	s.Start(t, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)
+	s.Start(t, testutils.NewNodeTestBaseContext(), kvcoord.InitFactoryForLocalTestCluster)
 	defer s.Stop()
 	verifier.run(s.DB, t)
 }

--- a/pkg/kv/kvclient/kvcoord/txn_intercepter_pipeliner_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_intercepter_pipeliner_client_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvcoord_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTxnCoordSenderCondenseLockSpans verifies that lock spans are condensed
+// along range boundaries when they exceed the maximum intent bytes threshold.
+//
+// TODO(andrei): Merge this test into TestTxnPipelinerCondenseLockSpans2, which
+// uses a txnPipeliner instead of a full TxnCoordSender.
+func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	a := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key(nil)}
+	b := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key(nil)}
+	c := roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key(nil)}
+	d := roachpb.Span{Key: roachpb.Key("ddddddd"), EndKey: roachpb.Key(nil)}
+	e := roachpb.Span{Key: roachpb.Key("e"), EndKey: roachpb.Key(nil)}
+	aToBClosed := roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b").Next()}
+	cToEClosed := roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e").Next()}
+	fTof0 := roachpb.Span{Key: roachpb.Key("f"), EndKey: roachpb.Key("f0")}
+	g := roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key(nil)}
+	g0Tog1 := roachpb.Span{Key: roachpb.Key("g0"), EndKey: roachpb.Key("g1")}
+	fTog1Closed := roachpb.Span{Key: roachpb.Key("f"), EndKey: roachpb.Key("g1")}
+	testCases := []struct {
+		span         roachpb.Span
+		expLocks     []roachpb.Span
+		expLocksSize int64
+	}{
+		{span: a, expLocks: []roachpb.Span{a}, expLocksSize: 1},
+		{span: b, expLocks: []roachpb.Span{a, b}, expLocksSize: 2},
+		{span: c, expLocks: []roachpb.Span{a, b, c}, expLocksSize: 3},
+		{span: d, expLocks: []roachpb.Span{a, b, c, d}, expLocksSize: 10},
+		// Note that c-e condenses and then lists first.
+		{span: e, expLocks: []roachpb.Span{cToEClosed, a, b}, expLocksSize: 5},
+		{span: fTof0, expLocks: []roachpb.Span{cToEClosed, a, b, fTof0}, expLocksSize: 8},
+		{span: g, expLocks: []roachpb.Span{cToEClosed, a, b, fTof0, g}, expLocksSize: 9},
+		{span: g0Tog1, expLocks: []roachpb.Span{fTog1Closed, cToEClosed, aToBClosed}, expLocksSize: 9},
+		// Add a key in the middle of a span, which will get merged on commit.
+		{span: c, expLocks: []roachpb.Span{fTog1Closed, cToEClosed, aToBClosed, c}, expLocksSize: 10},
+	}
+	splits := []roachpb.Span{
+		{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+		{Key: roachpb.Key("c"), EndKey: roachpb.Key("f")},
+		{Key: roachpb.Key("f"), EndKey: roachpb.Key("j")},
+	}
+	descs := []roachpb.RangeDescriptor{kvcoord.TestMetaRangeDescriptor}
+	for i, s := range splits {
+		descs = append(descs, roachpb.RangeDescriptor{
+			RangeID:          roachpb.RangeID(2 + i),
+			StartKey:         roachpb.RKey(s.Key),
+			EndKey:           roachpb.RKey(s.EndKey),
+			InternalReplicas: []roachpb.ReplicaDescriptor{{NodeID: 1, StoreID: 1}},
+		})
+	}
+	descDB := kvcoord.TestingMockRangeDescriptorDBForDescs(descs...)
+	s := createTestDB(t)
+	st := s.Store.ClusterSettings()
+	kvcoord.TrackedWritesMaxSize.Override(ctx, &st.SV, 10) /* 10 bytes and it will condense */
+	defer s.Stop()
+
+	// Check end transaction locks, which should be condensed and split
+	// at range boundaries.
+	expLocks := []roachpb.Span{aToBClosed, cToEClosed, fTog1Closed}
+	sendFn := func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+		resp := ba.CreateReply()
+		resp.Txn = ba.Txn
+		if req, ok := ba.GetArg(roachpb.EndTxn); ok {
+			if !req.(*roachpb.EndTxnRequest).Commit {
+				t.Errorf("expected commit to be true")
+			}
+			et := req.(*roachpb.EndTxnRequest)
+			if a, e := et.LockSpans, expLocks; !reflect.DeepEqual(a, e) {
+				t.Errorf("expected end transaction to have locks %+v; got %+v", e, a)
+			}
+			resp.Txn.Status = roachpb.COMMITTED
+		}
+		return resp, nil
+	}
+	ambient := log.MakeTestingAmbientCtxWithNewTracer()
+	ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
+		AmbientCtx: ambient,
+		Clock:      s.Clock,
+		NodeDescs:  s.Gossip,
+		RPCContext: s.Cfg.RPCContext,
+		TestingKnobs: kvcoord.ClientTestingKnobs{
+			TransportFactory: kvcoord.TestingAdaptSimpleTransport(sendFn),
+		},
+		RangeDescriptorDB: descDB,
+		Settings:          cluster.MakeTestingClusterSettings(),
+	})
+	tsf := kvcoord.NewTxnCoordSenderFactory(
+		kvcoord.TxnCoordSenderFactoryConfig{
+			AmbientCtx: ambient,
+			Settings:   st,
+			Clock:      s.Clock,
+			Stopper:    s.Stopper(),
+		},
+		ds,
+	)
+	db := kv.NewDB(ambient, tsf, s.Clock, s.Stopper())
+
+	txn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
+	// Disable txn pipelining so that all write spans are immediately
+	// added to the transaction's lock footprint.
+	if err := txn.DisablePipelining(); err != nil {
+		t.Fatal(err)
+	}
+	for i, tc := range testCases {
+		if tc.span.EndKey != nil {
+			if _, err := txn.DelRange(ctx, tc.span.Key, tc.span.EndKey, false /* returnKeys */); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			if err := txn.Put(ctx, tc.span.Key, []byte("value")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		tcs := txn.Sender().(*kvcoord.TxnCoordSender)
+		locks := tcs.TestingGetLockFootprint(false /* mergeAndSort */)
+		if a, e := locks, tc.expLocks; !reflect.DeepEqual(a, e) {
+			t.Errorf("%d: expected keys %+v; got %+v", i, e, a)
+		}
+		locksSize := int64(0)
+		for _, i := range locks {
+			locksSize += int64(len(i.Key) + len(i.EndKey))
+		}
+		if a, e := locksSize, tc.expLocksSize; a != e {
+			t.Errorf("%d: keys size expected %d; got %d", i, e, a)
+		}
+	}
+
+	metrics := txn.Sender().(*kvcoord.TxnCoordSender).Metrics()
+	require.Equal(t, int64(1), metrics.TxnsWithCondensedIntents.Count())
+	require.Equal(t, int64(1), metrics.TxnsWithCondensedIntentsGauge.Value())
+
+	if err := txn.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	require.Zero(t, metrics.TxnsWithCondensedIntentsGauge.Value())
+}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -51,7 +51,7 @@ var pipelinedWritesMaxBatchSize = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
-// trackedWritesMaxSize is a byte threshold for the tracking of writes performed
+// TrackedWritesMaxSize is a byte threshold for the tracking of writes performed
 // a single transaction. This includes the tracking of lock spans and of
 // in-flight writes, both stored in the txnPipeliner.
 //
@@ -74,7 +74,7 @@ var pipelinedWritesMaxBatchSize = settings.RegisterIntSetting(
 // because it needs to hold broad latches and iterate through the range to
 // find matching intents.
 // See #54029 for more details.
-var trackedWritesMaxSize = settings.RegisterIntSetting(
+var TrackedWritesMaxSize = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"kv.transaction.max_intents_bytes",
 	"maximum number of bytes used to track locks in transactions",
@@ -274,7 +274,7 @@ func (tp *txnPipeliner) SendLocked(
 	// request (think ResumeSpan); even if the check passes, we might end up over
 	// budget.
 	rejectOverBudget := rejectTxnOverTrackedWritesBudget.Get(&tp.st.SV)
-	maxBytes := trackedWritesMaxSize.Get(&tp.st.SV)
+	maxBytes := TrackedWritesMaxSize.Get(&tp.st.SV)
 	if rejectOverBudget {
 		if err := tp.maybeRejectOverBudget(ba, maxBytes); err != nil {
 			return nil, roachpb.NewError(err)
@@ -437,7 +437,7 @@ func (tp *txnPipeliner) canUseAsyncConsensus(ctx context.Context, ba roachpb.Bat
 	// There's a memory budget for lock tracking. If this batch would push us over
 	// this setting, don't allow it to perform async consensus.
 	addedIFBytes := int64(0)
-	maxTrackingBytes := trackedWritesMaxSize.Get(&tp.st.SV)
+	maxTrackingBytes := TrackedWritesMaxSize.Get(&tp.st.SV)
 
 	// We provide a setting to bound the number of writes we permit in a batch
 	// that uses async consensus. This is useful because we'll have to prove

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvcoord
+package kvcoord_test
 
 import (
 	"bytes"
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -106,7 +107,7 @@ func BenchmarkSingleRoundtripWithLatency(b *testing.B) {
 		b.Run(fmt.Sprintf("latency=%s", latency), func(b *testing.B) {
 			var s localtestcluster.LocalTestCluster
 			s.Latency = latency
-			s.Start(b, testutils.NewNodeTestBaseContext(), InitFactoryForLocalTestCluster)
+			s.Start(b, testutils.NewNodeTestBaseContext(), kvcoord.InitFactoryForLocalTestCluster)
 			defer s.Stop()
 			defer b.StopTimer()
 			key := roachpb.Key("key")


### PR DESCRIPTION
The earlier form prevented localtestcluster to transitively depend on
kvcoord, something we want in #73876 through the rangefeed package.
This commit moves a few tests to package external ones; to do so it
exports a few symbols (cluster setting variables) and defines some
(public) testing methods to mutate/retrieve internal state.

Release note: None