### PR TITLE
release-21.1: sql: fix ALTER DATABASE help text

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1483,10 +1483,11 @@ alter_sequence_options_stmt:
 // %Category: DDL
 // %Text:
 // ALTER DATABASE <name> RENAME TO <newname>
+// ALTER DATABASE <name> CONFIGURE ZONE <zone config>
 // ALTER DATABASE <name> OWNER TO <newowner>
 // ALTER DATABASE <name> CONVERT TO SCHEMA WITH PARENT <name>
-// ALTER DATABASE <name> ADD REGIONS <regions>
-// ALTER DATABASE <name> DROP REGIONS <regions>
+// ALTER DATABASE <name> ADD REGION [IF NOT EXISTS] <region>
+// ALTER DATABASE <name> DROP REGION [IF EXISTS] <region>
 // ALTER DATABASE <name> PRIMARY REGION <region>
 // ALTER DATABASE <name> SURVIVE <failure type>
 // %SeeAlso: WEBDOCS/alter-database.html


### PR DESCRIPTION
Backport 1/1 commits from #74929.

/cc @cockroachdb/release

Release justification: Docs-only change

---

Prior to this commit, the CLI help text shown for `ALTER DATABASE`
was incomplete and incorrect. This commit fixes the help text to
include some omitted options and fixes `ADD REGIONS` and `DROP REGIONS`
to say `ADD REGION` and `DROP REGION`.

Release note (cli change): Fixed the CLI help text for `ALTER DATABASE`
to show correct options for `ADD REGION` and `DROP REGION`, and include
some missing options such as `CONFIGURE ZONE`.
