### PR TITLE
streamingccl/streampb: ensure there's at least one go source file

### DIFF
--- a/pkg/ccl/streamingccl/streampb/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streampb/BUILD.bazel
@@ -32,6 +32,7 @@ go_proto_library(
 
 go_library(
     name = "streampb",
+    srcs = ["empty.go"],
     embed = [":streampb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streampb",
     visibility = ["//visibility:public"],

--- a/pkg/ccl/streamingccl/streampb/empty.go
+++ b/pkg/ccl/streamingccl/streampb/empty.go
@@ -1,0 +1,11 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streampb
+
+// This file is intentionally left empty.


### PR DESCRIPTION
Fixes #74887

When the directory is empty (prior to deriving .pb.go from .proto),
the go compiler has no package name for that directory.

This prevents the execution of `go mod tidy` and `make
vendor_rebuild`, and even prevents the generation of the `.pb.go`
file, resulting in a catch-22.

Release note: None