### PR TITLE
release-21.1: release-21.2: backupccl,jobs: handle panics from invalid cron parsing

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -154,8 +154,15 @@ func computeScheduleRecurrence(
 			`error parsing schedule expression: %q; it must be a valid cron expression`,
 			cron)
 	}
-	nextRun := expr.Next(now)
-	frequency := expr.Next(nextRun).Sub(nextRun)
+	nextRun, err := jobs.CronParseNext(expr, now, cron)
+	if err != nil {
+		return nil, err
+	}
+	nextToNextRun, err := jobs.CronParseNext(expr, nextRun, cron)
+	if err != nil {
+		return nil, err
+	}
+	frequency := nextToNextRun.Sub(nextRun)
 	return &scheduleRecurrence{cron, frequency}, nil
 }
 

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -389,6 +389,12 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			query:  `CREATE SCHEDULE FOR BACKUP INTO 'foo' WITH encryption_passphrase=$1 RECURRING '@hourly'`,
 			errMsg: "failed to evaluate backup encryption_passphrase",
 		},
+		{
+			name:   "malformed-cron-expression",
+			query:  "CREATE SCHEDULE backup_schedule FOR BACKUP INTO 'userfile:///a' RECURRING '* 12-8 * * *';",
+			user:   freeUser,
+			errMsg: "pq: failed to parse cron expression: \"\\* 12-8 \\* \\* \\*\"",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -826,9 +832,10 @@ INSERT INTO t values (1), (10), (100);
 		// to the next scheduled recurrence.
 		for _, id := range []int64{fullID, incID} {
 			s := loadSchedule(t, id)
-			require.EqualValues(t,
-				cronexpr.MustParse(s.ScheduleExpr()).Next(th.env.Now()).Round(time.Microsecond),
-				s.NextRun())
+			expr := cronexpr.MustParse(s.ScheduleExpr())
+			nextRun, err := jobs.CronParseNext(expr, th.env.Now(), s.ScheduleExpr())
+			require.NoError(t, err)
+			require.EqualValues(t, nextRun.Round(time.Microsecond), s.NextRun())
 		}
 
 		// We expect that, eventually, both backups would succeed.

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "scheduled_job_executor.go",
         "testing_knobs.go",
         "update.go",
+        "utils.go",
         "validate.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/jobs",

--- a/pkg/jobs/executor_impl_test.go
+++ b/pkg/jobs/executor_impl_test.go
@@ -34,8 +34,13 @@ func TestInlineExecutorFailedJobsHandling(t *testing.T) {
 		expectedNextRun time.Time
 	}{
 		{
-			onError:         jobspb.ScheduleDetails_RETRY_SCHED,
-			expectedNextRun: cronexpr.MustParse("@daily").Next(h.env.Now()).Round(time.Microsecond),
+			onError: jobspb.ScheduleDetails_RETRY_SCHED,
+			expectedNextRun: func() time.Time {
+				expr := cronexpr.MustParse("@daily")
+				nextRun, err := CronParseNext(expr, h.env.Now(), "@daily")
+				require.NoError(t, err)
+				return nextRun.Round(time.Microsecond)
+			}(),
 		},
 		{
 			onError:         jobspb.ScheduleDetails_RETRY_SOON,

--- a/pkg/jobs/scheduled_job.go
+++ b/pkg/jobs/scheduled_job.go
@@ -183,8 +183,14 @@ func (j *ScheduledJob) Frequency() (time.Duration, error) {
 			"parsing schedule expression: %q; it must be a valid cron expression",
 			j.rec.ScheduleExpr)
 	}
-	next := expr.Next(j.env.Now())
-	nextNext := expr.Next(next)
+	next, err := CronParseNext(expr, j.env.Now(), j.rec.ScheduleExpr)
+	if err != nil {
+		return 0, err
+	}
+	nextNext, err := CronParseNext(expr, next, j.rec.ScheduleExpr)
+	if err != nil {
+		return 0, err
+	}
 	return nextNext.Sub(next), nil
 }
 
@@ -198,7 +204,11 @@ func (j *ScheduledJob) ScheduleNextRun() error {
 	if err != nil {
 		return errors.Wrapf(err, "parsing schedule expression: %q", j.rec.ScheduleExpr)
 	}
-	j.SetNextRun(expr.Next(j.env.Now()))
+	nextRun, err := CronParseNext(expr, j.env.Now(), j.rec.ScheduleExpr)
+	if err != nil {
+		return err
+	}
+	j.SetNextRun(nextRun)
 	return nil
 }
 

--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package jobs
+
+import (
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gorhill/cronexpr"
+)
+
+// CronParseNext is a helper that parses the next time for the given expression
+// but captures any panic that may occur in the underlying library.
+func CronParseNext(
+	e *cronexpr.Expression, fromTime time.Time, cron string,
+) (t time.Time, err error) {
+	defer func() {
+		if recover() != nil {
+			t = time.Time{}
+			err = errors.Newf("failed to parse cron expression: %q", cron)
+		}
+	}()
+
+	return e.Next(fromTime), nil
+}


### PR DESCRIPTION
Backport 1/1 commits from #74880.

/cc @cockroachdb/release

---

This change changes all calls to `func (expr *Expression) Next`
in the `gorhill/cronexpr` package to use a utility method instead,
that handles panics that might be thrown by the underlying library.

Fixes: #74873

Release justification (bug fix): certain invalid cron expr could
result in a panic from the undelying cronexpr parsing libarary
causing the node to crash
