### PR TITLE
sql: avoid CREATE INDEX failure on retry

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -938,3 +938,10 @@ CREATE TABLE t74216 (
     a REGTYPE,
     UNIQUE ((a::STRING))
 )
+
+# create index using an expression works even when retried
+statement ok
+BEGIN;
+CREATE INDEX t_a_times_three_idx ON t ((a * 3));
+SELECT crdb_internal.force_retry('10ms');
+COMMIT


### PR DESCRIPTION
Previously, if a transaction including a CREATE INDEX statement that
used expressions in the list of included columns encountered a
TransactionRetryWithProtoRefreshError, the retry would fail with an
error such as

```
(42703) column "crdb_internal_idx_expr_6" does not exist
column_resolver.go:196: in NewUndefinedColumnError()
```

This was the result of makeIndexDescriptor substituting the
expressions with the names of the newly added columns on the
CreateIndexNode itself. When the transaction is retried, the
generated column names do not yet exist.

Here, we resolve this issue by only modifying a copy of the
IndexElemList when generating an index descriptor.

Release note (bug fix): CREATE INDEX statements using expressions
previously failed in some cases if they encountered an internal retry.