### PR TITLE
kvserver: deflake TestReplicateQueue{UpAndDownReplicateNonVoters,Shou…

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -331,7 +331,16 @@ func TestReplicateQueueUpAndDownReplicateNonVoters(t *testing.T) {
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1,
-		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					SpanConfig: &spanconfig.TestingKnobs{
+						ConfigureScratchRange: true,
+					},
+				},
+			},
+		},
 	)
 	defer tc.Stopper().Stop(context.Background())
 
@@ -833,6 +842,11 @@ func TestReplicateQueueShouldQueueNonVoter(t *testing.T) {
 					{
 						Key: "rack", Value: strconv.Itoa(i),
 					},
+				},
+			},
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					ConfigureScratchRange: true,
 				},
 			},
 		}


### PR DESCRIPTION
…ldQueueNonVoter}

These tests altered `RANGE DEFAULT` and expect the changes to apply to
the scratch range. This is gated behind a testing knob with the move to
the span configurations infrastructure. This patch adds the testing
knob.

Closes #74995

Release note: None