### PR TITLE
changefeedccl: filter out virtual computed columns from events

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2285,30 +2285,69 @@ func TestChangefeedVirtualComputedColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
-		sqlDB := sqlutils.MakeSQLRunner(db)
-		sqlDB.Exec(t, `CREATE TABLE cc (
-		a INT primary key, b INT, c INT AS (b + 1) VIRTUAL NOT NULL
-	)`)
-		sqlDB.Exec(t, `INSERT INTO cc VALUES (1, 1)`)
-
-		cc := feed(t, f, `CREATE CHANGEFEED FOR cc with diff`)
-		defer closeFeed(t, cc)
-
-		assertPayloads(t, cc, []string{
-			`cc: [1]->{"after": {"a": 1, "b": 1, "c": null}, "before": null}`,
-		})
-
-		sqlDB.Exec(t, `UPDATE cc SET b=10 WHERE a=1`)
-		assertPayloads(t, cc, []string{
-			`cc: [1]->{"after": {"a": 1, "b": 10, "c": null}, "before": {"a": 1, "b": 1, "c": null}}`,
-		})
+	tests := map[string]struct {
+		formatOpt               changefeedbase.FormatType
+		virtualColumnVisibility changefeedbase.VirtualColumnVisibility
+		changeFeedStmt          string
+		payloadAfterInsert      []string
+		payloadAfterUpdate      []string
+	}{
+		`format="json",virtual_columns="omitted"`: {
+			formatOpt:               changefeedbase.OptFormatJSON,
+			virtualColumnVisibility: changefeedbase.OptVirtualColumnsOmitted,
+			payloadAfterInsert:      []string{`cc: [1]->{"after": {"a": 1, "b": 1}, "before": null}`},
+			payloadAfterUpdate:      []string{`cc: [1]->{"after": {"a": 1, "b": 10}, "before": {"a": 1, "b": 1}}`},
+		},
+		`format="json",virtual_columns="null"`: {
+			formatOpt:               changefeedbase.OptFormatJSON,
+			virtualColumnVisibility: changefeedbase.OptVirtualColumnsNull,
+			payloadAfterInsert:      []string{`cc: [1]->{"after": {"a": 1, "b": 1, "c": null}, "before": null}`},
+			payloadAfterUpdate:      []string{`cc: [1]->{"after": {"a": 1, "b": 10, "c": null}, "before": {"a": 1, "b": 1, "c": null}}`},
+		},
+		`format="avro",virtual_columns="omitted"`: {
+			formatOpt:               changefeedbase.OptFormatAvro,
+			virtualColumnVisibility: changefeedbase.OptVirtualColumnsOmitted,
+			payloadAfterInsert:      []string{`cc: {"a":{"long":1}}->{"after":{"cc":{"a":{"long":1},"b":{"long":1}}},"before":null}`},
+			payloadAfterUpdate:      []string{`cc: {"a":{"long":1}}->{"after":{"cc":{"a":{"long":1},"b":{"long":10}}},"before":{"cc_before":{"a":{"long":1},"b":{"long":1}}}}`},
+		},
+		`format="avro",virtual_columns="null"`: {
+			formatOpt:               changefeedbase.OptFormatAvro,
+			virtualColumnVisibility: changefeedbase.OptVirtualColumnsNull,
+			payloadAfterInsert:      []string{`cc: {"a":{"long":1}}->{"after":{"cc":{"a":{"long":1},"b":{"long":1},"c":null}},"before":null}`},
+			payloadAfterUpdate:      []string{`cc: {"a":{"long":1}}->{"after":{"cc":{"a":{"long":1},"b":{"long":10},"c":null}},"before":{"cc_before":{"a":{"long":1},"b":{"long":1},"c":null}}}`},
+		},
 	}
 
-	t.Run(`sinkless`, sinklessTest(testFn))
-	t.Run(`enterprise`, enterpriseTest(testFn))
-	t.Run(`kafka`, kafkaTest(testFn))
-	t.Run(`webhook`, webhookTest(testFn))
+	for _, test := range tests {
+		testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+			sqlDB := sqlutils.MakeSQLRunner(db)
+
+			sqlDB.Exec(t, `CREATE TABLE cc (
+					a INT primary key, b INT, c INT AS (b + 1) VIRTUAL NOT NULL
+				)`)
+			defer sqlDB.Exec(t, `DROP TABLE cc`)
+
+			sqlDB.Exec(t, `INSERT INTO cc VALUES (1, 1)`)
+
+			changeFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR cc WITH diff, format="%s", virtual_columns="%s"`,
+				test.formatOpt, test.virtualColumnVisibility))
+			defer closeFeed(t, changeFeed)
+
+			assertPayloads(t, changeFeed, test.payloadAfterInsert)
+
+			sqlDB.Exec(t, `UPDATE cc SET b=10 WHERE a=1`)
+
+			assertPayloads(t, changeFeed, test.payloadAfterUpdate)
+		}
+
+		if test.formatOpt != changefeedbase.OptFormatAvro {
+			t.Run(`sinkless`, sinklessTest(testFn))
+			t.Run(`enterprise`, enterpriseTest(testFn))
+			t.Run(`webhook`, webhookTest(testFn))
+		}
+
+		t.Run(`kafka`, kafkaTest(testFn))
+	}
 }
 
 func TestChangefeedUpdatePrimaryKey(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -27,6 +27,10 @@ type SchemaChangeEventClass string
 // change event which is a member of the changefeed's schema change events.
 type SchemaChangePolicy string
 
+// VirtualColumnVisibility defines the behaviour of how the changefeed will
+// include virtual columns in an event
+type VirtualColumnVisibility string
+
 // Constants for the options.
 const (
 	OptAvroSchemaPrefix         = `avro_schema_prefix`
@@ -50,6 +54,10 @@ const (
 	OptWebhookClientTimeout     = `webhook_client_timeout`
 	OptOnError                  = `on_error`
 	OptMetricsScope             = `metrics_label`
+	OptVirtualColumns           = `virtual_columns`
+
+	OptVirtualColumnsOmitted VirtualColumnVisibility = `omitted`
+	OptVirtualColumnsNull    VirtualColumnVisibility = `null`
 
 	// OptSchemaChangeEventClassColumnChange corresponds to all schema change
 	// events which add or remove any column.
@@ -170,6 +178,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptWebhookClientTimeout:     sql.KVStringOptRequireValue,
 	OptOnError:                  sql.KVStringOptRequireValue,
 	OptMetricsScope:             sql.KVStringOptRequireValue,
+	OptVirtualColumns:           sql.KVStringOptRequireValue,
 }
 
 func makeStringSet(opts ...string) map[string]struct{} {
@@ -189,7 +198,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEnvelope,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
 	OptInitialScan, OptNoInitialScan,
-	OptMinCheckpointFrequency, OptMetricsScope)
+	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns)
 
 // SQLValidOptions is options exclusive to SQL sink
 var SQLValidOptions map[string]struct{} = nil

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -56,13 +56,17 @@ func ValidateTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDesc
 }
 
 // WarningsForTable returns any known nonfatal issues with running a changefeed on this kind of table.
-func WarningsForTable(targets jobspb.ChangefeedTargets, tableDesc catalog.TableDescriptor) []error {
+func WarningsForTable(
+	targets jobspb.ChangefeedTargets, tableDesc catalog.TableDescriptor, opts map[string]string,
+) []error {
 	warnings := []error{}
-	for _, col := range tableDesc.AccessibleColumns() {
-		if col.IsVirtual() {
-			warnings = append(warnings,
-				errors.Errorf("Changefeeds will emit null values for virtual column %s in table %s", col.ColName(), tableDesc.GetName()),
-			)
+	if _, ok := opts[OptVirtualColumns]; !ok {
+		for _, col := range tableDesc.AccessibleColumns() {
+			if col.IsVirtual() {
+				warnings = append(warnings,
+					errors.Errorf("Changefeeds will filter out values for virtual column %s in table %s", col.ColName(), tableDesc.GetName()),
+				)
+			}
 		}
 	}
 	return warnings


### PR DESCRIPTION
changefeedccl: filter out virtual computed columns from events

Resolves #74688

Release note (backward-incompatible change): Changefeeds will
now filter out virtual computed columns from events by default.