### PR TITLE
loqrecovery: prevent connections from dead nodes

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -57,9 +57,15 @@ message ReplicaUpdate {
     (gogoproto.moretags) = 'yaml:"NextReplicaID"'];
 }
 
-// ReplicaUpdatePlan Collection of updates for all recoverable replicas in the cluster.
+// ReplicaUpdatePlan Collection of updates for all recoverable replicas in the cluster
+// as well as other metadata changes that is needed to guardrail from accidental errors
+// when performing recovery.
 message ReplicaUpdatePlan {
-  repeated ReplicaUpdate updates = 1 [(gogoproto.nullable) = false];
+  repeated ReplicaUpdate updates = 1 [(gogoproto.nullable) = false,
+    (gogoproto.moretags) = 'yaml:"Updates"'];
+  repeated int32 tombstoned_node_ids = 2 [(gogoproto.customname) = "TombstonedNodeIDs",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
+    (gogoproto.moretags) = 'yaml:"RemovedNodeIDs,omitempty,flow"'];
 }
 
 // ReplicaRecoveryRecord is a struct that loss of quorum recovery commands

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -270,7 +270,7 @@ func (e *quorumRecoveryEnv) handleMakePlan(t *testing.T, d datadriven.TestData) 
 		return "", err
 	}
 	// We only marshal actual data without container to reduce clutter.
-	out, err := yaml.Marshal(e.plan.Updates)
+	out, err := yaml.Marshal(e.plan)
 	if err != nil {
 		t.Fatalf("failed to marshal plan into yaml for verification: %v", err)
 	}

--- a/pkg/kv/kvserver/loqrecovery/testdata/learners_lose
+++ b/pkg/kv/kvserver/loqrecovery/testdata/learners_lose
@@ -39,6 +39,7 @@ ok
 
 make-plan
 ----
+Updates:
 - RangeID: 1
   StartKey: /Min
   OldReplicaID: 1
@@ -47,6 +48,7 @@ make-plan
     StoreID: 1
     ReplicaID: 16
   NextReplicaID: 17
+RemovedNodeIDs: [3, 4, 5]
 
 apply-plan stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/max_applied_voter_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/max_applied_voter_wins
@@ -37,6 +37,7 @@ ok
 
 make-plan
 ----
+Updates:
 - RangeID: 1
   StartKey: /Min
   OldReplicaID: 1
@@ -45,6 +46,7 @@ make-plan
     StoreID: 1
     ReplicaID: 16
   NextReplicaID: 17
+RemovedNodeIDs: [3, 4, 5]
 
 apply-plan stores=(1,2)
 ----
@@ -161,7 +163,7 @@ ok
 
 make-plan
 ----
-[]
+Updates: []
 
 apply-plan stores=(1,2,5,6)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/max_store_voter_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/max_store_voter_wins
@@ -38,6 +38,7 @@ ok
 
 make-plan
 ----
+Updates:
 - RangeID: 1
   StartKey: /Min
   OldReplicaID: 2
@@ -46,6 +47,7 @@ make-plan
     StoreID: 2
     ReplicaID: 16
   NextReplicaID: 17
+RemovedNodeIDs: [3, 4, 5]
 
 apply-plan stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_no_dead_peers
+++ b/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_no_dead_peers
@@ -41,7 +41,7 @@ ok
 
 make-plan
 ----
-[]
+Updates: []
 
 apply-plan stores=(1,2,3)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_quorum
+++ b/pkg/kv/kvserver/loqrecovery/testdata/no_change_when_quorum
@@ -30,7 +30,7 @@ ok
 
 make-plan
 ----
-[]
+Updates: []
 
 apply-plan stores=(1,2)
 ----

--- a/pkg/kv/kvserver/loqrecovery/testdata/replica_changes_recorded
+++ b/pkg/kv/kvserver/loqrecovery/testdata/replica_changes_recorded
@@ -43,6 +43,7 @@ ok
 
 make-plan
 ----
+Updates:
 - RangeID: 1
   StartKey: /Min
   OldReplicaID: 1
@@ -67,6 +68,7 @@ make-plan
     StoreID: 2
     ReplicaID: 16
   NextReplicaID: 17
+RemovedNodeIDs: [4, 5]
 
 apply-plan stores=(1,2)
 ----


### PR DESCRIPTION
Previously, if user performed unsafe loss of quorum recovery,
but subsequently brought online "dead" node by mistake, nodes
could react unpredictably or crash in face of replica inconsistency.
This diff adds a protection against that, by placing node tombstones
for dead ondes on surviving ones when performing offline recovery.

Release note: None

When running a `debug recovery plan` user will be presented with additional info regarding the need to tombstone nodes:
```
Plan created
To complete recovery, distribute the plan to the below nodes and
 1) perform replica recovery by invoking `debug recover apply-plan` on:
  - node n4, store(s) s4
  - node n5, store(s) s5
 2) additionally tobmstone deleted nodes to prevent accidental restart by invoking `debug recover apply-plan` on:
  - node n1
  - node n6
```

And subsequently when applying a plan to a node information about tombstoned nodes would be presented:
```
Applying plan to node 4
Replica (n4,s4):3 for range 88:/Table/57/1/"boston"/"\"\"\"\"\"\"B\x00\x80\x00\x00\x00\x00\x00\x00\x02" will be updated to (n4,s4):15 with peer replica(s) removed: (n3,s3):1,(n2,s2):4
Replica (n4,s4):3 for range 84:/Table/57/1/"new york"/"\x11\x11\x11\x11\x11\x11A\x00\x80\x00\x00\x00\x00\x00\x00\x01" will be updated to (n4,s4):15 with peer replica(s) removed: (n3,s3):1,(n2,s2):4
Replica (n4,s4):3 for range 73:/Table/57/1/"seattle"/"ffffffH\x00\x80\x00\x00\x00\x00\x00\x00\x06" will be updated to (n4,s4):15 with peer replica(s) removed: (n3,s3):1,(n2,s2):4
Replica (n4,s4):3 for range 55:/Table/58/1/"paris"/"\xe1G\xae\x14z\xe1H\x00\x80\x00\x00\x00\x00\x00\x01\xb8" will be updated to (n4,s4):16 with peer replica(s) removed: (n2,s2):4,(n3,s3):5

Nodes [n2, n3] marked as tombstoned to prevent accidental rejoin

Proceed with above changes [y/N] y
```
 