### PR TITLE
bulk: send splits when running as a tenant as well

### DIFF
--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -218,10 +218,7 @@ func newSplitAndScatterProcessor(
 		return nil, err
 	}
 
-	var scatterer = makeSplitAndScatterer(db, kr)
-	if !flowCtx.Cfg.Codec.ForSystemTenant() {
-		scatterer = noopSplitAndScatterer{}
-	}
+	scatterer := makeSplitAndScatterer(db, kr)
 	ssp := &splitAndScatterProcessor{
 		flowCtx:   flowCtx,
 		spec:      spec,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -553,10 +553,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			// Attach a child memory monitor to enable control over the BulkAdder's
 			// memory usage.
 			bulkMon := execinfra.NewMonitor(ctx, bulkMemoryMonitor, "bulk-adder-monitor")
-			if !codec.ForSystemTenant() {
-				// Tenants aren't allowed to split, so force off the split-after opt.
-				opts.SplitAndScatterAfter = func() int64 { return kvserverbase.DisableExplicitSplits }
-			}
 			return bulk.MakeBulkAdder(ctx, db, cfg.distSender.RangeDescriptorCache(), cfg.Settings, ts, opts, bulkMon)
 		},
 


### PR DESCRIPTION
Fixes #74856.