### PR TITLE
workload: Support multiple cloud storage providers.

### DIFF
--- a/pkg/ccl/workloadccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/BUILD.bazel
@@ -2,20 +2,27 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "workloadccl",
-    srcs = ["fixture.go"],
+    srcs = [
+        "fixture.go",
+        "storage.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
+        "//pkg/cloud",
+        "//pkg/cloud/amazon",
+        "//pkg/cloud/azure",
+        "//pkg/cloud/gcp",
+        "//pkg/security",
+        "//pkg/settings/cluster",
         "//pkg/util/ctxgroup",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
-        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
-        "@com_google_cloud_go_storage//:storage",
-        "@org_golang_google_api//iterator",
     ],
 )
 
@@ -41,6 +48,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
@@ -48,8 +56,5 @@ go_test(
         "//pkg/workload/tpcc",
         "@com_github_spf13_pflag//:pflag",
         "@com_github_stretchr_testify//require",
-        "@com_google_cloud_go_storage//:storage",
-        "@org_golang_google_api//option",
-        "@org_golang_x_oauth2//google",
     ],
 )

--- a/pkg/ccl/workloadccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/cliccl/BUILD.bazel
@@ -16,7 +16,5 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_spf13_pflag//:pflag",
-        "@com_google_cloud_go_storage//:storage",
-        "@org_golang_google_api//option",
     ],
 )

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -21,20 +21,14 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"cloud.google.com/go/storage"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
-	"google.golang.org/api/iterator"
-)
-
-const (
-	fixtureGCSURIScheme = `gs`
 )
 
 func init() {
@@ -43,12 +37,21 @@ func init() {
 
 // FixtureConfig describes a storage place for fixtures.
 type FixtureConfig struct {
-	// GCSBucket is a Google Cloud Storage bucket.
-	GCSBucket string
+	// StorageProvider specifies the name of storage provider as supported by cloud
+	// storage.  Default "gs" (other providers include "s3", and "azure").
+	StorageProvider string
 
-	// GCSPrefix is a prefix to prepend to each Google Cloud Storage object
-	// path.
-	GCSPrefix string
+	// Bucket is a Cloud Storage bucket.
+	Bucket string
+
+	// Basename is appended to the bucket to form a path to the fixtures directory.
+	Basename string
+
+	// AuthParams are the authentication related query parameters added to the URI
+	// to be able to access fixture path.  By default, IMPLICIT authentication is used.
+	// Otherwise, it can be overriden to add cloud specific authentication parameters,
+	// such as access keys, billing projects, and others.
+	AuthParams string
 
 	// CSVServerURL is a url to a `./workload csv-server` to use as a source of
 	// CSV data. The url is anything accepted by our backup/restore. Notably, if
@@ -56,29 +59,15 @@ type FixtureConfig struct {
 	// `http://localhost:<port>` will work.
 	CSVServerURL string
 
-	// BillingProject if non-empty, is the Google Cloud project to bill for all
-	// storage requests. This is required to be set if using a "requestor pays"
-	// bucket.
-	BillingProject string
-
 	// If TableStats is true, CREATE STATISTICS is called on all tables before
 	// creating the fixture.
 	TableStats bool
 }
 
-func (s FixtureConfig) objectPathToURI(folder string) string {
-	u := &url.URL{
-		Scheme: fixtureGCSURIScheme,
-		Host:   s.GCSBucket,
-		Path:   folder,
-	}
-	q := url.Values{}
-	if s.BillingProject != `` {
-		q.Add("GOOGLE_BILLING_PROJECT", s.BillingProject)
-	}
-	q.Add("AUTH", "implicit")
-	u.RawQuery = q.Encode()
-	return u.String()
+// ObjectPathToURI returns URI for the optional folder path components.
+func (s FixtureConfig) ObjectPathToURI(folders ...string) string {
+	path := filepath.Join(folders...)
+	return fmt.Sprintf("%s://%s/%s/%s?%s", s.StorageProvider, s.Bucket, s.Basename, path, s.AuthParams)
 }
 
 // Fixture describes pre-computed data for a Generator, allowing quick
@@ -104,12 +93,28 @@ func serializeOptions(gen workload.Generator) string {
 		return ``
 	}
 	// NB: VisitAll visits in a deterministic (alphabetical) order.
+
 	var buf bytes.Buffer
 	flags := f.Flags()
 	flags.VisitAll(func(f *pflag.Flag) {
 		if flags.Meta != nil && flags.Meta[f.Name].RuntimeOnly {
 			return
 		}
+		// Only care about some of the options for naming.
+		// Keeping options, such as regions (which is an array), results in some issues
+		// with URL encoded paths (i.e. we think the name should be regions=%5B%5D, but providers
+		// interpret it as regions=[].).  Regardless, keeping *all* options is just too much.
+		// So, keep only some of the options, and ignore others.
+		// TODO: Would be nice to support name override.
+		switch f.Name {
+		case "version", "warehouses", "fks", "families", "seed":
+			if len(f.Value.String()) == 0 {
+				return
+			}
+		default:
+			return
+		}
+
 		if buf.Len() > 0 {
 			buf.WriteString(`,`)
 		}
@@ -118,65 +123,46 @@ func serializeOptions(gen workload.Generator) string {
 	return buf.String()
 }
 
-func generatorToGCSFolder(config FixtureConfig, gen workload.Generator) string {
+func generatorToStorageFolder(gen workload.Generator) string {
 	meta := gen.Meta()
-	return filepath.Join(
-		config.GCSPrefix,
-		meta.Name,
-		fmt.Sprintf(`version=%s,%s`, meta.Version, serializeOptions(gen)),
-	)
+	return filepath.Join(meta.Name,
+		fmt.Sprintf(`version=%s,%s`, meta.Version, serializeOptions(gen)))
 }
 
-// FixtureURL returns the URL for pre-computed Generator data stored on GCS.
+// FixtureURL returns the URL for pre-computed Generator data stored in the cloud.
 func FixtureURL(config FixtureConfig, gen workload.Generator) string {
-	return config.objectPathToURI(generatorToGCSFolder(config, gen))
+	return config.ObjectPathToURI(generatorToStorageFolder(gen))
 }
 
-// GetFixture returns a handle for pre-computed Generator data stored on GCS. It
+// GetFixture returns a handle for pre-computed Generator data stored in the cloud. It
 // is expected that the generator will have had Configure called on it.
 func GetFixture(
-	ctx context.Context, gcs *storage.Client, config FixtureConfig, gen workload.Generator,
+	ctx context.Context, es cloud.ExternalStorage, config FixtureConfig, gen workload.Generator,
 ) (Fixture, error) {
 	var fixture Fixture
-	var err error
-	var notFound bool
-	for r := retry.StartWithCtx(ctx, retry.Options{MaxRetries: 10}); r.Next(); {
-		err = func() error {
-			b := gcs.Bucket(config.GCSBucket)
-			if config.BillingProject != `` {
-				b = b.UserProject(config.BillingProject)
-			}
-
-			fixtureFolder := generatorToGCSFolder(config, gen)
-			_, err := b.Objects(ctx, &storage.Query{Prefix: fixtureFolder, Delimiter: `/`}).Next()
-			if errors.Is(err, iterator.Done) {
-				notFound = true
-				return errors.Errorf(`fixture not found: %s`, fixtureFolder)
-			} else if err != nil {
-				return err
-			}
-
-			fixture = Fixture{Config: config, Generator: gen}
-			for _, table := range gen.Tables() {
-				tableFolder := filepath.Join(fixtureFolder, table.Name)
-				_, err := b.Objects(ctx, &storage.Query{Prefix: tableFolder, Delimiter: `/`}).Next()
-				if errors.Is(err, iterator.Done) {
-					return errors.Errorf(`fixture table not found: %s`, tableFolder)
-				} else if err != nil {
-					return err
-				}
-				fixture.Tables = append(fixture.Tables, FixtureTable{
-					TableName: table.Name,
-					BackupURI: config.objectPathToURI(tableFolder),
-				})
-			}
+	fixtureFolder := generatorToStorageFolder(gen)
+	fixture = Fixture{Config: config, Generator: gen}
+	for _, table := range gen.Tables() {
+		tableFolder := filepath.Join(fixtureFolder, table.Name)
+		var files []string
+		if err := listDir(ctx, es, func(s string) error {
+			files = append(files, s)
 			return nil
-		}()
-		if err == nil || notFound {
-			break
+		}, tableFolder); err != nil {
+			return Fixture{}, err
 		}
+
+		if len(files) == 0 {
+			return Fixture{}, errors.Newf(
+				"expected non zero files for table %q in fixture folder %q", table.Name, tableFolder)
+		}
+
+		fixture.Tables = append(fixture.Tables, FixtureTable{
+			TableName: table.Name,
+			BackupURI: config.ObjectPathToURI(tableFolder),
+		})
 	}
-	return fixture, err
+	return fixture, nil
 }
 
 func csvServerPaths(
@@ -250,7 +236,7 @@ const numNodesQuery = `SELECT count(node_id) FROM "".crdb_internal.gossip_livene
 func MakeFixture(
 	ctx context.Context,
 	sqlDB *gosql.DB,
-	gcs *storage.Client,
+	es cloud.ExternalStorage,
 	config FixtureConfig,
 	gen workload.Generator,
 	filesPerNode int,
@@ -263,10 +249,10 @@ func MakeFixture(
 		}
 	}
 
-	fixtureFolder := generatorToGCSFolder(config, gen)
-	if _, err := GetFixture(ctx, gcs, config, gen); err == nil {
+	fixtureFolder := generatorToStorageFolder(gen)
+	if _, err := GetFixture(ctx, es, config, gen); err == nil {
 		return Fixture{}, errors.Errorf(
-			`fixture %s already exists`, config.objectPathToURI(fixtureFolder))
+			`fixture %s already exists`, config.ObjectPathToURI(fixtureFolder))
 	}
 
 	dbName := gen.Meta().Name
@@ -275,6 +261,7 @@ func MakeFixture(
 	}
 	l := ImportDataLoader{
 		FilesPerNode: filesPerNode,
+		dbName:       dbName,
 	}
 	// NB: Intentionally don't use workloadsql.Setup because it runs the PostLoad
 	// hooks (adding foreign keys, etc), but historically the BACKUPs created by
@@ -313,7 +300,7 @@ func MakeFixture(
 		t := t
 		g.Go(func() error {
 			q := fmt.Sprintf(`BACKUP "%s"."%s" TO $1`, dbName, t.Name)
-			output := config.objectPathToURI(filepath.Join(fixtureFolder, t.Name))
+			output := config.ObjectPathToURI(filepath.Join(fixtureFolder, t.Name))
 			log.Infof(ctx, "Backing %s up to %q...", t.Name, output)
 			_, err := sqlDB.Exec(q, output)
 			return err
@@ -323,7 +310,7 @@ func MakeFixture(
 		return Fixture{}, err
 	}
 
-	return GetFixture(ctx, gcs, config, gen)
+	return GetFixture(ctx, es, config, gen)
 }
 
 // ImportDataLoader is an InitialDataLoader implementation that loads data with
@@ -332,6 +319,7 @@ type ImportDataLoader struct {
 	FilesPerNode int
 	InjectStats  bool
 	CSVServer    string
+	dbName       string
 }
 
 // InitialDataLoad implements the InitialDataLoader interface.
@@ -344,9 +332,8 @@ func (l ImportDataLoader) InitialDataLoad(
 
 	log.Infof(ctx, "starting import of %d tables", len(gen.Tables()))
 	start := timeutil.Now()
-	const useConnectionDB = ``
 	bytes, err := ImportFixture(
-		ctx, db, gen, useConnectionDB, l.FilesPerNode, l.InjectStats, l.CSVServer)
+		ctx, db, gen, l.dbName, l.FilesPerNode, l.InjectStats, l.CSVServer)
 	if err != nil {
 		return 0, errors.Wrap(err, `importing fixture`)
 	}
@@ -666,32 +653,33 @@ func RestoreFixture(
 	return atomic.LoadInt64(&bytesAtomic), nil
 }
 
+func listDir(
+	ctx context.Context, es cloud.ExternalStorage, lsFn cloud.ListingFn, dir string,
+) error {
+	// There are no directories in cloud storage; so, we simulate.
+	// Directory must end in "/".  And we use "/" as delimiter.  That is, we will list
+	// anything under "dir/", but stop before the next "/".
+	if dir[len(dir)-1] != '/' {
+		dir = dir + "/"
+	}
+	if log.V(1) {
+		log.Infof(ctx, "Listing %s", dir)
+	}
+	return es.List(ctx, dir, "/", lsFn)
+}
+
 // ListFixtures returns the object paths to all fixtures stored in a FixtureConfig.
 func ListFixtures(
-	ctx context.Context, gcs *storage.Client, config FixtureConfig,
+	ctx context.Context, es cloud.ExternalStorage, config FixtureConfig,
 ) ([]string, error) {
-	b := gcs.Bucket(config.GCSBucket)
-	if config.BillingProject != `` {
-		b = b.UserProject(config.BillingProject)
-	}
-
 	var fixtures []string
-	gensPrefix := config.GCSPrefix + `/`
-	for genIter := b.Objects(ctx, &storage.Query{Prefix: gensPrefix, Delimiter: `/`}); ; {
-		gen, err := genIter.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		} else if err != nil {
+	for _, gen := range workload.Registered() {
+		if err := listDir(ctx, es, func(s string) error {
+			// Anything that looks like a directory is a fixture.
+			fixtures = append(fixtures, filepath.Join(gen.Name, s))
+			return nil
+		}, gen.Name); err != nil {
 			return nil, err
-		}
-		for genConfigIter := b.Objects(ctx, &storage.Query{Prefix: gen.Prefix, Delimiter: `/`}); ; {
-			genConfig, err := genConfigIter.Next()
-			if errors.Is(err, iterator.Done) {
-				break
-			} else if err != nil {
-				return nil, err
-			}
-			fixtures = append(fixtures, genConfig.Prefix)
 		}
 	}
 	return fixtures, nil

--- a/pkg/ccl/workloadccl/storage.go
+++ b/pkg/ccl/workloadccl/storage.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package workloadccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	// Import all the cloud provider storage we care about.
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/amazon"
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/azure"
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/gcp"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	clustersettings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/errors"
+)
+
+const storageError = `failed to create google cloud client ` +
+	`(You may need to setup the GCS application default credentials: ` +
+	`'gcloud auth application-default login --project=cockroach-shared')`
+
+// GetStorage returns a cloud storage implementation
+// The caller is responsible for closing it.
+func GetStorage(ctx context.Context, cfg FixtureConfig) (cloud.ExternalStorage, error) {
+	switch cfg.StorageProvider {
+	case "gs", "s3", "azure":
+	default:
+		return nil, errors.AssertionFailedf("unsupported external storage provider; valid providers are gs, s3, and azure")
+	}
+
+	s, err := cloud.ExternalStorageFromURI(ctx, cfg.ObjectPathToURI(),
+		base.ExternalIODirConfig{}, clustersettings.MakeClusterSettings(),
+		nil, security.SQLUsername{}, nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, storageError)
+	}
+	return s, nil
+}


### PR DESCRIPTION
Loading previously created fixtures speeds up data loading stage.
However, previuously, `workload fixture (make|load)` only supported GS
storage.  This change enhances workload to support s3:// and azure:// storage.

To keep backward compatibility, the default remaining GS.  However, it is now
possible to configure workload to read/write other storage providers:

```
workload fixtures  make  tpcc --warehouses=10000 --provider-override=s3 --auth-params-override="AUTH=implicit&AWS_REGION=us-east-1"
```

The `--provider-override` flag overrides the storage provider, which by default,
remaians "gs://".  Other valid providers include `s3` and `azure`.

The `--auth-params-override` flag overrides default authentication parameters.
These are cloud provider specific.  For example, AWS requires that the region
is specified.  See cloud storage documentation for more details on the supported
storage provider configurations.

Release Notes: None