### PR TITLE
release-21.2: colexechash: fix an internal error with distinct mode

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -30,9 +30,10 @@ var (
 	_ tree.AggType
 )
 
-// checkColAgainstItself is similar to checkCol, but it probes the vector
-// against itself.
-func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel []int) {
+// checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
+// vector against itself for the purposes of finding matches to unordered
+// distinct columns.
+func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint64, sel []int) {
 	probeVec, buildVec, probeSel := vec, vec, sel
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -84,7 +85,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -108,6 +108,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -145,7 +148,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -169,6 +171,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -208,7 +213,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -232,6 +236,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -268,7 +275,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -292,6 +298,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -332,7 +341,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -356,6 +364,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -391,7 +402,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -415,6 +425,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -452,7 +465,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -476,6 +488,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -510,7 +525,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -534,6 +548,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -591,7 +608,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -607,6 +623,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -644,7 +663,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -660,6 +678,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -699,7 +720,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -715,6 +735,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -751,7 +774,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -767,6 +789,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -807,7 +832,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -823,6 +847,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -858,7 +885,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -874,6 +900,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -911,7 +940,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -927,6 +955,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -961,7 +992,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -977,6 +1007,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1034,7 +1067,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1050,6 +1082,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1087,7 +1122,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1103,6 +1137,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1142,7 +1179,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1158,6 +1194,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1194,7 +1233,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1210,6 +1248,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1250,7 +1291,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1266,6 +1306,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1301,7 +1344,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1317,6 +1359,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1354,7 +1399,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1370,6 +1414,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1404,7 +1451,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1420,6 +1466,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1475,7 +1524,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1502,6 +1550,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1539,7 +1590,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1566,6 +1616,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1605,7 +1658,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1632,6 +1684,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1668,7 +1723,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1695,6 +1749,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1735,7 +1792,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1762,6 +1818,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1797,7 +1856,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1824,6 +1882,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -1861,7 +1922,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1888,6 +1948,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -1922,7 +1985,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -1949,6 +2011,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2001,7 +2066,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2028,6 +2092,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2065,7 +2132,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2092,6 +2158,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2131,7 +2200,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2158,6 +2226,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2194,7 +2265,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2221,6 +2291,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2261,7 +2334,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2288,6 +2360,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2323,7 +2398,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2350,6 +2424,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2387,7 +2464,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2414,6 +2490,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2448,7 +2527,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2475,6 +2553,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2529,7 +2610,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2556,6 +2636,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2593,7 +2676,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2620,6 +2702,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2659,7 +2744,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2686,6 +2770,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2722,7 +2809,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2749,6 +2835,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2789,7 +2878,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2816,6 +2904,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2851,7 +2942,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2878,6 +2968,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -2915,7 +3008,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -2942,6 +3034,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -2976,7 +3071,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3003,6 +3097,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3060,7 +3157,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3095,6 +3191,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3132,7 +3231,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3167,6 +3265,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3206,7 +3307,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3241,6 +3341,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3277,7 +3380,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3312,6 +3414,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3352,7 +3457,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3388,6 +3492,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
+									}
 								}
 							} else {
 								var (
@@ -3422,7 +3529,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3457,6 +3563,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3494,7 +3603,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3530,6 +3638,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
 									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
+									}
 								}
 							} else {
 								var (
@@ -3563,7 +3674,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3598,6 +3708,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3655,7 +3768,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3678,6 +3790,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3715,7 +3830,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3738,6 +3852,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3777,7 +3894,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3800,6 +3916,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3836,7 +3955,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3859,6 +3977,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -3899,7 +4020,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3922,6 +4042,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -3957,7 +4080,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -3980,6 +4102,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4017,7 +4142,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4040,6 +4164,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4074,7 +4201,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4097,6 +4223,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4154,7 +4283,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4170,6 +4298,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4207,7 +4338,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4223,6 +4353,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4262,7 +4395,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4278,6 +4410,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4314,7 +4449,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4330,6 +4464,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4370,7 +4507,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4386,6 +4522,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4421,7 +4560,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4437,6 +4575,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4474,7 +4615,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4490,6 +4630,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4524,7 +4667,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4540,6 +4682,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4597,7 +4742,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4619,6 +4763,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4656,7 +4803,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4678,6 +4824,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4717,7 +4866,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4739,6 +4887,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4775,7 +4926,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4797,6 +4947,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4837,7 +4990,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4859,6 +5011,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -4894,7 +5049,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4916,6 +5070,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -4953,7 +5110,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -4975,6 +5131,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5009,7 +5168,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5031,6 +5189,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5088,7 +5249,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5106,6 +5266,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5143,7 +5306,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5161,6 +5323,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5200,7 +5365,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5218,6 +5382,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5254,7 +5421,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5272,6 +5438,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5312,7 +5481,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5330,6 +5498,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5365,7 +5536,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5383,6 +5553,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5420,7 +5593,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5438,6 +5610,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							} else {
@@ -5472,7 +5647,6 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5490,6 +5664,9 @@ func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel
 
 											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 										}
+									}
+									if keyID == 0 {
+										ht.ProbeScratch.distinct[toCheck] = true
 									}
 								}
 							}
@@ -5552,7 +5729,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5614,7 +5790,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5678,7 +5853,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5739,7 +5913,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5807,7 +5980,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5869,7 +6041,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5933,7 +6104,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -5994,7 +6164,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6077,7 +6246,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6131,7 +6299,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6187,7 +6354,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6240,7 +6406,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6300,7 +6465,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6354,7 +6518,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6410,7 +6573,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6463,7 +6625,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6544,7 +6705,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6598,7 +6758,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6654,7 +6813,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6707,7 +6865,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6767,7 +6924,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6821,7 +6977,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6877,7 +7032,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -6930,7 +7084,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7003,7 +7156,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7068,7 +7220,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7135,7 +7286,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7199,7 +7349,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7270,7 +7419,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7335,7 +7483,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7402,7 +7549,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7466,7 +7612,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7553,7 +7698,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7618,7 +7762,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7685,7 +7828,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7749,7 +7891,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7820,7 +7961,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7885,7 +8025,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -7952,7 +8091,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8016,7 +8154,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8105,7 +8242,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8170,7 +8306,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8237,7 +8372,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8301,7 +8435,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8372,7 +8505,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8437,7 +8569,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8504,7 +8635,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8568,7 +8698,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8663,7 +8792,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8736,7 +8864,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8811,7 +8938,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8883,7 +9009,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -8962,7 +9087,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9035,7 +9159,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9110,7 +9233,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9182,7 +9304,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9279,7 +9400,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9340,7 +9460,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9403,7 +9522,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9463,7 +9581,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9530,7 +9647,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9591,7 +9707,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9654,7 +9769,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9714,7 +9828,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9796,7 +9909,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9850,7 +9962,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9906,7 +10017,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -9959,7 +10069,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10019,7 +10128,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10073,7 +10181,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10129,7 +10236,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10182,7 +10288,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10257,7 +10362,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10317,7 +10421,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10379,7 +10482,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10438,7 +10540,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10504,7 +10605,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10564,7 +10664,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10626,7 +10725,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10685,7 +10783,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10766,7 +10863,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10822,7 +10918,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10880,7 +10975,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10935,7 +11029,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -10997,7 +11090,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11053,7 +11145,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11111,7 +11202,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11166,7 +11256,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 										}
 										if probeIsNull {
 											ht.ProbeScratch.distinct[toCheck] = true
-											ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 										} else if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
@@ -11203,7 +11292,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 // in the probe table.
 func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
 	for i := range ht.keyCols {
-		ht.checkColAgainstItself(vecs[i], nToCheck, sel)
+		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
 	nDiffers := uint64(0)
 	toCheckSlice := ht.ProbeScratch.ToCheck
@@ -11212,7 +11301,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 		//gcassert:bce
 		toCheck := toCheckSlice[toCheckPos]
 		if ht.ProbeScratch.distinct[toCheck] {
-			ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.GroupID[toCheck]
+			ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
 			continue
 		}
 		if !ht.ProbeScratch.differs[toCheck] {

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -66,8 +66,10 @@ func _ASSIGN_NE(_, _, _, _, _, _ interface{}) int {
 // _BUILD_HAS_NULLS - a boolean as .BuildHasNulls that determines whether the
 // build vector might have NULL values.
 // _SELECT_DISTINCT - a boolean as .SelectDistinct that determines whether a
-// probe tuple should be marked as "distinct" if its GroupID is zero (meaning
-// that there is no tuple in the hash table with the same hash code).
+// probe tuple should be marked as "distinct" if there is no tuple in the hash
+// table that might be a duplicate of the probe tuple (either because the
+// GroupID of the probe tuple is 0 - meaning no hash matches - or because the
+// probe tuple has a NULL value when NULLs are treated as not equal).
 // _USE_PROBE_SEL - a boolean as .UseProbeSel that determines whether there is
 // a selection vector on the probe vector.
 // _PROBING_AGAINST_ITSELF - a boolean as .ProbingAgainstItself that tells us
@@ -151,20 +153,14 @@ func _CHECK_COL_BODY(
 				}
 			}
 			if probeIsNull {
-				// {{if or (.SelectDistinct) (.ProbingAgainstItself)}}
+				// {{if .SelectDistinct}}
 				// {{/*
 				//     We know that nulls are distinct (because
 				//     allowNullEquality case is handled above) and our probing
 				//     tuple has a NULL value in the current column, so the
-				//     probing tuple is distinct from the build table. Both
-				//     parts of the template condition above are only 'true' if
-				//     the hash table is used for the unordered distinct
-				//     operator, and in that scenario we want to mark the
-				//     current probing tuple as distinct but also set its
-				//     GroupID such that it (the probing tuple) matches itself.
+				//     probing tuple is distinct from the build table.
 				// */}}
 				ht.ProbeScratch.distinct[toCheck] = true
-				ht.ProbeScratch.GroupID[toCheck] = toCheck + 1
 				// {{else}}
 				ht.ProbeScratch.GroupID[toCheck] = 0
 				// {{end}}
@@ -189,30 +185,37 @@ func _CHECK_COL_BODY(
 }
 
 func _CHECK_COL_WITH_NULLS(
-	_USE_PROBE_SEL bool, _PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_MODE bool,
+	_SELECT_DISTINCT bool,
+	_USE_PROBE_SEL bool,
+	_PROBING_AGAINST_ITSELF bool,
+	_DELETING_PROBE_MODE bool,
 ) { // */}}
 	// {{define "checkColWithNulls" -}}
+	// {{$selectDistinct := .SelectDistinct}}
 	// {{$probingAgainstItself := .ProbingAgainstItself}}
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	if probeVec.MaybeHasNulls() {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(true, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(true, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(true, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(true, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	} else {
 		if buildVec.MaybeHasNulls() {
-			_CHECK_COL_BODY(false, true, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(false, true, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		} else {
-			_CHECK_COL_BODY(false, false, false, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+			_CHECK_COL_BODY(false, false, _SELECT_DISTINCT, _USE_PROBE_SEL, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 		}
 	}
 	// {{end}}
 	// {{/*
 }
 
-func _CHECK_COL_FUNCTION_TEMPLATE(_PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_MODE bool) { // */}}
+func _CHECK_COL_FUNCTION_TEMPLATE(
+	_SELECT_DISTINCT bool, _PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_MODE bool,
+) { // */}}
 	// {{define "checkColFunctionTemplate" -}}
+	// {{$selectDistinct := .SelectDistinct}}
 	// {{$probingAgainstItself := .ProbingAgainstItself}}
 	// {{$deletingProbeMode := .DeletingProbeMode}}
 	// {{with .Global}}
@@ -250,9 +253,9 @@ func _CHECK_COL_FUNCTION_TEMPLATE(_PROBING_AGAINST_ITSELF bool, _DELETING_PROBE_
 					probeKeys := probeVec._ProbeType()
 					buildKeys := buildVec._BuildType()
 					if probeSel != nil {
-						_CHECK_COL_WITH_NULLS(true, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+						_CHECK_COL_WITH_NULLS(_SELECT_DISTINCT, true, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 					} else {
-						_CHECK_COL_WITH_NULLS(false, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
+						_CHECK_COL_WITH_NULLS(_SELECT_DISTINCT, false, _PROBING_AGAINST_ITSELF, _DELETING_PROBE_MODE)
 					}
 					// {{end}}
 					// {{end}}
@@ -280,7 +283,7 @@ func (ht *HashTable) checkCol(
 	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
 ) {
 	// {{with .Overloads}}
-	_CHECK_COL_FUNCTION_TEMPLATE(false, false)
+	_CHECK_COL_FUNCTION_TEMPLATE(false, false, false)
 	// {{end}}
 }
 
@@ -288,16 +291,17 @@ func (ht *HashTable) checkCol(
 
 // {{if .HashTableMode.IsDistinctBuild}}
 
-// checkColAgainstItself is similar to checkCol, but it probes the vector
-// against itself.
-func (ht *HashTable) checkColAgainstItself(vec coldata.Vec, nToCheck uint64, sel []int) {
+// checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
+// vector against itself for the purposes of finding matches to unordered
+// distinct columns.
+func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint64, sel []int) {
 	// {{/*
 	// In order to reuse the same template function as checkCol uses, we use
 	// the same variable names.
 	// */}}
 	probeVec, buildVec, probeSel := vec, vec, sel
 	// {{with .Overloads}}
-	_CHECK_COL_FUNCTION_TEMPLATE(true, false)
+	_CHECK_COL_FUNCTION_TEMPLATE(true, true, false)
 	// {{end}}
 }
 
@@ -314,7 +318,7 @@ func (ht *HashTable) checkColDeleting(
 	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
 ) {
 	// {{with .Overloads}}
-	_CHECK_COL_FUNCTION_TEMPLATE(false, true)
+	_CHECK_COL_FUNCTION_TEMPLATE(false, false, true)
 	// {{end}}
 }
 
@@ -403,7 +407,16 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 		toCheck := toCheckSlice[toCheckPos]
 		// {{if .SelectDistinct}}
 		if ht.ProbeScratch.distinct[toCheck] {
-			ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.GroupID[toCheck]
+			// {{/*
+			//     The hash table is used for the unordered distinct operator.
+			//     This code block is only relevant when we're probing the batch
+			//     against itself in order to separate all tuples in the batch
+			//     into equality buckets (where equality buckets are specified
+			//     by the same HeadID values). In this case we see that the
+			//     probing tuple is distinct (i.e. it is unique in the batch),
+			//     so we want to mark it as equal to itself only.
+			// */}}
+			ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
 			continue
 		}
 		// {{end}}
@@ -512,7 +525,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 // in the probe table.
 func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
 	for i := range ht.keyCols {
-		ht.checkColAgainstItself(vecs[i], nToCheck, sel)
+		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
 	nDiffers := uint64(0)
 	_CHECK_BODY(false, false, true)

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -298,6 +298,28 @@ var distinctTestCases = []distinctTestCase{
 		errorOnDup:              "\"duplicate\" distinct nulls",
 		noError:                 true,
 	},
+	{
+		distinctCols: []uint32{0, 1},
+		typs:         []*types.T{types.Int, types.Int},
+		// Tuples have been carefully constructed so that all of them have the
+		// same hash, only one tuple among first three is inserted into the hash
+		// table, and the last two tuples are distinct. This is a regression
+		// unit test for #74795.
+		tuples: colexectestutils.Tuples{
+			{1, 2},
+			{1, 2},
+			{1, 2},
+			{nil, 7},
+			{nil, 7},
+		},
+		expected: colexectestutils.Tuples{
+			{1, 2},
+			{nil, 7},
+			{nil, 7},
+		},
+		isOrderedOnDistinctCols: false,
+		nullsAreDistinct:        true,
+	},
 }
 
 func mustParseJSON(s string) json.JSON {

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -81,6 +81,7 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		"_RIGHT_TYPE_WIDTH", typeWidthReplacement,
 		"_ProbeType", "{{.Left.VecMethod}}",
 		"_BuildType", "{{.Right.VecMethod}}",
+		"_SELECT_DISTINCT", "$selectDistinct",
 		"_USE_PROBE_SEL", ".UseProbeSel",
 		"_PROBING_AGAINST_ITSELF", "$probingAgainstItself",
 		"_DELETING_PROBE_MODE", "$deletingProbeMode",
@@ -96,14 +97,14 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		`{{template "checkColBody" buildDict "Global" .Global "ProbeHasNulls" $1 "BuildHasNulls" $2 "SelectDistinct" $3 "UseProbeSel" $4 "ProbingAgainstItself" $5 "DeletingProbeMode" $6}}`,
 	)
 
-	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 3)
+	checkColWithNulls := makeFunctionRegex("_CHECK_COL_WITH_NULLS", 4)
 	s = checkColWithNulls.ReplaceAllString(s,
-		`{{template "checkColWithNulls" buildDict "Global" . "UseProbeSel" $1 "ProbingAgainstItself" $2 "DeletingProbeMode" $3}}`,
+		`{{template "checkColWithNulls" buildDict "Global" . "SelectDistinct" $1 "UseProbeSel" $2 "ProbingAgainstItself" $3 "DeletingProbeMode" $4}}`,
 	)
 
-	checkColFunctionTemplate := makeFunctionRegex("_CHECK_COL_FUNCTION_TEMPLATE", 2)
+	checkColFunctionTemplate := makeFunctionRegex("_CHECK_COL_FUNCTION_TEMPLATE", 3)
 	s = checkColFunctionTemplate.ReplaceAllString(s,
-		`{{template "checkColFunctionTemplate" buildDict "Global" . "ProbingAgainstItself" $1 "DeletingProbeMode" $2}}`,
+		`{{template "checkColFunctionTemplate" buildDict "Global" . "SelectDistinct" $1 "ProbingAgainstItself" $2 "DeletingProbeMode" $3}}`,
 	)
 
 	checkColForDistinctWithNulls := makeFunctionRegex("_CHECK_COL_FOR_DISTINCT_WITH_NULLS", 1)

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -783,3 +783,27 @@ SELECT * FROM gen_as_id_seqopt ORDER BY a
 8   5   7
 9   8   11
 10  11  2
+
+# Regression test for hitting an internal error in the vectorized unordered
+# distinct when NULLs are present in the rows being inserted (#74795).
+statement ok
+CREATE TABLE t74795 (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id TEXT NOT NULL,
+    deletion_request_id TEXT,
+    UNIQUE INDEX (account_id, deletion_request_id)
+);
+INSERT INTO t74795
+    (account_id)
+VALUES
+    ('foo'),
+    ('foo'),
+    ('foo')
+ON CONFLICT (account_id, deletion_request_id) DO NOTHING;
+
+query TT
+SELECT account_id, deletion_request_id FROM t74795
+----
+foo  NULL
+foo  NULL
+foo  NULL


### PR DESCRIPTION
Backport 1/5 commits from #74825.

/cc @cockroachdb/release

---

**colexechash: fix an internal error with distinct mode**

This commit fixes a bug with the hash table when it is used by the
unordered distinct when NULLs are treated as different. This is the case
when UPSERT or INSERT ... ON CONFLICT queries have to perform
`upsert-distinct-on` operation.

The problem was that we were updating some internal state (`GroupID`
slice responsible for tracking what is the current duplicate candidate
for each row being probed) in more cases than necessary. The code path
in question is used for two purposes:
- first, when we're removing the duplicates from within the batch,
without looking at the state of the hash table at all. In this case we
do want the update mentioned above;
- next, when the batch only contains unique rows, we want to remove the
duplicates when comparing against the hash table. In this case we do not
want the update.

The bug is fixed by refactoring the code to not update the internal
state at all; instead, we now rely on the `distinct` flag for each row
to tell us that the row is distinct within the batch, and we then
correctly populate `HeadID` value for it (which was the ultimate goal
all the time, and previously we used `GroupID` value as an
intermediary).

This mistake would not result in incorrect results (because `distinct`
flag is still marked correctly) and could only result in an internal
error due to index out of bounds. In particular, for the error to occur
the last row in the vectorized batch must have a NULL value in any
column (except for the last one) used for the distinctness check.

Fixes: #74795.

Release note (bug fix): Previously, CockroachDB could encounter an
internal error when performing UPSERT or INSERT ... ON CONFLICT queries
in some cases when the new rows contained NULL values (either NULLS
explicitly specified or NULLs used since some columns were omitted).