### PR TITLE
sqlsmith: skip crdb_internal.replication_stream_progress builtin

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -495,6 +495,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.reset_multi_region_zone_configs_for_database",
 			"crdb_internal.reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",
+			"crdb_internal.replication_stream_progress",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
Related to: #75121.

Release note: None