### PR TITLE
roachprod: move default env. vars into config.go and remove the duplicates

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -45,36 +45,26 @@ var (
 	listPattern           string
 	secure                = false
 	extraSSHOptions       = ""
-	nodeEnv               = []string{
-		// NOTE: The defaults are also copied in roachtest's invocation of roachprod
-		// (which overrides the default). On changes, consider updating that one
-		// too.
-
-		// RPC compressions costs around 5% on kv95, so we disable it. It might help
-		// when moving snapshots around, though.
-		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
-		// Get rid of an annoying popup in the UI.
-		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
-	}
-	tag               string
-	external          = false
-	pgurlCertsDir     string
-	adminurlOpen      = false
-	adminurlPath      = ""
-	adminurlIPs       = false
-	useTreeDist       = true
-	sig               = 9
-	waitFlag          = false
-	createVMOpts      = vm.DefaultCreateOpts()
-	startOpts         = roachprod.DefaultStartOpts()
-	stageOS           string
-	stageDir          string
-	logsDir           string
-	logsFilter        string
-	logsProgramFilter string
-	logsFrom          time.Time
-	logsTo            time.Time
-	logsInterval      time.Duration
+	nodeEnv               []string
+	tag                   string
+	external              = false
+	pgurlCertsDir         string
+	adminurlOpen          = false
+	adminurlPath          = ""
+	adminurlIPs           = false
+	useTreeDist           = true
+	sig                   = 9
+	waitFlag              = false
+	createVMOpts          = vm.DefaultCreateOpts()
+	startOpts             = roachprod.DefaultStartOpts()
+	stageOS               string
+	stageDir              string
+	logsDir               string
+	logsFilter            string
+	logsProgramFilter     string
+	logsFrom              time.Time
+	logsTo                time.Time
+	logsInterval          time.Duration
 
 	monitorOpts        install.MonitorOpts
 	cachedHostsCluster string
@@ -188,7 +178,7 @@ func initFlags() {
 	startCmd.Flags().StringArrayVarP(&startOpts.ExtraArgs,
 		"args", "a", nil, "node arguments")
 	startCmd.Flags().StringArrayVarP(&nodeEnv,
-		"env", "e", nodeEnv, "node environment variables")
+		"env", "e", config.DefaultEnvVars(), "node environment variables")
 	startCmd.Flags().BoolVar(&startOpts.EncryptedStores,
 		"encrypt", startOpts.EncryptedStores, "start nodes with encryption at rest turned on")
 	startCmd.Flags().BoolVar(&startOpts.SkipInit,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1842,19 +1842,6 @@ func (c *clusterImpl) StartE(
 		}
 	}
 
-	// Set some env vars. The first two also the default for `roachprod start`,
-	// but we have to add them so that the third one doesn't wipe them out.
-	if !envExists(settings.Env, "COCKROACH_ENABLE_RPC_COMPRESSION") {
-		// RPC compressions costs around 5% on kv95, so we disable it. It might help
-		// when moving snapshots around, though.
-		settings.Env = append(settings.Env, "COCKROACH_ENABLE_RPC_COMPRESSION=false")
-	}
-
-	if !envExists(settings.Env, "COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED") {
-		// Get rid of an annoying popup in the UI.
-		settings.Env = append(settings.Env, "COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true")
-	}
-
 	if !envExists(settings.Env, "COCKROACH_CRASH_ON_SPAN_USE_AFTER_FINISH") {
 		// Panic on span use-after-Finish, so we catch such bugs.
 		settings.Env = append(settings.Env, "COCKROACH_CRASH_ON_SPAN_USE_AFTER_FINISH=true")

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -73,6 +73,20 @@ const (
 	DefaultAdminUIPort = 26258
 )
 
+// DefaultEnvVars returns default environment variables used in conjunction with CLI and MakeClusterSettings.
+// These can be overriden by specifying different values (last one wins).
+// See 'generateStartCmd' which sets 'ENV_VARS' for the systemd startup script (start.sh).
+func DefaultEnvVars() []string {
+	return []string{
+		// RPC compressions costs around 5% on kv95, so we disable it. It might help
+		// when moving snapshots around, though.
+		// (For other perf. related knobs, see https://github.com/cockroachdb/cockroach/issues/17165)
+		"COCKROACH_ENABLE_RPC_COMPRESSION=false",
+		// Get rid of an annoying popup in the UI.
+		"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
+	}
+}
+
 // IsLocalClusterName returns true if the given name is a valid name for a local
 // cluster.
 //

--- a/pkg/roachprod/install/cluster_settings.go
+++ b/pkg/roachprod/install/cluster_settings.go
@@ -100,11 +100,8 @@ func MakeClusterSettings(opts ...ClusterSettingOption) ClusterSettings {
 		PGUrlCertsDir: "./certs",
 		Secure:        false,
 		UseTreeDist:   true,
-		Env: []string{
-			"COCKROACH_ENABLE_RPC_COMPRESSION=false",
-			"COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true",
-		},
-		NumRacks: 0,
+		Env:           config.DefaultEnvVars(),
+		NumRacks:      0,
 	}
 	// Override default values using the passed options (if any).
 	for _, opt := range opts {


### PR DESCRIPTION
Both, COCKROACH_ENABLE_RPC_COMPRESSION=false and
COCKROACH_UI_RELEASE_NOTES_SIGNUP_DISMISSED=true are passed into ENV_VARS of
the systemd startup script (start.sh) by default.
The same behavior is preserved _modulo_ duplication.
Since roachprod can now be initialized either via CLI or API,
default env. vars have been consolidated into config.go (used by both).

Release note: None