### PR TITLE
importccl: add COMMENT ON FUNCTION to ignored stmt list

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5644,6 +5644,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 				GRANT SELECT ON SEQUENCE knex_migrations_id_seq TO opentrials_readonly;
 
 				COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+				COMMENT ON FUNCTION f() is 'f';
 				CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 				ALTER AGGREGATE myavg(integer) RENAME TO my_average;
@@ -5765,12 +5766,13 @@ revoke privileges on sequence: could not be parsed
 grant privileges on sequence: could not be parsed
 grant privileges on sequence: could not be parsed
 comment on extension: could not be parsed
+comment on function: could not be parsed
 create extension if not exists with: could not be parsed
 alter aggregate: could not be parsed
 alter domain: could not be parsed
-create function: could not be parsed
 `,
-			`alter function: could not be parsed
+			`create function: could not be parsed
+alter function: could not be parsed
 alter table alter column add: could not be parsed
 copy from unsupported format: could not be parsed
 grant privileges on schema with: could not be parsed

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -395,6 +395,7 @@ func TestUnimplementedSyntax(t *testing.T) {
 
 		{`CREATE ACCESS METHOD a`, 0, `create access method`, ``},
 
+		{`COMMENT ON FUNCTION f() is 'f'`, 17511, ``, ``},
 		{`COPY x FROM STDIN WHERE a = b`, 54580, ``, ``},
 
 		{`CREATE AGGREGATE a`, 0, `create aggregate`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3527,6 +3527,7 @@ comment_stmt:
     $$.val = &tree.CommentOnConstraint{Constraint:tree.Name($4), Table: $6.unresolvedObjectName(), Comment: $8.strPtr()}
   }
 | COMMENT ON EXTENSION error { return unimplemented(sqllex, "comment on extension") }
+| COMMENT ON FUNCTION error { return unimplementedWithIssueDetail(sqllex, 17511, "comment on function") }
 
 comment_text:
   SCONST


### PR DESCRIPTION
This change adds COMMENT ON FUNCTION as an unsupported statement
therefore allowing IMPORT PGDUMP to ignore it when run with the
`ignore_unsupported_statements` option.

Fixes: #74092

Release note: None