### PR TITLE
storage: preallocate SST buffer in UpdateTimestamps

### DIFF
--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -231,6 +231,7 @@ func CheckSSTConflicts(
 // can be copied across without recomputation.
 func UpdateSSTTimestamps(sst []byte, ts hlc.Timestamp) ([]byte, error) {
 	sstOut := &MemFile{}
+	sstOut.Buffer.Grow(len(sst))
 	writer := MakeIngestionSSTWriter(sstOut)
 	defer writer.Close()
 


### PR DESCRIPTION
Assume that a rewritten sstable with a new timestamp will have a similar
size, and allocate its buffer upfront to avoid the incremental
reallocations.

```
name                    old time/op    new time/op    delta
UpdateSSTTimestamps-24     187ms ± 0%     184ms ± 0%   -1.73%  (p=0.001 n=5+10)

name                    old alloc/op   new alloc/op   delta
UpdateSSTTimestamps-24    37.6MB ± 0%    29.8MB ± 0%  -20.80%  (p=0.001 n=5+10)

name                    old allocs/op  new allocs/op  delta
UpdateSSTTimestamps-24     1.45k ± 1%     1.44k ± 1%     ~     (p=0.789 n=5+10)
```

Release note: none