### PR TITLE
backupccl: add mulitregion `defaultdb` restore test

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -168,6 +168,7 @@ go_test(
         "//pkg/blobs",
         "//pkg/ccl/kvccl",
         "//pkg/ccl/multiregionccl",
+        "//pkg/ccl/multiregionccl/multiregionccltestutils",
         "//pkg/ccl/multitenantccl",
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
@@ -9162,4 +9163,76 @@ func TestBackupRestoreSeparateIncrementalPrefix(t *testing.T) {
 		sqlDB.Exec(t, "DROP DATABASE trad_fkdb;")
 		sqlDB.Exec(t, "DROP DATABASE inc_fkdb;")
 	}
+}
+
+// TestBackupRestoreMRDefaultDB is a regression test for
+// https://github.com/cockroachdb/cockroach/issues/74586 to ensure that
+// `defaultdb` is restored with the same `RegionConfig` as it was backed up
+// with.
+func TestBackupRestoreMRDefaultDB(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStressRace(t, "times out under stressrace")
+
+	clusterSize := 3
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	_, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, clusterSize, base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		}, multiregionccltestutils.WithBaseDirectory(dir),
+	)
+	defer cleanup()
+
+	_, err := sqlDB.Exec(`
+USE defaultdb;
+alter database defaultdb primary region "us-east3";
+alter database defaultdb add region "us-east2";
+alter database defaultdb add region "us-east1";`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`
+CREATE TABLE A (
+  a STRING PRIMARY KEY
+);
+alter table A set locality regional by row;
+insert into A (a) VALUES ('foo');
+`)
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`BACKUP INTO 'nodelocal://0/foo'`)
+	require.NoError(t, err)
+
+	_, sqlDBRestore, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, clusterSize, base.TestingKnobs{}, multiregionccltestutils.WithBaseDirectory(dir),
+	)
+	defer cleanup()
+
+	_, err = sqlDBRestore.Exec(`RESTORE FROM LATEST IN 'nodelocal://0/foo'`)
+	require.NoError(t, err)
+
+	checkRows := func() {
+		row, err := sqlDBRestore.Query(`SELECT * FROM defaultdb.a`)
+		require.NoError(t, err)
+		defer row.Close()
+		var a string
+		for row.Next() {
+			err := row.Scan(&a)
+			require.NoError(t, err)
+		}
+		require.Equal(t, "foo", a)
+	}
+	checkRows()
+
+	// Sanity check that database level `defaultdb` restore still works.
+	t.Run("restore-mr-defaultdb", func(t *testing.T) {
+		_, err = sqlDBRestore.Exec(`DROP DATABASE defaultdb CASCADE;`)
+		require.NoError(t, err)
+
+		_, err = sqlDBRestore.Exec(`RESTORE DATABASE defaultdb FROM LATEST IN 'nodelocal://0/foo';`)
+		require.NoError(t, err)
+
+		checkRows()
+	})
 }


### PR DESCRIPTION
This is a forward port of the test from #74607. In 22.1
onwards defalutdb is treated like any other database in the
backup and so it should be restored with the correct RegionConfig
without any intervention.

Release note: None