### PR TITLE
opt: do not error if distribute expression is a no-op

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -338,3 +338,18 @@ vectorized: true
                   spans: [/'ap-southeast-2'/'94e4b847-8f2f-4ac5-83f1-641d6e3df727' - /'ap-southeast-2'/'94e4b847-8f2f-4ac5-83f1-641d6e3df727'] [/'us-east-1'/'94e4b847-8f2f-4ac5-83f1-641d6e3df727' - /'us-east-1'/'94e4b847-8f2f-4ac5-83f1-641d6e3df727']
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykk99uGjsQxu_PU1hzk9PIhP0XICtFctTSlohCCpFaqUZos55N3IK9tb3tVhFXfba-V7W7JCmooCS9ANvj-Zjf5xluwX5dQAz9jxfDs8GI_P9qML2cvh--INP-sP_ykmgj0MyloCQ3eqntUb2sAzJFcjZtNvPv0t3ows3rhLvbQyKkTXWh3GZik0VeT8bvmhKWnI8Ho3URMr7bHUmVacJ44XkhrjOb2Ie3_Un_Ho-ckoOTCKOrXtRt9bIga0VJetzqhZnf6kS-6GAosm7QPQAKSgscJUu0EH-CCGYUcqNTtFabKnRbJwxECbFHQaq8cFV4RiHVBiG-BSfdAiGGy-RqgRNMBJq2BxQEukQu6p9tSFlu5DIxP4DCNE-UjUmbA-PQ5sB5eRJxXmL1ddV7w3nZy9rnv35yXma-4Lz0hTqtDt0DDm2PJEoQn2h3gwYojAsXE-ZTFlAWwWxFQRfugdS65Boh9lf0eW78R7upuL1nOXq0i2Cniwd4i0YmC1KoGhXFBv9s9Re7I93SeTvYNDqUS-mIvxPFe8qDDtQ3NA7FuZYKTTvcLNXMN2uWeTXScylKoPeyfpkbwjr3w8_CrRcL9z1a-BTSinDd-WgH5V3nh1p_KXLyWUtFtIoJqwTjEWHdTdAJKoGmZiXsmBIWVJ9D1tlJHD2FeII218riVp93dW1GAcU1NjNjdWFSvDA6rcs0x3GtqwMCrWtug-YwUPVV_W_6U-z_izjYKw43xN62ONwrjvaLo73i4y3xbPXf7wAAAP__Xc4AbA==
+
+# Regression test for #74890. Code should not panic due to distribution already
+# provided by input.
+statement ok nodeidx=3
+USE multi_region_test_db; CREATE TABLE t74890 AS
+SELECT generate_series(1, 5) AS g
+
+query I nodeidx=3
+USE multi_region_test_db; SELECT g FROM t74890 ORDER BY g
+----
+1
+2
+3
+4
+5

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1666,7 +1666,10 @@ func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (execPlan, er
 	distribution := distribute.ProvidedPhysical().Distribution
 	inputDistribution := distribute.Input.ProvidedPhysical().Distribution
 	if distribution.Equals(inputDistribution) {
-		return execPlan{}, errors.AssertionFailedf("distribution already provided by input")
+		// Don't bother creating a no-op distribution. This likely exists because
+		// the input is a Sort expression, and this is an artifact of how physical
+		// properties are enforced.
+		return input, err
 	}
 
 	// TODO(rytaft): This is currently a no-op. We should pass this distribution

--- a/pkg/sql/opt/xform/testdata/physprops/distribution
+++ b/pkg/sql/opt/xform/testdata/physprops/distribution
@@ -101,6 +101,59 @@ distribute
            ├── key: (1)
            └── fd: (1)-->(2,3), (2,3)~~>(1)
 
+# Combined with sorting. Distribute is not needed, but due to the way physical
+# properties are enforced (distribution is enforced before ordering), we end up
+# with a no-op distribute operator.
+opt locality=(region=us)
+SELECT * FROM abc WHERE a > 10 ORDER BY c
+----
+distribute
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── ordering: +3
+ ├── distribution: us
+ ├── input distribution: us
+ └── sort
+      ├── columns: a:1!null b:2 c:3
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (2,3)~~>(1)
+      ├── ordering: +3
+      └── scan abc
+           ├── columns: a:1!null b:2 c:3
+           ├── constraint: /1: [/11 - ]
+           ├── key: (1)
+           └── fd: (1)-->(2,3), (2,3)~~>(1)
+
+# Combined with ordering. Sort is not needed.
+opt locality=(region=ap)
+SELECT * FROM abc WHERE a > 10 ORDER BY a
+----
+distribute
+ ├── columns: a:1!null b:2 c:3
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── ordering: +1
+ ├── distribution: ap
+ ├── input distribution: us
+ └── scan abc
+      ├── columns: a:1!null b:2 c:3
+      ├── constraint: /1: [/11 - ]
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (2,3)~~>(1)
+      └── ordering: +1
+
+# Combined with ordering. Neither Sort nor Distribute is needed.
+opt locality=(region=us)
+SELECT * FROM abc WHERE a > 10 ORDER BY a
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── constraint: /1: [/11 - ]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── ordering: +1
+ └── distribution: us
 
 # Tests for distribution property with a partitioned table.
 


### PR DESCRIPTION
This commit removes an assertion that caused an internal error when
a distribute operator was unnecessary. This assertion made the incorrect
assumption that it should always be possible to remove no-op enforcers.
However, it is not possible to completely remove no-op distribute
operators when there is also a sort required. This due to the way
physical properties are enforced, in which distribution is enforced
before ordering. Therefore, a no-op distribute operator should not
cause an assertion failure.

Fixes #74890

There is no release note since this bug is not part of any release.

Release note: None