### PR TITLE
bazci,ci,dev: update how `stress` is invoked

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -38,7 +38,7 @@ do
                                           --test_env=COCKROACH_NIGHTLY_STRESS=true \
                                           --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
                                           --test_timeout="$TESTTIMEOUTSECS" \
-                                          --run_under "@com_github_cockroachdb_stress//:stress $STRESSFLAGS" \
+                                          --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'GO_TEST_JSON_OUTPUT_FILE=cat,XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' $STRESSFLAGS" \
                                           --define "gotags=$TAGS" \
                                           --nocache_test_results \
                                           ${EXTRA_BAZEL_FLAGS} \

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "lint.go",
         "logic.go",
         "main.go",
+        "merge_test_xmls.go",
         "test.go",
         "util.go",
     ],

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -114,6 +114,7 @@ Typical usage:
 		makeDoctorCmd(ret.doctor),
 		makeGenerateCmd(ret.generate),
 		makeGoCmd(ret.gocmd),
+		makeMergeTestXMLsCmd(ret.mergeTestXMLs),
 		makeTestLogicCmd(ret.testlogic),
 		makeLintCmd(ret.lint),
 		makeTestCmd(ret.test),

--- a/pkg/cmd/dev/merge_test_xmls.go
+++ b/pkg/cmd/dev/merge_test_xmls.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+	"os"
+
+	bazelutil "github.com/cockroachdb/cockroach/pkg/build/util"
+	"github.com/spf13/cobra"
+)
+
+func makeMergeTestXMLsCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
+	mergeTestXMLsCommand := &cobra.Command{
+		Use:   "merge-test-xmls XML1 [XML2...]",
+		Short: "Merge the given test XML's (utility command)",
+		Long:  "Merge the given test XML's (utility command)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  runE,
+	}
+	mergeTestXMLsCommand.Hidden = true
+	return mergeTestXMLsCommand
+}
+
+func (d *dev) mergeTestXMLs(cmd *cobra.Command, xmls []string) error {
+	var suites []bazelutil.TestSuites
+	for _, file := range xmls {
+		suitesToAdd := bazelutil.TestSuites{}
+		input, err := ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		err = xml.Unmarshal(input, &suitesToAdd)
+		if err != nil {
+			return err
+		}
+		suites = append(suites, suitesToAdd)
+	}
+	return bazelutil.MergeTestXMLs(suites, os.Stdout)
+}

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -219,7 +219,10 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		}
 		stressCmdArgs = append(stressCmdArgs, stressArgs)
 		args = append(args, "--run_under",
-			fmt.Sprintf("%s %s", stressTarget, strings.Join(stressCmdArgs, " ")))
+			// NB: Run with -bazel, which propagates `TEST_TMPDIR` to `TMPDIR`,
+			// and -shardable-artifacts set such that we can merge the XML output
+			// files.
+			fmt.Sprintf("%s -bazel -shardable-artifacts 'XML_OUTPUT_FILE=%s merge-test-xmls' %s", stressTarget, getDevBin(), strings.Join(stressCmdArgs, " ")))
 	}
 
 	if filter != "" {

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -84,7 +84,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' '--test_filter=TestStartChild*' --test_output streamed
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s
@@ -97,7 +97,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --local_cpu_resources=12 --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -p=12 ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --local_cpu_resources=12 --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -p=12 ' '--test_filter=TestStartChild*' --test_output streamed
 ----
 ----
 //pkg/util/tracing:tracing_test                                          [0m[32mPASSED[0m in 12.3s
@@ -110,7 +110,7 @@ bazel query 'kind(go_test, //pkg/util/tracing:all)'
 ----
 //pkg/util/tracing:tracing_test
 
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' '--test_filter=TestStartChild*' --test_arg -test.v --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=10s ' '--test_filter=TestStartChild*' --test_arg -test.v --test_output streamed
 ----
 ----
 ==================== Test output for //pkg/util/tracing:tracing_test:

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -31,17 +31,17 @@ bazel test //pkg/util/tracing:tracing_test --nocache_test_results --test_env=GOT
 dev test --stress pkg/util/tracing --filter TestStartChild*
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' ' '--test_filter=TestStartChild*' --test_output streamed
 
 dev test --stress pkg/util/tracing --filter TestStartChild* --cpus=12
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test --local_cpu_resources=12 --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -p=12 ' '--test_filter=TestStartChild*' --test_output streamed
+bazel test --local_cpu_resources=12 --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=86400 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -p=12 ' '--test_filter=TestStartChild*' --test_output streamed
 
 dev test --stress pkg/util/tracing --filter TestStartChild* --timeout=10s -v
 ----
 bazel query 'kind(go_test, //pkg/util/tracing:all)'
-bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -maxtime=10s ' '--test_filter=TestStartChild*' --test_arg -test.v --test_output streamed
+bazel test --test_sharding_strategy=disabled //pkg/util/tracing:tracing_test --test_env=GOTRACEBACK=all --test_timeout=70 --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=10s ' '--test_filter=TestStartChild*' --test_arg -test.v --test_output streamed
 
 dev test //pkg/testutils --timeout=10s
 ----

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -227,3 +227,11 @@ func logCommand(cmd string, args ...string) {
 	fullArgs = append(fullArgs, args...)
 	log.Printf("$ %s", shellescape.QuoteCommand(fullArgs))
 }
+
+// getDevBin returns the path to the running dev executable.
+func getDevBin() string {
+	if isTesting {
+		return "dev"
+	}
+	return os.Args[0]
+}


### PR DESCRIPTION
We give both `bazci` and `dev` a subcommand to merge `test.xml` files,
and update `dev` and the various `stress` invocations in CI accordingly
to make use of the `-shardable-artifacts` feature.

Closes #74325.

Release note: None