### PR TITLE
label-merged-pr: don't exit on finding ref w/o a version

### DIFF
--- a/pkg/cmd/label-merged-pr/main.go
+++ b/pkg/cmd/label-merged-pr/main.go
@@ -84,6 +84,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("Error getting first tag containing ref %s: %+v\n", ref, err)
 		}
+		if tag == "" {
+			log.Printf("Ref %s has not yet appeared in a released version.", ref)
+			continue
+		}
 		pr, err := getPrInfo(ref)
 		if err != nil {
 			log.Fatalf("Cannot find PR for ref %s: %+v\n", ref, err)
@@ -168,9 +172,6 @@ func getFirstTagContainingRef(ref string) (string, error) {
 		return "", err
 	}
 	version := matchVersion(string(out))
-	if version == "" {
-		return "", fmt.Errorf("cannot find valid version")
-	}
 	return version, nil
 }
 


### PR DESCRIPTION
Before, if a git ref was in a version tag, label-merged-pr would simply
exit saying it couldn't find a version for the ref. However, it should
be possible to run the command with a set of commits that are not yet in
a released version.

Now, it simply says the ref is not yet in a released version and
continues with processing commits.

Release note: None