### PR TITLE
sql: add a tracing tag with the txn ID

### DIFF
--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -204,6 +204,7 @@ func (ts *txnState) resetForNewSQLTxn(
 		}
 		ts.mu.txn = txn
 	}
+	sp.SetTag("txn", attribute.StringValue(ts.mu.txn.ID().String()))
 	ts.mu.txnStart = timeutil.Now()
 	ts.mu.Unlock()
 	if historicalTimestamp != nil {


### PR DESCRIPTION
This patch adds the txn's ID as a tag to the tracing span representing a
SQL txn. I'm creating a UI to explore the current spans, and this ID
will make it easy to navigate between a query/request blocking on a lock
held by some other txn, and the activity of that other txn.

Release note: None