### PR TITLE
dev,bazel: miscellaneous improvements

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,17 @@
 try-import %workspace%/.bazelrc.user
 
-build --symlink_prefix=_bazel/ --ui_event_filters=-DEBUG --define gotags=bazel,gss --experimental_proto_descriptor_sets_include_source_info --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
+build --define gotags=bazel,gss
+build --experimental_proto_descriptor_sets_include_source_info
+build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
+build --symlink_prefix=_bazel/ --experimental_no_product_name_out_symlink
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build:with_ui --define cockroach_with_ui=y
 build:test --define crdb_test=y
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
 test:test --test_env=TZ=
 test:race --test_timeout=1200,6000,18000,72000
+
+build --ui_event_filters=-DEBUG
 query --ui_event_filters=-DEBUG
 
 # CI should always run with `--config=ci`.
@@ -22,7 +27,7 @@ test:ci --test_tmpdir=/artifacts/tmp
 build:cross --stamp
 build:cross --define cockroach_cross=y
 
-# cross-compilation configurations. Add e.g. --config=crosslinux to turn these on.
+# Cross-compilation configurations. Add e.g. --config=crosslinux to turn these on.
 build:crosslinux --platforms=//build/toolchains:cross_linux
 build:crosslinux '--workspace_status_command=./build/bazelutil/stamp.sh x86_64-pc-linux-gnu'
 build:crosslinux --config=cross
@@ -36,10 +41,9 @@ build:crosslinuxarm --platforms=//build/toolchains:cross_linux_arm
 build:crosslinuxarm '--workspace_status_command=./build/bazelutil/stamp.sh aarch64-unknown-linux-gnu'
 build:crosslinuxarm --config=cross
 
-# developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
+# Developer configurations. Add e.g. --config=devdarwinx86_64 to turn these on.
+# NB: This is consumed in `BUILD` files (see build/toolchains/BUILD.bazel).
 build:devdarwinx86_64 --platforms=//build/toolchains:darwin_x86_64
-# NOTE(ricky): This is consumed in `BUILD` files (see
-# `build/toolchains/BUILD.bazel`).
 build:devdarwinx86_64 --config=dev
 build:dev --define cockroach_bazel_dev=y
 build:dev --stamp --workspace_status_command=./build/bazelutil/stamp.sh

--- a/bazel-out
+++ b/bazel-out
@@ -1,3 +1,0 @@
-This placeholder file prevents bazel from writing a symlink here which points to its output dir.
-That symlink often causes tools that traverse the repo to get confused when they find lots of extra go files.
-The _bazel/out symlink points to the same thing, but go doesn't traverse into paths that start with _.

--- a/build/bazelutil/stamp.sh
+++ b/build/bazelutil/stamp.sh
@@ -38,9 +38,9 @@ fi
 # * https://docs.bazel.build/versions/main/user-manual.html#workspace_status
 # * https://github.com/bazelbuild/rules_go/blob/master/go/core.rst#defines-and-stamping
 cat <<EOF
-STABLE_BUILD_GIT_COMMIT ${GIT_COMMIT-}
-STABLE_BUILD_GIT_TAG ${GIT_TAG-}
 STABLE_BUILD_GIT_BUILD_TYPE ${GIT_BUILD_TYPE-}
 STABLE_BUILD_TARGET_TRIPLE ${TARGET_TRIPLE-}
+BUILD_GIT_COMMIT ${GIT_COMMIT-}
+BUILD_GIT_TAG ${GIT_TAG-}
 BUILD_GIT_UTCTIME ${GIT_UTCTIME-}
 EOF

--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -15,9 +15,9 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {
         "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple": "{STABLE_BUILD_TARGET_TRIPLE}",
-        "github.com/cockroachdb/cockroach/pkg/build.rev": "{STABLE_BUILD_GIT_COMMIT}",
-        "github.com/cockroachdb/cockroach/pkg/build.tag": "{STABLE_BUILD_GIT_TAG}",
         "github.com/cockroachdb/cockroach/pkg/build.typ": "{STABLE_BUILD_GIT_BUILD_TYPE}",
+        "github.com/cockroachdb/cockroach/pkg/build.rev": "{BUILD_GIT_COMMIT}",
+        "github.com/cockroachdb/cockroach/pkg/build.tag": "{BUILD_GIT_TAG}",
         "github.com/cockroachdb/cockroach/pkg/build.utcTime": "{BUILD_GIT_UTCTIME}",
     },
     deps = [

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -78,7 +78,7 @@ Please perform the following steps:
 		if err != nil {
 			return err
 		}
-		if !strings.Contains(fileContents, "STABLE_BUILD_GIT_COMMIT") {
+		if !strings.Contains(fileContents, "STABLE_BUILD_GIT_BUILD_TYPE") {
 			passedStampTest = false
 		}
 	}

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -82,10 +82,14 @@ Please perform the following steps:
 			passedStampTest = false
 		}
 	}
+	workspace, err := d.getWorkspace(ctx)
+	if err != nil {
+		return err
+	}
 	if !passedStampTest {
 		success = false
 		log.Printf(`Your machine is not configured to "stamp" your built executables.
-Please add one of the following to your ~/.bazelrc:`)
+Please add one of the following to your %s/.bazelrc.user:`, workspace)
 		if runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
 			log.Printf("    build --config=devdarwinx86_64")
 		} else if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {


### PR DESCRIPTION
**build,bazel: avoid stamping builds with commit sha**

When building development binaries, we already skip tagging each build
with the UTC time to avoid busting the build cache. We could go further
and not tag crdb binaries with the current SHA/last git tag with the
knowledge that we’re not shipping binaries from local machines. This
shaves off around ~30s of go link time on my machine when switching
branches, regardless of cache hit rate. It also shaves a 30s delay
whenever a commit is amended/rebased but the source is unaffected (when
rewording commits for e.g., or during interactive rebase).

**dev: improve help message**

CRDB-specific configs should probably be placed in the gitignored
.bazelrc.user. Using the top-level rc file mucks with bazel builds for
other repositories.

**bazel: avoid writing to bazel-out**

In #74771 we put a regular file in bazel-out to prevent bazel from doing
it automatically (this was to prevent tools from tripping over when
finding extra go files). Bazel exposes a top-level flag we can use
instead.
