### PR TITLE
[WIP] admission: generalize store write admission control

### DIFF
--- a/pkg/util/admission/doc.go
+++ b/pkg/util/admission/doc.go
@@ -64,13 +64,14 @@
 //   consisting of (multi-tenant) KV nodes and (single-tenant) SQL nodes.
 //
 // The interfaces involved:
-// -  requester: handles all requests for a particular WorkKind. Implemented by
+// - requester: handles all requests for a particular WorkKind. Implemented by
 //   WorkQueue. The requester implementation is responsible for controlling
 //   the admission order within a WorkKind based on tenant fairness,
 //   importance of work etc.
 // - granter: the counterpart to requester which grants admission tokens or
-//   slots. The implementations are slotGranter, tokenGranter, kvGranter. The
-//   implementation of requester interacts with the granter interface.
+//   slots. The implementations are slotGranter, tokenGranter,
+//   kvStoreTokenGranter. The implementation of requester interacts with the
+//   granter interface.
 // - granterWithLockedCalls: this is an extension of granter that is used
 //   as part of the implementation of GrantCoordinator. This arrangement
 //   is partly to centralize locking in the GrantCoordinator (except for
@@ -82,20 +83,21 @@
 //   CPULoadListener is also implemented by these structs, to listen to
 //   the latest CPU load information from the scheduler.
 //
-// Load observation and slot count or token burst adjustment: Currently the
-// only dynamic adjustment is performed by kvSlotAdjuster for KVWork slots.
-// This is because KVWork is expected to usually be CPU bound (due to good
-// caching), and unlike SQLKVResponseWork and SQLSQLResponseWork (which are
-// even more CPU bound), we have a completion indicator -- so we can expect to
-// have a somewhat stable KVWork slot count even if the work sizes are
-// extremely heterogeneous.
+// Load observation and slot count or token burst adjustment: Dynamic
+// adjustment is performed by kvSlotAdjuster for KVWork slots. This is because
+// KVWork is expected to usually be CPU bound (due to good caching), and
+// unlike SQLKVResponseWork and SQLSQLResponseWork (which are even more CPU
+// bound), we have a completion indicator -- so we can expect to have a
+// somewhat stable KVWork slot count even if the work sizes are extremely
+// heterogeneous.
 //
-// Since there isn't token burst adjustment, the burst limits should be chosen
-// to err on the side of fully saturating CPU, since we have the fallback of
-// the cpuOverloadIndicator to stop granting even if tokens are available.
-// If we figure out a way to dynamically tune the token burst count, or
-// (even more ambitious) figure out a way to come up with a token rate, it
-// should fit in the general framework that is setup here.
+// There isn't token burst adjustment (except for each store -- see below),
+// the burst limits should be chosen to err on the side of fully saturating
+// CPU, since we have the fallback of the cpuOverloadIndicator to stop
+// granting even if tokens are available. If we figure out a way to
+// dynamically tune the token burst count, or (even more ambitious) figure out
+// a way to come up with a token rate, it should fit in the general framework
+// that is setup here.
 //
 
 // Partial usage example (regular cluster):
@@ -117,5 +119,9 @@
 // }
 // doWork()
 // if enabled { kvQueue.AdmittedWorkDone(tid) }
+
+// Additionally, each store has a single WorkQueue and GrantCoordinator for
+// writes. See kvStoreTokenGranter and how its tokens are dynamically adjusted
+// based on Pebble metrics.
 
 package admission

--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -58,7 +58,7 @@ granted chain-id=5
 ----
 continueGrantChain 5
 id 5: admit succeeded
-granted: returned true
+granted: returned 1
 
 # Both tenants are using 1 slot. The tie is broken arbitrarily in favor of
 # tenant 71.
@@ -82,7 +82,7 @@ tenantHeap len: 2 top tenant: 71
 # The work admitted for tenant 53 is done.
 work-done id=1
 ----
-returnGrant
+returnGrant 1
 
 # Tenant 53 now using fewer slots so it becomes the top of the heap.
 print
@@ -95,7 +95,7 @@ tenantHeap len: 2 top tenant: 53
 # reflected in the WorkQueue state.
 admit id=6 tenant=1 priority=0 create-time=6 bypass=true
 ----
-tookWithoutPermission
+tookWithoutPermission 1
 id 6: admit succeeded
 
 print
@@ -109,13 +109,13 @@ granted chain-id=7
 ----
 continueGrantChain 7
 id 2: admit succeeded
-granted: returned true
+granted: returned 1
 
 granted chain-id=9
 ----
 continueGrantChain 9
 id 4: admit succeeded
-granted: returned true
+granted: returned 1
 
 # No more waiting requests.
 print
@@ -128,7 +128,7 @@ tenantHeap len: 0
 # Granted returns false.
 granted chain-id=10
 ----
-granted: returned false
+granted: returned 0
 
 print
 ----

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -53,32 +53,34 @@ type testGranter struct {
 	returnValueFromTryGet bool
 }
 
+var _ granter = &testGranter{}
+
 func (tg *testGranter) grantKind() grantKind {
 	return slot
 }
-func (tg *testGranter) tryGet() bool {
+func (tg *testGranter) tryGet(count int64) bool {
 	tg.buf.printf("tryGet: returning %t", tg.returnValueFromTryGet)
 	return tg.returnValueFromTryGet
 }
-func (tg *testGranter) returnGrant() {
-	tg.buf.printf("returnGrant")
+func (tg *testGranter) returnGrant(count int64) {
+	tg.buf.printf("returnGrant %d", count)
 }
-func (tg *testGranter) tookWithoutPermission() {
-	tg.buf.printf("tookWithoutPermission")
+func (tg *testGranter) tookWithoutPermission(count int64) {
+	tg.buf.printf("tookWithoutPermission %d", count)
 }
 func (tg *testGranter) continueGrantChain(grantChainID grantChainID) {
 	tg.buf.printf("continueGrantChain %d", grantChainID)
 }
 func (tg *testGranter) grant(grantChainID grantChainID) {
 	rv := tg.r.granted(grantChainID)
-	if rv {
+	if rv > 0 {
 		// Need deterministic output, and this is racing with the goroutine that
 		// was admitted. Sleep to let it get scheduled. We could do something more
 		// sophisticated like monitoring goroutine states like in
 		// concurrency_manager_test.go.
 		time.Sleep(50 * time.Millisecond)
 	}
-	tg.buf.printf("granted: returned %t", rv)
+	tg.buf.printf("granted: returned %d", rv)
 }
 
 type testWork struct {
@@ -324,8 +326,9 @@ func TestWorkQueueTokenResetRace(t *testing.T) {
 }
 
 // TODO(sumeer):
+// - Test WorkQueue for tokens, with multiple tokens being requested
+// - Test StoreWorkQueue
 // - Test metrics
 // - Test race between grant and cancellation
-// - Test WorkQueue for tokens
 // - Add microbenchmark with high concurrency and procs for full admission
 //   system


### PR DESCRIPTION
The store write admission control path now uses a StoreWorkQueue
which wraps a WorkQueue and provides additional functionality:
- Work can specify WriteBytes and whether it is an IngestRequest.
  This is used to decide how many byte tokens to consume.
- Done work specifies how many bytes were ingested into L0, so
  token consumption can be adjusted.

The main framework change is that a single work item can consume
multiple (byte) tokens, which ripples through the various
interfaces including requester, granter. There is associated
cleanup: kvGranter that was handling both slots and tokens is
eliminated since in practice it was only doing one or the other.
Instead for the slot case the slotGranter is reused. For the token
case the kvStoreTokenGranter is created.

The main logic change is in ioLoadListener which computes byte
tokens and various estimates.

There are TODOs to fix tests that will fail.

Informs #75066

Release note: None