### PR TITLE
bulk: bump default split-after size to 384mb

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -93,7 +93,7 @@ func MakeBulkAdder(
 	if opts.SplitAndScatterAfter == nil {
 		// splitting _before_ hitting max reduces chance of auto-splitting after the
 		// range is full and is more expensive to split/move.
-		opts.SplitAndScatterAfter = func() int64 { return 48 << 20 }
+		opts.SplitAndScatterAfter = func() int64 { return 384 << 20 }
 	} else if opts.SplitAndScatterAfter() == kvserverbase.DisableExplicitSplits {
 		opts.SplitAndScatterAfter = nil
 	}


### PR DESCRIPTION
The 48mb default was set when the default range size was 64mb.
The desired behavior was to split when a single range had been
send >= 75% of 'a range's worth' of data, to explicitly start
a new range before sending more, and thus avoid overfilling one
range and causing a split the has to move a non-empty RHS.

The default range size has since been changed to 512mb, so this
constant should now be 384mb.

A future change could lookup the zone for the span being ingested
into and pass some fraction of that, but that can also be done
by the caller, so either way, this default should be updated.

Release note: none.