### PR TITLE
sql,kvstreamer: use Streamer with multiple column families

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -142,12 +142,7 @@ func (r Result) Release(ctx context.Context) {
 	}
 }
 
-// Streamer provides a streaming oriented API for reading from the KV layer. At
-// the moment the Streamer only works when SQL rows are comprised of a single KV
-// (i.e. a single column family).
-// TODO(yuzefovich): lift the restriction on a single column family once KV is
-// updated so that rows are never split across different BatchResponses when
-// TargetBytes limitBytes is exceeded.
+// Streamer provides a streaming oriented API for reading from the KV layer.
 //
 // The example usage is roughly as follows:
 //
@@ -207,9 +202,10 @@ type Streamer struct {
 	distSender *kvcoord.DistSender
 	stopper    *stop.Stopper
 
-	mode   OperationMode
-	hints  Hints
-	budget *budget
+	mode          OperationMode
+	hints         Hints
+	maxKeysPerRow int32
+	budget        *budget
 
 	coordinator          workerCoordinator
 	coordinatorStarted   bool
@@ -353,7 +349,10 @@ func NewStreamer(
 // Hints can be used to hint the aggressiveness of the caching policy. In
 // particular, it can be used to disable caching when the client knows that all
 // looked-up keys are unique (e.g. in the case of an index-join).
-func (s *Streamer) Init(mode OperationMode, hints Hints) {
+//
+// maxKeysPerRow indicates the maximum number of KV pairs that comprise a single
+// SQL row (i.e. the number of column families in the index being scanned).
+func (s *Streamer) Init(mode OperationMode, hints Hints, maxKeysPerRow int) {
 	if mode != OutOfOrder {
 		panic(errors.AssertionFailedf("only OutOfOrder mode is supported"))
 	}
@@ -362,6 +361,7 @@ func (s *Streamer) Init(mode OperationMode, hints Hints) {
 		panic(errors.AssertionFailedf("only unique requests are currently supported"))
 	}
 	s.hints = hints
+	s.maxKeysPerRow = int32(maxKeysPerRow)
 	s.waitForResults = make(chan struct{}, 1)
 }
 
@@ -1008,6 +1008,7 @@ func (w *workerCoordinator) performRequestAsync(
 			ba.Header.WaitPolicy = w.lockWaitPolicy
 			ba.Header.TargetBytes = targetBytes
 			ba.Header.AllowEmpty = !headOfLine
+			ba.Header.WholeRowsOfSize = w.s.maxKeysPerRow
 			// TODO(yuzefovich): consider setting MaxSpanRequestKeys whenever
 			// applicable (#67885).
 			ba.AdmissionHeader = w.requestAdmissionHeader

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -242,7 +242,8 @@ type cFetcher struct {
 
 	// maxKeysPerRow memoizes the maximum number of keys per row in the index
 	// we're fetching from. This is used to calculate the kvBatchFetcher's
-	// firstBatchLimit.
+	// firstBatchLimit as well as by the ColIndexJoin when it is using the
+	// Streamer API.
 	maxKeysPerRow int
 
 	// True if the index key must be decoded. This is only false if there are no

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -144,6 +144,7 @@ func (s *ColIndexJoin) Init(ctx context.Context) {
 		s.streamerInfo.Streamer.Init(
 			kvstreamer.OutOfOrder,
 			kvstreamer.Hints{UniqueRequests: true},
+			s.cf.maxKeysPerRow,
 		)
 	}
 }
@@ -455,23 +456,13 @@ func NewColIndexJoin(
 
 	useStreamer := row.CanUseStreamer(ctx, flowCtx.EvalCtx.Settings) && !spec.MaintainOrdering
 	if useStreamer {
-		// TODO(yuzefovich): remove this conditional once multiple column
-		// families are supported.
-		if maxKeysPerRow, err := tableArgs.desc.KeysPerRow(tableArgs.index.GetID()); err != nil {
-			return nil, err
-		} else if maxKeysPerRow > 1 {
-			// Currently, the streamer only supports cases with a single column
-			// family.
-			useStreamer = false
-		} else {
-			if streamerBudgetAcc == nil {
-				return nil, errors.AssertionFailedf("streamer budget account is nil when the Streamer API is desired")
-			}
-			// Keep the quarter of the memory limit for the output batch of the
-			// cFetcher, and we'll give the remaining three quarters to the
-			// streamer budget below.
-			memoryLimit = int64(math.Ceil(float64(memoryLimit) / 4.0))
+		if streamerBudgetAcc == nil {
+			return nil, errors.AssertionFailedf("streamer budget account is nil when the Streamer API is desired")
 		}
+		// Keep the quarter of the memory limit for the output batch of the
+		// cFetcher, and we'll give the remaining three quarters to the streamer
+		// budget below.
+		memoryLimit = int64(math.Ceil(float64(memoryLimit) / 4.0))
 	}
 
 	fetcher := cFetcherPool.Get().(*cFetcher)

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -26,7 +26,7 @@ import (
 // CanUseStreamer returns whether the kvstreamer.Streamer API should be used.
 func CanUseStreamer(ctx context.Context, settings *cluster.Settings) bool {
 	// TODO(yuzefovich): remove the version gate in 22.2 cycle.
-	return settings.Version.IsActive(ctx, clusterversion.TargetBytesAvoidExcess) &&
+	return settings.Version.IsActive(ctx, clusterversion.ScanWholeRows) &&
 		useStreamerEnabled.Get(&settings.SV)
 }
 


### PR DESCRIPTION
This commit takes advantage of the recently introduced `WholeRowsOfSize`
argument of the `BatchRequest`s (which allows for SQL rows not being
split across multiple responses when multiple column families are
present) to support multi-column family case in the `Streamer`.

Addresses: #54680.

Release note: None
