### PR TITLE
bazel: document stringer confusion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -235,9 +235,11 @@
 /pkg/roachpb/metadata*       @cockroachdb/kv-prs
 /pkg/roachpb/method*         @cockroachdb/kv-prs
 /pkg/roachpb/mocks*          @cockroachdb/kv-prs
+/pkg/roachpb/replica_*       @cockroachdb/kv-prs
 /pkg/roachpb/span*           @cockroachdb/kv-prs
 /pkg/roachpb/string_test.go  @cockroachdb/kv-prs
 /pkg/roachpb/tenant*         @cockroachdb/kv-prs
+/pkg/roachpb/testdata/repl*  @cockroachdb/kv-prs
 /pkg/roachpb/version*        @cockroachdb/server
 /pkg/roachprod/              @cockroachdb/dev-inf
 /pkg/rpc/                    @cockroachdb/server-prs

--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -205,7 +205,7 @@ func replicaUnavailableError(
 	var _ redact.SafeFormatter = desc
 	var _ redact.SafeFormatter = replDesc
 
-	err := errors.Errorf("replica %s of %s is unavailable", desc, replDesc)
+	err := roachpb.NewReplicaUnavailableError(desc, replDesc)
 	err = errors.Wrapf(
 		err,
 		"raft status: %+v", redact.Safe(rs), // raft status contains no PII

--- a/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
+++ b/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
@@ -1,3 +1,3 @@
 echo
 ----
-replicas on non-live nodes: (n2,s20):2 (lost quorum: true): raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: replica r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0] of (n1,s10):1 is unavailable
+replicas on non-live nodes: (n2,s20):2 (lost quorum: true): raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: replica (n1,s10):1 unable to serve request to r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0]

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "metadata.go",
         "metadata_replicas.go",
         "method.go",
+        "replica_unavailable_error.go",
         "span_config.go",
         "span_group.go",
         "tenant.go",
@@ -154,10 +155,12 @@ go_test(
         "merge_spans_test.go",
         "metadata_replicas_test.go",
         "metadata_test.go",
+        "replica_unavailable_error_test.go",
         "span_group_test.go",
         "tenant_test.go",
         "version_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":with-mocks"],  # keep
     tags = ["no-remote"],
     deps = [
@@ -165,6 +168,7 @@ go_test(
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/storage/enginepb",
         "//pkg/testutils/buildutil",
+        "//pkg/testutils/echotest",
         "//pkg/testutils/zerofields",
         "//pkg/util",
         "//pkg/util/bitarray",

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -373,6 +373,13 @@ message AmbiguousResultError {
   optional Error wrapped_err = 2;
 }
 
+message ReplicaUnavailableError {
+  option (gogoproto.goproto_stringer) = false;
+
+  optional roachpb.RangeDescriptor desc = 2 [(gogoproto.nullable) = false];
+  optional roachpb.ReplicaDescriptor replica = 4 [(gogoproto.nullable) = false];
+}
+
 // A RaftGroupDeletedError indicates a raft group has been deleted for
 // the replica.
 message RaftGroupDeletedError {

--- a/pkg/roachpb/replica_unavailable_error.go
+++ b/pkg/roachpb/replica_unavailable_error.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachpb
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// NewReplicaUnavailableError initializes a new *ReplicaUnavailableError. It is
+// provided with the range descriptor known to the replica, and the relevant
+// replica descriptor within.
+func NewReplicaUnavailableError(desc *RangeDescriptor, replDesc ReplicaDescriptor) error {
+	return &ReplicaUnavailableError{
+		Desc:    *desc,
+		Replica: replDesc,
+	}
+}
+
+var _ errors.SafeFormatter = (*ReplicaUnavailableError)(nil)
+var _ fmt.Formatter = (*ReplicaUnavailableError)(nil)
+
+// SafeFormatError implements errors.SafeFormatter.
+func (e *ReplicaUnavailableError) SafeFormatError(p errors.Printer) error {
+	e.printTo(p.Printf)
+	return nil
+}
+
+// See https://github.com/cockroachdb/errors/issues/88.
+func (e *ReplicaUnavailableError) printTo(printf func(string, ...interface{})) {
+	printf("replica %s unable to serve request to %s", e.Replica, e.Desc)
+}
+
+// Format implements fmt.Formatter.
+func (e *ReplicaUnavailableError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }
+
+// Error implements error.
+func (e *ReplicaUnavailableError) Error() string {
+	var s string
+	e.printTo(func(format string, args ...interface{}) {
+		s = fmt.Sprintf(format, args...)
+	})
+	return s
+}
+
+func (e *ReplicaUnavailableError) String() string {
+	return redact.Sprint(e).StripMarkers()
+}

--- a/pkg/roachpb/replica_unavailable_error_test.go
+++ b/pkg/roachpb/replica_unavailable_error_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package roachpb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+func TestReplicaUnavailableError(t *testing.T) {
+	ctx := context.Background()
+	var _ = (*ReplicaUnavailableError)(nil)
+	rDesc := ReplicaDescriptor{NodeID: 1, StoreID: 2, ReplicaID: 3}
+	var set ReplicaSet
+	set.AddReplica(rDesc)
+	desc := NewRangeDescriptor(123, RKeyMin, RKeyMax, set)
+
+	var err error = NewReplicaUnavailableError(desc, rDesc)
+	err = errors.DecodeError(ctx, errors.EncodeError(ctx, err))
+
+	s := fmt.Sprintf("%s\n%s", err, redact.Sprint(err))
+	echotest.Require(t, s, filepath.Join("testdata", "replica_unavailable_error.txt"))
+}

--- a/pkg/roachpb/testdata/replica_unavailable_error.txt
+++ b/pkg/roachpb/testdata/replica_unavailable_error.txt
@@ -1,0 +1,4 @@
+echo
+----
+replica (n1,s2):3 unable to serve request to r123:/M{in-ax} [(n1,s2):1, next=2, gen=0]
+replica (n1,s2):3 unable to serve request to r123:‹/M{in-ax}› [(n1,s2):1, next=2, gen=0]


### PR DESCRIPTION
Bazel fails with

```
Run Bazel build] bazel-out/host/bin/pkg/roachpb/roachpb_go_proto_/github.com/cockroachdb/cockroach/pkg/roachpb/errors.pb.go:1162:47: cannot use m (type *ReplicaUnavailableError) as type "github.com/gogo/protobuf/proto".Message in argument to xxx_messageInfo_ReplicaUnavailableError.Merge:
[15:15:01]
[Run Bazel build] 	*ReplicaUnavailableError does not implement "github.com/gogo/protobuf/proto".Message (missing String method)
[15:15:01]
[Run Bazel build] bazel-out/host/bin/pkg/roachpb/roachpb_go_proto_/github.com/cockroachdb/cockroach/pkg/roachpb/errors.pb.go:1168:56: cannot use m (type *ReplicaUnavailableError) as type "github.com/gogo/protobuf/proto".Message in argument to xxx_messageInfo_ReplicaUnavailableError.DiscardUnknown:
[15:15:01]
[Run Bazel build] 	*ReplicaUnavailableError does not implement "github.com/gogo/protobuf/proto".Message (missing String method)
[15:15:01]
[Run Bazel build] bazel-out/host/bin/pkg/roachpb/roachpb_go_proto_/github.com/cockroachdb/cockroach/pkg/roachpb/errors.pb.go:2420:47: cannot use (*ReplicaUnavailableError)(nil) (type *ReplicaUnavailableError) as type "github.com/gogo/protobuf/proto".Message in argument to "github.com/gogo/protobuf/proto".RegisterType:
[15:15:01]
[Run Bazel build] 	*ReplicaUnavailableError does not implement "github.com/gogo/protobuf/proto".Message (missing String method)
[15:15:01]
[Run Bazel build] compilepkg: error running subcommand external/go_sdk/pkg/tool/linux_amd64/compile: exit status 2
```

However, `*ReplicaUnavailableError` does implement `fmt.Stringer` (see `replica_unavailable_error.go`).

I'm sure this would work if I used the proto-generated stringer (which is disabled for `message ReplicaUnavailableError`).

`make bazel-generate` comes back clean.
