### PR TITLE
kvserver/concurrency,tracing: add tracing tags while waiting for locks 

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
+        "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/stop",
@@ -37,6 +38,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -153,7 +153,7 @@ type Manager interface {
 	TransactionManager
 	RangeStateListener
 	MetricExporter
-	TestStateExporter
+	TestingAccessor
 }
 
 // RequestSequencer is concerned with the sequencing of concurrent requests. It
@@ -321,16 +321,20 @@ type MetricExporter interface {
 	// TxnWaitQueueMetrics()
 }
 
-// TestStateExporter is concerned with providing testing hooks that expose the
+// TestingAccessor is concerned with providing testing hooks that expose the
 // state of the concurrency manager, to be used by unit tests outside of the
 // concurrency package. It is one of the roles of Manager.
-type TestStateExporter interface {
+type TestingAccessor interface {
 	// TestingLockTableString returns a debug string representing the state of the
 	// lockTable.
 	TestingLockTableString() string
 
 	// TestingTxnWaitQueue returns the concurrency manager's txnWaitQueue.
 	TestingTxnWaitQueue() *txnwait.Queue
+
+	// TestingSetMaxLocks updates the locktable's lock limit. This can be used to
+	// force the locktable to exceed its limit and clear locks.
+	TestingSetMaxLocks(n int64)
 }
 
 ///////////////////////////////////

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -603,6 +603,11 @@ func (m *managerImpl) TestingTxnWaitQueue() *txnwait.Queue {
 	return m.twq.(*txnwait.Queue)
 }
 
+// TestingSetMaxLocks implements the TestingAccessor interface.
+func (m *managerImpl) TestingSetMaxLocks(maxLocks int64) {
+	m.lt.(*lockTableImpl).setMaxLocks(maxLocks)
+}
+
 func (r *Request) txnMeta() *enginepb.TxnMeta {
 	if r.Txn == nil {
 		return nil

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -143,7 +143,8 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, timeutil.DefaultTimeSource{})
+	timeSource := timeutil.DefaultTimeSource{}
+	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, timeSource)
 	*m = managerImpl{
 		st: cfg.Settings,
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
@@ -157,13 +158,14 @@ func NewManager(cfg Config) Manager {
 		},
 		lt: lt,
 		ltw: &lockTableWaiterImpl{
-			st:                cfg.Settings,
-			clock:             cfg.Clock,
-			stopper:           cfg.Stopper,
-			ir:                cfg.IntentResolver,
-			lt:                lt,
-			disableTxnPushing: cfg.DisableTxnPushing,
-			onContentionEvent: cfg.OnContentionEvent,
+			st:                   cfg.Settings,
+			clock:                cfg.Clock,
+			stopper:              cfg.Stopper,
+			ir:                   cfg.IntentResolver,
+			lt:                   lt,
+			contentionEventClock: timeSource,
+			disableTxnPushing:    cfg.DisableTxnPushing,
+			onContentionEvent:    cfg.OnContentionEvent,
 		},
 		// TODO(nvanbenschoten): move pkg/storage/txnwait to a new
 		// pkg/storage/concurrency/txnwait package.

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -79,6 +79,7 @@ import (
 // debug-disable-txn-pushes
 // debug-set-clock           ts=<secs>
 // debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=<count>
+// debug-set-max-locks <limit>
 // reset
 //
 func TestConcurrencyManagerBasic(t *testing.T) {
@@ -275,6 +276,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 					m.PoisonReq(guard)
 				})
 				return c.waitAndCollect(t, mon)
+
 			case "handle-write-intent-error":
 				var reqName string
 				d.ScanArgs(t, "req", &reqName)
@@ -532,6 +534,12 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				var n int
 				d.ScanArgs(t, "n", &n)
 				c.setDiscoveredLocksThresholdToConsultFinalizedTxnCache(n)
+				return ""
+
+			case "debug-set-max-locks":
+				var n int
+				d.ScanArgs(t, "n", &n)
+				m.TestingSetMaxLocks(int64(n))
 				return ""
 
 			case "reset":

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -79,7 +79,7 @@ import (
 // debug-disable-txn-pushes
 // debug-set-clock           ts=<secs>
 // debug-set-discovered-locks-threshold-to-consult-finalized-txn-cache n=<count>
-// debug-set-max-locks <limit>
+// debug-set-max-locks n=<count>
 // reset
 //
 func TestConcurrencyManagerBasic(t *testing.T) {

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1636,7 +1636,6 @@ func (l *lockState) tryActiveWait(
 				// would be more fair, but more complicated, and we expect that the
 				// common case is that this waiter will be at the end of the queue.
 				g.mu.startWait = true
-				g.mu.curLockWaitStart = timeProvider.Now()
 				state := waitForState
 				state.kind = waitQueueMaxLengthExceeded
 				g.mu.state = state

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -884,7 +884,7 @@ func (h *contentionEventHelper) emitAndInit(s waitingState) {
 	// If true, we want to emit the current event and possibly start a new one.
 	// Otherwise,
 	switch s.kind {
-	case waitFor, waitForDistinguished, waitSelf:
+	case waitFor, waitForDistinguished, waitSelf, waitElsewhere:
 		// If we're tracking an event and see a different txn/key, the event is
 		// done and we initialize the new event tracking the new txn/key.
 		//
@@ -901,12 +901,9 @@ func (h *contentionEventHelper) emitAndInit(s waitingState) {
 			}
 			h.tBegin = timeutil.Now()
 		}
-	case waitElsewhere, waitQueueMaxLengthExceeded, doneWaiting:
-		// If we have an event, emit it now and that's it - the case we're in
-		// does not give us a new transaction/key.
-		if h.ev != nil {
-			h.emit()
-		}
+	case waitQueueMaxLengthExceeded, doneWaiting:
+		// There will be no more state updates; we're done waiting.
+		h.emit()
 	default:
 		panic("unhandled waitingState.kind")
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -11,7 +11,6 @@
 package concurrency
 
 import (
-	"bytes"
 	"context"
 	"math"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // LockTableLivenessPushDelay sets the delay before pushing in order to detect
@@ -96,11 +97,12 @@ var LockTableDeadlockDetectionPushDelay = settings.RegisterDurationSetting(
 
 // lockTableWaiterImpl is an implementation of lockTableWaiter.
 type lockTableWaiterImpl struct {
-	st      *cluster.Settings
-	clock   *hlc.Clock
-	stopper *stop.Stopper
-	ir      IntentResolver
-	lt      lockTable
+	st                   *cluster.Settings
+	clock                *hlc.Clock
+	stopper              *stop.Stopper
+	ir                   IntentResolver
+	lt                   lockTable
+	contentionEventClock timeutil.TimeSource
 
 	// When set, WriteIntentError are propagated instead of pushing
 	// conflicting transactions.
@@ -145,11 +147,8 @@ func (w *lockTableWaiterImpl) WaitOn(
 	// Used to enforce lock timeouts.
 	var lockDeadline time.Time
 
-	h := contentionEventHelper{
-		sp:      tracing.SpanFromContext(ctx),
-		onEvent: w.onContentionEvent,
-	}
-	defer h.emit()
+	h := getOrCreateContentionEventTracer(ctx, w.onContentionEvent, w.contentionEventClock)
+	defer h.close()
 
 	for {
 		select {
@@ -162,7 +161,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 			timerC = nil
 			state := guard.CurState()
 			log.Eventf(ctx, "lock wait-queue event: %s", state)
-			h.emitAndInit(state)
+			h.notify(ctx, state)
 			switch state.kind {
 			case waitFor, waitForDistinguished:
 				if req.WaitPolicy == lock.WaitPolicy_Error {
@@ -843,70 +842,244 @@ func (c *txnCache) insertFrontLocked(txn *roachpb.Transaction) {
 	c.txns[0] = txn
 }
 
-// contentionEventHelper tracks and emits ContentionEvents.
-type contentionEventHelper struct {
+// tagContentionTracer is the tracing span tag that the *contentionEventTracer
+// lives under.
+const tagContentionTracer = "contention_tracer"
+
+// tagWaitKey is the tracing span tag indicating the key of the lock the request
+// is currently waiting on.
+const tagWaitKey = "lock_wait_key"
+
+// tagWaitStart is the tracing span tag indicating when the request started
+// waiting on the lock it's currently waiting on.
+const tagWaitStart = "lock_wait_start"
+
+// tagLockHolderTxn is the tracing span tag indicating the ID of the txn holding
+// the lock (or a reservation on the lock) that the request is currently waiting
+// on.
+const tagLockHolderTxn = "lock_holder_txn"
+
+// tagNumLocks is the tracing span tag indicating the number of locks that the
+// request has previously waited on. If the request is currently waiting on
+// a lock, that lock is included.
+const tagNumLocks = "lock_num"
+
+// tagWaited is the tracing span tag indicating the total time that the span has
+// waited on locks. If the span is currently waiting on a lock, the time it has
+// already waited on that lock is included.
+const tagWaited = "lock_wait"
+
+// contentionEventTracer adds lock contention information to the trace, in the
+// form of events and tags. The contentionEventTracer is associated with a
+// tracing span.
+//
+// A contentionEventTracer should be created through
+// getOrCreateContentionEventTracer() when a request starts waiting in the lock
+// table (on what might turn out to be multiple locks). If the span has waited
+// on locks before, the same contentionEventTracer from before is reused, as it
+// keeps track of prior wait times. close() should be called when the waiting is
+// over.
+//
+// contentionEventTracer is thread-safe; Render can be called asynchronously.
+type contentionEventTracer struct {
 	sp      *tracing.Span
 	onEvent func(event *roachpb.ContentionEvent) // may be nil
+	clock   timeutil.TimeSource
 
-	// Internal.
-	ev     *roachpb.ContentionEvent
-	tBegin time.Time
+	mu struct {
+		syncutil.Mutex
+
+		// closed is set on close(), and reset by getOrCreateContentionEventTracer
+		// if the contentionEventTracer is used again.
+		closed bool
+		// lockWait accumulates time waited for locks when the contentionEventTracer
+		// is closed.
+		lockWait time.Duration
+
+		// waiting is set if the contentionEventTracer has been notified of a lock
+		// that the underlying request is waiting on. The contentionEventTracer
+		// starts with waiting=false, and transitions to waiting=true on the first
+		// notify=true call.
+		waiting bool
+
+		// waitStart represents the timestamp when the request started waiting on
+		// locks in the current iteration of the contentionEventTracer. The wait
+		// time in previous iterations is accumulated in lockWait. On close,
+		// timeutil.Since(waitStart) is added to lockWait.
+		waitStart time.Time
+
+		// curState is the current wait state, if any. It is overwritten every time
+		// the lock table notify()s the contentionEventTracer of a new state. It is
+		// not set if waiting is false.
+		curState waitingState
+
+		// numLocks counts the number of locks this contentionEventTracer has seen so
+		// far, including the one we're currently waiting on (if any).
+		numLocks int
+	}
 }
 
-// emit emits the open contention event, if any.
-func (h *contentionEventHelper) emit() {
-	if h.ev == nil {
+var _ tracing.LazyTag = &contentionEventTracer{}
+
+// getOrCreateContentionEventTracer looks in the span to see if there's already
+// a contentionEventTracer. If there is, it returns it. If there isn't, a new
+// one is created and associated with the span as a lazy tag.
+func getOrCreateContentionEventTracer(
+	ctx context.Context, onEvent func(ev *roachpb.ContentionEvent), clock timeutil.TimeSource,
+) *contentionEventTracer {
+	sp := tracing.SpanFromContext(ctx)
+	var h *contentionEventTracer
+	t, ok := sp.GetLazyTag(tagContentionTracer)
+	if ok {
+		h = t.(*contentionEventTracer)
+		h.clock = clock
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if !h.mu.closed {
+			log.Fatalf(ctx, "unexpectedly found non-closed contentionEventTracer")
+		}
+		h.mu.closed = false
+		h.mu.waiting = false
+		h.mu.waitStart = h.clock.Now()
+		return h
+	}
+	h = &contentionEventTracer{
+		sp:      sp,
+		onEvent: onEvent,
+		clock:   clock,
+	}
+	h.mu.waitStart = h.clock.Now()
+	sp.SetLazyTag(tagContentionTracer, h)
+	return h
+}
+
+// Render implements the tracing.LazyTag interface.
+func (h *contentionEventTracer) Render() []attribute.KeyValue {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	tags := make([]attribute.KeyValue, 0, 4)
+	if h.mu.numLocks > 0 {
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagNumLocks,
+			Value: attribute.IntValue(h.mu.numLocks),
+		})
+	}
+	// Compute how long the request has waited on locks by adding the prior wait
+	// time (if any) and the current wait time (if we're currently waiting).
+	lockWait := h.mu.lockWait
+	if !h.mu.waitStart.IsZero() {
+		lockWait += h.clock.Since(h.mu.waitStart)
+	}
+	tags = append(tags, attribute.KeyValue{
+		Key:   tagWaited,
+		Value: attribute.StringValue(string(humanizeutil.Duration(lockWait))),
+	})
+
+	if h.mu.waiting {
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagWaitKey,
+			Value: attribute.StringValue(h.mu.curState.key.String()),
+		})
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagLockHolderTxn,
+			Value: attribute.StringValue(h.mu.curState.txn.ID.String()),
+		})
+		tags = append(tags, attribute.KeyValue{
+			Key:   tagWaitStart,
+			Value: attribute.StringValue(h.mu.curState.lockWaitStart.Format("15:04:05.123")),
+		})
+	}
+	return tags
+}
+
+// emitLocked records a ContentionEvent to the tracing span corresponding to the
+// current wait state (if any).
+func (h *contentionEventTracer) emitLocked() {
+	if !h.mu.waiting {
 		return
 	}
-	h.ev.Duration = timeutil.Since(h.tBegin)
+	ev := &roachpb.ContentionEvent{
+		Key:      h.mu.curState.key,
+		TxnMeta:  *h.mu.curState.txn,
+		Duration: h.clock.Since(h.mu.curState.lockWaitStart),
+	}
 	if h.onEvent != nil {
 		// NB: this is intentionally above the call to RecordStructured so that
 		// this interceptor gets to mutate the event (used for test determinism).
-		h.onEvent(h.ev)
+		h.onEvent(ev)
 	}
-	h.sp.RecordStructured(h.ev)
-	h.ev = nil
+	h.sp.RecordStructured(ev)
 }
 
-// emitAndInit compares the waitingState's active txn (if any) against the current
-// ContentionEvent (if any). If the they match, we are continuing to handle the
+// notify processes an event from the lock table.
+// compares the waitingState's active txn (if any) against the current
+// ContentionEvent (if any). If they match, we are continuing to handle the
 // same event and no action is taken. If they differ, the open event (if any) is
 // finalized and added to the Span, and a new event initialized from the inputs.
-func (h *contentionEventHelper) emitAndInit(s waitingState) {
+func (h *contentionEventTracer) notify(ctx context.Context, s waitingState) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.mu.closed {
+		log.Fatalf(ctx, "notify() unexpectedly called after close(). new state: %s", s)
+	}
 	if h.sp == nil {
-		// No span to attach payloads to - don't do any work.
-		//
-		// TODO(tbg): we could special case the noop span here too, but the plan is for
-		// nobody to use noop spans any more (trace.mode=background).
+		// No span to manipulate - don't do any work.
 		return
 	}
 
-	// If true, we want to emit the current event and possibly start a new one.
-	// Otherwise,
+	firstLock := !h.mu.waiting
+
+	// Depending on the kind of notification, we check whether we're now waiting
+	// on a different key than we were previously. If so, we emitLocked a
+	// ContentionEvent.
 	switch s.kind {
 	case waitFor, waitForDistinguished, waitSelf, waitElsewhere:
 		// If we're tracking an event and see a different txn/key, the event is
 		// done and we initialize the new event tracking the new txn/key.
 		//
 		// NB: we're guaranteed to have `s.{txn,key}` populated here.
-		if h.ev != nil &&
-			(!h.ev.TxnMeta.ID.Equal(s.txn.ID) || !bytes.Equal(h.ev.Key, s.key)) {
-			h.emit() // h.ev is now nil
+		var differentLock bool
+		if firstLock {
+			differentLock = true
+		} else {
+			curLockHolder, curKey := h.mu.curState.txn.ID, h.mu.curState.key
+			differentLock = !curLockHolder.Equal(s.txn.ID) || !curKey.Equal(s.key)
 		}
-
-		if h.ev == nil {
-			h.ev = &roachpb.ContentionEvent{
-				Key:     s.key,
-				TxnMeta: *s.txn,
-			}
-			h.tBegin = timeutil.Now()
+		if differentLock {
+			h.emitLocked()
+			h.mu.numLocks++
 		}
-	case waitQueueMaxLengthExceeded, doneWaiting:
+		h.mu.curState = s
+		h.mu.waiting = true
+	case doneWaiting, waitQueueMaxLengthExceeded:
 		// There will be no more state updates; we're done waiting.
-		h.emit()
+		h.closeLocked()
+		return
 	default:
-		panic("unhandled waitingState.kind")
+		kind := s.kind // escapes to the heap
+		log.Fatalf(ctx, "unhandled waitingState.kind: %v", kind)
 	}
+}
+
+// close marks the contentionEventTracer as not waiting on a lock.
+func (h *contentionEventTracer) close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.closeLocked()
+}
+
+func (h *contentionEventTracer) closeLocked() {
+	if h.mu.closed || h.sp == nil {
+		return
+	}
+
+	h.emitLocked()
+	h.mu.closed = true
+	// Accumulate the wait time.
+	h.mu.lockWait += h.clock.Since(h.mu.waitStart)
+	h.mu.curState = waitingState{}
+	h.mu.waiting = false
+	h.mu.waitStart = time.Time{}
 }
 
 const (

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -115,11 +115,12 @@ func setupLockTableWaiterTest() (
 		signal: make(chan struct{}, 1),
 	}
 	w := &lockTableWaiterImpl{
-		st:      st,
-		clock:   hlc.NewClock(manual.UnixNano, time.Nanosecond),
-		stopper: stop.NewStopper(),
-		ir:      ir,
-		lt:      &mockLockTable{},
+		st:                   st,
+		clock:                hlc.NewClock(manual.UnixNano, time.Nanosecond),
+		stopper:              stop.NewStopper(),
+		ir:                   ir,
+		lt:                   &mockLockTable{},
+		contentionEventClock: timeutil.DefaultTimeSource{},
 	}
 	return w, ir, guard, manual
 }
@@ -927,47 +928,84 @@ func BenchmarkTxnCache(b *testing.B) {
 }
 
 func TestContentionEventHelper(t *testing.T) {
-	// This is mostly a regression test that ensures that we don't
-	// accidentally update tBegin when continuing to handle the same event.
-	// General coverage of the helper results from TestConcurrencyManagerBasic.
-
 	tr := tracing.NewTracer()
-	sp := tr.StartSpan("foo", tracing.WithForceRealSpan())
+	ctx, sp := tr.StartSpanCtx(context.Background(), "foo", tracing.WithRecording(tracing.RecordingVerbose))
+	defer sp.Finish()
 
-	var sl []*roachpb.ContentionEvent
-	h := contentionEventHelper{
-		sp: sp,
-		onEvent: func(ev *roachpb.ContentionEvent) {
-			sl = append(sl, ev)
-		},
-	}
+	var events []*roachpb.ContentionEvent
+
+	h := getOrCreateContentionEventTracer(ctx,
+		func(ev *roachpb.ContentionEvent) {
+			events = append(events, ev)
+		}, timeutil.DefaultTimeSource{})
+	defer h.close()
 	txn := makeTxnProto("foo")
-	h.emitAndInit(waitingState{
+	h.notify(ctx, waitingState{
 		kind: waitForDistinguished,
 		key:  roachpb.Key("a"),
 		txn:  &txn.TxnMeta,
 	})
-	require.Empty(t, sl)
-	require.NotZero(t, h.tBegin)
-	tBegin := h.tBegin
+	require.Zero(t, h.mu.lockWait)
+	require.NotZero(t, h.mu.waitStart)
+	require.Empty(t, events)
+	rec := sp.GetRecording(tracing.RecordingVerbose)
+	require.Equal(t, "1", rec[0].Tags[tagNumLocks])
+	require.Contains(t, rec[0].Tags, tagWaited)
+	require.Contains(t, rec[0].Tags, tagWaitKey)
+	require.Contains(t, rec[0].Tags, tagWaitStart)
+	require.Contains(t, rec[0].Tags, tagLockHolderTxn)
 
-	// Another event for the same txn/key should not mutate tBegin
-	// or emit an event.
-	h.emitAndInit(waitingState{
+	// Another event for the same txn/key should not mutate
+	// or emitLocked an event.
+	prevNumLocks := h.mu.numLocks
+	h.notify(ctx, waitingState{
 		kind: waitFor,
 		key:  roachpb.Key("a"),
 		txn:  &txn.TxnMeta,
 	})
-	require.Empty(t, sl)
-	require.Equal(t, tBegin, h.tBegin)
+	require.Empty(t, events)
+	require.Zero(t, h.mu.lockWait)
+	require.Equal(t, prevNumLocks, h.mu.numLocks)
 
-	h.emitAndInit(waitingState{
+	h.notify(ctx, waitingState{
 		kind: waitForDistinguished,
 		key:  roachpb.Key("b"),
 		txn:  &txn.TxnMeta,
 	})
-	require.Len(t, sl, 1)
-	require.Equal(t, txn.TxnMeta, sl[0].TxnMeta)
-	require.Equal(t, roachpb.Key("a"), sl[0].Key)
-	require.NotZero(t, sl[0].Duration)
+	require.Zero(t, h.mu.lockWait)
+	require.Len(t, events, 1)
+	require.Equal(t, txn.TxnMeta, events[0].TxnMeta)
+	require.Equal(t, roachpb.Key("a"), events[0].Key)
+	require.NotZero(t, events[0].Duration)
+
+	h.close()
+	require.NotZero(t, h.mu.lockWait)
+	require.Len(t, events, 2)
+
+	oldH := h
+	h = getOrCreateContentionEventTracer(ctx,
+		func(ev *roachpb.ContentionEvent) {
+			events = append(events, ev)
+		}, timeutil.DefaultTimeSource{})
+	require.Equal(t, oldH, h)
+	require.Equal(t, 2, h.mu.numLocks)
+	require.NotZero(t, h.mu.lockWait)
+	lockWaitBefore := h.mu.lockWait
+
+	h.notify(ctx, waitingState{
+		kind: waitFor,
+		key:  roachpb.Key("b"),
+		txn:  &txn.TxnMeta,
+	})
+	h.notify(ctx, waitingState{
+		kind: doneWaiting,
+	})
+	require.Len(t, events, 3)
+	require.Less(t, lockWaitBefore, h.mu.lockWait)
+	rec = sp.GetRecording(tracing.RecordingVerbose)
+	require.Equal(t, "3", rec[0].Tags[tagNumLocks])
+	require.Contains(t, rec[0].Tags, tagWaited)
+	require.NotContains(t, rec[0].Tags, tagWaitKey)
+	require.NotContains(t, rec[0].Tags, tagWaitStart)
+	require.NotContains(t, rec[0].Tags, tagLockHolderTxn)
 }

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -1,0 +1,115 @@
+# Test the wait_elsewhere wait state. The test sets up a lock table with a very
+# low limit on the number of locks. The limit is exceeded, causing the lock
+# table to be cleared. This will cause a waiter to move to the wait_elsewhere
+# state.
+
+# Low lock-table limit.
+debug-set-max-locks n=1
+----
+
+new-txn name=txnWriter ts=10,1 epoch=0
+----
+
+new-request name=reqFirstLock txn=txnWriter ts=10,1
+  put key=k value=val1
+----
+
+new-request name=reqSecondLock txn=txnWriter ts=10,1
+  put key=k2 value=val1
+----
+
+new-txn name=txnWaiter ts=20,1 epoch=0
+----
+
+new-request name=reqWaiter txn=txnWaiter ts=20,1
+  put key=k value=val2
+----
+
+
+sequence req=reqFirstLock
+----
+[1] sequence reqFirstLock: sequencing request
+[1] sequence reqFirstLock: acquiring latches
+[1] sequence reqFirstLock: scanning lock table for conflicting locks
+[1] sequence reqFirstLock: sequencing complete, returned guard
+
+on-lock-acquired req=reqFirstLock key=k dur=r
+----
+[-] acquire lock: txn 00000001 @ k
+
+finish req=reqFirstLock
+----
+[-] finish reqFirstLock: finishing request
+
+
+sequence req=reqWaiter
+----
+[2] sequence reqWaiter: sequencing request
+[2] sequence reqWaiter: acquiring latches
+[2] sequence reqWaiter: scanning lock table for conflicting locks
+[2] sequence reqWaiter: sequencing complete, returned guard
+
+# Simulate that the replicated lock was discovered, so it's added to the lock
+# table.
+handle-write-intent-error req=reqWaiter lease-seq=1
+ intent txn=txnWriter key=k
+----
+[3] handle write intent error reqWaiter: handled conflicting intents on "k", released latches
+
+sequence req=reqWaiter
+----
+[4] sequence reqWaiter: re-sequencing request
+[4] sequence reqWaiter: acquiring latches
+[4] sequence reqWaiter: scanning lock table for conflicting locks
+[4] sequence reqWaiter: waiting in lock wait-queues
+[4] sequence reqWaiter: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key "k" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence reqWaiter: pushing txn 00000001 to abort
+[4] sequence reqWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+debug-lock-table
+----
+global: num=1
+ lock: "k"
+  holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,1, info: repl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 2, txn: 00000002-0000-0000-0000-000000000000
+   distinguished req: 2
+local: num=0
+
+sequence req=reqSecondLock
+----
+[5] sequence reqSecondLock: sequencing request
+[5] sequence reqSecondLock: acquiring latches
+[5] sequence reqSecondLock: scanning lock table for conflicting locks
+[5] sequence reqSecondLock: sequencing complete, returned guard
+
+on-lock-acquired req=reqSecondLock key=k2 dur=u
+----
+[-] acquire lock: txn 00000001 @ k2
+
+finish req=reqSecondLock
+----
+[-] finish reqSecondLock: finishing request
+
+# Abort the writing txn. This will cause the blocked request to unblock. Note
+# that we expect the "conflicted with" contention event after the push. This
+# shows that the event is emitted only after the request exits both the waitFor
+# and the waitElsewhere states.
+on-txn-updated txn=txnWriter status=aborted
+----
+[-] update txn: aborting txnWriter
+[4] sequence reqWaiter: resolving intent "k" for txn 00000001 with ABORTED status
+[4] sequence reqWaiter: lock wait-queue event: wait elsewhere for txn 00000001 @ key "k"
+[4] sequence reqWaiter: pushing txn 00000001 to abort
+[4] sequence reqWaiter: resolving intent "k" for txn 00000001 with ABORTED status
+[4] sequence reqWaiter: conflicted with 00000001-0000-0000-0000-000000000000 on "k" for 1.234s
+[4] sequence reqWaiter: acquiring latches
+[4] sequence reqWaiter: scanning lock table for conflicting locks
+[4] sequence reqWaiter: sequencing complete, returned guard
+
+finish req=reqWaiter
+----
+[-] finish reqWaiter: finishing request
+
+reset
+----

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2895,8 +2895,8 @@ message ContentionEvent {
 
   // Key is the key that this and the other transaction conflicted on.
   bytes key = 1 [(gogoproto.casttype) = "Key"];
-  // TxnMeta is the transaction conflicted
-  // with, i.e. the transaction holding a lock.
+  // TxnMeta is the transaction conflicted with, i.e. the transaction holding a
+  // lock or lock reservation.
   cockroach.storage.enginepb.TxnMeta txn_meta = 2 [(gogoproto.nullable) = false];
   // Duration spent contending against the other transaction.
   google.protobuf.Duration duration = 3 [(gogoproto.nullable) = false,

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -117,12 +117,9 @@ type crdbSpanMu struct {
 
 	recording recordingState
 
-	// tags are only captured when recording. These are tags that have been
-	// added to this Span, and will be appended to the tags in logTags when
-	// someone needs to actually observe the total set of tags that is a part of
-	// this Span.
-	// TODO(radu): perhaps we want a recording to capture all the tags (even
-	// those that were set before recording started)?
+	// tags are a list of key/value pairs associated with the span through
+	// SetTag(). They will be appended to the tags in logTags when someone needs
+	// to actually observe the total set of tags that is a part of this Span.
 	tags []attribute.KeyValue
 }
 

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -121,6 +121,14 @@ type crdbSpanMu struct {
 	// SetTag(). They will be appended to the tags in logTags when someone needs
 	// to actually observe the total set of tags that is a part of this Span.
 	tags []attribute.KeyValue
+	// lazyTags are tags whose values are only string-ified on demand. Each lazy
+	// tag is expected to implement either fmt.Stringer or LazyTag.
+	lazyTags []lazyTag
+}
+
+type lazyTag struct {
+	Key   string
+	Value interface{}
 }
 
 type recordingState struct {
@@ -498,6 +506,33 @@ func (s *crdbSpan) setTagLocked(key string, value attribute.Value) {
 	s.mu.tags = append(s.mu.tags, attribute.KeyValue{Key: k, Value: value})
 }
 
+// setLazyTagLocked sets a tag that's only stringified if s' recording is
+// collected.
+//
+// value is expected to implement either Stringer or LazyTag.
+//
+// key is expected to not match the key of a non-lazy tag.
+func (s *crdbSpan) setLazyTagLocked(key string, value interface{}) {
+	for i := range s.mu.lazyTags {
+		if s.mu.lazyTags[i].Key == key {
+			s.mu.lazyTags[i].Value = value
+			return
+		}
+	}
+	s.mu.lazyTags = append(s.mu.lazyTags, lazyTag{Key: key, Value: value})
+}
+
+// getLazyTagLocked returns the value of the tag with the given key. If that tag
+// doesn't exist, the bool retval is false.
+func (s *crdbSpan) getLazyTagLocked(key string) (interface{}, bool) {
+	for i := range s.mu.lazyTags {
+		if s.mu.lazyTags[i].Key == key {
+			return s.mu.lazyTags[i].Value, true
+		}
+	}
+	return nil, false
+}
+
 // record includes a log message in s' recording.
 func (s *crdbSpan) record(msg redact.RedactableString) {
 	if s.recordingType() != RecordingVerbose {
@@ -697,6 +732,18 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		for _, kv := range s.mu.tags {
 			// We encode the tag values as strings.
 			addTag(string(kv.Key), kv.Value.Emit())
+		}
+		for _, kv := range s.mu.lazyTags {
+			switch v := kv.Value.(type) {
+			case LazyTag:
+				for _, tag := range v.Render() {
+					addTag(string(tag.Key), tag.Value.Emit())
+				}
+			case fmt.Stringer:
+				addTag(kv.Key, v.String())
+			default:
+				addTag(kv.Key, fmt.Sprintf("<can't render %T>", kv.Value))
+			}
 		}
 	}
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -436,6 +436,44 @@ func (sp *Span) SetTag(key string, value attribute.Value) {
 	sp.i.SetTag(key, value)
 }
 
+// LazyTag is a tag value that expands into a series of key-value tags when
+// included in a recording. LazyTags can be used when it's useful to maintain a
+// single, structured tag in a Span (for example because the tag is accessed
+// through Span.GetLazyTag(key)), but that tag should render as multiple
+// key-value pairs when the Span's recording is collected. Recordings can only
+// contain string tags, for simplicity.
+type LazyTag interface {
+	// Render produces the list of key-value tags for the span's recording.
+	Render() []attribute.KeyValue
+}
+
+// SetLazyTag adds a tag to the span. The tag's value is expected to implement
+// either fmt.Stringer or LazyTag, and is only stringified using one of
+// the two on demand:
+// - if the Span has an otel span or a net.Trace, the tag
+//   is stringified immediately and passed to the external trace (see
+//   SetLazyStatusTag if you want to avoid that).
+//- if/when the span's recording is collected, the tag is stringified on demand.
+//  If the recording is collected multiple times, the tag is stringified
+//  multiple times (so, the tag can evolve over time). Since generally the
+//  collection of a recording can happen asynchronously, the implementation of
+//  Stringer or LazyTag should be thread-safe.
+func (sp *Span) SetLazyTag(key string, value interface{}) {
+	if sp.detectUseAfterFinish() {
+		return
+	}
+	sp.i.SetLazyTag(key, value)
+}
+
+// GetLazyTag returns the value of the tag with the given key. If that tag doesn't
+// exist, the bool retval is false.
+func (sp *Span) GetLazyTag(key string) (interface{}, bool) {
+	if sp.detectUseAfterFinish() {
+		return attribute.Value{}, false
+	}
+	return sp.i.GetLazyTag(key)
+}
+
 // TraceID retrieves a span's trace ID.
 func (sp *Span) TraceID() tracingpb.TraceID {
 	if sp.detectUseAfterFinish() {

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -155,10 +155,6 @@ func (s *spanInner) SetTag(key string, value attribute.Value) *spanInner {
 	if s.isNoop() {
 		return s
 	}
-	return s.setTagInner(key, value, false /* locked */)
-}
-
-func (s *spanInner) setTagInner(key string, value attribute.Value, locked bool) *spanInner {
 	if s.otelSpan != nil {
 		s.otelSpan.SetAttributes(attribute.KeyValue{
 			Key:   attribute.Key(key),
@@ -169,10 +165,8 @@ func (s *spanInner) setTagInner(key string, value attribute.Value, locked bool) 
 		s.netTr.LazyPrintf("%s:%v", key, value)
 	}
 	// The internal tags will be used if we start a recording on this Span.
-	if !locked {
-		s.crdb.mu.Lock()
-		defer s.crdb.mu.Unlock()
-	}
+	s.crdb.mu.Lock()
+	defer s.crdb.mu.Unlock()
 	s.crdb.setTagLocked(key, value)
 	return s
 }

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -164,11 +164,31 @@ func (s *spanInner) SetTag(key string, value attribute.Value) *spanInner {
 	if s.netTr != nil {
 		s.netTr.LazyPrintf("%s:%v", key, value)
 	}
-	// The internal tags will be used if we start a recording on this Span.
 	s.crdb.mu.Lock()
 	defer s.crdb.mu.Unlock()
 	s.crdb.setTagLocked(key, value)
 	return s
+}
+
+func (s *spanInner) SetLazyTag(key string, value interface{}) *spanInner {
+	if s.isNoop() {
+		return s
+	}
+	s.crdb.mu.Lock()
+	defer s.crdb.mu.Unlock()
+	s.crdb.setLazyTagLocked(key, value)
+	return s
+}
+
+// GetLazyTag returns the value of the tag with the given key. If that tag doesn't
+// exist, the bool retval is false.
+func (s *spanInner) GetLazyTag(key string) (interface{}, bool) {
+	if s.isNoop() {
+		return attribute.Value{}, false
+	}
+	s.crdb.mu.Lock()
+	defer s.crdb.mu.Unlock()
+	return s.crdb.getLazyTagLocked(key)
 }
 
 func (s *spanInner) RecordStructured(item Structured) {


### PR DESCRIPTION
When the evaluation of a request blocks on a lock acquisition, this
patch annotates the tracing span representing the evaluation with
tags about the lock's key, holder, time when the waiting started, and
number of locks that the evaluation waited on previously.

To do this, the patch adds support in the tracing library for "lazy
tags": tags that are only stringified on demand, when a span's recording
is collected. This is useful if the stringification is expensive (so we
only want to pay for it if someone actually looks at the span), and also
for structured tags whose state can change over time. A lazy tag can
implement one of two interfaces: Stringer or LazyTag. The latter allows
the tag to be represented as a set of key-value pairs in a recording.

The point of the new contention tags is to be featured prominently in
the visualizer for the active spans registry that I'm working on.
Looking at queries/requests experiencing contention is likely to be a
very common scenario.

This patch spruces up the contentionEventHelper in the lock table, to
maintain the state of a waiter as a lazy tag.

Release note: None
Release justification: Low risk, high observability value.