### PR TITLE
sql: fix call of `FindIndexWithName`

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1613,7 +1613,7 @@ func validateConstraintNameIsNotUsed(
 		if name == "" {
 			return false, nil
 		}
-		idx, _ := tableDesc.FindIndexWithName(name.String())
+		idx, _ := tableDesc.FindIndexWithName(string(name))
 		if idx == nil {
 			return false, nil
 		}


### PR DESCRIPTION
In e89093faf7225a635ddb5d4f260b20a4d8dd64e2, we added
`tableDesc.FindIndexWithName(name.String())`. However, `name.String()`
can return a `EncodeRestrictedSQLIdent` version of the string.

This fixes the call to use `string(name)`.

I couldn't produce an error with this at the moment, mostly because
there is some other check preventing it from happening from the
combinations I've tried.

Release note: None