### PR TITLE
schemachanger: columns are not always backfilled in transactions

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -245,7 +245,9 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 
 		if m.Adding() {
 			if col := m.AsColumn(); col != nil {
-				needColumnBackfill = catalog.ColumnNeedsBackfill(col)
+				// Its possible have a mix of columns that need a backfill and others
+				// that don't, so preserve the flag if its already been flipped.
+				needColumnBackfill = needColumnBackfill || catalog.ColumnNeedsBackfill(col)
 			} else if idx := m.AsIndex(); idx != nil {
 				addedIndexSpans = append(addedIndexSpans, tableDesc.IndexSpan(sc.execCfg.Codec, idx.GetID()))
 				addedIndexes = append(addedIndexes, idx.GetID())
@@ -273,7 +275,9 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 			}
 		} else if m.Dropped() {
 			if col := m.AsColumn(); col != nil {
-				needColumnBackfill = catalog.ColumnNeedsBackfill(col)
+				// Its possible have a mix of columns that need a backfill and others
+				// that don't, so preserve the flag if its already been flipped.
+				needColumnBackfill = needColumnBackfill || catalog.ColumnNeedsBackfill(col)
 			} else if idx := m.AsIndex(); idx != nil {
 				// no-op
 			} else if c := m.AsConstraint(); c != nil {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2106,3 +2106,45 @@ ALTER TABLE colsource ADD COLUMN customer_id UUID  REFERENCES colref(id), ADD CO
 
 statement ok
 COMMIT
+
+# Issue #75074 occurred when we added multiple columns inside a single transaction,
+# where the backfill logic was completely skipped because the last added column
+# did not require one. This test will add multiple columns and confirm that a
+# backfill has occurred.
+subtest add_multiple_in_txn
+
+statement ok
+CREATE SEQUENCE IF NOT EXISTS multipleinstmt_seq MAXVALUE 9007199254740991;
+
+statement ok
+CREATE TABLE IF NOT EXISTS multipleinstmt (
+	id INT8 DEFAULT nextval('multipleinstmt_seq') PRIMARY KEY, key STRING, value STRING
+);
+INSERT INTO multipleinstmt (key, value) VALUES ('a', 'a');
+INSERT INTO multipleinstmt (key, value) VALUES ('b', 'b');
+INSERT INTO multipleinstmt (key, value) VALUES ('c', 'c');
+
+
+statement ok
+BEGIN;
+ALTER TABLE multipleinstmt ADD COLUMN IF NOT EXISTS a BOOL DEFAULT false;
+ALTER TABLE multipleinstmt ADD COLUMN IF NOT EXISTS b STRING;
+COMMIT;
+
+query ITTBT
+SELECT * FROM multipleinstmt ORDER BY id ASC;
+----
+1  a  a  false  NULL
+2  b  b  false  NULL
+3  c  c  false  NULL
+
+statement ok
+ALTER TABLE multipleinstmt ADD COLUMN IF NOT EXISTS c BOOL DEFAULT true,
+                           ADD COLUMN IF NOT EXISTS d STRING;
+
+query ITTBTBT
+SELECT * FROM multipleinstmt ORDER BY id ASC;
+----
+1  a  a  false  NULL  true  NULL
+2  b  b  false  NULL  true  NULL
+3  c  c  false  NULL  true  NULL


### PR DESCRIPTION
Fixes: #75074

Previously, when multiple columns were added in a transaction,
the schema changer incorrectly determined if a backfill was
required based on the last column that was added. This was
inadequate because in a transaction multiple columns can
be added concurrently, where some may require a backfill,
and others may not. To address this, this patch checks
if any of the columns added need a backfill and uses that
to determine if a backfill is required.

Release note (bug fix): If multiple columns were added to
a table inside a transaction, then none of the columns
will be backfilled if the last column did not require
a backfill.