### PR TITLE
Revert "build: add <release branch> to nightly and latest tag values"

### DIFF
--- a/build/release/teamcity-make-and-publish-build.sh
+++ b/build/release/teamcity-make-and-publish-build.sh
@@ -11,11 +11,8 @@ build/builder.sh make .buildinfo/tag
 build_name="${TAG_NAME:-$(cat .buildinfo/tag)}"
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
-release_branch="$(echo "$TC_BUILD_BRANCH" || echo "")"
+release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 is_custom_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
-
-# Prepend release branch onto build_name
-build_name="${release_branch}-${build_name}"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   bucket="${BUCKET-cockroach-builds}"

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -4,13 +4,13 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 # mark_build marks a build with a given label specified as a parameter on
 # docker. For example, calling this function on the label "qualified", on a
-# v19.2.4 build would tag it as `latest-release-19.2-qualified-build`.
+# v19.2.4 build would tag it as `latest-v19.2-qualified-build`.
 mark_build() {
   tc_start_block "Variable Setup"
   build_label=$1
 
   # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
-  release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9]+\.[0-9]+)|(master)" || echo"")"
+  release_branch="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 
   if [[ -z "${DRY_RUN}" ]] ; then
     google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS


### PR DESCRIPTION
This reverts commit 9653dd13cecc846a78640c0a9511bbbc959dfca3.

In #74434, the release branch was prefixed onto the build tag, run by "Make and Publish Build" and "Qualify Build". However, this is currently causing a failure in [Make and Publish Build](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Release_MakeAndPublishBuild/4136863?showRootCauses=true&expandBuildChangesSection=true&expandBuildProblemsSection=true)

```
  2022/01/17 02:46:19 main.go:137: refusing to build release with invalid version name 'master-v22.1.0-alpha.00000000-2949-ge84001d861' (err: invalid version string 'master-v22.1.0-alpha.00000000-2949-ge84001d861')
  Process exited with code 1
```

Reverting commit so that builds can continue to pass until this change works end-to-end.

Release note: None
