### PR TITLE
colexechash: cleanup and speed up the hash table a bit (mostly around null handling)

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1166,20 +1166,31 @@ func benchmarkAggregateFunction(
 // benchmark is measuring the performance of the aggregators themselves
 // depending on the parameters of the input.
 func BenchmarkAggregator(b *testing.B) {
-	aggFn := execinfrapb.Min
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
 	groupSizes := []int{1, 2, 32, 128, coldata.BatchSize()}
 	if testing.Short() {
 		numRows = []int{32, 32 * coldata.BatchSize()}
 		groupSizes = []int{1, coldata.BatchSize()}
 	}
-	for _, agg := range aggTypes {
-		for _, numInputRows := range numRows {
-			for _, groupSize := range groupSizes {
-				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
-					groupSize, 0 /* distinctProb */, numInputRows,
-					0 /* chunkSize */, 0 /* limit */)
+	for _, aggFn := range []execinfrapb.AggregatorSpec_Func{
+		// We choose any_not_null aggregate function because it is the simplest
+		// possible and, thus, its Compute function call will have the least
+		// impact when benchmarking the aggregator logic.
+		execinfrapb.AnyNotNull,
+		// min aggregate function has been used before transitioning to
+		// any_not_null in 22.1 cycle. It is kept so that we could use it for
+		// comparison of 22.1 against 21.2.
+		// TODO(yuzefovich): use only any_not_null in 22.2 (#75106).
+		execinfrapb.Min,
+	} {
+		for _, agg := range aggTypes {
+			for _, numInputRows := range numRows {
+				for _, groupSize := range groupSizes {
+					benchmarkAggregateFunction(
+						b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
+						groupSize, 0 /* distinctProb */, numInputRows,
+						0 /* chunkSize */, 0 /* limit */)
+				}
 			}
 		}
 	}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -57,29 +57,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -117,28 +104,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -178,28 +152,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -236,27 +197,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -299,11 +247,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -311,15 +255,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -357,26 +294,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -416,26 +342,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -472,25 +387,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -548,29 +452,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -600,28 +491,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -653,28 +531,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -703,27 +568,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -758,11 +610,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -770,15 +618,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -808,26 +649,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -859,26 +689,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -907,25 +726,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -975,29 +783,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1027,28 +822,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1080,28 +862,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1130,27 +899,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1185,11 +941,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1197,15 +949,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1235,26 +980,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1286,26 +1020,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1334,25 +1057,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1400,29 +1112,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1463,28 +1162,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1527,28 +1213,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1588,27 +1261,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1654,11 +1314,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1666,15 +1322,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1715,26 +1364,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1777,26 +1415,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1836,25 +1463,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1910,29 +1526,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1973,28 +1576,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2037,28 +1627,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2098,27 +1675,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2164,11 +1728,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -2176,15 +1736,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2225,26 +1778,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2287,26 +1829,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2346,25 +1877,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2422,29 +1942,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2485,28 +1992,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2549,28 +2043,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2610,27 +2091,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2676,11 +2144,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -2688,15 +2152,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2737,26 +2194,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2799,26 +2245,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2858,25 +2293,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2937,29 +2361,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3008,28 +2419,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3080,28 +2478,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3149,27 +2534,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3223,11 +2595,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -3235,15 +2603,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3292,26 +2653,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3362,26 +2712,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3429,25 +2768,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3516,29 +2844,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3575,28 +2890,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3635,28 +2937,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3692,27 +2981,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3754,11 +3030,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -3766,15 +3038,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3811,26 +3076,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3869,26 +3123,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3924,25 +3167,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3999,29 +3231,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4051,28 +3270,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4104,28 +3310,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4154,27 +3347,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4209,11 +3389,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -4221,15 +3397,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4259,26 +3428,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4310,26 +3468,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4358,25 +3505,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4426,29 +3562,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4484,28 +3607,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4543,28 +3653,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4599,27 +3696,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4660,11 +3744,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -4672,15 +3752,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4716,26 +3789,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4773,26 +3835,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4827,25 +3878,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4901,29 +3941,16 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4955,28 +3982,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5010,28 +4024,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5062,27 +4063,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
-									// The vector is probed against itself, so buildVec has the same
-									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5119,11 +4107,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5131,15 +4115,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5171,26 +4148,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5224,26 +4190,15 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5274,25 +4229,14 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5350,12 +4294,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5363,15 +4303,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5412,27 +4345,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5475,27 +4397,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5535,26 +4446,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5613,12 +4513,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5626,15 +4522,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5667,27 +4556,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5722,27 +4600,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5774,26 +4641,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5850,12 +4706,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5863,15 +4715,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5904,27 +4749,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5959,27 +4793,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6011,26 +4834,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6079,12 +4891,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6092,15 +4900,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6144,27 +4945,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6210,27 +5000,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6273,26 +5052,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6355,12 +5123,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6368,15 +5132,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6420,27 +5177,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6486,27 +5232,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6549,26 +5284,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6633,12 +5357,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6646,15 +5366,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6698,27 +5411,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6764,27 +5466,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6827,26 +5518,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6917,12 +5597,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6930,15 +5606,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6990,27 +5659,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7064,27 +5722,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7135,26 +5782,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7227,12 +5863,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7240,15 +5872,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7288,27 +5913,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7350,27 +5964,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7409,26 +6012,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7486,12 +6078,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7499,15 +6087,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7540,27 +6121,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7595,27 +6165,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7647,26 +6206,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7717,12 +6265,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7730,15 +6274,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7777,27 +6314,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7838,27 +6364,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7896,26 +6411,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7972,12 +6476,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7985,15 +6485,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8028,27 +6521,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8085,27 +6567,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 							)
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8139,26 +6610,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIsNull, buildIsNull bool
 							)
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-									// the build table key (calculated using keys[keyID - 1] = key) is
-									// compared to the corresponding probe table to determine if a match is
-									// found.
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
-											// Both values are NULLs, and since we're allowing null equality, we
-											// proceed to the next value to check.
 											continue
 										} else if probeIsNull {
-											// Only probing value is NULL, so it is different from the build value
-											// (which is non-NULL). We mark it as "different" and proceed to the
-											// next value to check. This behavior is special in case of allowing
-											// null equality because we don't want to reset the GroupID of the
-											// current probing tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8211,15 +6671,12 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 			continue
 		}
 		if !ht.ProbeScratch.differs[toCheck] {
-			// If the current key matches with the probe key, we want to update HeadID
-			// with the current key if it has not been set yet.
 			keyID := ht.ProbeScratch.GroupID[toCheck]
 			if ht.ProbeScratch.HeadID[toCheck] == 0 {
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 			}
 		}
 		if ht.ProbeScratch.differs[toCheck] {
-			// Continue probing in this next chain for the probe key.
 			ht.ProbeScratch.differs[toCheck] = false
 			//gcassert:bce
 			toCheckSlice[nDiffers] = toCheck
@@ -8258,7 +6715,6 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 				if hasVisited := visited[HeadID-1]; !hasVisited {
 					sel[distinctCount] = sel[HeadID-1]
 					visited[HeadID-1] = true
-					// Compacting and deduplicating hash buffer.
 					//gcassert:bce
 					hashBuffer[distinctCount] = hashBuffer[i]
 					distinctCount++
@@ -8286,7 +6742,6 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 				if hasVisited := visited[HeadID-1]; !hasVisited {
 					sel[distinctCount] = int(HeadID - 1)
 					visited[HeadID-1] = true
-					// Compacting and deduplicating hash buffer.
 					//gcassert:bce
 					hashBuffer[distinctCount] = hashBuffer[i]
 					distinctCount++

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -50,380 +50,288 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-											unique = cmpResult != 0
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-											unique = cmpResult != 0
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -445,316 +353,224 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -776,316 +592,224 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1105,404 +829,312 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1519,404 +1151,312 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -1935,404 +1475,312 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2354,468 +1802,376 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -2837,372 +2193,280 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											unique = cmpResult != 0
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
+										unique = cmpResult != 0
 									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
 
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-									}
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											unique = cmpResult != 0
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
+										unique = cmpResult != 0
 									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
 
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-									}
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3224,316 +2488,224 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3555,364 +2727,272 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-											unique = cmpResult != 0
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-											unique = cmpResult != 0
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -3934,332 +3014,240 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = probeSel[keyID-1]
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
 									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
 
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-									}
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
-
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
 									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
 
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-									}
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								}
 							}
 						}
@@ -4287,103 +3275,89 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Bool()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-											unique = cmpResult != 0
+									{
+										var cmpResult int
+
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4391,99 +3365,67 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											if !probeVal && buildVal {
-												cmpResult = -1
-											} else if probeVal && !buildVal {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-
-											unique = cmpResult != 0
+										if !probeVal && buildVal {
+											cmpResult = -1
+										} else if probeVal && !buildVal {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4506,87 +3448,73 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Bytes()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4594,83 +3522,51 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = bytes.Compare(probeVal, buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = bytes.Compare(probeVal, buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4699,87 +3595,73 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Decimal()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4787,83 +3669,51 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4884,109 +3734,95 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Int16()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -4994,105 +3830,73 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5116,109 +3920,95 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Int32()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5226,105 +4016,73 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5350,109 +4108,95 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Int64()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5460,105 +4204,73 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := int64(probeVal), int64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
+											a, b := int64(probeVal), int64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5590,125 +4302,111 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Float64()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5716,121 +4414,89 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
 
 										{
-											var cmpResult int
-
-											{
-												a, b := float64(probeVal), float64(buildVal)
-												if a < b {
-													cmpResult = -1
-												} else if a > b {
-													cmpResult = 1
-												} else if a == b {
+											a, b := float64(probeVal), float64(buildVal)
+											if a < b {
+												cmpResult = -1
+											} else if a > b {
+												cmpResult = 1
+											} else if a == b {
+												cmpResult = 0
+											} else if math.IsNaN(a) {
+												if math.IsNaN(b) {
 													cmpResult = 0
-												} else if math.IsNaN(a) {
-													if math.IsNaN(b) {
-														cmpResult = 0
-													} else {
-														cmpResult = -1
-													}
 												} else {
-													cmpResult = 1
+													cmpResult = -1
 												}
+											} else {
+												cmpResult = 1
 											}
-
-											unique = cmpResult != 0
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5856,101 +4522,87 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Timestamp()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
-											unique = cmpResult != 0
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -5958,97 +4610,65 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
+										}
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										if probeVal.Before(buildVal) {
+											cmpResult = -1
+										} else if buildVal.Before(probeVal) {
+											cmpResult = 1
+										} else {
+											cmpResult = 0
 										}
+										unique = cmpResult != 0
 									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
 
-										{
-											var cmpResult int
-
-											if probeVal.Before(buildVal) {
-												cmpResult = -1
-											} else if buildVal.Before(probeVal) {
-												cmpResult = 1
-											} else {
-												cmpResult = 0
-											}
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-									}
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -6071,87 +4691,73 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Interval()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -6159,83 +4765,51 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
-											cmpResult = probeVal.Compare(buildVal)
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+									{
+										var cmpResult int
+										cmpResult = probeVal.Compare(buildVal)
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -6258,99 +4832,85 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.JSON()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
 											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-											unique = cmpResult != 0
+									{
+										var cmpResult int
+
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
+										}
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -6358,95 +4918,63 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
 
-										{
-											var cmpResult int
+									{
+										var cmpResult int
 
-											var err error
-											cmpResult, err = probeVal.Compare(buildVal)
-											if err != nil {
-												colexecerror.ExpectedError(err)
-											}
-
-											unique = cmpResult != 0
+										var err error
+										cmpResult, err = probeVal.Compare(buildVal)
+										if err != nil {
+											colexecerror.ExpectedError(err)
 										}
 
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										unique = cmpResult != 0
 									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -6469,91 +4997,77 @@ func (ht *HashTable) checkColForDistinctTuples(
 					buildKeys := buildVec.Datum()
 					if probeVec.MaybeHasNulls() {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											if !buildIsNull {
+												ht.ProbeScratch.differs[toCheck] = true
+											}
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									if buildIsNull {
+										ht.ProbeScratch.differs[toCheck] = true
+										continue
+									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
+									probeIsNull := probeVecNulls.NullAt(probeIdx)
 									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
+										if ht.allowNullEquality {
+											ht.ProbeScratch.differs[toCheck] = true
+										} else {
+											ht.ProbeScratch.distinct[toCheck] = true
 										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
@@ -6561,87 +5075,55 @@ func (ht *HashTable) checkColForDistinctTuples(
 						}
 					} else {
 						if buildVec.MaybeHasNulls() {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVecNulls.NullAt(buildIdx)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
-									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
+									buildIsNull := buildVecNulls.NullAt(buildIdx)
+									if buildIsNull {
 										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
-
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										continue
 									}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
+									}
+
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
-							var (
-								probeIdx, buildIdx       int
-								probeIsNull, buildIsNull bool
-							)
+							var probeIdx, buildIdx int
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								keyID := ht.ProbeScratch.GroupID[toCheck]
 								if keyID != 0 {
-
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									if ht.allowNullEquality {
-										if probeIsNull && buildIsNull {
-											continue
-										} else if probeIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-											continue
-										}
+									probeVal := probeKeys.Get(probeIdx)
+									buildVal := buildKeys.Get(buildIdx)
+									var unique bool
+
+									{
+										var cmpResult int
+
+										cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+										unique = cmpResult != 0
 									}
-									if probeIsNull {
-										ht.ProbeScratch.distinct[toCheck] = true
-									} else if buildIsNull {
-										ht.ProbeScratch.differs[toCheck] = true
-									} else {
-										probeVal := probeKeys.Get(probeIdx)
-										buildVal := buildKeys.Get(buildIdx)
-										var unique bool
 
-										{
-											var cmpResult int
-
-											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-											unique = cmpResult != 0
-										}
-
-										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-									}
+									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 								} else {
 									ht.ProbeScratch.distinct[toCheck] = true
 								}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -8164,27 +8164,3 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 		b.SetLength(distinctCount)
 	}
 }
-
-// DistinctCheck determines if the current key in the GroupID bucket matches the
-// equality column key. If there is a match, then the key is removed from
-// ToCheck. If the bucket has reached the end, the key is rejected. The ToCheck
-// list is reconstructed to only hold the indices of the eqCol keys that have
-// not been found. The new length of ToCheck is returned by this function.
-func (ht *HashTable) DistinctCheck(nToCheck uint64, probeSel []int) uint64 {
-	ht.checkCols(ht.Keys, nToCheck, probeSel)
-	// Select the indices that differ and put them into ToCheck.
-	nDiffers := uint64(0)
-	toCheckSlice := ht.ProbeScratch.ToCheck
-	_ = toCheckSlice[nToCheck-1]
-	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
-		//gcassert:bce
-		toCheck := toCheckSlice[toCheckPos]
-		if ht.ProbeScratch.differs[toCheck] {
-			ht.ProbeScratch.differs[toCheck] = false
-			//gcassert:bce
-			toCheckSlice[nDiffers] = toCheck
-			nDiffers++
-		}
-	}
-	return nDiffers
-}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -6675,8 +6675,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 			if ht.ProbeScratch.HeadID[toCheck] == 0 {
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 			}
-		}
-		if ht.ProbeScratch.differs[toCheck] {
+		} else {
 			ht.ProbeScratch.differs[toCheck] = false
 			//gcassert:bce
 			toCheckSlice[nDiffers] = toCheck

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -54,6 +54,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -62,11 +64,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -113,6 +115,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -121,7 +124,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -173,6 +176,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -184,7 +188,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -292,6 +296,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -300,9 +306,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -349,6 +355,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -357,7 +364,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -407,6 +414,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -416,7 +424,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -537,6 +545,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -545,11 +555,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -588,6 +598,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -596,7 +607,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -640,6 +651,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -651,7 +663,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -743,6 +755,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -751,9 +765,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -792,6 +806,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -800,7 +815,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -842,6 +857,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -851,7 +867,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -956,6 +972,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -964,11 +982,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1007,6 +1025,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1015,7 +1034,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -1059,6 +1078,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1070,7 +1090,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1162,6 +1182,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1170,9 +1192,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1211,6 +1233,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1219,7 +1242,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -1261,6 +1284,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1270,7 +1294,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1373,6 +1397,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1381,11 +1407,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1435,6 +1461,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1443,7 +1470,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -1498,6 +1525,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1509,7 +1537,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1623,6 +1651,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1631,9 +1661,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1683,6 +1713,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1691,7 +1722,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -1744,6 +1775,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1753,7 +1785,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1875,6 +1907,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1883,11 +1917,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -1937,6 +1971,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1945,7 +1980,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -2000,6 +2035,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2011,7 +2047,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2125,6 +2161,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2133,9 +2171,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2185,6 +2223,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2193,7 +2232,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -2246,6 +2285,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2255,7 +2295,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2379,6 +2419,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2387,11 +2429,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2441,6 +2483,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2449,7 +2492,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -2504,6 +2547,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2515,7 +2559,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2629,6 +2673,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2637,9 +2683,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2689,6 +2735,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2697,7 +2744,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -2750,6 +2797,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2759,7 +2807,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2886,6 +2934,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2894,11 +2944,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -2956,6 +3006,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2964,7 +3015,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -3027,6 +3078,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3038,7 +3090,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3168,6 +3220,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3176,9 +3230,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3236,6 +3290,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3244,7 +3299,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -3305,6 +3360,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3314,7 +3370,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3457,6 +3513,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3465,11 +3523,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3515,6 +3573,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3523,7 +3582,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -3574,6 +3633,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3585,7 +3645,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3691,6 +3751,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3699,9 +3761,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3747,6 +3809,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3755,7 +3818,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -3804,6 +3867,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3813,7 +3877,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3932,6 +3996,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3940,11 +4006,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -3983,6 +4049,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3991,7 +4058,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -4035,6 +4102,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4046,7 +4114,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4138,6 +4206,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4146,9 +4216,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4187,6 +4257,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4195,7 +4266,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -4237,6 +4308,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4246,7 +4318,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4351,6 +4423,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4359,11 +4433,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4408,6 +4482,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4416,7 +4491,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -4466,6 +4541,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4477,7 +4553,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4581,6 +4657,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4589,9 +4667,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4636,6 +4714,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4644,7 +4723,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -4692,6 +4771,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4701,7 +4781,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4818,6 +4898,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4826,11 +4908,11 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -4871,6 +4953,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4879,7 +4962,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
@@ -4925,6 +5008,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4936,7 +5020,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// The vector is probed against itself, so buildVec has the same
 									// selection vector as probeVec.
 									buildIdx = probeSel[keyID-1]
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5032,6 +5116,8 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5040,9 +5126,9 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5083,6 +5169,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5091,7 +5178,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									// found.
 
 									probeIdx = int(toCheck)
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -5135,6 +5222,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5144,7 +5232,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 
 									probeIdx = int(toCheck)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5259,6 +5347,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5268,9 +5358,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5320,6 +5410,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5329,7 +5420,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -5382,6 +5473,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5392,7 +5484,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5518,6 +5610,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5527,9 +5621,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5571,6 +5665,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5580,7 +5675,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -5625,6 +5720,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5635,7 +5731,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5751,6 +5847,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5760,9 +5858,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5804,6 +5902,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5813,7 +5912,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -5858,6 +5957,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5868,7 +5968,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -5976,6 +6076,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5985,9 +6087,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6040,6 +6142,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6049,7 +6152,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -6105,6 +6208,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6115,7 +6219,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6248,6 +6352,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6257,9 +6363,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6312,6 +6418,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6321,7 +6428,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -6377,6 +6484,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6387,7 +6495,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6522,6 +6630,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6531,9 +6641,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6586,6 +6696,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6595,7 +6706,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -6651,6 +6762,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6661,7 +6773,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6802,6 +6914,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6811,9 +6925,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -6874,6 +6988,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6883,7 +6998,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -6947,6 +7062,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6957,7 +7073,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7108,6 +7224,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7117,9 +7235,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7168,6 +7286,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7177,7 +7296,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -7229,6 +7348,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7239,7 +7359,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7363,6 +7483,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7372,9 +7494,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7416,6 +7538,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7425,7 +7548,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -7470,6 +7593,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7480,7 +7604,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7590,6 +7714,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7599,9 +7725,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7649,6 +7775,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7658,7 +7785,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -7709,6 +7836,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7719,7 +7847,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7841,6 +7969,8 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7850,9 +7980,9 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we
@@ -7896,6 +8026,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							probeVecNulls := probeVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7905,7 +8036,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 									// found.
 
 									probeIdx = probeSel[toCheck]
-									probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+									probeIsNull = probeVecNulls.NullAt(probeIdx)
 									buildIdx = int(keyID - 1)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
@@ -7952,6 +8083,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 								probeIdx, buildIdx       int
 								probeIsNull, buildIsNull bool
 							)
+							buildVecNulls := buildVec.Nulls()
 							for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 								// keyID of 0 is reserved to represent the end of the next chain.
 								keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7962,7 +8094,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 									probeIdx = probeSel[toCheck]
 									buildIdx = int(keyID - 1)
-									buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+									buildIsNull = buildVecNulls.NullAt(buildIdx)
 									if ht.allowNullEquality {
 										if probeIsNull && buildIsNull {
 											// Both values are NULLs, and since we're allowing null equality, we

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -56,6 +56,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -65,9 +67,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -115,6 +117,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -124,7 +127,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -175,6 +178,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -185,7 +189,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -294,6 +298,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -303,9 +309,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -353,6 +359,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -362,7 +369,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -413,6 +420,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -423,7 +431,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -547,6 +555,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -556,9 +566,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -598,6 +608,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -607,7 +618,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -650,6 +661,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -660,7 +672,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -753,6 +765,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -762,9 +776,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -804,6 +818,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -813,7 +828,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -856,6 +871,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -866,7 +882,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -974,6 +990,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -983,9 +1001,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1025,6 +1043,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1034,7 +1053,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1077,6 +1096,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1087,7 +1107,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1180,6 +1200,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1189,9 +1211,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1231,6 +1253,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1240,7 +1263,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1283,6 +1306,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1293,7 +1317,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1399,6 +1423,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1408,9 +1434,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1461,6 +1487,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1470,7 +1497,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1524,6 +1551,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1534,7 +1562,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1649,6 +1677,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1658,9 +1688,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1711,6 +1741,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1720,7 +1751,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1774,6 +1805,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1784,7 +1816,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1903,6 +1935,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1912,9 +1946,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1965,6 +1999,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1974,7 +2009,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2028,6 +2063,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2038,7 +2074,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2153,6 +2189,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2162,9 +2200,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2215,6 +2253,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2224,7 +2263,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2278,6 +2317,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2288,7 +2328,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2408,6 +2448,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2417,9 +2459,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2470,6 +2512,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2479,7 +2522,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2533,6 +2576,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2543,7 +2587,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2658,6 +2702,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2667,9 +2713,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2720,6 +2766,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2729,7 +2776,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2783,6 +2830,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2793,7 +2841,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2918,6 +2966,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2927,9 +2977,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2980,6 +3030,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2989,7 +3040,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3043,6 +3094,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3053,7 +3105,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3168,6 +3220,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3177,9 +3231,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3230,6 +3284,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3239,7 +3294,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3293,6 +3348,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3303,7 +3359,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3422,6 +3478,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3431,9 +3489,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3484,6 +3542,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3493,7 +3552,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3547,6 +3606,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3557,7 +3617,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3672,6 +3732,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3681,9 +3743,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3734,6 +3796,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3743,7 +3806,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3797,6 +3860,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3807,7 +3871,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3927,6 +3991,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3936,9 +4002,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3989,6 +4055,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3998,7 +4065,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4052,6 +4119,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4062,7 +4130,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4177,6 +4245,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4186,9 +4256,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4239,6 +4309,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4248,7 +4319,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4302,6 +4373,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4312,7 +4384,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4438,6 +4510,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4447,9 +4521,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4500,6 +4574,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4509,7 +4584,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4563,6 +4638,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4573,7 +4649,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4688,6 +4764,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4697,9 +4775,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4750,6 +4828,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4759,7 +4838,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4813,6 +4892,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4823,7 +4903,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4942,6 +5022,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4951,9 +5033,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5004,6 +5086,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5013,7 +5096,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5067,6 +5150,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5077,7 +5161,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5192,6 +5276,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5201,9 +5287,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5254,6 +5340,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5263,7 +5350,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5317,6 +5404,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5327,7 +5415,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5447,6 +5535,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5456,9 +5546,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5509,6 +5599,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5518,7 +5609,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5572,6 +5663,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5582,7 +5674,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5697,6 +5789,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5706,9 +5800,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5759,6 +5853,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5768,7 +5863,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5822,6 +5917,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5832,7 +5928,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5962,6 +6058,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5971,9 +6069,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6032,6 +6130,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6041,7 +6140,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6103,6 +6202,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6113,7 +6213,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6244,6 +6344,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6253,9 +6355,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6314,6 +6416,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6323,7 +6426,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6385,6 +6488,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6395,7 +6499,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6541,6 +6645,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6550,9 +6656,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6599,6 +6705,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6608,7 +6715,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6658,6 +6765,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6668,7 +6776,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6775,6 +6883,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6784,9 +6894,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6833,6 +6943,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6842,7 +6953,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6892,6 +7003,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6902,7 +7014,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7024,6 +7136,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7033,9 +7147,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7075,6 +7189,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7084,7 +7199,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7127,6 +7242,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7137,7 +7253,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7230,6 +7346,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7239,9 +7357,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7281,6 +7399,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7290,7 +7409,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7333,6 +7452,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7343,7 +7463,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7451,6 +7571,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7460,9 +7582,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7508,6 +7630,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7517,7 +7640,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7566,6 +7689,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7576,7 +7700,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7681,6 +7805,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7690,9 +7816,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7738,6 +7864,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7747,7 +7874,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7796,6 +7923,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7806,7 +7934,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7926,6 +8054,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7935,9 +8065,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7979,6 +8109,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7988,7 +8119,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -8033,6 +8164,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8043,7 +8175,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8140,6 +8272,8 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8149,9 +8283,9 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8193,6 +8327,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8202,7 +8337,7 @@ func (ht *HashTable) checkCol(
 										// found.
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -8247,6 +8382,7 @@ func (ht *HashTable) checkCol(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8257,7 +8393,7 @@ func (ht *HashTable) checkCol(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -59,12 +59,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -72,15 +68,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -119,27 +108,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -180,27 +158,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -238,26 +205,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -301,12 +257,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -314,15 +266,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -361,27 +306,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -422,27 +356,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -480,26 +403,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -558,12 +470,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -571,15 +479,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -610,27 +511,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -663,27 +553,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -713,26 +592,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -768,12 +636,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -781,15 +645,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -820,27 +677,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -873,27 +719,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -923,26 +758,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -993,12 +817,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1006,15 +826,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1045,27 +858,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1098,27 +900,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1148,26 +939,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1203,12 +983,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1216,15 +992,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1255,27 +1024,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1308,27 +1066,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1358,26 +1105,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1426,12 +1162,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1439,15 +1171,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1489,27 +1214,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1553,27 +1267,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1614,26 +1317,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1680,12 +1372,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1693,15 +1381,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1743,27 +1424,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1807,27 +1477,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1868,26 +1527,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1938,12 +1586,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -1951,15 +1595,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2001,27 +1638,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2065,27 +1691,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2126,26 +1741,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2192,12 +1796,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -2205,15 +1805,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2255,27 +1848,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2319,27 +1901,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2380,26 +1951,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2451,12 +2011,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -2464,15 +2020,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2514,27 +2063,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2578,27 +2116,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2639,26 +2166,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2705,12 +2221,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -2718,15 +2230,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2768,27 +2273,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2832,27 +2326,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2893,26 +2376,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2969,12 +2441,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -2982,15 +2450,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3032,27 +2493,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3096,27 +2546,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3157,26 +2596,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3223,12 +2651,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -3236,15 +2660,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3286,27 +2703,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3350,27 +2756,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3411,26 +2806,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3481,12 +2865,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -3494,15 +2874,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3544,27 +2917,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3608,27 +2970,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3669,26 +3020,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3735,12 +3075,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -3748,15 +3084,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3798,27 +3127,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3862,27 +3180,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3923,26 +3230,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3994,12 +3290,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -4007,15 +3299,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4057,27 +3342,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4121,27 +3395,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4182,26 +3445,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4248,12 +3500,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -4261,15 +3509,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4311,27 +3552,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4375,27 +3605,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4436,26 +3655,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4513,12 +3721,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -4526,15 +3730,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4576,27 +3773,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4640,27 +3826,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4701,26 +3876,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4767,12 +3931,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -4780,15 +3940,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4830,27 +3983,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4894,27 +4036,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4955,26 +4086,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5025,12 +4145,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5038,15 +4154,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5088,27 +4197,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5152,27 +4250,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5213,26 +4300,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5279,12 +4355,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5292,15 +4364,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5342,27 +4407,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5406,27 +4460,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5467,26 +4510,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5538,12 +4570,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5551,15 +4579,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5601,27 +4622,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5665,27 +4675,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5726,26 +4725,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5792,12 +4780,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -5805,15 +4789,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5855,27 +4832,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5919,27 +4885,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5980,26 +4935,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6061,12 +5005,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6074,15 +5014,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6132,27 +5065,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6204,27 +5126,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6273,26 +5184,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6347,12 +5247,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6360,15 +5256,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6418,27 +5307,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6490,27 +5368,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6559,26 +5426,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6648,12 +5504,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6661,15 +5513,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6707,27 +5552,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6767,27 +5601,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6824,26 +5647,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6886,12 +5698,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -6899,15 +5707,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6945,27 +5746,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7005,27 +5795,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7062,26 +5841,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7139,12 +5907,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7152,15 +5916,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7191,27 +5948,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7244,27 +5990,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7294,26 +6029,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7349,12 +6073,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7362,15 +6082,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7401,27 +6114,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7454,27 +6156,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7504,26 +6195,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7574,12 +6254,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7587,15 +6263,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7632,27 +6301,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7691,27 +6349,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7747,26 +6394,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7808,12 +6444,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -7821,15 +6453,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7866,27 +6491,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7925,27 +6539,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7981,26 +6584,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8057,12 +6649,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -8070,15 +6658,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8111,27 +6692,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8166,27 +6736,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8218,26 +6777,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8275,12 +6823,8 @@ func (ht *HashTable) checkCol(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
@@ -8288,15 +6832,8 @@ func (ht *HashTable) checkCol(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8329,27 +6866,16 @@ func (ht *HashTable) checkCol(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8384,27 +6910,16 @@ func (ht *HashTable) checkCol(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8436,26 +6951,15 @@ func (ht *HashTable) checkCol(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -52,197 +52,151 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -250,197 +204,151 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -463,165 +371,119 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -629,165 +491,119 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -810,165 +626,119 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -976,165 +746,119 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1155,209 +879,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1365,209 +1043,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1579,209 +1211,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1789,209 +1375,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2004,209 +1544,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2214,209 +1708,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2434,209 +1882,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2644,209 +2046,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2858,209 +2214,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3068,209 +2378,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3283,209 +2547,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3493,209 +2711,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3714,209 +2886,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3924,209 +3050,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4138,209 +3218,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4348,209 +3382,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4563,209 +3551,163 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4773,209 +3715,163 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4998,241 +3894,195 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5240,241 +4090,195 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5497,193 +4301,147 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
-												unique = cmpResult != 0
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5691,193 +4449,147 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
-												unique = cmpResult != 0
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5900,165 +4612,119 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6066,165 +4732,119 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6247,189 +4867,143 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6437,189 +5011,143 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6642,173 +5170,127 @@ func (ht *HashTable) checkCol(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6816,173 +5298,127 @@ func (ht *HashTable) checkCol(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -57,6 +57,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -72,9 +74,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -122,6 +124,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -137,7 +140,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -188,6 +191,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -204,7 +208,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -319,6 +323,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -334,9 +340,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -384,6 +390,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -399,7 +406,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -450,6 +457,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -466,7 +474,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -596,6 +604,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -611,9 +621,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -653,6 +663,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -668,7 +679,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -711,6 +722,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -727,7 +739,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -826,6 +838,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -841,9 +855,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -883,6 +897,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -898,7 +913,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -941,6 +956,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -957,7 +973,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1071,6 +1087,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1086,9 +1104,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1128,6 +1146,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1143,7 +1162,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1186,6 +1205,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1202,7 +1222,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1301,6 +1321,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1316,9 +1338,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1358,6 +1380,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1373,7 +1396,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1416,6 +1439,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1432,7 +1456,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1544,6 +1568,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1559,9 +1585,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1612,6 +1638,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1627,7 +1654,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1681,6 +1708,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1697,7 +1725,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1818,6 +1846,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1833,9 +1863,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -1886,6 +1916,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1901,7 +1932,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -1955,6 +1986,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1971,7 +2003,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2096,6 +2128,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2111,9 +2145,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2164,6 +2198,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2179,7 +2214,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2233,6 +2268,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2249,7 +2285,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2370,6 +2406,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2385,9 +2423,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2438,6 +2476,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2453,7 +2492,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2507,6 +2546,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2523,7 +2563,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2649,6 +2689,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2664,9 +2706,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2717,6 +2759,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2732,7 +2775,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -2786,6 +2829,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2802,7 +2846,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2923,6 +2967,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2938,9 +2984,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -2991,6 +3037,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3006,7 +3053,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3060,6 +3107,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3076,7 +3124,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3207,6 +3255,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3222,9 +3272,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3275,6 +3325,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3290,7 +3341,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3344,6 +3395,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3360,7 +3412,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3481,6 +3533,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3496,9 +3550,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3549,6 +3603,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3564,7 +3619,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3618,6 +3673,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3634,7 +3690,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3759,6 +3815,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3774,9 +3832,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -3827,6 +3885,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3842,7 +3901,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -3896,6 +3955,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3912,7 +3972,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4033,6 +4093,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4048,9 +4110,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4101,6 +4163,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4116,7 +4179,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4170,6 +4233,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4186,7 +4250,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4312,6 +4376,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4327,9 +4393,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4380,6 +4446,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4395,7 +4462,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4449,6 +4516,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4465,7 +4533,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4586,6 +4654,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4601,9 +4671,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4654,6 +4724,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4669,7 +4740,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -4723,6 +4794,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4739,7 +4811,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4871,6 +4943,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4886,9 +4960,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -4939,6 +5013,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4954,7 +5029,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5008,6 +5083,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5024,7 +5100,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5145,6 +5221,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5160,9 +5238,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5213,6 +5291,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5228,7 +5307,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5282,6 +5361,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5298,7 +5378,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5423,6 +5503,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5438,9 +5520,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5491,6 +5573,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5506,7 +5589,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5560,6 +5643,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5576,7 +5660,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5697,6 +5781,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5712,9 +5798,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5765,6 +5851,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5780,7 +5867,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -5834,6 +5921,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5850,7 +5938,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -5976,6 +6064,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5991,9 +6081,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6044,6 +6134,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6059,7 +6150,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6113,6 +6204,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6129,7 +6221,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6250,6 +6342,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6265,9 +6359,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6318,6 +6412,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6333,7 +6428,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6387,6 +6482,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6403,7 +6499,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6539,6 +6635,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6554,9 +6652,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6615,6 +6713,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6630,7 +6729,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6692,6 +6791,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6708,7 +6808,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6845,6 +6945,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6860,9 +6962,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -6921,6 +7023,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6936,7 +7039,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -6998,6 +7101,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7014,7 +7118,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7166,6 +7270,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7181,9 +7287,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7230,6 +7336,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7245,7 +7352,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7295,6 +7402,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7311,7 +7419,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7424,6 +7532,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7439,9 +7549,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7488,6 +7598,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7503,7 +7614,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7553,6 +7664,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7569,7 +7681,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7697,6 +7809,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7712,9 +7826,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7754,6 +7868,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7769,7 +7884,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -7812,6 +7927,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7828,7 +7944,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7927,6 +8043,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7942,9 +8060,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -7984,6 +8102,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7999,7 +8118,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -8042,6 +8161,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8058,7 +8178,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8172,6 +8292,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8187,9 +8309,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8235,6 +8357,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8250,7 +8373,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -8299,6 +8422,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8315,7 +8439,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8426,6 +8550,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8441,9 +8567,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8489,6 +8615,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8504,7 +8631,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -8553,6 +8680,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8569,7 +8697,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8695,6 +8823,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8710,9 +8840,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8754,6 +8884,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8769,7 +8900,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -8814,6 +8945,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8830,7 +8962,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8933,6 +9065,8 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -8948,9 +9082,9 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we
@@ -8992,6 +9126,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -9007,7 +9142,7 @@ func (ht *HashTable) checkColDeleting(
 										}
 
 										probeIdx = int(toCheck)
-										probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
@@ -9052,6 +9187,7 @@ func (ht *HashTable) checkColDeleting(
 									probeIdx, buildIdx       int
 									probeIsNull, buildIsNull bool
 								)
+								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -9068,7 +9204,7 @@ func (ht *HashTable) checkColDeleting(
 
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
 												// Both values are NULLs, and since we're allowing null equality, we

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -60,15 +60,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -79,15 +73,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -126,15 +113,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -144,15 +125,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -193,15 +167,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -211,15 +179,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -257,15 +218,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -274,15 +229,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -326,15 +274,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -345,15 +287,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -392,15 +327,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -410,15 +339,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -459,15 +381,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -477,15 +393,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -523,15 +432,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -540,15 +443,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -607,15 +503,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -626,15 +516,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -665,15 +548,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -683,15 +560,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -724,15 +594,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -742,15 +606,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -780,15 +637,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -797,15 +648,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -841,15 +685,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -860,15 +698,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -899,15 +730,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -917,15 +742,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -958,15 +776,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -976,15 +788,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1014,15 +819,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1031,15 +830,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1090,15 +882,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1109,15 +895,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1148,15 +927,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1166,15 +939,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1207,15 +973,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1225,15 +985,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1263,15 +1016,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1280,15 +1027,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1324,15 +1064,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1343,15 +1077,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1382,15 +1109,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1400,15 +1121,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1441,15 +1155,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1459,15 +1167,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1497,15 +1198,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1514,15 +1209,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1571,15 +1259,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1590,15 +1272,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1640,15 +1315,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1658,15 +1327,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1710,15 +1372,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1728,15 +1384,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1777,15 +1426,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1794,15 +1437,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1849,15 +1485,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1868,15 +1498,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1918,15 +1541,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -1936,15 +1553,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -1988,15 +1598,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2006,15 +1610,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2055,15 +1652,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2072,15 +1663,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2131,15 +1715,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2150,15 +1728,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2200,15 +1771,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2218,15 +1783,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2270,15 +1828,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2288,15 +1840,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2337,15 +1882,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2354,15 +1893,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2409,15 +1941,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2428,15 +1954,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2478,15 +1997,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2496,15 +2009,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2548,15 +2054,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2566,15 +2066,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2615,15 +2108,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2632,15 +2119,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2692,15 +2172,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2711,15 +2185,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2761,15 +2228,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2779,15 +2240,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2831,15 +2285,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2849,15 +2297,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2898,15 +2339,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2915,15 +2350,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -2970,15 +2398,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -2989,15 +2411,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3039,15 +2454,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3057,15 +2466,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3109,15 +2511,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3127,15 +2523,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3176,15 +2565,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3193,15 +2576,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3258,15 +2634,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3277,15 +2647,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3327,15 +2690,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3345,15 +2702,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3397,15 +2747,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3415,15 +2759,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3464,15 +2801,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3481,15 +2812,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3536,15 +2860,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3555,15 +2873,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3605,15 +2916,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3623,15 +2928,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3675,15 +2973,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3693,15 +2985,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3742,15 +3027,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3759,15 +3038,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3818,15 +3090,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3837,15 +3103,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3887,15 +3146,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3905,15 +3158,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -3957,15 +3203,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -3975,15 +3215,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4024,15 +3257,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4041,15 +3268,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4096,15 +3316,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4115,15 +3329,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4165,15 +3372,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4183,15 +3384,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4235,15 +3429,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4253,15 +3441,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4302,15 +3483,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4319,15 +3494,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4379,15 +3547,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4398,15 +3560,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4448,15 +3603,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4466,15 +3615,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4518,15 +3660,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4536,15 +3672,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4585,15 +3714,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4602,15 +3725,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4657,15 +3773,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4676,15 +3786,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4726,15 +3829,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4744,15 +3841,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4796,15 +3886,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4814,15 +3898,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4863,15 +3940,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4880,15 +3951,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -4946,15 +4010,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -4965,15 +4023,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5015,15 +4066,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5033,15 +4078,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5085,15 +4123,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5103,15 +4135,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5152,15 +4177,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5169,15 +4188,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5224,15 +4236,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5243,15 +4249,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5293,15 +4292,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5311,15 +4304,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5363,15 +4349,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5381,15 +4361,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5430,15 +4403,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5447,15 +4414,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5506,15 +4466,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5525,15 +4479,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5575,15 +4522,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5593,15 +4534,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5645,15 +4579,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5663,15 +4591,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5712,15 +4633,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5729,15 +4644,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5784,15 +4692,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5803,15 +4705,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5853,15 +4748,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5871,15 +4760,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5923,15 +4805,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -5941,15 +4817,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -5990,15 +4859,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6007,15 +4870,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6067,15 +4923,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6086,15 +4936,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6136,15 +4979,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6154,15 +4991,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6206,15 +5036,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6224,15 +5048,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6273,15 +5090,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6290,15 +5101,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6345,15 +5149,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6364,15 +5162,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6414,15 +5205,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6432,15 +5217,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6484,15 +5262,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6502,15 +5274,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6551,15 +5316,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6568,15 +5327,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6638,15 +5390,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6657,15 +5403,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6715,15 +5454,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6733,15 +5466,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6793,15 +5519,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6811,15 +5531,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6868,15 +5581,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6885,15 +5592,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -6948,15 +5648,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -6967,15 +5661,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7025,15 +5712,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7043,15 +5724,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7103,15 +5777,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7121,15 +5789,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7178,15 +5839,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7195,15 +5850,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7273,15 +5921,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7292,15 +5934,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7338,15 +5973,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7356,15 +5985,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7404,15 +6026,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7422,15 +6038,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7467,15 +6076,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7484,15 +6087,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7535,15 +6131,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7554,15 +6144,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7600,15 +6183,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7618,15 +6195,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7666,15 +6236,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7684,15 +6248,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7729,15 +6286,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7746,15 +6297,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7812,15 +6356,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7831,15 +6369,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7870,15 +6401,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7888,15 +6413,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7929,15 +6447,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -7947,15 +6459,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -7985,15 +6490,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8002,15 +6501,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8046,15 +6538,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8065,15 +6551,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8104,15 +6583,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8122,15 +6595,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8163,15 +6629,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8181,15 +6641,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8219,15 +6672,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8236,15 +6683,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8295,15 +6735,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8314,15 +6748,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8359,15 +6786,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8377,15 +6798,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8424,15 +6838,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8442,15 +6850,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8486,15 +6887,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8503,15 +6898,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8553,15 +6941,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8572,15 +6954,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8617,15 +6992,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8635,15 +7004,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8682,15 +7044,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8700,15 +7056,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8744,15 +7093,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8761,15 +7104,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8826,15 +7162,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8845,15 +7175,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8886,15 +7209,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8904,15 +7221,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -8947,15 +7257,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -8965,15 +7269,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -9005,15 +7302,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -9022,15 +7313,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -9068,15 +7352,9 @@ func (ht *HashTable) checkColDeleting(
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -9087,15 +7365,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -9128,15 +7399,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -9146,15 +7411,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -9189,15 +7447,9 @@ func (ht *HashTable) checkColDeleting(
 								)
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -9207,15 +7459,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIsNull = buildVecNulls.NullAt(buildIdx)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -9247,15 +7492,9 @@ func (ht *HashTable) checkColDeleting(
 									probeIsNull, buildIsNull bool
 								)
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-									// keyID of 0 is reserved to represent the end of the next chain.
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
-										// the build table key (calculated using keys[keyID - 1] = key) is
-										// compared to the corresponding probe table to determine if a match is
-										// found.
 										if ht.Visited[keyID] {
-											// This build tuple has already been matched, so we treat
-											// it as different from the probe tuple.
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
@@ -9264,15 +7503,8 @@ func (ht *HashTable) checkColDeleting(
 										buildIdx = int(keyID - 1)
 										if ht.allowNullEquality {
 											if probeIsNull && buildIsNull {
-												// Both values are NULLs, and since we're allowing null equality, we
-												// proceed to the next value to check.
 												continue
 											} else if probeIsNull {
-												// Only probing value is NULL, so it is different from the build value
-												// (which is non-NULL). We mark it as "different" and proceed to the
-												// next value to check. This behavior is special in case of allowing
-												// null equality because we don't want to reset the GroupID of the
-												// current probing tuple.
 												ht.ProbeScratch.differs[toCheck] = true
 												continue
 											}
@@ -9326,20 +7558,12 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					// If the current key matches with the probe key, we want to update HeadID
-					// with the current key if it has not been set yet.
 					keyID := ht.ProbeScratch.GroupID[toCheck]
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
 					firstID := ht.ProbeScratch.HeadID[toCheck]
 					if !ht.Visited[keyID] {
-						// We can then add this keyID into the same array at the end of the
-						// corresponding linked list and mark this ID as visited. Since there
-						// can be multiple keys that match this probe key, we want to mark
-						// differs at this position to be true. This way, the prober will
-						// continue probing for this key until it reaches the end of the next
-						// chain.
 						ht.ProbeScratch.differs[toCheck] = true
 						ht.Visited[keyID] = true
 						if firstID != keyID {
@@ -9349,7 +7573,6 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					}
 				}
 				if ht.ProbeScratch.differs[toCheck] {
-					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -9363,15 +7586,12 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					// If the current key matches with the probe key, we want to update HeadID
-					// with the current key if it has not been set yet.
 					keyID := ht.ProbeScratch.GroupID[toCheck]
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
 				}
 				if ht.ProbeScratch.differs[toCheck] {
-					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -9387,23 +7607,11 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					// If the current key matches with the probe key, we want to update HeadID
-					// with the current key if it has not been set yet.
 					keyID := ht.ProbeScratch.GroupID[toCheck]
-					// We need to check whether this key hasn't been "deleted" (we
-					// reuse 'visited' array for tracking which tuples are deleted).
-					// TODO(yuzefovich): rather than reusing 'visited' array to have
-					// "deleted" marks we could be actually removing tuples' keyIDs
-					// from the hash chains. This will require changing our use of
-					// singly linked list 'next' to doubly linked list.
 					if !ht.Visited[keyID] {
-						// It hasn't been deleted, so we match it with 'ToCheck'
-						// probing tuple and "delete" the key.
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 						ht.Visited[keyID] = true
 					} else {
-						// It has been deleted, so we need to continue probing on the
-						// next chain if it's not the end of the chain already.
 						if keyID != 0 {
 							//gcassert:bce
 							toCheckSlice[nDiffers] = toCheck
@@ -9413,7 +7621,6 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					continue
 				}
 				if ht.ProbeScratch.differs[toCheck] {
-					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -9427,23 +7634,11 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if !ht.ProbeScratch.differs[toCheck] {
-					// If the current key matches with the probe key, we want to update HeadID
-					// with the current key if it has not been set yet.
 					keyID := ht.ProbeScratch.GroupID[toCheck]
-					// We need to check whether this key hasn't been "deleted" (we
-					// reuse 'visited' array for tracking which tuples are deleted).
-					// TODO(yuzefovich): rather than reusing 'visited' array to have
-					// "deleted" marks we could be actually removing tuples' keyIDs
-					// from the hash chains. This will require changing our use of
-					// singly linked list 'next' to doubly linked list.
 					if !ht.Visited[keyID] {
-						// It hasn't been deleted, so we match it with 'ToCheck'
-						// probing tuple and "delete" the key.
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 						ht.Visited[keyID] = true
 					} else {
-						// It has been deleted, so we need to continue probing on the
-						// next chain if it's not the end of the chain already.
 						if keyID != 0 {
 							//gcassert:bce
 							toCheckSlice[nDiffers] = toCheck
@@ -9453,7 +7648,6 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					continue
 				}
 				if ht.ProbeScratch.differs[toCheck] {
-					// Continue probing in this next chain for the probe key.
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -53,10 +53,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -66,51 +63,47 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -119,52 +112,42 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -173,50 +156,36 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -224,42 +193,27 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -267,10 +221,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -280,51 +231,47 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -333,52 +280,42 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -387,50 +324,36 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -438,42 +361,27 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												if !probeVal && buildVal {
-													cmpResult = -1
-												} else if probeVal && !buildVal {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-
-												unique = cmpResult != 0
+											if !probeVal && buildVal {
+												cmpResult = -1
+											} else if probeVal && !buildVal {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -496,10 +404,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -509,43 +414,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -554,44 +455,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -600,42 +491,28 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -643,34 +520,19 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -678,10 +540,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -691,43 +550,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -736,44 +591,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -782,42 +627,28 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -825,34 +656,19 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = bytes.Compare(probeVal, buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = bytes.Compare(probeVal, buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -875,10 +691,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -888,43 +701,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -933,44 +742,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -979,42 +778,28 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -1022,34 +807,19 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1057,10 +827,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -1070,43 +837,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1115,44 +878,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1161,42 +914,28 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -1204,34 +943,19 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = tree.CompareDecimals(&probeVal, &buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1252,10 +976,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -1265,54 +986,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1321,55 +1038,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1378,53 +1085,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -1432,45 +1125,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1478,10 +1156,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -1491,54 +1166,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1547,55 +1218,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1604,53 +1265,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -1658,45 +1305,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1708,10 +1340,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -1721,54 +1350,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1777,55 +1402,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -1834,53 +1449,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -1888,45 +1489,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -1934,10 +1520,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -1947,54 +1530,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2003,55 +1582,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2060,53 +1629,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -2114,45 +1669,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2165,10 +1705,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -2178,54 +1715,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2234,55 +1767,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2291,53 +1814,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -2345,45 +1854,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2391,10 +1885,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -2404,54 +1895,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2460,55 +1947,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2517,53 +1994,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -2571,45 +2034,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2627,10 +2075,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -2640,54 +2085,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2696,55 +2137,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2753,53 +2184,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -2807,45 +2224,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -2853,10 +2255,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -2866,54 +2265,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2922,55 +2317,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -2979,53 +2364,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -3033,45 +2404,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3083,10 +2439,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -3096,54 +2449,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3152,55 +2501,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3209,53 +2548,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -3263,45 +2588,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3309,10 +2619,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -3322,54 +2629,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3378,55 +2681,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3435,53 +2728,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -3489,45 +2768,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3540,10 +2804,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -3553,54 +2814,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3609,55 +2866,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3666,53 +2913,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -3720,45 +2953,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -3766,10 +2984,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -3779,54 +2994,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3835,55 +3046,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -3892,53 +3093,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -3946,45 +3133,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4003,10 +3175,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -4016,54 +3185,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4072,55 +3237,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4129,53 +3284,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -4183,45 +3324,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4229,10 +3355,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -4242,54 +3365,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4298,55 +3417,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4355,53 +3464,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -4409,45 +3504,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4459,10 +3539,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -4472,54 +3549,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4528,55 +3601,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4585,53 +3648,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -4639,45 +3688,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4685,10 +3719,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -4698,54 +3729,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4754,55 +3781,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4811,53 +3828,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -4865,45 +3868,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -4916,10 +3904,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -4929,54 +3914,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -4985,55 +3966,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5042,53 +4013,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -5096,45 +4053,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5142,10 +4084,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -5155,54 +4094,50 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5211,55 +4146,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5268,53 +4193,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -5322,45 +4233,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := int64(probeVal), int64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else {
-														cmpResult = 0
-													}
+												a, b := int64(probeVal), int64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else {
+													cmpResult = 0
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5383,10 +4279,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -5396,62 +4289,58 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5460,63 +4349,53 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5525,61 +4404,47 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -5587,53 +4452,38 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5641,10 +4491,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -5654,62 +4501,58 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5718,63 +4561,53 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5783,61 +4616,47 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -5845,53 +4664,38 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
 
 											{
-												var cmpResult int
-
-												{
-													a, b := float64(probeVal), float64(buildVal)
-													if a < b {
-														cmpResult = -1
-													} else if a > b {
-														cmpResult = 1
-													} else if a == b {
+												a, b := float64(probeVal), float64(buildVal)
+												if a < b {
+													cmpResult = -1
+												} else if a > b {
+													cmpResult = 1
+												} else if a == b {
+													cmpResult = 0
+												} else if math.IsNaN(a) {
+													if math.IsNaN(b) {
 														cmpResult = 0
-													} else if math.IsNaN(a) {
-														if math.IsNaN(b) {
-															cmpResult = 0
-														} else {
-															cmpResult = -1
-														}
 													} else {
-														cmpResult = 1
+														cmpResult = -1
 													}
+												} else {
+													cmpResult = 1
 												}
-
-												unique = cmpResult != 0
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -5914,10 +4718,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -5927,50 +4728,46 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
-												unique = cmpResult != 0
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -5979,51 +4776,41 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6032,49 +4819,35 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -6082,41 +4855,26 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6124,10 +4882,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -6137,50 +4892,46 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
-												unique = cmpResult != 0
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6189,51 +4940,41 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6242,49 +4983,35 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
+											}
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -6292,41 +5019,26 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											if probeVal.Before(buildVal) {
+												cmpResult = -1
+											} else if buildVal.Before(probeVal) {
+												cmpResult = 1
+											} else {
+												cmpResult = 0
 											}
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												if probeVal.Before(buildVal) {
-													cmpResult = -1
-												} else if buildVal.Before(probeVal) {
-													cmpResult = 1
-												} else {
-													cmpResult = 0
-												}
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6349,10 +5061,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -6362,43 +5071,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6407,44 +5112,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6453,42 +5148,28 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -6496,34 +5177,19 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6531,10 +5197,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -6544,43 +5207,39 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6589,44 +5248,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6635,42 +5284,28 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -6678,34 +5313,19 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
-												cmpResult = probeVal.Compare(buildVal)
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+										{
+											var cmpResult int
+											cmpResult = probeVal.Compare(buildVal)
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6728,10 +5348,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -6741,49 +5358,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6792,50 +5405,40 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6844,48 +5447,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -6893,40 +5482,25 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -6934,10 +5508,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -6947,49 +5518,45 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
 												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-												unique = cmpResult != 0
+										{
+											var cmpResult int
+
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -6998,50 +5565,40 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
+											}
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7050,48 +5607,34 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -7099,40 +5642,25 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
 
-											{
-												var cmpResult int
+										{
+											var cmpResult int
 
-												var err error
-												cmpResult, err = probeVal.Compare(buildVal)
-												if err != nil {
-													colexecerror.ExpectedError(err)
-												}
-
-												unique = cmpResult != 0
+											var err error
+											cmpResult, err = probeVal.Compare(buildVal)
+											if err != nil {
+												colexecerror.ExpectedError(err)
 											}
 
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											unique = cmpResult != 0
 										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -7155,10 +5683,7 @@ func (ht *HashTable) checkColDeleting(
 					if probeSel != nil {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -7168,45 +5693,41 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7215,46 +5736,36 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7263,44 +5774,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -7308,36 +5805,21 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = probeSel[toCheck]
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
@@ -7345,10 +5827,7 @@ func (ht *HashTable) checkColDeleting(
 					} else {
 						if probeVec.MaybeHasNulls() {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
@@ -7358,45 +5837,41 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												if !buildIsNull {
+													ht.ProbeScratch.differs[toCheck] = true
+												}
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										if buildIsNull {
+											ht.ProbeScratch.differs[toCheck] = true
+											continue
+										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								probeVecNulls := probeVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7405,46 +5880,36 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
-										probeIsNull = probeVecNulls.NullAt(probeIdx)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
+										probeIsNull := probeVecNulls.NullAt(probeIdx)
 										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
+											if ht.allowNullEquality {
+												ht.ProbeScratch.differs[toCheck] = true
+											} else {
+												ht.ProbeScratch.GroupID[toCheck] = 0
 											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}
 						} else {
 							if buildVec.MaybeHasNulls() {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								buildVecNulls := buildVec.Nulls()
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -7453,44 +5918,30 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										buildIsNull = buildVecNulls.NullAt(buildIdx)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
-										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
+										buildIsNull := buildVecNulls.NullAt(buildIdx)
+										if buildIsNull {
 											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
-
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
+											continue
 										}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
+										}
+
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							} else {
-								var (
-									probeIdx, buildIdx       int
-									probeIsNull, buildIsNull bool
-								)
+								var probeIdx, buildIdx int
 								for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 									keyID := ht.ProbeScratch.GroupID[toCheck]
 									if keyID != 0 {
@@ -7498,36 +5949,21 @@ func (ht *HashTable) checkColDeleting(
 											ht.ProbeScratch.differs[toCheck] = true
 											continue
 										}
-
 										probeIdx = int(toCheck)
 										buildIdx = int(keyID - 1)
-										if ht.allowNullEquality {
-											if probeIsNull && buildIsNull {
-												continue
-											} else if probeIsNull {
-												ht.ProbeScratch.differs[toCheck] = true
-												continue
-											}
+										probeVal := probeKeys.Get(probeIdx)
+										buildVal := buildKeys.Get(buildIdx)
+										var unique bool
+
+										{
+											var cmpResult int
+
+											cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
+
+											unique = cmpResult != 0
 										}
-										if probeIsNull {
-											ht.ProbeScratch.GroupID[toCheck] = 0
-										} else if buildIsNull {
-											ht.ProbeScratch.differs[toCheck] = true
-										} else {
-											probeVal := probeKeys.Get(probeIdx)
-											buildVal := buildKeys.Get(buildIdx)
-											var unique bool
 
-											{
-												var cmpResult int
-
-												cmpResult = coldataext.CompareDatum(probeVal, probeKeys, buildVal)
-
-												unique = cmpResult != 0
-											}
-
-											ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-										}
+										ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
 									}
 								}
 							}

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -7562,17 +7562,18 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
-					firstID := ht.ProbeScratch.HeadID[toCheck]
 					if !ht.Visited[keyID] {
-						ht.ProbeScratch.differs[toCheck] = true
-						ht.Visited[keyID] = true
+						firstID := ht.ProbeScratch.HeadID[toCheck]
 						if firstID != keyID {
 							ht.Same[keyID] = ht.Same[firstID]
 							ht.Same[firstID] = keyID
 						}
+						ht.Visited[keyID] = true
+						//gcassert:bce
+						toCheckSlice[nDiffers] = toCheck
+						nDiffers++
 					}
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -7590,8 +7591,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 					if ht.ProbeScratch.HeadID[toCheck] == 0 {
 						ht.ProbeScratch.HeadID[toCheck] = keyID
 					}
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -7618,9 +7618,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 							nDiffers++
 						}
 					}
-					continue
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -7645,9 +7643,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 							nDiffers++
 						}
 					}
-					continue
-				}
-				if ht.ProbeScratch.differs[toCheck] {
+				} else {
 					ht.ProbeScratch.differs[toCheck] = false
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -483,7 +483,6 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 					nDiffers++
 				}
 			}
-			continue
 			// {{else}}
 			// {{/*
 			//     If we have an equality match, we want to update HeadID with
@@ -493,27 +492,43 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 			}
 			// {{if .SelectSameTuples}}
-			firstID := ht.ProbeScratch.HeadID[toCheck]
 			if !ht.Visited[keyID] {
 				// {{/*
-				//     We can add this keyID into the Same array at the end
-				//     of the corresponding linked list and mark this ID as
-				//     visited. Since there can be multiple keys that match this
-				//     probe key, we want to mark 'differs' at this position to
-				//     be true. This way, the prober will continue probing for
-				//     this key until it reaches the end of the Next chain.
+				//     This is the first time we found a match for this tuple
+				//     from the hash table.
+				//
+				//     First, we check if there is already another tuple in the
+				//     equality chain for this tuple from the hash table (the
+				//     value of HeadID is different from the keyID - if it is
+				//     the same, then we've just inserted it right above).
 				// */}}
-				ht.ProbeScratch.differs[toCheck] = true
-				ht.Visited[keyID] = true
+				firstID := ht.ProbeScratch.HeadID[toCheck]
 				if firstID != keyID {
+					// {{/*
+					//     There is already at least on other tuple, so we
+					//     insert this tuple right after the head of the
+					//     equality chain.
+					// */}}
 					ht.Same[keyID] = ht.Same[firstID]
 					ht.Same[firstID] = keyID
 				}
+				// {{/*
+				//     Now mark this tuple as visited so that it doesn't get
+				//     inserted into the equality chain again.
+				// */}}
+				ht.Visited[keyID] = true
+				// {{/*
+				//     Since there can be more tuples in the hash table that
+				//     match this probing tuple, we include the probing tuple in
+				//     the ToCheck for the next probing iteration.
+				// */}}
+				//gcassert:bce
+				toCheckSlice[nDiffers] = toCheck
+				nDiffers++
 			}
 			// {{end}}
 			// {{end}}
-		}
-		if ht.ProbeScratch.differs[toCheck] {
+		} else {
 			// {{/*
 			//     Continue probing in this Next chain for the probe key.
 			// */}}

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -104,6 +104,12 @@ func _CHECK_COL_BODY(
 		probeIdx, buildIdx       int
 		probeIsNull, buildIsNull bool
 	)
+	// {{if .ProbeHasNulls}}
+	probeVecNulls := probeVec.Nulls()
+	// {{end}}
+	// {{if .BuildHasNulls}}
+	buildVecNulls := buildVec.Nulls()
+	// {{end}}
 	for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
 		// keyID of 0 is reserved to represent the end of the next chain.
 		keyID := ht.ProbeScratch.GroupID[toCheck]
@@ -138,7 +144,7 @@ func _CHECK_COL_BODY(
 			probeIdx = int(toCheck)
 			// {{end}}
 			// {{if .ProbeHasNulls}}
-			probeIsNull = probeVec.Nulls().NullAt(probeIdx)
+			probeIsNull = probeVecNulls.NullAt(probeIdx)
 			// {{end}}
 			// {{/*
 			//     Usually, the build vector is already stored in the hash table,
@@ -157,7 +163,7 @@ func _CHECK_COL_BODY(
 			buildIdx = int(keyID - 1)
 			// {{end}}
 			// {{if .BuildHasNulls}}
-			buildIsNull = buildVec.Nulls().NullAt(buildIdx)
+			buildIsNull = buildVecNulls.NullAt(buildIdx)
 			// {{end}}
 			if ht.allowNullEquality {
 				if probeIsNull && buildIsNull {

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -111,7 +111,13 @@ func _CHECK_COL_BODY(
 	buildVecNulls := buildVec.Nulls()
 	// {{end}}
 	for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-		// keyID of 0 is reserved to represent the end of the next chain.
+		// {{/*
+		//     The build table tuple (identified by GroupID value) is being
+		//     compared to the corresponding probing tuple (with the ordinal
+		//     'toCheck') to determine if it is an equality match. keyID of 0
+		//     indicates that for the probing tuple there are no more build
+		//     tuples to try.
+		// */}}
 		keyID := ht.ProbeScratch.GroupID[toCheck]
 		// {{if or (not .SelectDistinct) (not .ProbingAgainstItself)}}
 		// {{/*
@@ -126,13 +132,12 @@ func _CHECK_COL_BODY(
 		// */}}
 		if keyID != 0 {
 			// {{end}}
-			// the build table key (calculated using keys[keyID - 1] = key) is
-			// compared to the corresponding probe table to determine if a match is
-			// found.
 			// {{if .DeletingProbeMode}}
 			if ht.Visited[keyID] {
-				// This build tuple has already been matched, so we treat
-				// it as different from the probe tuple.
+				// {{/*
+				//     This build tuple has already been matched, so we treat
+				//     it as different from the probing tuple.
+				// */}}
 				ht.ProbeScratch.differs[toCheck] = true
 				continue
 			}
@@ -156,8 +161,10 @@ func _CHECK_COL_BODY(
 			//     means .UseBuildSel if we were to introduce it.
 			// */}}
 			// {{if and (.UseProbeSel) (.ProbingAgainstItself)}}
-			// The vector is probed against itself, so buildVec has the same
-			// selection vector as probeVec.
+			// {{/*
+			//     The vector is probed against itself, so buildVec has the same
+			//     selection vector as probeVec.
+			// */}}
 			buildIdx = probeSel[keyID-1]
 			// {{else}}
 			buildIdx = int(keyID - 1)
@@ -167,15 +174,21 @@ func _CHECK_COL_BODY(
 			// {{end}}
 			if ht.allowNullEquality {
 				if probeIsNull && buildIsNull {
-					// Both values are NULLs, and since we're allowing null equality, we
-					// proceed to the next value to check.
+					// {{/*
+					//     Both values are NULLs, and since we're allowing null
+					//     equality, we proceed to the next vector to check.
+					// */}}
 					continue
 				} else if probeIsNull {
-					// Only probing value is NULL, so it is different from the build value
-					// (which is non-NULL). We mark it as "different" and proceed to the
-					// next value to check. This behavior is special in case of allowing
-					// null equality because we don't want to reset the GroupID of the
-					// current probing tuple.
+					// {{/*
+					//     Only probing value is NULL, so it is different from
+					//     the build value (which is non-NULL). We mark it as
+					//     "different" and will eventually proceed to check the
+					//     next build table for equality. This behavior is
+					//     special in case of allowing null equality because we
+					//     don't want to reset the GroupID of the current
+					//     probing tuple.
+					// */}}
 					ht.ProbeScratch.differs[toCheck] = true
 					continue
 				}
@@ -376,14 +389,16 @@ func (ht *HashTable) checkColForDistinctTuples(
 				// {{range .RightWidths}}
 				// {{$rightWidth := .Width}}
 				// {{if and (eq $leftFamily $rightFamily) (eq $leftWidth $rightWidth)}}
-				// {{/* We're being this tricky with code generation because we
+				// {{/*
+				//      We're being this tricky with code generation because we
 				//      know that both probeVec and buildVec are of the same
 				//      type, so we need to iterate over one level of type
 				//      family - width. But, the checkCol function above needs
 				//      two layers, so in order to keep these templated
 				//      functions in a single file we make sure that we
 				//      generate the code only if the "second" level is the
-				//      same as the "first" one */}}
+				//      same as the "first" one
+				// */}}
 				case _RIGHT_TYPE_WIDTH:
 					probeKeys := probeVec._ProbeType()
 					buildKeys := buildVec._ProbeType()
@@ -439,24 +454,29 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 		}
 		// {{end}}
 		if !ht.ProbeScratch.differs[toCheck] {
-			// If the current key matches with the probe key, we want to update HeadID
-			// with the current key if it has not been set yet.
 			keyID := ht.ProbeScratch.GroupID[toCheck]
 			// {{if .DeletingProbeMode}}
-			// We need to check whether this key hasn't been "deleted" (we
-			// reuse 'visited' array for tracking which tuples are deleted).
-			// TODO(yuzefovich): rather than reusing 'visited' array to have
-			// "deleted" marks we could be actually removing tuples' keyIDs
-			// from the hash chains. This will require changing our use of
-			// singly linked list 'next' to doubly linked list.
+			// {{/*
+			//     We need to check whether this matching tuple hasn't been
+			//     "deleted" (we reuse 'visited' array for tracking which tuples
+			//     are deleted).
+			//     TODO(yuzefovich): rather than reusing 'visited' array to have
+			//     "deleted" marks we could be actually removing tuples' keyIDs
+			//     from the hash chains. This will require changing our use of
+			//     singly linked list 'Next' to doubly linked list.
+			// */}}
 			if !ht.Visited[keyID] {
-				// It hasn't been deleted, so we match it with 'ToCheck'
-				// probing tuple and "delete" the key.
+				// {{/*
+				//     It hasn't been deleted, so we match it with 'toCheck'
+				//     probing tuple and "delete" the key.
+				// */}}
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 				ht.Visited[keyID] = true
 			} else {
-				// It has been deleted, so we need to continue probing on the
-				// next chain if it's not the end of the chain already.
+				// {{/*
+				//     It has been deleted, so we need to continue probing on
+				//     the Next chain if it's not the end of the chain already.
+				// */}}
 				if keyID != 0 {
 					//gcassert:bce
 					toCheckSlice[nDiffers] = toCheck
@@ -465,18 +485,24 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 			}
 			continue
 			// {{else}}
+			// {{/*
+			//     If we have an equality match, we want to update HeadID with
+			//     the current keyID if it has not been set yet.
+			// */}}
 			if ht.ProbeScratch.HeadID[toCheck] == 0 {
 				ht.ProbeScratch.HeadID[toCheck] = keyID
 			}
 			// {{if .SelectSameTuples}}
 			firstID := ht.ProbeScratch.HeadID[toCheck]
 			if !ht.Visited[keyID] {
-				// We can then add this keyID into the same array at the end of the
-				// corresponding linked list and mark this ID as visited. Since there
-				// can be multiple keys that match this probe key, we want to mark
-				// differs at this position to be true. This way, the prober will
-				// continue probing for this key until it reaches the end of the next
-				// chain.
+				// {{/*
+				//     We can add this keyID into the Same array at the end
+				//     of the corresponding linked list and mark this ID as
+				//     visited. Since there can be multiple keys that match this
+				//     probe key, we want to mark 'differs' at this position to
+				//     be true. This way, the prober will continue probing for
+				//     this key until it reaches the end of the Next chain.
+				// */}}
 				ht.ProbeScratch.differs[toCheck] = true
 				ht.Visited[keyID] = true
 				if firstID != keyID {
@@ -488,7 +514,9 @@ func _CHECK_BODY(_SELECT_SAME_TUPLES bool, _DELETING_PROBE_MODE bool, _SELECT_DI
 			// {{end}}
 		}
 		if ht.ProbeScratch.differs[toCheck] {
-			// Continue probing in this next chain for the probe key.
+			// {{/*
+			//     Continue probing in this Next chain for the probe key.
+			// */}}
 			ht.ProbeScratch.differs[toCheck] = false
 			//gcassert:bce
 			toCheckSlice[nDiffers] = toCheck
@@ -576,7 +604,9 @@ func _UPDATE_SEL_BODY(_USE_SEL bool) { // */}}
 				sel[distinctCount] = int(HeadID - 1)
 				// {{end}}
 				visited[HeadID-1] = true
-				// Compacting and deduplicating hash buffer.
+				// {{/*
+				//     Compacting and de-duplicating hash buffer.
+				// */}}
 				//gcassert:bce
 				hashBuffer[distinctCount] = hashBuffer[i]
 				distinctCount++

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -604,28 +604,4 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 	}
 }
 
-// DistinctCheck determines if the current key in the GroupID bucket matches the
-// equality column key. If there is a match, then the key is removed from
-// ToCheck. If the bucket has reached the end, the key is rejected. The ToCheck
-// list is reconstructed to only hold the indices of the eqCol keys that have
-// not been found. The new length of ToCheck is returned by this function.
-func (ht *HashTable) DistinctCheck(nToCheck uint64, probeSel []int) uint64 {
-	ht.checkCols(ht.Keys, nToCheck, probeSel)
-	// Select the indices that differ and put them into ToCheck.
-	nDiffers := uint64(0)
-	toCheckSlice := ht.ProbeScratch.ToCheck
-	_ = toCheckSlice[nToCheck-1]
-	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
-		//gcassert:bce
-		toCheck := toCheckSlice[toCheckPos]
-		if ht.ProbeScratch.differs[toCheck] {
-			ht.ProbeScratch.differs[toCheck] = false
-			//gcassert:bce
-			toCheckSlice[nDiffers] = toCheck
-			nDiffers++
-		}
-	}
-	return nDiffers
-}
-
 // {{end}}

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -460,7 +460,6 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
 
-	aggFn := execinfrapb.Min
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
 	groupSizes := []int{1, 2, 32, 128, coldata.BatchSize()}
 	if testing.Short() {
@@ -468,36 +467,48 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 		groupSizes = []int{1, coldata.BatchSize()}
 	}
 	var memAccounts []*mon.BoundAccount
-	for _, numInputRows := range numRows {
-		for _, groupSize := range groupSizes {
-			for _, agg := range []aggType{
-				{
-					new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
-						return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
+	for _, aggFn := range []execinfrapb.AggregatorSpec_Func{
+		// We choose any_not_null aggregate function because it is the simplest
+		// possible and, thus, its Compute function call will have the least
+		// impact when benchmarking the aggregator logic.
+		execinfrapb.AnyNotNull,
+		// min aggregate function has been used before transitioning to
+		// any_not_null in 22.1 cycle. It is kept so that we could use it for
+		// comparison of 22.1 against 21.2.
+		// TODO(yuzefovich): use only any_not_null in 22.2 (#75106).
+		execinfrapb.Min,
+	} {
+		for _, numInputRows := range numRows {
+			for _, groupSize := range groupSizes {
+				for _, agg := range []aggType{
+					{
+						new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
+							return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
+						},
+						name:  "tracking=false",
+						order: unordered,
 					},
-					name:  "tracking=false",
-					order: unordered,
-				},
-				{
-					new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
-						spillingQueueMemAcc := testMemMonitor.MakeBoundAccount()
-						memAccounts = append(memAccounts, &spillingQueueMemAcc)
-						return NewHashAggregator(args, &colexecutils.NewSpillingQueueArgs{
-							UnlimitedAllocator: colmem.NewAllocator(ctx, &spillingQueueMemAcc, testColumnFactory),
-							Types:              args.InputTypes,
-							MemoryLimit:        execinfra.DefaultMemoryLimit,
-							DiskQueueCfg:       queueCfg,
-							FDSemaphore:        &colexecop.TestingSemaphore{},
-							DiskAcc:            testDiskAcc,
-						}, testAllocator, math.MaxInt64)
+					{
+						new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
+							spillingQueueMemAcc := testMemMonitor.MakeBoundAccount()
+							memAccounts = append(memAccounts, &spillingQueueMemAcc)
+							return NewHashAggregator(args, &colexecutils.NewSpillingQueueArgs{
+								UnlimitedAllocator: colmem.NewAllocator(ctx, &spillingQueueMemAcc, testColumnFactory),
+								Types:              args.InputTypes,
+								MemoryLimit:        execinfra.DefaultMemoryLimit,
+								DiskQueueCfg:       queueCfg,
+								FDSemaphore:        &colexecop.TestingSemaphore{},
+								DiskAcc:            testDiskAcc,
+							}, testAllocator, math.MaxInt64)
+						},
+						name:  "tracking=true",
+						order: unordered,
 					},
-					name:  "tracking=true",
-					order: unordered,
-				},
-			} {
-				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
-					0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
+				} {
+					benchmarkAggregateFunction(
+						b, agg, aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
+						0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
+				}
 			}
 		}
 	}
@@ -521,7 +532,6 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 	queueCfg, cleanup := colcontainerutils.NewTestingDiskQueueCfg(b, false /* inMem */)
 	defer cleanup()
 
-	aggFn := execinfrapb.Min
 	numRows := []int{1, 32, coldata.BatchSize(), 32 * coldata.BatchSize(), 1024 * coldata.BatchSize()}
 	// chunkSizes is the number of distinct values in the ordered group column.
 	chunkSizes := []int{1, 32, coldata.BatchSize() + 1}
@@ -546,34 +556,46 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 			DiskAcc:            testDiskAcc,
 		}, testAllocator, math.MaxInt64)
 	}
-	for _, numInputRows := range numRows {
-		for _, limit := range limits {
-			if limit > numInputRows {
-				continue
-			}
-			for _, groupSize := range groupSizes {
-				for _, chunkSize := range chunkSizes {
-					if groupSize > chunkSize || chunkSize > numInputRows {
-						continue
-					}
-					for _, agg := range []aggType{
-						{
-							new:   f,
-							name:  fmt.Sprintf("hash-unordered/limit=%d/chunkSize=%d", limit, chunkSize),
-							order: unordered,
-						},
-						{
-							new:   f,
-							name:  fmt.Sprintf("hash-partial-order/limit=%d/chunkSize=%d", limit, chunkSize),
-							order: partial,
-						},
-					} {
-						if agg.order == unordered && chunkSize != chunkSizes[0] {
-							// Chunk size isn't a factor for the unordered hash aggregator,
-							// so we can skip all but one case.
+	for _, aggFn := range []execinfrapb.AggregatorSpec_Func{
+		// We choose any_not_null aggregate function because it is the simplest
+		// possible and, thus, its Compute function call will have the least
+		// impact when benchmarking the aggregator logic.
+		execinfrapb.AnyNotNull,
+		// min aggregate function has been used before transitioning to
+		// any_not_null in 22.1 cycle. It is kept so that we could use it for
+		// comparison of 22.1 against 21.2.
+		// TODO(yuzefovich): use only any_not_null in 22.2 (#75106).
+		execinfrapb.Min,
+	} {
+		for _, numInputRows := range numRows {
+			for _, limit := range limits {
+				if limit > numInputRows {
+					continue
+				}
+				for _, groupSize := range groupSizes {
+					for _, chunkSize := range chunkSizes {
+						if groupSize > chunkSize || chunkSize > numInputRows {
 							continue
 						}
-						benchmarkAggregateFunction(b, agg, aggFn, []*types.T{types.Int}, 2, groupSize, 0, numInputRows, chunkSize, limit)
+						for _, agg := range []aggType{
+							{
+								new:   f,
+								name:  fmt.Sprintf("hash-unordered/limit=%d/chunkSize=%d", limit, chunkSize),
+								order: unordered,
+							},
+							{
+								new:   f,
+								name:  fmt.Sprintf("hash-partial-order/limit=%d/chunkSize=%d", limit, chunkSize),
+								order: partial,
+							},
+						} {
+							if agg.order == unordered && chunkSize != chunkSizes[0] {
+								// Chunk size isn't a factor for the unordered hash aggregator,
+								// so we can skip all but one case.
+								continue
+							}
+							benchmarkAggregateFunction(b, agg, aggFn, []*types.T{types.Int}, 2, groupSize, 0, numInputRows, chunkSize, limit)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
**colexec: switch min to any_not_null for aggregator benchmarks**

`any_not_null` will have the least impact when benchmarking the
aggregators. For 22.1 cycle we will keep the previous function (`min`)
so that we could use it for comparison against 21.2 branch.

Release note: None

**colexec: shuffle input for unordered distinct benchmark**

Previously, we were using the same way to construct the input data set
for both ordered and unordered distinct benchmarks (the latter was just
not taking an explicit advantage of the ordering). However, this is not
very realistic - we should properly shuffle the input for the unordered
distinct which is what this commit adds.

Note that this commit doesn't remove the old benchmark - instead, a new
bench case with a different name is added in order to preserve the
comparison against 21.2 branch. The old benchmark can be removed in
22.2.

Additionally, this commit removes a couple of bench cases which have too
high variance in the numbers. For example, here is a comparison of the
same code against itself:
```
Distinct/Unordered/hasNulls=false/newTupleProbability=0.001/rows=262144/ordCols=0/type=int-24     536MB/s ± 1%   679MB/s ± 2%  +26.67%  (p=0.000 n=10+10)
Distinct/Unordered/hasNulls=false/newTupleProbability=0.001/rows=262144/ordCols=0/type=bytes-24   236MB/s ± 1%   146MB/s ± 1%  -38.28%  (p=0.000 n=10+10)
Distinct/Unordered/hasNulls=true/newTupleProbability=0.001/rows=262144/ordCols=0/type=int-24      278MB/s ± 2%   218MB/s ± 2%  -21.68%  (p=0.000 n=10+10)
Distinct/Unordered/hasNulls=true/newTupleProbability=0.001/rows=262144/ordCols=0/type=bytes-24    184MB/s ± 1%   151MB/s ± 1%  -18.03%  (p=0.000 n=10+9)
```
Fixes: #64762.

Release note: None

**colexechash: move a non-templated function out of generated code**

Release note: None

**colexechash: pull out nulls bitmap retrieval out of the loop**

Release note: None

**colexechash: remove most comments from the generated code**

This commit converts all inline comments within the functions with the
generated code into the template-time only comments (i.e. the comments
are now only present in the template files). These comments aren't that
useful in the generated code. Additionally, the comments are reworded
slightly and wrapped at 80 characters.

Release note: None

**colexechash: clean up the check functions**

This commit cleans up the template for the functions that check the
results of a single iteration of probing (i.e. the code that runs after
probing tuples have been compared against the corresponding possible
matches, and we now have `differs` and `distinct` populated).

Previously, the code was of the form:
```
if !differs[i] {
...
// In some cases, set differs[i] to true.
...
}
if differs[i] {
...
}
```
This was so because we were modifying `differs` in the first block and
wanted to perform the logic of the second block. This commit, instead,
inlines the code of the second block in the case where we previously
were updating `differs[i]`. As a result, two `if`s have been squashed
into `if-else`.

Additionally, the comments have been improved.

Release note: None

**colexechash: clean up the logic around null checks**

This commit restructures the code so that the code for null checks is
only generated when the vectors might have null values. Additionally,
now the check whether null equality is allowed is only performed when we
have a NULL value (previously it was always performed, even when no
NULLs are present in the vectors).

Release note: None