### PR TITLE
label-merged-pr: use common base commit for finding commits

### DIFF
--- a/pkg/cmd/label-merged-pr/main.go
+++ b/pkg/cmd/label-merged-pr/main.go
@@ -74,7 +74,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot read token from %s: %+v\n", tokenPath, err)
 	}
-	refList, err := getRefs(fromRef, toRef)
+	commonBaseRef, err := getCommonBaseRef(fromRef, toRef)
+	if err != nil {
+		log.Fatalf("Cannot get common base ref: %+v\n", err)
+	}
+
+	refList, err := getRefs(commonBaseRef, toRef)
 	if err != nil {
 		log.Fatalf("Cannot get refs: %+v\n", err)
 	}
@@ -105,6 +110,15 @@ func readToken(path string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(token)), nil
+}
+
+func getCommonBaseRef(fromRef, toRef string) (string, error) {
+	cmd := exec.Command("git", "merge-base", fromRef, toRef)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func filterPullRequests(text string) []string {


### PR DESCRIPTION
Previously, the `from` and `to` refs were used directly in the
`git log` command to find the list of refs to evaluate. This command
also uses the `--ancestry-path` parameter which returns a set of commits
only when then `from` ref is an ancestor of the `to` ref.

It is common that the `from` ref supplied to the program is not an
ancestor of the `to` ref with the expectation that the common base ref
of the two refs is used as the `from` ref when determining the the set
of commits to evaluate.

Now, the common base commit of `from` and `to` is determined and then
used as the `from` argument when finding the refs to evaluate.

Release note: None