### PR TITLE
kvserver: add metric for replica circuit breaker

### DIFF
--- a/pkg/kv/kvserver/metric_rules_test.go
+++ b/pkg/kv/kvserver/metric_rules_test.go
@@ -29,6 +29,7 @@ func TestMetricRules(t *testing.T) {
 	ruleRegistry := metric.NewRuleRegistry()
 	CreateAndAddRules(context.Background(), ruleRegistry)
 	require.NotNil(t, ruleRegistry.GetRuleForTest(unavailableRangesRuleName))
+	require.NotNil(t, ruleRegistry.GetRuleForTest(trippedReplicaCircuitBreakersRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(underreplicatedRangesRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(requestsStuckInRaftRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(highOpenFDCountRuleName))
@@ -39,5 +40,5 @@ func TestMetricRules(t *testing.T) {
 	require.NotNil(t, ruleRegistry.GetRuleForTest(capacityAvailableRatioRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(nodeCapacityAvailableRatioRuleName))
 	require.NotNil(t, ruleRegistry.GetRuleForTest(clusterCapacityAvailableRatioRuleName))
-	require.Equal(t, 11, ruleRegistry.GetRuleCountForTest())
+	require.Equal(t, 12, ruleRegistry.GetRuleCountForTest())
 }

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1252,6 +1252,26 @@ throttled they do count towards 'delay.total' and 'delay.enginebackpressure'.
 		Measurement: "Attempts",
 		Unit:        metric.Unit_COUNT,
 	}
+
+	// Replica circuit breaker.
+	metaReplicaCircuitBreakerCurTripped = metric.Metadata{
+		Name: "kv.replica_circuit_breaker.num_tripped_replicas",
+		Help: `Number of Replicas for which the per-Replica circuit breaker is currently tripped.
+
+A nonzero value indicates range or replica unavailability, and should be investigated.
+Replicas in this state will fail-fast all inbound requests.
+`,
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	// Replica circuit breaker.
+	metaReplicaCircuitBreakerCumTripped = metric.Metadata{
+		Name:        "kv.replica_circuit_breaker.num_tripped_events",
+		Help:        `Number of times the per-Replica circuit breakers tripped since process start.`,
+		Measurement: "Events",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // StoreMetrics is the set of metrics for a given store.
@@ -1470,6 +1490,10 @@ type StoreMetrics struct {
 
 	// Closed timestamp metrics.
 	ClosedTimestampMaxBehindNanos *metric.Gauge
+
+	// Replica circuit breaker.
+	ReplicaCircuitBreakerCurTripped *metric.Gauge
+	ReplicaCircuitBreakerCumTripped *metric.Counter
 }
 
 type tenantMetricsRef struct {
@@ -1908,6 +1932,10 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 
 		// Closed timestamp metrics.
 		ClosedTimestampMaxBehindNanos: metric.NewGauge(metaClosedTimestampMaxBehindNanos),
+
+		// Replica circuit breaker.
+		ReplicaCircuitBreakerCurTripped: metric.NewGauge(metaReplicaCircuitBreakerCurTripped),
+		ReplicaCircuitBreakerCumTripped: metric.NewCounter(metaReplicaCircuitBreakerCumTripped),
 	}
 	storeRegistry.AddMetricStruct(sm)
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -128,7 +129,17 @@ func newUnloadedReplica(
 	r.splitQueueThrottle = util.Every(splitQueueThrottleDuration)
 	r.mergeQueueThrottle = util.Every(mergeQueueThrottleDuration)
 
-	r.breaker = newReplicaCircuitBreaker(store.cfg.Settings, store.stopper, r.AmbientContext, r)
+	onTrip := func() {
+		telemetry.Inc(telemetryTripAsync)
+		r.store.Metrics().ReplicaCircuitBreakerCumTripped.Inc(1)
+		store.Metrics().ReplicaCircuitBreakerCurTripped.Inc(1)
+	}
+	onReset := func() {
+		store.Metrics().ReplicaCircuitBreakerCurTripped.Dec(1)
+	}
+	r.breaker = newReplicaCircuitBreaker(
+		store.cfg.Settings, store.stopper, r.AmbientContext, r, onTrip, onReset,
+	)
 	return r
 }
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -881,26 +881,33 @@ var charts = []sectionDescription{
 			{
 				Title:       "Latch",
 				Downsampler: DescribeAggregator_MAX,
-				Percentiles: false,
 				Metrics:     []string{"requests.slow.latch"},
 			},
 			{
 				Title:       "Stuck Acquiring Lease",
 				Downsampler: DescribeAggregator_MAX,
-				Percentiles: false,
 				Metrics:     []string{"requests.slow.lease"},
 			},
 			{
 				Title:       "Stuck in Raft",
 				Downsampler: DescribeAggregator_MAX,
-				Percentiles: false,
 				Metrics:     []string{"requests.slow.raft"},
 			},
 			{
 				Title:       "Stuck sending RPCs to range",
 				Downsampler: DescribeAggregator_MAX,
-				Percentiles: false,
 				Metrics:     []string{"requests.slow.distsender"},
+			},
+			{
+				Title:       "Replicas with tripped circuit breakers",
+				Downsampler: DescribeAggregator_MAX,
+				Metrics:     []string{"kv.replica_circuit_breaker.num_tripped_replicas"},
+			},
+			{
+				Title:       "Replica circuit breaker trip events",
+				Downsampler: DescribeAggregator_MAX,
+				Rate:        DescribeDerivative_NON_NEGATIVE_DERIVATIVE,
+				Metrics:     []string{"kv.replica_circuit_breaker.num_tripped_events"},
 			},
 		},
 	},


### PR DESCRIPTION
Add a metric that tracks how many replicas have tripped circuit
breakers.
Add a metric that counts the trip events as well. This can highlight
problems where the circuit is tripped in error and immediately untrips
(which may not be caught by the first metric).

Also, as requested by @mwang1026, report the latter via telemetry as
well.

Fixes #74505.

Release note: None
