### PR TITLE
colexechash: improve comments on the hash table

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -54,7 +54,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -97,7 +97,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -135,7 +135,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -166,7 +166,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -198,7 +198,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -241,7 +241,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -279,7 +279,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -310,7 +310,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -357,7 +357,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -392,7 +392,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -422,7 +422,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -445,7 +445,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -469,7 +469,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -504,7 +504,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -534,7 +534,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -557,7 +557,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -596,7 +596,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -631,7 +631,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -661,7 +661,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -684,7 +684,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -708,7 +708,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -743,7 +743,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -773,7 +773,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -796,7 +796,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -833,7 +833,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -879,7 +879,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -920,7 +920,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -954,7 +954,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -989,7 +989,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1035,7 +1035,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1076,7 +1076,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -1110,7 +1110,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -1155,7 +1155,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1201,7 +1201,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1242,7 +1242,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -1276,7 +1276,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -1311,7 +1311,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1357,7 +1357,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1398,7 +1398,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -1432,7 +1432,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -1479,7 +1479,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1525,7 +1525,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1566,7 +1566,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -1600,7 +1600,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -1635,7 +1635,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1681,7 +1681,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1722,7 +1722,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -1756,7 +1756,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -1806,7 +1806,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1860,7 +1860,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -1909,7 +1909,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -1951,7 +1951,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -1994,7 +1994,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2048,7 +2048,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2097,7 +2097,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2139,7 +2139,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -2197,7 +2197,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2239,7 +2239,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2276,7 +2276,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2306,7 +2306,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -2337,7 +2337,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2379,7 +2379,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2416,7 +2416,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2446,7 +2446,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -2492,7 +2492,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2527,7 +2527,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2557,7 +2557,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2580,7 +2580,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -2604,7 +2604,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2639,7 +2639,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2669,7 +2669,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2692,7 +2692,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -2731,7 +2731,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2772,7 +2772,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2808,7 +2808,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2837,7 +2837,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -2867,7 +2867,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2908,7 +2908,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -2944,7 +2944,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -2973,7 +2973,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -3018,7 +3018,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -3055,7 +3055,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -3087,7 +3087,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -3112,7 +3112,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
 									probeVal := probeKeys.Get(probeIdx)
@@ -3138,7 +3138,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -3175,7 +3175,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeIsNull := probeVecNulls.NullAt(probeIdx)
@@ -3207,7 +3207,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull := buildVecNulls.NullAt(buildIdx)
@@ -3232,7 +3232,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									probeVal := probeKeys.Get(probeIdx)
@@ -3279,7 +3279,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3326,7 +3326,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3368,7 +3368,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3403,7 +3403,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3452,7 +3452,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3491,7 +3491,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3525,7 +3525,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3552,7 +3552,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3599,7 +3599,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3638,7 +3638,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3672,7 +3672,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3699,7 +3699,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3738,7 +3738,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3788,7 +3788,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3833,7 +3833,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3871,7 +3871,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3924,7 +3924,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -3974,7 +3974,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4019,7 +4019,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4057,7 +4057,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4112,7 +4112,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4162,7 +4162,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4207,7 +4207,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4245,7 +4245,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4306,7 +4306,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4364,7 +4364,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4417,7 +4417,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4463,7 +4463,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4526,7 +4526,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4572,7 +4572,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4613,7 +4613,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4647,7 +4647,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4695,7 +4695,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4734,7 +4734,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4768,7 +4768,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4795,7 +4795,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4836,7 +4836,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4881,7 +4881,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4921,7 +4921,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -4954,7 +4954,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5001,7 +5001,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5042,7 +5042,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5078,7 +5078,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5107,7 +5107,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 						} else {
 							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								keyID := ht.ProbeScratch.GroupID[toCheck]
+								keyID := ht.ProbeScratch.ToCheckID[toCheck]
 								if keyID != 0 {
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
@@ -5153,7 +5153,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 			continue
 		}
 		if !ht.ProbeScratch.differs[toCheck] {
-			keyID := ht.ProbeScratch.GroupID[toCheck]
+			keyID := ht.ProbeScratch.ToCheckID[toCheck]
 			if ht.ProbeScratch.HeadID[toCheck] == 0 {
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 			}

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -29,7 +29,7 @@ var (
 	_ tree.AggType
 )
 
-// checkCol determines if the current key column in the GroupID buckets matches
+// checkCol determines if the current key column in the ToCheckID buckets matches
 // the specified equality column key. If there is no match, then the key is
 // added to differs. If the bucket has reached the end, the key is rejected. If
 // the HashTable disallows null equality, then if any element in the key is
@@ -56,7 +56,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -68,7 +68,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -101,7 +101,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -110,7 +110,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -141,7 +141,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -174,7 +174,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -208,7 +208,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -220,7 +220,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -253,7 +253,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -262,7 +262,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -293,7 +293,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -326,7 +326,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -375,7 +375,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -387,7 +387,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -412,7 +412,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -421,7 +421,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -444,7 +444,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -469,7 +469,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -495,7 +495,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -507,7 +507,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -532,7 +532,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -541,7 +541,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -564,7 +564,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -589,7 +589,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -630,7 +630,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -642,7 +642,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -667,7 +667,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -676,7 +676,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -699,7 +699,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -724,7 +724,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -750,7 +750,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -762,7 +762,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -787,7 +787,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -796,7 +796,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -819,7 +819,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -844,7 +844,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -883,7 +883,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -895,7 +895,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -931,7 +931,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -940,7 +940,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -974,7 +974,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1010,7 +1010,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1047,7 +1047,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1059,7 +1059,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1095,7 +1095,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1104,7 +1104,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1138,7 +1138,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1174,7 +1174,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1215,7 +1215,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1227,7 +1227,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1263,7 +1263,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1272,7 +1272,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1306,7 +1306,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1342,7 +1342,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1379,7 +1379,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1391,7 +1391,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1427,7 +1427,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1436,7 +1436,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1470,7 +1470,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1506,7 +1506,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1548,7 +1548,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1560,7 +1560,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1596,7 +1596,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1605,7 +1605,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1639,7 +1639,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1675,7 +1675,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1712,7 +1712,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1724,7 +1724,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1760,7 +1760,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1769,7 +1769,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1803,7 +1803,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1839,7 +1839,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -1886,7 +1886,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1898,7 +1898,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1934,7 +1934,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -1943,7 +1943,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1977,7 +1977,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2013,7 +2013,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2050,7 +2050,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2062,7 +2062,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2098,7 +2098,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2107,7 +2107,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2141,7 +2141,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2177,7 +2177,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2218,7 +2218,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2230,7 +2230,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2266,7 +2266,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2275,7 +2275,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2309,7 +2309,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2345,7 +2345,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2382,7 +2382,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2394,7 +2394,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2430,7 +2430,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2439,7 +2439,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2473,7 +2473,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2509,7 +2509,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2551,7 +2551,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2563,7 +2563,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2599,7 +2599,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2608,7 +2608,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2642,7 +2642,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2678,7 +2678,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2715,7 +2715,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2727,7 +2727,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2763,7 +2763,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2772,7 +2772,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2806,7 +2806,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2842,7 +2842,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -2890,7 +2890,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2902,7 +2902,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2938,7 +2938,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -2947,7 +2947,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2981,7 +2981,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3017,7 +3017,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3054,7 +3054,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3066,7 +3066,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3102,7 +3102,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3111,7 +3111,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3145,7 +3145,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3181,7 +3181,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3222,7 +3222,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3234,7 +3234,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3270,7 +3270,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3279,7 +3279,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3313,7 +3313,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3349,7 +3349,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3386,7 +3386,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3398,7 +3398,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3434,7 +3434,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3443,7 +3443,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3477,7 +3477,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3513,7 +3513,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3555,7 +3555,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3567,7 +3567,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3603,7 +3603,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3612,7 +3612,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3646,7 +3646,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3682,7 +3682,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3719,7 +3719,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3731,7 +3731,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3767,7 +3767,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3776,7 +3776,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3810,7 +3810,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3846,7 +3846,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -3898,7 +3898,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3910,7 +3910,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3954,7 +3954,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -3963,7 +3963,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4005,7 +4005,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4049,7 +4049,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4094,7 +4094,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4106,7 +4106,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4150,7 +4150,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4159,7 +4159,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4201,7 +4201,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4245,7 +4245,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4305,7 +4305,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4317,7 +4317,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4349,7 +4349,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4358,7 +4358,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4388,7 +4388,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4420,7 +4420,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4453,7 +4453,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4465,7 +4465,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4497,7 +4497,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4506,7 +4506,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4536,7 +4536,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4568,7 +4568,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4616,7 +4616,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4628,7 +4628,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4653,7 +4653,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4662,7 +4662,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4685,7 +4685,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4710,7 +4710,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4736,7 +4736,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4748,7 +4748,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4773,7 +4773,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4782,7 +4782,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4805,7 +4805,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4830,7 +4830,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -4871,7 +4871,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4883,7 +4883,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4914,7 +4914,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4923,7 +4923,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4952,7 +4952,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -4983,7 +4983,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -5015,7 +5015,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5027,7 +5027,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5058,7 +5058,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5067,7 +5067,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5096,7 +5096,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5127,7 +5127,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5174,7 +5174,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -5186,7 +5186,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5213,7 +5213,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -5222,7 +5222,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5247,7 +5247,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -5274,7 +5274,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
@@ -5302,7 +5302,7 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5314,7 +5314,7 @@ func (ht *HashTable) checkCol(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5341,7 +5341,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5350,7 +5350,7 @@ func (ht *HashTable) checkCol(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5375,7 +5375,7 @@ func (ht *HashTable) checkCol(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
@@ -5402,7 +5402,7 @@ func (ht *HashTable) checkCol(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -30,11 +30,11 @@ var (
 	_ tree.AggType
 )
 
-// checkColDeleting determines if the current key column in the GroupID buckets
-// matches the specified equality column key. If there is no match *or* the key
-// has been already used, then the key is added to differs. If the bucket has
-// reached the end, the key is rejected. If the HashTable disallows null
-// equality, then if any element in the key is null, there is no match.
+// checkColDeleting determines if the current key column in the ToCheckID
+// buckets matches the specified equality column key. If there is no match *or*
+// the key has been already used, then the key is added to differs. If the
+// bucket has reached the end, the key is rejected. If the HashTable disallows
+// null equality, then if any element in the key is null, there is no match.
 func (ht *HashTable) checkColDeleting(
 	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
 ) {
@@ -57,7 +57,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -73,7 +73,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -106,7 +106,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -119,7 +119,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -150,7 +150,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -187,7 +187,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -225,7 +225,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -241,7 +241,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -274,7 +274,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -287,7 +287,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -318,7 +318,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -355,7 +355,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -408,7 +408,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -424,7 +424,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -449,7 +449,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -462,7 +462,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -485,7 +485,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -514,7 +514,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -544,7 +544,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -560,7 +560,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -585,7 +585,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -598,7 +598,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -621,7 +621,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -650,7 +650,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -695,7 +695,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -711,7 +711,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -736,7 +736,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -749,7 +749,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -772,7 +772,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -801,7 +801,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -831,7 +831,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -847,7 +847,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -872,7 +872,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -885,7 +885,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -908,7 +908,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -937,7 +937,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -980,7 +980,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -996,7 +996,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1032,7 +1032,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1045,7 +1045,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1079,7 +1079,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1119,7 +1119,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1160,7 +1160,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1176,7 +1176,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1212,7 +1212,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1225,7 +1225,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1259,7 +1259,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1299,7 +1299,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1344,7 +1344,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1360,7 +1360,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1396,7 +1396,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1409,7 +1409,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1443,7 +1443,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1483,7 +1483,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1524,7 +1524,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1540,7 +1540,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1576,7 +1576,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1589,7 +1589,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1623,7 +1623,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1663,7 +1663,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1709,7 +1709,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1725,7 +1725,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1761,7 +1761,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1774,7 +1774,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1808,7 +1808,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1848,7 +1848,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1889,7 +1889,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1905,7 +1905,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1941,7 +1941,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -1954,7 +1954,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -1988,7 +1988,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2028,7 +2028,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2079,7 +2079,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2095,7 +2095,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2131,7 +2131,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2144,7 +2144,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2178,7 +2178,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2218,7 +2218,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2259,7 +2259,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2275,7 +2275,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2311,7 +2311,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2324,7 +2324,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2358,7 +2358,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2398,7 +2398,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2443,7 +2443,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2459,7 +2459,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2495,7 +2495,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2508,7 +2508,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2542,7 +2542,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2582,7 +2582,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2623,7 +2623,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2639,7 +2639,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2675,7 +2675,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2688,7 +2688,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2722,7 +2722,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2762,7 +2762,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2808,7 +2808,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2824,7 +2824,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2860,7 +2860,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2873,7 +2873,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -2907,7 +2907,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2947,7 +2947,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -2988,7 +2988,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3004,7 +3004,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3040,7 +3040,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3053,7 +3053,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3087,7 +3087,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3127,7 +3127,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3179,7 +3179,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3195,7 +3195,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3231,7 +3231,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3244,7 +3244,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3278,7 +3278,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3318,7 +3318,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3359,7 +3359,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3375,7 +3375,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3411,7 +3411,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3424,7 +3424,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3458,7 +3458,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3498,7 +3498,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3543,7 +3543,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3559,7 +3559,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3595,7 +3595,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3608,7 +3608,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3642,7 +3642,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3682,7 +3682,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3723,7 +3723,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3739,7 +3739,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3775,7 +3775,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3788,7 +3788,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3822,7 +3822,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3862,7 +3862,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3908,7 +3908,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3924,7 +3924,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -3960,7 +3960,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -3973,7 +3973,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4007,7 +4007,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4047,7 +4047,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4088,7 +4088,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4104,7 +4104,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4140,7 +4140,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4153,7 +4153,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4187,7 +4187,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4227,7 +4227,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4283,7 +4283,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4299,7 +4299,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4343,7 +4343,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4356,7 +4356,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4398,7 +4398,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4446,7 +4446,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4495,7 +4495,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4511,7 +4511,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4555,7 +4555,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4568,7 +4568,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4610,7 +4610,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4658,7 +4658,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4722,7 +4722,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4738,7 +4738,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4770,7 +4770,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4783,7 +4783,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4813,7 +4813,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4849,7 +4849,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4886,7 +4886,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4902,7 +4902,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4934,7 +4934,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -4947,7 +4947,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -4977,7 +4977,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5013,7 +5013,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5065,7 +5065,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5081,7 +5081,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5106,7 +5106,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5119,7 +5119,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5142,7 +5142,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5171,7 +5171,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5201,7 +5201,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5217,7 +5217,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5242,7 +5242,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5255,7 +5255,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5278,7 +5278,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5307,7 +5307,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5352,7 +5352,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5368,7 +5368,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5399,7 +5399,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5412,7 +5412,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5441,7 +5441,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5476,7 +5476,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5512,7 +5512,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5528,7 +5528,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5559,7 +5559,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5572,7 +5572,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5601,7 +5601,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5636,7 +5636,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5687,7 +5687,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5703,7 +5703,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5730,7 +5730,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5743,7 +5743,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5768,7 +5768,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5799,7 +5799,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5831,7 +5831,7 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5847,7 +5847,7 @@ func (ht *HashTable) checkColDeleting(
 													ht.ProbeScratch.differs[toCheck] = true
 												}
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5874,7 +5874,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5887,7 +5887,7 @@ func (ht *HashTable) checkColDeleting(
 											if ht.allowNullEquality {
 												ht.ProbeScratch.differs[toCheck] = true
 											} else {
-												ht.ProbeScratch.GroupID[toCheck] = 0
+												ht.ProbeScratch.ToCheckID[toCheck] = 0
 											}
 											continue
 										}
@@ -5912,7 +5912,7 @@ func (ht *HashTable) checkColDeleting(
 								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5943,7 +5943,7 @@ func (ht *HashTable) checkColDeleting(
 							} else {
 								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									keyID := ht.ProbeScratch.GroupID[toCheck]
+									keyID := ht.ProbeScratch.ToCheckID[toCheck]
 									if keyID != 0 {
 										if ht.Visited[keyID] {
 											ht.ProbeScratch.differs[toCheck] = true
@@ -5975,9 +5975,9 @@ func (ht *HashTable) checkColDeleting(
 	}
 }
 
-// Check performs an equality check between the current key in the GroupID bucket
-// and the probe key at that index. If there is a match, the HashTable's same
-// array is updated to lazily populate the linked list of identical build
+// Check performs an equality check between the current key in the ToCheckID
+// bucket and the probe key at that index. If there is a match, the HashTable's
+// same array is updated to lazily populate the linked list of identical build
 // table keys. The visited flag for corresponding build table key is also set. A
 // key is removed from ToCheck if it has already been visited in a previous
 // probe, or the bucket has reached the end (key not found in build table). The
@@ -5994,7 +5994,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					keyID := ht.ProbeScratch.GroupID[toCheck]
+					keyID := ht.ProbeScratch.ToCheckID[toCheck]
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
@@ -6023,7 +6023,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					keyID := ht.ProbeScratch.GroupID[toCheck]
+					keyID := ht.ProbeScratch.ToCheckID[toCheck]
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
@@ -6043,7 +6043,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					keyID := ht.ProbeScratch.GroupID[toCheck]
+					keyID := ht.ProbeScratch.ToCheckID[toCheck]
 					if !ht.Visited[keyID] {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 						ht.Visited[keyID] = true
@@ -6068,7 +6068,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					keyID := ht.ProbeScratch.GroupID[toCheck]
+					keyID := ht.ProbeScratch.ToCheckID[toCheck]
 					if !ht.Visited[keyID] {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 						ht.Visited[keyID] = true

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.eg.go
@@ -80,7 +80,7 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 }
 
 // distinctCollect prepares the batch with the joined output columns where the build
-// row index for each probe row is given in the GroupID slice. This function
+// row index for each probe row is given in the ToCheckID slice. This function
 // requires assumes a N-1 hash join.
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := 0
@@ -470,11 +470,11 @@ func collectProbeNoOuter_false(
 func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
 	// Early bounds checks.
 	// Capture the slices in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
+	toCheckIDs := hj.ht.ProbeScratch.ToCheckID
 	probeRowUnmatched := hj.probeState.probeRowUnmatched
 	buildIdx := hj.probeState.buildIdx
 	probeIdx := hj.probeState.probeIdx
-	_ = groupIDs[batchSize-1]
+	_ = toCheckIDs[batchSize-1]
 	_ = probeRowUnmatched[batchSize-1]
 	_ = buildIdx[batchSize-1]
 	_ = probeIdx[batchSize-1]
@@ -482,7 +482,7 @@ func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
 	for i := 0; i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
 		//gcassert:bce
-		id := groupIDs[i]
+		id := toCheckIDs[i]
 		rowUnmatched := id == 0
 		//gcassert:bce
 		probeRowUnmatched[i] = rowUnmatched
@@ -515,18 +515,18 @@ func distinctCollectProbeOuter_true(hj *hashJoiner, batchSize int, sel []int) {
 func distinctCollectProbeOuter_false(hj *hashJoiner, batchSize int, sel []int) {
 	// Early bounds checks.
 	// Capture the slices in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
+	toCheckIDs := hj.ht.ProbeScratch.ToCheckID
 	probeRowUnmatched := hj.probeState.probeRowUnmatched
 	buildIdx := hj.probeState.buildIdx
 	probeIdx := hj.probeState.probeIdx
-	_ = groupIDs[batchSize-1]
+	_ = toCheckIDs[batchSize-1]
 	_ = probeRowUnmatched[batchSize-1]
 	_ = buildIdx[batchSize-1]
 	_ = probeIdx[batchSize-1]
 	for i := 0; i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
 		//gcassert:bce
-		id := groupIDs[i]
+		id := toCheckIDs[i]
 		rowUnmatched := id == 0
 		//gcassert:bce
 		probeRowUnmatched[i] = rowUnmatched
@@ -560,12 +560,12 @@ func distinctCollectProbeNoOuter_true(
 	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
 	// Early bounds checks.
 	// Capture the slice in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	_ = groupIDs[batchSize-1]
+	toCheckIDs := hj.ht.ProbeScratch.ToCheckID
+	_ = toCheckIDs[batchSize-1]
 	_ = sel[batchSize-1]
 	for i := 0; i < batchSize; i++ {
 		//gcassert:bce
-		id := groupIDs[i]
+		id := toCheckIDs[i]
 		if id != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
 			hj.probeState.buildIdx[nResults] = int(id - 1)
@@ -588,11 +588,11 @@ func distinctCollectProbeNoOuter_false(
 	hj *hashJoiner, batchSize int, nResults int, sel []int) int {
 	// Early bounds checks.
 	// Capture the slice in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	_ = groupIDs[batchSize-1]
+	toCheckIDs := hj.ht.ProbeScratch.ToCheckID
+	_ = toCheckIDs[batchSize-1]
 	for i := 0; i < batchSize; i++ {
 		//gcassert:bce
-		id := groupIDs[i]
+		id := toCheckIDs[i]
 		if id != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
 			hj.probeState.buildIdx[nResults] = int(id - 1)

--- a/pkg/sql/colexec/colexecjoin/hashjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner_tmpl.go
@@ -194,11 +194,11 @@ func collectRightSemiAnti(hj *hashJoiner, batchSize int) {
 func distinctCollectProbeOuter(hj *hashJoiner, batchSize int, sel []int, useSel bool) {
 	// Early bounds checks.
 	// Capture the slices in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
+	toCheckIDs := hj.ht.ProbeScratch.ToCheckID
 	probeRowUnmatched := hj.probeState.probeRowUnmatched
 	buildIdx := hj.probeState.buildIdx
 	probeIdx := hj.probeState.probeIdx
-	_ = groupIDs[batchSize-1]
+	_ = toCheckIDs[batchSize-1]
 	_ = probeRowUnmatched[batchSize-1]
 	_ = buildIdx[batchSize-1]
 	_ = probeIdx[batchSize-1]
@@ -208,7 +208,7 @@ func distinctCollectProbeOuter(hj *hashJoiner, batchSize int, sel []int, useSel 
 	for i := 0; i < batchSize; i++ {
 		// Index of keys and outputs in the hash table is calculated as ID - 1.
 		//gcassert:bce
-		id := groupIDs[i]
+		id := toCheckIDs[i]
 		rowUnmatched := id == 0
 		//gcassert:bce
 		probeRowUnmatched[i] = rowUnmatched
@@ -235,14 +235,14 @@ func distinctCollectProbeNoOuter(
 ) int {
 	// Early bounds checks.
 	// Capture the slice in order for BCE to occur.
-	groupIDs := hj.ht.ProbeScratch.GroupID
-	_ = groupIDs[batchSize-1]
+	toCheckIDs := hj.ht.ProbeScratch.ToCheckID
+	_ = toCheckIDs[batchSize-1]
 	if useSel {
 		_ = sel[batchSize-1]
 	}
 	for i := 0; i < batchSize; i++ {
 		//gcassert:bce
-		id := groupIDs[i]
+		id := toCheckIDs[i]
 		if id != 0 {
 			// Index of keys and outputs in the hash table is calculated as ID - 1.
 			hj.probeState.buildIdx[nResults] = int(id - 1)
@@ -290,7 +290,7 @@ func (hj *hashJoiner) collect(batch coldata.Batch, batchSize int, sel []int) int
 }
 
 // distinctCollect prepares the batch with the joined output columns where the build
-// row index for each probe row is given in the GroupID slice. This function
+// row index for each probe row is given in the ToCheckID slice. This function
 // requires assumes a N-1 hash join.
 func (hj *hashJoiner) distinctCollect(batch coldata.Batch, batchSize int, sel []int) int {
 	nResults := 0

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -282,10 +282,10 @@ func (op *hashAggregator) setupScratchSlices(numBuffered int) {
 // simple hash function h(i) = i % 2 with two buckets in the hash table.
 //
 // I. we get a batch [-3, -3, -2, -1].
-//   1. a) compute hash buckets: ProbeScratch.next = [reserved, 1, 1, 0, 1]
-//      b) build 'next' chains between hash buckets:
-//           ProbeScratch.first = [3, 1] (length of first == # of hash buckets)
-//           ProbeScratch.next = [reserved, 2, 4, 0, 0]
+//   1. a) compute hash buckets: ProbeScratch.Next = [reserved, 1, 1, 0, 1]
+//      b) build 'Next' chains between hash buckets:
+//           ProbeScratch.First = [3, 1] (length of First == # of hash buckets)
+//           ProbeScratch.Next = [reserved, 2, 4, 0, 0]
 //         (Note that we have a hash collision in the bucket with hash 1.)
 //      c) find "equality" buckets (populate HeadID):
 //           ProbeScratch.HeadID = [1, 1, 3, 4]
@@ -306,10 +306,10 @@ func (op *hashAggregator) setupScratchSlices(numBuffered int) {
 //   We have fully processed the first batch.
 //
 // II. we get a batch [-4, -1, -1, -4].
-//   1. a) compute hash buckets: ProbeScratch.next = [reserved, 0, 1, 1, 0]
+//   1. a) compute hash buckets: ProbeScratch.Next = [reserved, 0, 1, 1, 0]
 //      b) build 'next' chains between hash buckets:
-//           ProbeScratch.first = [1, 2]
-//           ProbeScratch.next = [reserved, 4, 3, 0, 0]
+//           ProbeScratch.First = [1, 2]
+//           ProbeScratch.Next = [reserved, 4, 3, 0, 0]
 //      c) find "equality" buckets:
 //           ProbeScratch.HeadID = [1, 2, 2, 1]
 //   2. divide all tuples into the equality chains based on HeadID:
@@ -332,7 +332,7 @@ func (op *hashAggregator) setupScratchSlices(numBuffered int) {
 //
 //  We have processed the input fully, so we're ready to emit the output.
 //
-// NOTE: b *must* be non-zero length batch.
+// NOTE: b *must* be a non-zero length batch.
 func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 	op.setupScratchSlices(b.Length())
 	inputVecs := b.ColVecs()


### PR DESCRIPTION
**colexechash: improve comments on the hash table**

Some comments around the hash table code have rotted, so this commit
refreshes them. It adds an extensive comment with an example of how the
hash table is used by the unordered distinct. Only a minor mechanical
change is done to the actual code in order to increase its clarity.

Release note: None

**colexechash: rename GroupID to ToCheckID**

This makes the purpose of this field more clear.

Release note: None