### PR TITLE
sql: clean up mutable not-null columns hack

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -447,9 +447,8 @@ type TableDescriptor interface {
 	// details.
 	AccessibleColumns() []Column
 	// ReadableColumns is a list of columns (including those undergoing a schema
-	// change) which can be scanned. Columns in the process of a schema change
-	// are all set to nullable while column backfilling is still in
-	// progress, as mutation columns may have NULL values.
+	// change) which can be scanned. Note that mutation columns may produce NULL
+	// values when scanned, even if they are marked as not nullable.
 	ReadableColumns() []Column
 	// UserDefinedTypeColumns returns a slice of Column interfaces
 	// containing the table's columns with user defined types, in the

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -315,22 +315,12 @@ func newColumnCache(desc *descpb.TableDescriptor, mutations *mutationCache) *col
 		c.writable = c.public
 		c.nonDrop = c.public
 	} else {
-		readableDescs := make([]descpb.ColumnDescriptor, 0, numMutations)
-		readableBackingStructs := make([]column, 0, numMutations)
 		for _, col := range c.deletable {
 			if !col.DeleteOnly() {
 				lazyAllocAppendColumn(&c.writable, col, numDeletable)
 			}
 			if !col.Dropped() {
 				lazyAllocAppendColumn(&c.nonDrop, col, numDeletable)
-			}
-			if !col.Public() && !col.IsNullable() {
-				j := len(readableDescs)
-				readableDescs = append(readableDescs, *col.ColumnDesc())
-				readableDescs[j].Nullable = true
-				readableBackingStructs = append(readableBackingStructs, *col.(*column))
-				readableBackingStructs[j].desc = &readableDescs[j]
-				col = &readableBackingStructs[j]
 			}
 			lazyAllocAppendColumn(&c.readable, col, numDeletable)
 		}

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1379,7 +1379,7 @@ func (rf *cFetcher) fillNulls() error {
 		if table.compositeIndexColOrdinals.Contains(i) {
 			continue
 		}
-		if !table.cols[i].IsNullable() {
+		if !table.cols[i].IsNullable() && table.cols[i].Public() {
 			var indexColValues strings.Builder
 			rf.writeDecodedCols(&indexColValues, table.indexColOrdinals, ',')
 			return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(


### PR DESCRIPTION
Mutation columns in some cases need to be scanned even if they haven't
been backfilled yet, which means that we may retrieve NULL values even
if they are marked as not-nullable.

We currently have a hack in the table descriptor which changes the
nullable flags in the column descriptors when `ReadableColumns()` is
used. It is very surprising that we can get different descriptors for
a given ColumnID depending if we look for it in `ReadableColumns()` or
in `AllColumns()` (e.g. via FindColumnWithID).

This commit cleans this up, changing the scanning code to check for
`Public()` instead.

Release note: None