### PR TITLE
kvstreamer: fix a couple of edge case bugs

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/admission",
+        "//pkg/util/buildutil",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/stop",

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -434,6 +434,10 @@ func (s *Streamer) Enqueue(
 	// requestsToServe, and the worker coordinator will then pick those batches
 	// up to execute asynchronously.
 	var totalReqsMemUsage int64
+	// Use a local variable for requestsToServe rather than
+	// s.mu.requestsToServe. This is needed in order for the worker coordinator
+	// to not pick up any work until we account for totalReqsMemUsage.
+	var requestsToServe []singleRangeBatch
 	// TODO(yuzefovich): in InOrder mode we need to treat the head-of-the-line
 	// request differently.
 	seekKey := rs.Key
@@ -492,7 +496,7 @@ func (s *Streamer) Enqueue(
 			sort.Sort(&r)
 		}
 
-		s.mu.requestsToServe = append(s.mu.requestsToServe, r)
+		requestsToServe = append(requestsToServe, r)
 
 		// Determine next seek key, taking potentially sparse requests into
 		// consideration.
@@ -516,8 +520,8 @@ func (s *Streamer) Enqueue(
 		return err
 	}
 
-	// TODO(yuzefovich): it might be better to notify the coordinator once
-	// one singleRangeBatch object has been appended to s.mu.requestsToServe.
+	// Memory reservation was approved, so the requests are good to go.
+	s.mu.requestsToServe = requestsToServe
 	s.coordinator.mu.hasWork.Signal()
 	return nil
 }


### PR DESCRIPTION
**kvstreamer: fix rare race condition**

This commit refactors the locking logic in an error case in `Enqueue`
where previously we had a rare race condition. We divided the locking
state across two things (the mutex and a boolean indicating whether the
mutex is locked) which together were not accessed atomically. This
commit removes the boolean by forcing that the mutex is held when
`Enqueue` returns.

Release note: None

**kvstreamer: fix the case when root pool is exhausted**

Each request processed asynchronously assumes that the memory footprint
of the spans in the request has already been accounted for. This
assumption was broken in case `Enqueue` encountered an error when
consuming from the budget due to root pool being exhausted.

The sequence of steps to get into a problematic state was as follows:
- spin up the worker coordinator, it blocks until there are any requests
to serve
- populate requests to serve
- `s.mu` is unlocked to perform the memory accounting
- the worker coordinator wakes up and picks up some work
- memory reservation is denied in `Enqueue`, an error is returned; thus,
we have a drift in the memory accounting
- concurrent request is responded to, and when it attempts to reconcile
the memory accounting, a crash (in test builds) occurs because the
memory reservation in `Enqueue` was denied.

This is now fixed by not telling the worker coordinator about the
requests to serve until after the memory accounting is performed.

Fixes: #74898.

Release note: None