### PR TITLE
*: de-flake TestPaginatedBackupTenant and remove data race

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2336,6 +2336,9 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 	}
 
 	now := s.cfg.Clock.NowAsClockTimestamp()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if err := s.mu.replicasByKey.VisitKeyRange(ctx, sp.Key, sp.EndKey, AscendingKeyOrder,
 		func(ctx context.Context, it replicaOrPlaceholder) error {
 			repl := it.repl

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1478,6 +1478,7 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	params, _ := tests.CreateTestServerParams()
+	params.Knobs.SpanConfig = &spanconfig.TestingKnobs{ManagerDisableJobCreation: true} // TODO(irfansharif): #74919.
 	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: params,
 	})


### PR DESCRIPTION
See individual commits; this PR squashes a data race in KV among other things.

---

This test readily fails under stress with span configs enabled (#73876).
Now that we split within the tenant keyspace for tenant tables, the
export requests generated for each BACKUP is liable to be retried if
concurrent with range splits. The splits causes KV to error out with
RangeKeyMismatchErrors, at which point the request is internally
retried. The test, which wants to assert on what ExportSpan requests are
intercepted, previously did not need to consider these retries/need to
de-dup -- it now does.

Release note: None