### PR TITLE
release-21.2: backupccl,jobs: handle panics from invalid cron parsing

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -202,8 +202,15 @@ func computeScheduleRecurrence(
 			`error parsing schedule expression: %q; it must be a valid cron expression`,
 			cron)
 	}
-	nextRun := expr.Next(now)
-	frequency := expr.Next(nextRun).Sub(nextRun)
+	nextRun, err := jobs.CronParseNext(expr, now, cron)
+	if err != nil {
+		return nil, err
+	}
+	nextToNextRun, err := jobs.CronParseNext(expr, nextRun, cron)
+	if err != nil {
+		return nil, err
+	}
+	frequency := nextToNextRun.Sub(nextRun)
 	return &scheduleRecurrence{cron, frequency}, nil
 }
 

--- a/pkg/jobs/executor_impl_test.go
+++ b/pkg/jobs/executor_impl_test.go
@@ -39,8 +39,13 @@ func TestInlineExecutorFailedJobsHandling(t *testing.T) {
 		expectedNextRun time.Time
 	}{
 		{
-			onError:         jobspb.ScheduleDetails_RETRY_SCHED,
-			expectedNextRun: cronexpr.MustParse("@daily").Next(h.env.Now()).Round(time.Microsecond),
+			onError: jobspb.ScheduleDetails_RETRY_SCHED,
+			expectedNextRun: func() time.Time {
+				expr := cronexpr.MustParse("@daily")
+				nextRun, err := CronParseNext(expr, h.env.Now(), "@daily")
+				require.NoError(t, err)
+				return nextRun.Round(time.Microsecond)
+			}(),
 		},
 		{
 			onError:         jobspb.ScheduleDetails_RETRY_SOON,

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -74,7 +74,7 @@ func TestJobSchedulerReschedulesRunning(t *testing.T) {
 				}))
 
 			// Verify the job has expected nextRun time.
-			expectedRunTime := cronexpr.MustParse("@hourly").Next(h.env.Now())
+			expectedRunTime := getNextRunTime(t, "@hourly", h.env.Now())
 			loaded := h.loadSchedule(t, j.ScheduleID())
 			require.Equal(t, expectedRunTime, loaded.NextRun())
 
@@ -92,7 +92,7 @@ func TestJobSchedulerReschedulesRunning(t *testing.T) {
 			if wait == jobspb.ScheduleDetails_WAIT {
 				expectedRunTime = h.env.Now().Add(recheckRunningAfter)
 			} else {
-				expectedRunTime = cronexpr.MustParse("@hourly").Next(h.env.Now())
+				expectedRunTime = getNextRunTime(t, "@hourly", h.env.Now())
 			}
 			loaded = h.loadSchedule(t, j.ScheduleID())
 			require.Equal(t, expectedRunTime, loaded.NextRun())
@@ -132,7 +132,7 @@ func TestJobSchedulerExecutesAfterTerminal(t *testing.T) {
 				}))
 
 			// Verify the job has expected nextRun time.
-			expectedRunTime := cronexpr.MustParse("@hourly").Next(h.env.Now())
+			expectedRunTime := getNextRunTime(t, "@hourly", h.env.Now())
 			loaded := h.loadSchedule(t, j.ScheduleID())
 			require.Equal(t, expectedRunTime, loaded.NextRun())
 
@@ -146,7 +146,7 @@ func TestJobSchedulerExecutesAfterTerminal(t *testing.T) {
 					return s.executeSchedules(ctx, allSchedules, txn)
 				}))
 
-			expectedRunTime = cronexpr.MustParse("@hourly").Next(h.env.Now())
+			expectedRunTime = getNextRunTime(t, "@hourly", h.env.Now())
 			loaded = h.loadSchedule(t, j.ScheduleID())
 			require.Equal(t, expectedRunTime, loaded.NextRun())
 		})
@@ -172,7 +172,7 @@ func TestJobSchedulerExecutesAndSchedulesNextRun(t *testing.T) {
 		}))
 
 	// Verify the job has expected nextRun time.
-	expectedRunTime := cronexpr.MustParse("@hourly").Next(h.env.Now())
+	expectedRunTime := getNextRunTime(t, "@hourly", h.env.Now())
 	loaded := h.loadSchedule(t, j.ScheduleID())
 	require.Equal(t, expectedRunTime, loaded.NextRun())
 
@@ -186,9 +186,17 @@ func TestJobSchedulerExecutesAndSchedulesNextRun(t *testing.T) {
 			return s.executeSchedules(ctx, allSchedules, txn)
 		}))
 
-	expectedRunTime = cronexpr.MustParse("@hourly").Next(h.env.Now())
+	expectedRunTime = getNextRunTime(t, "@hourly", h.env.Now())
 	loaded = h.loadSchedule(t, j.ScheduleID())
 	require.Equal(t, expectedRunTime, loaded.NextRun())
+}
+
+func getNextRunTime(t *testing.T, cron string, fromNow time.Time) time.Time {
+	t.Helper()
+	expr := cronexpr.MustParse(cron)
+	nextRun, err := CronParseNext(expr, fromNow, cron)
+	require.NoError(t, err)
+	return nextRun
 }
 
 func TestJobSchedulerDaemonInitialScanDelay(t *testing.T) {
@@ -557,7 +565,11 @@ func TestJobSchedulerRetriesFailed(t *testing.T) {
 	}{
 		{jobspb.ScheduleDetails_PAUSE_SCHED, time.Time{}},
 		{jobspb.ScheduleDetails_RETRY_SOON, execTime.Add(retryFailedJobAfter).Round(time.Microsecond)},
-		{jobspb.ScheduleDetails_RETRY_SCHED, cron.Next(execTime).Round(time.Microsecond)},
+		{jobspb.ScheduleDetails_RETRY_SCHED, func() time.Time {
+			nextRun, err := CronParseNext(cron, execTime, "@hourly")
+			require.NoError(t, err)
+			return nextRun.Round(time.Microsecond)
+		}()},
 	} {
 		t.Run(tc.onError.String(), func(t *testing.T) {
 			h.env.SetTime(startTime)

--- a/pkg/jobs/scheduled_job.go
+++ b/pkg/jobs/scheduled_job.go
@@ -200,8 +200,14 @@ func (j *ScheduledJob) Frequency() (time.Duration, error) {
 			"parsing schedule expression: %q; it must be a valid cron expression",
 			j.rec.ScheduleExpr)
 	}
-	next := expr.Next(j.env.Now())
-	nextNext := expr.Next(next)
+	next, err := CronParseNext(expr, j.env.Now(), j.rec.ScheduleExpr)
+	if err != nil {
+		return 0, err
+	}
+	nextNext, err := CronParseNext(expr, next, j.rec.ScheduleExpr)
+	if err != nil {
+		return 0, err
+	}
 	return nextNext.Sub(next), nil
 }
 
@@ -215,7 +221,11 @@ func (j *ScheduledJob) ScheduleNextRun() error {
 	if err != nil {
 		return errors.Wrapf(err, "parsing schedule expression: %q", j.rec.ScheduleExpr)
 	}
-	j.SetNextRun(expr.Next(j.env.Now()))
+	nextRun, err := CronParseNext(expr, j.env.Now(), j.rec.ScheduleExpr)
+	if err != nil {
+		return err
+	}
+	j.SetNextRun(nextRun)
 	return nil
 }
 


### PR DESCRIPTION
This change changes all calls to `func (expr *Expression) Next`
in the `gorhill/cronexpr` package to use a utility method instead,
that handles panics that might be thrown by the underlying library.

Fixes: #74873

Release justification (bug fix): certain invalid cron expr could
result in a panic from the undelying cronexpr parsing libarary
causing the node to crash