### PR TITLE
ui: allow stmts page to search across explain plan page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.spec.tsx
@@ -17,6 +17,8 @@ import {
   flattenTreeAttributes,
   flattenAttributes,
   standardizeKey,
+  planNodeToString,
+  planNodeAttrsToString,
 } from "./planView";
 import IAttr = cockroach.sql.ExplainTreePlanNode.IAttr;
 
@@ -258,6 +260,96 @@ describe("planView", () => {
     it("should remove '(anti)' from the key", () => {
       assert.equal(standardizeKey("lookup join (anti)"), "lookupJoin");
       assert.equal(standardizeKey("(anti) hello world"), "helloWorld");
+    });
+  });
+
+  describe("planNodeAttrsToString", () => {
+    it("should convert an array of FlatPlanNodeAttribute[] into a string", () => {
+      const testNodeAttrs: FlatPlanNodeAttribute[] = [
+        {
+          key: "Into",
+          values: ["users(id, city, name, address, credit_card)"],
+          warn: false,
+        },
+        {
+          key: "Size",
+          values: ["5 columns, 3 rows"],
+          warn: false,
+        },
+      ];
+
+      const expectedString =
+        "Into users(id, city, name, address, credit_card) Size 5 columns, 3 rows";
+
+      assert.equal(planNodeAttrsToString(testNodeAttrs), expectedString);
+    });
+  });
+
+  describe("planNodeToString", () => {
+    it("should recursively convert a FlatPlanNode into a string.", () => {
+      const testPlanNode: FlatPlanNode = {
+        name: "insert fast path",
+        attrs: [
+          {
+            key: "Into",
+            values: ["users(id, city, name, address, credit_card)"],
+            warn: false,
+          },
+          {
+            key: "Size",
+            values: ["5 columns, 3 rows"],
+            warn: false,
+          },
+        ],
+        children: [],
+      };
+
+      const expectedString =
+        "insert fast path Into users(id, city, name, address, credit_card) Size 5 columns, 3 rows";
+
+      assert.equal(planNodeToString(testPlanNode), expectedString);
+    });
+
+    it("should recursively convert a FlatPlanNode (with children) into a string.", () => {
+      const testPlanNode: FlatPlanNode = {
+        name: "render",
+        attrs: [],
+        children: [
+          {
+            name: "group (scalar)",
+            attrs: [],
+            children: [
+              {
+                name: "filter",
+                attrs: [
+                  {
+                    key: "filter",
+                    values: ["variable = _"],
+                    warn: false,
+                  },
+                ],
+                children: [
+                  {
+                    name: "virtual table",
+                    attrs: [
+                      {
+                        key: "table",
+                        values: ["cluster_settings@primary"],
+                        warn: false,
+                      },
+                    ],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const expectedString =
+        "render  group (scalar)  filter filter variable = _ virtual table table cluster_settings@primary";
+      assert.equal(planNodeToString(testPlanNode), expectedString);
     });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.tsx
@@ -56,6 +56,24 @@ function warnForAttribute(attr: IAttr): boolean {
   return false;
 }
 
+// planNodeAttrsToString converts an array of FlatPlanNodeAttribute[] into a string.
+export function planNodeAttrsToString(attrs: FlatPlanNodeAttribute[]): string {
+  return attrs.map(attr => `${attr.key} ${attr.values.join(" ")}`).join(" ");
+}
+
+// planNodeToString recursively converts a FlatPlanNode into a string.
+export function planNodeToString(plan: FlatPlanNode): string {
+  const str = `${plan.name} ${planNodeAttrsToString(plan.attrs)}`;
+
+  if (plan.children.length > 0) {
+    return `${str} ${plan.children
+      .map(child => planNodeToString(child))
+      .join(" ")}`;
+  }
+
+  return str;
+}
+
 // flattenAttributes takes a list of attrs (IAttr[]) and collapses
 // all the values for the same key (FlatPlanNodeAttribute). For example,
 // if attrs was:

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -14,11 +14,14 @@ import { ReactWrapper, mount } from "enzyme";
 import { MemoryRouter } from "react-router-dom";
 
 import {
+  filterBySearchQuery,
   StatementsPage,
   StatementsPageProps,
   StatementsPageState,
 } from "src/statementsPage";
 import statementsPagePropsFixture from "./statementsPage.fixture";
+import { AggregateStatistics } from "../statementsTable";
+import { FlatPlanNode } from "../statementDetails";
 
 describe("StatementsPage", () => {
   describe("Statements table", () => {
@@ -42,5 +45,66 @@ describe("StatementsPage", () => {
       );
       assert.equal(statementsPageInstance.props.sortSetting.ascending, false);
     });
+  });
+
+  describe("filterBySearchQuery", () => {
+    const testPlanNode: FlatPlanNode = {
+      name: "render",
+      attrs: [],
+      children: [
+        {
+          name: "group (scalar)",
+          attrs: [],
+          children: [
+            {
+              name: "filter",
+              attrs: [
+                {
+                  key: "filter",
+                  values: ["variable = _"],
+                  warn: false,
+                },
+              ],
+              children: [
+                {
+                  name: "virtual table",
+                  attrs: [
+                    {
+                      key: "table",
+                      values: ["cluster_settings@primary"],
+                      warn: false,
+                    },
+                  ],
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const statement: AggregateStatistics = {
+      aggregatedFingerprintID: "",
+      aggregatedTs: 0,
+      aggregationInterval: 0,
+      database: "",
+      fullScan: false,
+      implicitTxn: false,
+      summary: "",
+      label:
+        "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = '_'",
+      stats: {
+        sensitive_info: {
+          most_recent_plan_description: testPlanNode,
+        },
+      },
+    };
+
+    assert.equal(filterBySearchQuery(statement, "select"), true);
+    assert.equal(filterBySearchQuery(statement, "virtual table"), true);
+    assert.equal(filterBySearchQuery(statement, "group (scalar)"), true);
+    assert.equal(filterBySearchQuery(statement, "node_build_info"), false);
+    assert.equal(filterBySearchQuery(statement, "crdb_internal"), false);
   });
 });


### PR DESCRIPTION
Closes #71615.
    
Previously, the search functionality for the stmts page only allowed a search
through the statement query. This change adds the statement's Plan as part of
that search.

Release note (ui change): logical plan text included in searchable text for
stmts page.

Demo video: shows that the search feature works for statements' plan

https://user-images.githubusercontent.com/35943354/150594026-ba6325b1-90f1-4830-9b88-c021d4781596.mov