### PR TITLE
sql: fix ALTER DATABASE help text

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1665,12 +1665,14 @@ alter_sequence_options_stmt:
 // %Category: DDL
 // %Text:
 // ALTER DATABASE <name> RENAME TO <newname>
+// ALTER DATABASE <name> CONFIGURE ZONE <zone config>
 // ALTER DATABASE <name> OWNER TO <newowner>
 // ALTER DATABASE <name> CONVERT TO SCHEMA WITH PARENT <name>
-// ALTER DATABASE <name> ADD REGIONS <regions>
-// ALTER DATABASE <name> DROP REGIONS <regions>
+// ALTER DATABASE <name> ADD REGION [IF NOT EXISTS] <region>
+// ALTER DATABASE <name> DROP REGION [IF EXISTS] <region>
 // ALTER DATABASE <name> PRIMARY REGION <region>
 // ALTER DATABASE <name> SURVIVE <failure type>
+// ALTER DATABASE <name> PLACEMENT { RESTRICTED | DEFAULT }
 // ALTER DATABASE <name> SET var { TO | = } { value | DEFAULT }
 // ALTER DATABASE <name> RESET { var | ALL }
 // %SeeAlso: WEBDOCS/alter-database.html


### PR DESCRIPTION
Prior to this commit, the CLI help text shown for `ALTER DATABASE`
was incomplete and incorrect. This commit fixes the help text to
include some omitted options and fixes `ADD REGIONS` and `DROP REGIONS`
to say `ADD REGION` and `DROP REGION`.

Release note (cli change): Fixed the CLI help text for `ALTER DATABASE`
to show correct options for `ADD REGION` and `DROP REGION`, and include
some missing options such as `CONFIGURE ZONE`.