### PR TITLE
sql/row: remove descriptor return values from fetcher

### DIFF
--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -648,7 +648,7 @@ func processEntryFiles(
 	}
 
 	for {
-		datums, _, _, err := rf.NextRowDecoded(ctx)
+		datums, err := rf.NextRowDecoded(ctx)
 		if err != nil {
 			return errors.Wrapf(err, "decode row")
 		}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -330,7 +330,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 	iv.Cols = append(iv.Cols, cb.added...)
 	cb.evalCtx.IVarContainer = iv
 	for i := int64(0); i < int64(chunkSize); i++ {
-		datums, _, _, err := cb.fetcher.NextRowDecoded(ctx)
+		datums, err := cb.fetcher.NextRowDecoded(ctx)
 		if err != nil {
 			return roachpb.Key{}, err
 		}
@@ -890,7 +890,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 		return nil
 	}
 	for i := int64(0); i < chunkSize; i++ {
-		encRow, _, _, err := fetcher.NextRow(ctx)
+		encRow, err := fetcher.NextRow(ctx)
 		if err != nil {
 			return nil, nil, 0, err
 		}

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -402,7 +402,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 		))
 		var rows []tree.Datums
 		for {
-			datums, _, _, err := fetcher.NextRowDecoded(ctx)
+			datums, err := fetcher.NextRowDecoded(ctx)
 			require.NoError(t, err)
 			if datums == nil {
 				break

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -258,7 +258,7 @@ func DecodeRowInfo(
 	if err := rf.StartScanFrom(ctx, &f, false /* traceKV */); err != nil {
 		return nil, nil, nil, err
 	}
-	datums, _, _, err := rf.NextRowDecoded(ctx)
+	datums, err := rf.NextRowDecoded(ctx)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -126,7 +126,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 		}
 		var rows []rowWithMVCCMetadata
 		for {
-			datums, _, _, err := rf.NextRowDecoded(ctx)
+			datums, err := rf.NextRowDecoded(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -166,7 +166,7 @@ func TestNextRowSingle(t *testing.T) {
 
 			expectedVals := [2]int64{1, 1}
 			for {
-				datums, desc, index, err := rf.NextRowDecoded(context.Background())
+				datums, err := rf.NextRowDecoded(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -175,14 +175,6 @@ func TestNextRowSingle(t *testing.T) {
 				}
 
 				count++
-
-				if desc.GetID() != tableDesc.GetID() || index.GetID() != tableDesc.GetPrimaryIndexID() {
-					t.Fatalf(
-						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
-						tableDesc.GetName(), tableDesc.GetPrimaryIndex().GetName(),
-						desc.GetName(), index.GetName(),
-					)
-				}
 
 				if table.nCols != len(datums) {
 					t.Fatalf("expected %d columns, got %d columns", table.nCols, len(datums))
@@ -285,7 +277,7 @@ func TestNextRowBatchLimiting(t *testing.T) {
 
 			expectedVals := [2]int64{1, 1}
 			for {
-				datums, desc, index, err := rf.NextRowDecoded(context.Background())
+				datums, err := rf.NextRowDecoded(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -294,14 +286,6 @@ func TestNextRowBatchLimiting(t *testing.T) {
 				}
 
 				count++
-
-				if desc.GetID() != tableDesc.GetID() || index.GetID() != tableDesc.GetPrimaryIndexID() {
-					t.Fatalf(
-						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
-						tableDesc.GetName(), tableDesc.GetPrimaryIndex().GetName(),
-						desc.GetName(), index.GetName(),
-					)
-				}
 
 				if table.nCols != len(datums) {
 					t.Fatalf("expected %d columns, got %d columns", table.nCols, len(datums))
@@ -480,7 +464,7 @@ INDEX(c)
 	for {
 		// Just try to grab the row - we don't need to validate the contents
 		// in this test.
-		datums, _, _, err := rf.NextRowDecoded(context.Background())
+		datums, err := rf.NextRowDecoded(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -639,7 +623,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 			nullCount := 0
 			var prevIdxVal int64
 			for {
-				datums, desc, index, err := rf.NextRowDecoded(context.Background())
+				datums, err := rf.NextRowDecoded(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -648,14 +632,6 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 				}
 
 				count++
-
-				if desc.GetID() != tableDesc.GetID() || index.GetID() != tableDesc.PublicNonPrimaryIndexes()[0].GetID() {
-					t.Fatalf(
-						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
-						tableDesc.GetName(), tableDesc.PublicNonPrimaryIndexes()[0].GetName(),
-						desc.GetName(), index.GetName(),
-					)
-				}
 
 				if table.nCols != len(datums) {
 					t.Fatalf("expected %d columns, got %d columns", table.nCols, len(datums))

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -524,7 +524,7 @@ func (ij *invertedJoiner) performScan() (invertedJoinerState, *execinfrapb.Produ
 	// Read the entire set of rows that are part of the scan.
 	for {
 		// Fetch the next row and copy it into the row container.
-		scannedRow, _, _, err := ij.fetcher.NextRow(ij.Ctx)
+		scannedRow, err := ij.fetcher.NextRow(ij.Ctx)
 		if err != nil {
 			ij.MoveToDraining(scrub.UnwrapScrubError(err))
 			return ijStateUnknown, ij.DrainHelper()

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -938,7 +938,7 @@ func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMet
 		}
 
 		// Fetch the next row and tell the strategy to process it.
-		lookedUpRow, _, _, err := jr.fetcher.NextRow(jr.Ctx)
+		lookedUpRow, err := jr.fetcher.NextRow(jr.Ctx)
 		if err != nil {
 			jr.MoveToDraining(scrub.UnwrapScrubError(err))
 			return jrStateUnknown, jr.DrainHelper()

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -49,8 +49,7 @@ type rowFetcher interface {
 		forceProductionKVBatchSize bool,
 	) error
 
-	NextRow(ctx context.Context) (
-		rowenc.EncDatumRow, catalog.TableDescriptor, catalog.Index, error)
+	NextRow(ctx context.Context) (rowenc.EncDatumRow, error)
 
 	// PartialKey is not stat-related but needs to be supported.
 	PartialKey(int) (roachpb.Key, error)

--- a/pkg/sql/rowexec/stats.go
+++ b/pkg/sql/rowexec/stats.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -92,16 +91,14 @@ func newRowFetcherStatCollector(f *row.Fetcher) *rowFetcherStatCollector {
 }
 
 // NextRow is part of the rowFetcher interface.
-func (c *rowFetcherStatCollector) NextRow(
-	ctx context.Context,
-) (rowenc.EncDatumRow, catalog.TableDescriptor, catalog.Index, error) {
+func (c *rowFetcherStatCollector) NextRow(ctx context.Context) (rowenc.EncDatumRow, error) {
 	start := timeutil.Now()
-	row, t, i, err := c.Fetcher.NextRow(ctx)
+	row, err := c.Fetcher.NextRow(ctx)
 	if row != nil {
 		c.stats.NumTuples.Add(1)
 	}
 	c.stats.WaitTime.Add(timeutil.Since(start))
-	return row, t, i, err
+	return row, err
 }
 
 // StartScan is part of the rowFetcher interface.

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -269,7 +269,7 @@ func (tr *tableReader) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 			return nil, meta
 		}
 
-		row, _, _, err := tr.fetcher.NextRow(tr.Ctx)
+		row, err := tr.fetcher.NextRow(tr.Ctx)
 		if row == nil || err != nil {
 			tr.MoveToDraining(err)
 			break

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -560,7 +560,7 @@ func (z *zigzagJoiner) fetchRowFromSide(
 		return false
 	}
 	for {
-		fetchedRow, _, _, err = z.infos[side].fetcher.NextRow(ctx)
+		fetchedRow, err = z.infos[side].fetcher.NextRow(ctx)
 		if fetchedRow == nil || err != nil {
 			return fetchedRow, err
 		}


### PR DESCRIPTION
The fetcher's next-row methods return the table and index descriptor.
This was only useful for interleaved tables which no longer exist.
This commit cleans up the code to remove these unnecessary return
values.

Release note: None