### PR TITLE
sql: add support for MOVE cursor

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -126,6 +126,7 @@ FILES = [
     "joined_table",
     "like_table_option_list",
     "limit_clause",
+    "move_cursor_stmt",
     "not_null_column_level",
     "offset_clause",
     "on_conflict",

--- a/docs/generated/sql/bnf/fetch_cursor_stmt.bnf
+++ b/docs/generated/sql/bnf/fetch_cursor_stmt.bnf
@@ -1,2 +1,2 @@
 fetch_cursor_stmt ::=
-	'FETCH' fetch_specifier
+	'FETCH' cursor_movement_specifier

--- a/docs/generated/sql/bnf/move_cursor_stmt.bnf
+++ b/docs/generated/sql/bnf/move_cursor_stmt.bnf
@@ -1,0 +1,2 @@
+move_cursor_stmt ::=
+	'MOVE' cursor_movement_specifier

--- a/docs/generated/sql/bnf/stmt.bnf
+++ b/docs/generated/sql/bnf/stmt.bnf
@@ -20,3 +20,4 @@ stmt ::=
 	| close_cursor_stmt
 	| declare_cursor_stmt
 	| fetch_cursor_stmt
+	| move_cursor_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -23,6 +23,7 @@ stmt ::=
 	| close_cursor_stmt
 	| declare_cursor_stmt
 	| fetch_cursor_stmt
+	| move_cursor_stmt
 	| 
 
 preparable_stmt ::=
@@ -130,7 +131,10 @@ declare_cursor_stmt ::=
 	'DECLARE' cursor_name opt_binary opt_sensitivity opt_scroll 'CURSOR' opt_hold 'FOR' select_stmt
 
 fetch_cursor_stmt ::=
-	'FETCH' fetch_specifier
+	'FETCH' cursor_movement_specifier
+
+move_cursor_stmt ::=
+	'MOVE' cursor_movement_specifier
 
 alter_stmt ::=
 	alter_ddl_stmt
@@ -424,7 +428,7 @@ opt_hold ::=
 	| 'WITHOUT' 'HOLD'
 	| 
 
-fetch_specifier ::=
+cursor_movement_specifier ::=
 	cursor_name
 	| from_or_in cursor_name
 	| next_prior opt_from_or_in cursor_name
@@ -1084,6 +1088,7 @@ unreserved_keyword ::=
 	| 'MULTIPOLYGONZ'
 	| 'MULTIPOLYGONZM'
 	| 'MONTH'
+	| 'MOVE'
 	| 'NAMES'
 	| 'NAN'
 	| 'NEVER'

--- a/pkg/cli/clisqlexec/run_query.go
+++ b/pkg/cli/clisqlexec/run_query.go
@@ -280,6 +280,7 @@ var tagsWithRowsAffected = map[string]struct{}{
 	"INSERT":    {},
 	"UPDATE":    {},
 	"DELETE":    {},
+	"MOVE":      {},
 	"DROP USER": {},
 	// This one is used with e.g. CREATE TABLE AS (other SELECT
 	// statements have type Rows, not RowsAffected).

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -138,6 +138,7 @@ DOCS_SRCS = [
   "//docs/generated/sql/bnf:joined_table.bnf",
   "//docs/generated/sql/bnf:like_table_option_list.bnf",
   "//docs/generated/sql/bnf:limit_clause.bnf",
+  "//docs/generated/sql/bnf:move_cursor_stmt.bnf",
   "//docs/generated/sql/bnf:not_null_column_level.bnf",
   "//docs/generated/sql/bnf:offset_clause.bnf",
   "//docs/generated/sql/bnf:on_conflict.bnf",

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1076,10 +1076,11 @@ func (r *DistSQLReceiver) Push(
 	}
 
 	if r.stmtType != tree.Rows {
+		n := int(tree.MustBeDInt(row[0].Datum))
 		// We only need the row count. planNodeToRowSource is set up to handle
 		// ensuring that the last stage in the pipeline will return a single-column
 		// row with the row count in it, so just grab that and exit.
-		r.resultWriter.IncrementRowsAffected(r.ctx, int(tree.MustBeDInt(row[0].Datum)))
+		r.resultWriter.IncrementRowsAffected(r.ctx, n)
 		return r.status
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -1,6 +1,6 @@
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY, b INT);
-INSERT INTO a VALUES (1, 2), (2, 2)
+INSERT INTO a VALUES (1, 2), (2, 3)
 
 statement error DECLARE CURSOR can only be used in transaction blocks
 DECLARE foo CURSOR FOR SELECT * FROM a
@@ -32,7 +32,7 @@ FETCH 1 foo
 query II
 FETCH 1 foo
 ----
-2  2
+2  3
 
 query II
 FETCH 2 foo
@@ -58,13 +58,13 @@ DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a
 # are not visible to the cursor. We mimic this behavior.
 
 statement ok
-INSERT INTO a VALUES(3, 2)
+INSERT INTO a VALUES(3, 4)
 
 query II
 FETCH 3 foo
 ----
 1  2
-2  2
+2  3
 
 statement ok
 CLOSE foo;
@@ -74,8 +74,8 @@ query II
 FETCH 3 foo
 ----
 1  2
-2  2
-3  2
+2  3
+3  4
 
 statement ok
 COMMIT
@@ -146,8 +146,8 @@ query II
 FETCH ALL foo
 ----
 1  2
-2  2
-3  2
+2  3
+3  4
 
 query II
 FETCH ALL foo
@@ -161,8 +161,8 @@ query II
 FETCH FORWARD ALL foo
 ----
 1  2
-2  2
-3  2
+2  3
+3  4
 
 query II
 FETCH FORWARD ALL foo
@@ -191,12 +191,12 @@ FETCH FIRST foo
 query II
 FETCH NEXT foo
 ----
-2  2
+2  3
 
 query II
 FETCH NEXT foo
 ----
-3  2
+3  4
 
 query II
 FETCH FORWARD 3 foo
@@ -309,9 +309,155 @@ statement error cursor can only scan forward
 ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
 FETCH BACKWARD ALL foo
 
+# Error cases for MOVE.
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE -1 foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE BACKWARD 1 foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE FORWARD -1 foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE LAST foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE LAST foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE 10 foo;
+MOVE ABSOLUTE 9 foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE 10 foo;
+MOVE RELATIVE -1 foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE 10 foo;
+MOVE FIRST foo;
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE ABSOLUTE -1 foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE PRIOR foo
+
+statement error cursor can only scan forward
+ROLLBACK; BEGIN; DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a;
+MOVE BACKWARD ALL foo
+
 statement ok
 ROLLBACK
 
+# Test MOVE.
+statement ok
+BEGIN;
+DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a
+
+query II
+FETCH 1 foo
+----
+1  2
+
+statement ok
+MOVE 1 foo
+
+query II
+FETCH 1 foo
+----
+3  4
+
+statement ok
+MOVE 10 foo
+
+query II
+FETCH 1 foo
+----
+14  15
+
+statement ok
+ROLLBACK;
+BEGIN;
+DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a
+
+statement ok
+MOVE 0 foo
+
+statement ok
+MOVE FIRST foo
+
+query II
+FETCH FIRST foo
+----
+1  2
+
+statement ok
+MOVE FIRST foo
+
+statement ok
+MOVE NEXT foo
+
+query II
+FETCH 1 foo
+----
+3  4
+
+statement ok
+MOVE FORWARD 3 foo
+
+query II
+FETCH 1 foo
+----
+7  8
+
+statement ok
+MOVE RELATIVE 3 foo
+
+query II
+FETCH 1 foo
+----
+11  12
+
+statement ok
+MOVE FORWARD foo
+
+query II
+FETCH 1 foo
+----
+13  14
+
+statement ok
+MOVE ABSOLUTE 15 foo
+
+statement ok
+MOVE ABSOLUTE 15 foo
+
+query II
+FETCH 1 foo
+----
+16 17
+
+statement ok
+MOVE ABSOLUTE 100 foo
+
+query II
+FETCH 1 foo
+----
+
+statement ok
+ROLLBACK
 
 # Test pg_catalog.pg_cursors
 query TTBBBT colnames

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -172,11 +172,13 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 	case *tree.DropView:
 		return p.DropView(ctx, n)
 	case *tree.FetchCursor:
-		return p.FetchCursor(ctx, n)
+		return p.FetchCursor(ctx, &n.CursorStmt, false /* isMove */)
 	case *tree.Grant:
 		return p.Grant(ctx, n)
 	case *tree.GrantRole:
 		return p.GrantRole(ctx, n)
+	case *tree.MoveCursor:
+		return p.FetchCursor(ctx, &n.CursorStmt, true /* isMove */)
 	case *tree.ReassignOwnedBy:
 		return p.ReassignOwnedBy(ctx, n)
 	case *tree.RefreshMaterializedView:
@@ -293,6 +295,7 @@ func init() {
 		&tree.FetchCursor{},
 		&tree.Grant{},
 		&tree.GrantRole{},
+		&tree.MoveCursor{},
 		&tree.ReassignOwnedBy{},
 		&tree.RefreshMaterializedView{},
 		&tree.RenameColumn{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -241,6 +241,9 @@ func TestContextualHelp(t *testing.T) {
 		{`FETCH ??`, `FETCH`},
 		{`FETCH 1 ??`, `FETCH`},
 
+		{`MOVE ??`, `MOVE`},
+		{`MOVE 1 ??`, `MOVE`},
+
 		{`INSERT INTO ??`, `INSERT`},
 		{`INSERT INTO blah (??`, `<SELECTCLAUSE>`},
 		{`INSERT INTO blah VALUES (1) RETURNING ??`, `INSERT`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -767,8 +767,8 @@ func (u *sqlSymUnion) cursorSensitivity() tree.CursorSensitivity {
 func (u *sqlSymUnion) cursorScrollOption() tree.CursorScrollOption {
     return u.val.(tree.CursorScrollOption)
 }
-func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
-    return u.val.(*tree.FetchCursor)
+func (u *sqlSymUnion) cursorStmt() tree.CursorStmt {
+    return u.val.(tree.CursorStmt)
 }
 %}
 
@@ -845,7 +845,7 @@ func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
 %token <str> LINESTRING LINESTRINGM LINESTRINGZ LINESTRINGZM
 %token <str> LIST LOCAL LOCALITY LOCALTIME LOCALTIMESTAMP LOCKED LOGIN LOOKUP LOW LSHIFT
 
-%token <str> MATCH MATERIALIZED MERGE MINVALUE MAXVALUE METHOD MINUTE MODIFYCLUSTERSETTING MONTH
+%token <str> MATCH MATERIALIZED MERGE MINVALUE MAXVALUE METHOD MINUTE MODIFYCLUSTERSETTING MONTH MOVE
 %token <str> MULTILINESTRING MULTILINESTRINGM MULTILINESTRINGZ MULTILINESTRINGZM
 %token <str> MULTIPOINT MULTIPOINTM MULTIPOINTZ MULTIPOINTZM
 %token <str> MULTIPOLYGON MULTIPOLYGONM MULTIPOLYGONZ MULTIPOLYGONZM
@@ -1158,7 +1158,8 @@ func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
 %type <tree.Statement> close_cursor_stmt
 %type <tree.Statement> declare_cursor_stmt
 %type <tree.Statement> fetch_cursor_stmt
-%type <*tree.FetchCursor> fetch_specifier
+%type <tree.Statement> move_cursor_stmt
+%type <tree.CursorStmt> cursor_movement_specifier
 %type <bool> opt_hold opt_binary
 %type <tree.CursorSensitivity> opt_sensitivity
 %type <tree.CursorScrollOption> opt_scroll
@@ -1573,6 +1574,7 @@ stmt:
 | close_cursor_stmt         // EXTEND WITH HELP: CLOSE
 | declare_cursor_stmt       // EXTEND WITH HELP: DECLARE
 | fetch_cursor_stmt         // EXTEND WITH HELP: FETCH
+| move_cursor_stmt          // EXTEND WITH HELP: MOVE
 | reindex_stmt
 | /* EMPTY */
   {
@@ -5406,46 +5408,61 @@ opt_hold:
 // %Help: FETCH - fetch rows from a SQL cursor
 // %Category: Misc
 // %Text: FETCH [ direction [ FROM | IN ] ] <name>
-// %SeeAlso: CLOSE, DECLARE
+// %SeeAlso: MOVE, CLOSE, DECLARE
 fetch_cursor_stmt:
-  FETCH fetch_specifier
+  FETCH cursor_movement_specifier
   {
-    $$.val = $2.fetchCursor()
+    $$.val = &tree.FetchCursor{
+      CursorStmt: $2.cursorStmt(),
+    }
   }
 | FETCH error // SHOW HELP: FETCH
 
-fetch_specifier:
+// %Help: MOVE - move a SQL cursor without fetching rows
+// %Category: Misc
+// %Text: MOVE [ direction [ FROM | IN ] ] <name>
+// %SeeAlso: FETCH, CLOSE, DECLARE
+move_cursor_stmt:
+  MOVE cursor_movement_specifier
+  {
+    $$.val = &tree.MoveCursor{
+      CursorStmt: $2.cursorStmt(),
+    }
+  }
+| MOVE error // SHOW HELP: MOVE
+
+cursor_movement_specifier:
   cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($1),
       Count: 1,
     }
   }
 | from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($2),
       Count: 1,
     }
   }
 | next_prior opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($3),
       Count: $1.int64(),
     }
   }
 | forward_backward opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($3),
       Count: $1.int64(),
     }
   }
 | opt_forward_backward signed_iconst64 opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($4),
       Count: $2.int64() * $1.int64(),
     }
@@ -5457,14 +5474,14 @@ fetch_specifier:
     if count < 0 {
       fetchType = tree.FetchBackwardAll
     }
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($4),
       FetchType: fetchType,
     }
   }
 | ABSOLUTE signed_iconst64 opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($4),
       FetchType: tree.FetchAbsolute,
       Count: $2.int64(),
@@ -5472,7 +5489,7 @@ fetch_specifier:
   }
 | RELATIVE signed_iconst64 opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($4),
       FetchType: tree.FetchRelative,
       Count: $2.int64(),
@@ -5480,14 +5497,14 @@ fetch_specifier:
   }
 | FIRST opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($3),
       FetchType: tree.FetchFirst,
     }
   }
 | LAST opt_from_or_in cursor_name
   {
-    $$.val = &tree.FetchCursor{
+    $$.val = tree.CursorStmt{
       Name: tree.Name($3),
       FetchType: tree.FetchLast,
     }
@@ -14028,6 +14045,7 @@ unreserved_keyword:
 | MULTIPOLYGONZ
 | MULTIPOLYGONZM
 | MONTH
+| MOVE
 | NAMES
 | NAN
 | NEVER

--- a/pkg/sql/parser/testdata/cursor
+++ b/pkg/sql/parser/testdata/cursor
@@ -43,7 +43,7 @@ FETCH 10 foo
 ----
 FETCH 10 foo
 FETCH 10 foo -- fully parenthesized
-FETCH 10 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH 10 _ -- identifiers removed
 
 parse
@@ -51,7 +51,7 @@ FETCH 10 FROM foo
 ----
 FETCH 10 foo -- normalized!
 FETCH 10 foo -- fully parenthesized
-FETCH 10 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH 10 _ -- identifiers removed
 
 parse
@@ -59,7 +59,7 @@ FETCH 10 IN foo
 ----
 FETCH 10 foo -- normalized!
 FETCH 10 foo -- fully parenthesized
-FETCH 10 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH 10 _ -- identifiers removed
 
 parse
@@ -67,7 +67,7 @@ FETCH NEXT foo
 ----
 FETCH 1 foo -- normalized!
 FETCH 1 foo -- fully parenthesized
-FETCH 1 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH 1 _ -- identifiers removed
 
 parse
@@ -75,7 +75,7 @@ FETCH PRIOR foo
 ----
 FETCH -1 foo -- normalized!
 FETCH -1 foo -- fully parenthesized
-FETCH -1 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH -1 _ -- identifiers removed
 
 parse
@@ -99,7 +99,7 @@ FETCH RELATIVE -3 foo
 ----
 FETCH RELATIVE -3 foo
 FETCH RELATIVE -3 foo -- fully parenthesized
-FETCH RELATIVE -3 foo -- literals removed
+FETCH RELATIVE 0 foo -- literals removed
 FETCH RELATIVE -3 _ -- identifiers removed
 
 parse
@@ -107,7 +107,7 @@ FETCH ABSOLUTE 3 foo
 ----
 FETCH ABSOLUTE 3 foo
 FETCH ABSOLUTE 3 foo -- fully parenthesized
-FETCH ABSOLUTE 3 foo -- literals removed
+FETCH ABSOLUTE 0 foo -- literals removed
 FETCH ABSOLUTE 3 _ -- identifiers removed
 
 parse
@@ -123,7 +123,7 @@ FETCH FORWARD foo
 ----
 FETCH 1 foo -- normalized!
 FETCH 1 foo -- fully parenthesized
-FETCH 1 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH 1 _ -- identifiers removed
 
 parse
@@ -131,7 +131,7 @@ FETCH BACKWARD foo
 ----
 FETCH -1 foo -- normalized!
 FETCH -1 foo -- fully parenthesized
-FETCH -1 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH -1 _ -- identifiers removed
 
 parse
@@ -155,7 +155,7 @@ FETCH FORWARD 10 foo
 ----
 FETCH 10 foo -- normalized!
 FETCH 10 foo -- fully parenthesized
-FETCH 10 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH 10 _ -- identifiers removed
 
 parse
@@ -163,7 +163,7 @@ FETCH BACKWARD 10 foo
 ----
 FETCH -10 foo -- normalized!
 FETCH -10 foo -- fully parenthesized
-FETCH -10 foo -- literals removed
+FETCH 0 foo -- literals removed
 FETCH -10 _ -- identifiers removed
 
 parse
@@ -181,3 +181,131 @@ CLOSE foo
 CLOSE foo -- fully parenthesized
 CLOSE foo -- literals removed
 CLOSE _ -- identifiers removed
+
+parse
+MOVE 10 foo
+----
+MOVE 10 foo
+MOVE 10 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE 10 _ -- identifiers removed
+
+parse
+MOVE 10 FROM foo
+----
+MOVE 10 foo -- normalized!
+MOVE 10 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE 10 _ -- identifiers removed
+
+parse
+MOVE 10 IN foo
+----
+MOVE 10 foo -- normalized!
+MOVE 10 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE 10 _ -- identifiers removed
+
+parse
+MOVE NEXT foo
+----
+MOVE 1 foo -- normalized!
+MOVE 1 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE 1 _ -- identifiers removed
+
+parse
+MOVE PRIOR foo
+----
+MOVE -1 foo -- normalized!
+MOVE -1 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE -1 _ -- identifiers removed
+
+parse
+MOVE FIRST foo
+----
+MOVE FIRST foo
+MOVE FIRST foo -- fully parenthesized
+MOVE FIRST foo -- literals removed
+MOVE FIRST _ -- identifiers removed
+
+parse
+MOVE LAST foo
+----
+MOVE LAST foo
+MOVE LAST foo -- fully parenthesized
+MOVE LAST foo -- literals removed
+MOVE LAST _ -- identifiers removed
+
+parse
+MOVE RELATIVE -3 foo
+----
+MOVE RELATIVE -3 foo
+MOVE RELATIVE -3 foo -- fully parenthesized
+MOVE RELATIVE 0 foo -- literals removed
+MOVE RELATIVE -3 _ -- identifiers removed
+
+parse
+MOVE ABSOLUTE 3 foo
+----
+MOVE ABSOLUTE 3 foo
+MOVE ABSOLUTE 3 foo -- fully parenthesized
+MOVE ABSOLUTE 0 foo -- literals removed
+MOVE ABSOLUTE 3 _ -- identifiers removed
+
+parse
+MOVE ALL foo
+----
+MOVE ALL foo
+MOVE ALL foo -- fully parenthesized
+MOVE ALL foo -- literals removed
+MOVE ALL _ -- identifiers removed
+
+parse
+MOVE FORWARD foo
+----
+MOVE 1 foo -- normalized!
+MOVE 1 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE 1 _ -- identifiers removed
+
+parse
+MOVE BACKWARD foo
+----
+MOVE -1 foo -- normalized!
+MOVE -1 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE -1 _ -- identifiers removed
+
+parse
+MOVE FORWARD ALL foo
+----
+MOVE ALL foo -- normalized!
+MOVE ALL foo -- fully parenthesized
+MOVE ALL foo -- literals removed
+MOVE ALL _ -- identifiers removed
+
+parse
+MOVE BACKWARD ALL foo
+----
+MOVE BACKWARD ALL foo
+MOVE BACKWARD ALL foo -- fully parenthesized
+MOVE BACKWARD ALL foo -- literals removed
+MOVE BACKWARD ALL _ -- identifiers removed
+
+parse
+MOVE FORWARD 10 foo
+----
+MOVE 10 foo -- normalized!
+MOVE 10 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE 10 _ -- identifiers removed
+
+parse
+MOVE BACKWARD 10 foo
+----
+MOVE -10 foo -- normalized!
+MOVE -10 foo -- fully parenthesized
+MOVE 0 foo -- literals removed
+MOVE -10 _ -- identifiers removed

--- a/pkg/sql/sem/tree/cursor.go
+++ b/pkg/sql/sem/tree/cursor.go
@@ -104,14 +104,24 @@ func (o CursorSensitivity) String() string {
 	return ""
 }
 
-// FetchCursor represents a FETCH statement.
-type FetchCursor struct {
+// CursorStmt represents the shared structure between a FETCH and MOVE statement.
+type CursorStmt struct {
 	Name      Name
 	FetchType FetchType
 	Count     int64
 }
 
-// FetchType represents the type of a FETCH statement.
+// FetchCursor represents a FETCH statement.
+type FetchCursor struct {
+	CursorStmt
+}
+
+// MoveCursor represents a MOVE statement.
+type MoveCursor struct {
+	CursorStmt
+}
+
+// FetchType represents the type of a FETCH (or MOVE) statement.
 type FetchType int
 
 const (
@@ -163,18 +173,33 @@ func (o FetchType) HasCount() bool {
 }
 
 // Format implements the NodeFormatter interface.
-func (f FetchCursor) Format(ctx *FmtCtx) {
-	ctx.WriteString("FETCH ")
-	fetchType := f.FetchType.String()
+func (c CursorStmt) Format(ctx *FmtCtx) {
+	fetchType := c.FetchType.String()
 	if fetchType != "" {
 		ctx.WriteString(fetchType)
 		ctx.WriteString(" ")
 	}
-	if f.FetchType.HasCount() {
-		ctx.WriteString(strconv.Itoa(int(f.Count)))
+	if c.FetchType.HasCount() {
+		if ctx.HasFlags(FmtHideConstants) {
+			ctx.WriteByte('0')
+		} else {
+			ctx.WriteString(strconv.Itoa(int(c.Count)))
+		}
 		ctx.WriteString(" ")
 	}
-	ctx.FormatNode(&f.Name)
+	ctx.FormatNode(&c.Name)
+}
+
+// Format implements the NodeFormatter interface.
+func (f FetchCursor) Format(ctx *FmtCtx) {
+	ctx.WriteString("FETCH ")
+	f.CursorStmt.Format(ctx)
+}
+
+// Format implements the NodeFormatter interface.
+func (m MoveCursor) Format(ctx *FmtCtx) {
+	ctx.WriteString("MOVE ")
+	m.CursorStmt.Format(ctx)
 }
 
 // CloseCursor represents a CLOSE statement.

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2353,8 +2353,8 @@ func (node *DeclareCursor) doc(p *PrettyCfg) pretty.Doc {
 	return p.rlTable(node.docTable(p)...)
 }
 
-func (node *FetchCursor) doc(p *PrettyCfg) pretty.Doc {
-	ret := pretty.Keyword("FETCH")
+func (node *CursorStmt) doc(p *PrettyCfg) pretty.Doc {
+	ret := pretty.Nil
 	fetchType := node.FetchType.String()
 	if fetchType != "" {
 		ret = pretty.ConcatSpace(ret, pretty.Keyword(fetchType))
@@ -2367,6 +2367,14 @@ func (node *FetchCursor) doc(p *PrettyCfg) pretty.Doc {
 		pretty.Keyword("FROM"),
 		p.Doc(&node.Name),
 	)
+}
+
+func (node *FetchCursor) doc(p *PrettyCfg) pretty.Doc {
+	return pretty.ConcatSpace(pretty.Keyword("FETCH"), node.CursorStmt.doc(p))
+}
+
+func (node *MoveCursor) doc(p *PrettyCfg) pretty.Doc {
+	return pretty.ConcatSpace(pretty.Keyword("MOVE"), node.CursorStmt.doc(p))
 }
 
 func (node *CloseCursor) doc(p *PrettyCfg) pretty.Doc {

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -880,6 +880,15 @@ func (*FetchCursor) StatementType() StatementType { return TypeDML }
 // StatementTag returns a short string identifying the type of statement.
 func (*FetchCursor) StatementTag() string { return "FETCH" }
 
+// StatementReturnType implements the Statement interface.
+func (n *MoveCursor) StatementReturnType() StatementReturnType { return RowsAffected }
+
+// StatementType implements the Statement interface.
+func (*MoveCursor) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*MoveCursor) StatementTag() string { return "MOVE" }
+
 // StatementType implements the Statement interface.
 func (*Grant) StatementType() StatementType { return TypeDCL }
 
@@ -1831,6 +1840,7 @@ func (n *Export) String() string                         { return AsString(n) }
 func (n *FetchCursor) String() string                    { return AsString(n) }
 func (n *Grant) String() string                          { return AsString(n) }
 func (n *GrantRole) String() string                      { return AsString(n) }
+func (n *MoveCursor) String() string                     { return AsString(n) }
 func (n *Insert) String() string                         { return AsString(n) }
 func (n *Import) String() string                         { return AsString(n) }
 func (n *ParenSelect) String() string                    { return AsString(n) }

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -109,9 +109,11 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 
 var errBackwardScan = pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "cursor can only scan forward")
 
-// FetchCursor implements the FETCH statement.
+// FetchCursor implements the FETCH and MOVE statements.
 // See https://www.postgresql.org/docs/current/sql-fetch.html for details.
-func (p *planner) FetchCursor(_ context.Context, s *tree.FetchCursor) (planNode, error) {
+func (p *planner) FetchCursor(
+	_ context.Context, s *tree.CursorStmt, isMove bool,
+) (planNode, error) {
 	cursor, err := p.sqlCursors.getCursor(s.Name.String())
 	if err != nil {
 		return nil, err
@@ -123,6 +125,7 @@ func (p *planner) FetchCursor(_ context.Context, s *tree.FetchCursor) (planNode,
 		n:         s.Count,
 		fetchType: s.FetchType,
 		cursor:    cursor,
+		isMove:    isMove,
 	}
 	if s.FetchType != tree.FetchNormal {
 		node.n = 0
@@ -139,6 +142,10 @@ type fetchNode struct {
 	// mode.
 	offset    int64
 	fetchType tree.FetchType
+	// isMove is true if this is a MOVE statement, which is identical to a FETCH
+	// statement but returns only a statement tag of how many rows would have been
+	// fetched.
+	isMove bool
 
 	seeked bool
 

--- a/pkg/sql/sql_cursor_test.go
+++ b/pkg/sql/sql_cursor_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Make sure that preparing a DECLARE doesn't cause problems.
-func TestPrepareDeclare(t *testing.T) {
+// Make sure that preparing cursor statements don't cause problems.
+func TestPrepareCursors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -66,6 +66,12 @@ func TestPrepareDeclare(t *testing.T) {
 		require.Equal(t, 2, actual)
 		more = r.Next()
 		require.Equal(t, false, more)
+
+		stmt, err = conn.PrepareContext(ctx, "MOVE 1 foo")
+		require.NoError(t, err)
+		_, err = stmt.Exec()
+		require.NoError(t, err)
+
 		_, err = conn.ExecContext(ctx, "COMMIT")
 		require.NoError(t, err)
 	})
@@ -93,6 +99,11 @@ func TestPrepareDeclare(t *testing.T) {
 		require.Equal(t, 2, actual)
 		more = r.Next()
 		require.Equal(t, false, more)
+
+		stmt, err = tx.Prepare("MOVE 1 foo")
+		require.NoError(t, err)
+		_, err = stmt.Exec()
+		require.NoError(t, err)
 
 		require.NoError(t, tx.Commit())
 	})


### PR DESCRIPTION
Closes #77100.

Release note (sql change): add support for the MOVE command, which moves
a SQL cursor without fetching any rows from it. MOVE is identical to
FETCH, including in its arguments and syntax, except it doesn't return
any rows.

Release justification: low-risk update to new functionality