### PR TITLE
kvstreamer: fix some bugs (indefinite hang, request corruption)

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/admission",
+        "//pkg/util/buildutil",
         "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/stop",

--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/randutil",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvclient/kvstreamer/budget.go
+++ b/pkg/kv/kvclient/kvstreamer/budget.go
@@ -12,6 +12,7 @@ package kvstreamer
 
 import (
 	"context"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -23,8 +24,9 @@ import (
 // This struct is a wrapper on top of mon.BoundAccount because we want to
 // support the notion of budget "going in debt". This can occur in a degenerate
 // case when a single large row exceeds the provided limit. The Streamer is
-// expected to have only a single request in flight in this case. Additionally,
-// the budget provides blocking (via waitCh) until it gets out of debt.
+// expected to have only a single request in progress in this case.
+// Additionally, the budget provides blocking until some memory is returned to
+// the budget or, if the budget is already in debt, until it gets out of debt.
 type budget struct {
 	mu struct {
 		// If the Streamer's mutex also needs to be locked, the budget's mutex
@@ -33,15 +35,18 @@ type budget struct {
 		// acc represents the current reservation of this budget against the
 		// root memory pool.
 		acc *mon.BoundAccount
+		// waitForBudget is used by the main loop of the workerCoordinator to
+		// block until the next release() call or, if the budget is currently in
+		// debt, until it gets out of debt.
+		waitForBudget *sync.Cond
 	}
 	// limitBytes is the maximum amount of bytes that this budget should reserve
 	// against acc, i.e. acc.Used() should not exceed limitBytes. However, in a
 	// degenerate case of a single large row, the budget can go into debt and
 	// acc.Used() might exceed limitBytes.
+	//
+	// Available budget can be calculated as limitBytes - mu.acc.Used().
 	limitBytes int64
-	// waitCh is used by the main loop of the workerCoordinator to block until
-	// available() becomes positive (until some release calls occur).
-	waitCh chan struct{}
 }
 
 // newBudget creates a new budget with the specified limit. The limit determines
@@ -58,25 +63,10 @@ type budget struct {
 // to interact with the account only after canceling the Streamer (because
 // memory accounts are not thread-safe).
 func newBudget(acc *mon.BoundAccount, limitBytes int64) *budget {
-	b := budget{
-		limitBytes: limitBytes,
-		waitCh:     make(chan struct{}),
-	}
+	b := budget{limitBytes: limitBytes}
 	b.mu.acc = acc
+	b.mu.waitForBudget = sync.NewCond(&b.mu.Mutex)
 	return &b
-}
-
-// available returns how many bytes are currently available in the budget. The
-// answer can be negative, in case the Streamer has used un-budgeted memory
-// (e.g. one result was very large putting the budget in debt).
-//
-// Note that it's possible that actually available budget is less than the
-// number returned - this might occur if --max-sql-memory root pool is almost
-// used up.
-func (b *budget) available() int64 {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.limitBytes - b.mu.acc.Used()
 }
 
 // consume draws bytes from the available budget. An error is returned if the
@@ -110,17 +100,22 @@ func (b *budget) consumeLocked(ctx context.Context, bytes int64, allowDebt bool)
 	return b.mu.acc.Grow(ctx, bytes)
 }
 
-// release returns bytes to the available budget.
+// release returns bytes to the available budget. The budget's mutex must not be
+// held.
 func (b *budget) release(ctx context.Context, bytes int64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.releaseLocked(ctx, bytes)
+}
+
+// releaseLocked is the same as release but assumes that the budget's mutex is
+// already being held.
+func (b *budget) releaseLocked(ctx context.Context, bytes int64) {
+	b.mu.AssertHeld()
 	b.mu.acc.Shrink(ctx, bytes)
 	if b.limitBytes > b.mu.acc.Used() {
-		// Since we now have some available budget, we non-blockingly send on
-		// the wait channel to notify the mainCoordinator about it.
-		select {
-		case b.waitCh <- struct{}{}:
-		default:
-		}
+		// Since we now have some available budget, signal the worker
+		// coordinator.
+		b.mu.waitForBudget.Signal()
 	}
 }

--- a/pkg/kv/kvclient/kvstreamer/budget.go
+++ b/pkg/kv/kvclient/kvstreamer/budget.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // budget abstracts the memory budget that is provided to the Streamer by its
@@ -94,7 +95,10 @@ func (b *budget) consumeLocked(ctx context.Context, bytes int64, allowDebt bool)
 	// check whether we'll stay within the budget.
 	if !allowDebt && b.limitBytes > 5 {
 		if b.mu.acc.Used()+bytes > b.limitBytes {
-			return mon.MemoryResource.NewBudgetExceededError(bytes, b.mu.acc.Used(), b.limitBytes)
+			return errors.Wrap(
+				mon.MemoryResource.NewBudgetExceededError(bytes, b.mu.acc.Used(), b.limitBytes),
+				"streamer budget",
+			)
 		}
 	}
 	return b.mu.acc.Grow(ctx, bytes)

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -434,6 +434,10 @@ func (s *Streamer) Enqueue(
 	// requestsToServe, and the worker coordinator will then pick those batches
 	// up to execute asynchronously.
 	var totalReqsMemUsage int64
+	// Use a local variable for requestsToServe rather than
+	// s.mu.requestsToServe. This is needed in order for the worker coordinator
+	// to not pick up any work until we account for totalReqsMemUsage.
+	var requestsToServe []singleRangeBatch
 	// TODO(yuzefovich): in InOrder mode we need to treat the head-of-the-line
 	// request differently.
 	seekKey := rs.Key
@@ -492,7 +496,7 @@ func (s *Streamer) Enqueue(
 			sort.Sort(&r)
 		}
 
-		s.mu.requestsToServe = append(s.mu.requestsToServe, r)
+		requestsToServe = append(requestsToServe, r)
 
 		// Determine next seek key, taking potentially sparse requests into
 		// consideration.
@@ -516,8 +520,8 @@ func (s *Streamer) Enqueue(
 		return err
 	}
 
-	// TODO(yuzefovich): it might be better to notify the coordinator once
-	// one singleRangeBatch object has been appended to s.mu.requestsToServe.
+	// Memory reservation was approved, so the requests are good to go.
+	s.mu.requestsToServe = requestsToServe
 	s.coordinator.mu.hasWork.Signal()
 	return nil
 }

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -738,7 +738,7 @@ type workerCoordinator struct {
 }
 
 // mainLoop runs throughout the lifetime of the Streamer (from the first Enqueue
-// call until Cancel) and routes the single-range batches for asynchronous
+// call until Close) and routes the single-range batches for asynchronous
 // execution. This function is dividing up the Streamer's budget for each of
 // those batches and won't start executing the batches if the available budget
 // is insufficient. The function exits when an error is encountered by one of
@@ -1040,92 +1040,18 @@ func (w *workerCoordinator) performRequestAsync(
 				return
 			}
 
-			var resumeReq singleRangeBatch
-			// We will reuse the slices for the resume spans, if any.
-			resumeReq.reqs = req.reqs[:0]
-			resumeReq.positions = req.positions[:0]
-			var results []Result
-			var numCompleteGetResponses int
-			// memoryFootprintBytes tracks the total memory footprint of
-			// non-empty responses. This will be equal to the sum of memory
-			// tokens created for all Results.
-			var memoryFootprintBytes int64
-			var hasNonEmptyScanResponse bool
-			for i, resp := range br.Responses {
-				enqueueKey := req.positions[i]
-				if w.s.enqueueKeys != nil {
-					enqueueKey = w.s.enqueueKeys[req.positions[i]]
-				}
-				reply := resp.GetInner()
-				origReq := req.reqs[i]
-				// Unset the original request so that we lose the reference to
-				// the span.
-				req.reqs[i] = roachpb.RequestUnion{}
-				switch origRequest := origReq.GetInner().(type) {
-				case *roachpb.GetRequest:
-					get := reply.(*roachpb.GetResponse)
-					if get.ResumeSpan != nil {
-						// This Get wasn't completed - update the original
-						// request according to the ResumeSpan and include it
-						// into the batch again.
-						origRequest.SetSpan(*get.ResumeSpan)
-						resumeReq.reqs = append(resumeReq.reqs, origReq)
-						resumeReq.positions = append(resumeReq.positions, req.positions[i])
-					} else {
-						// This Get was completed.
-						toRelease := int64(get.Size())
-						result := Result{
-							GetResp: get,
-							// This currently only works because all requests
-							// are unique.
-							EnqueueKeysSatisfied: []int{enqueueKey},
-							position:             req.positions[i],
-						}
-						result.memoryTok.streamer = w.s
-						result.memoryTok.toRelease = toRelease
-						memoryFootprintBytes += toRelease
-						results = append(results, result)
-						numCompleteGetResponses++
-					}
-
-				case *roachpb.ScanRequest:
-					scan := reply.(*roachpb.ScanResponse)
-					resumeSpan := scan.ResumeSpan
-					if len(scan.Rows) > 0 || len(scan.BatchResponses) > 0 {
-						toRelease := int64(scan.Size())
-						result := Result{
-							// This currently only works because all requests
-							// are unique.
-							EnqueueKeysSatisfied: []int{enqueueKey},
-							position:             req.positions[i],
-						}
-						result.memoryTok.streamer = w.s
-						result.memoryTok.toRelease = toRelease
-						result.ScanResp.ScanResponse = scan
-						// Complete field will be set below.
-						memoryFootprintBytes += toRelease
-						results = append(results, result)
-						hasNonEmptyScanResponse = true
-					}
-					if resumeSpan != nil {
-						// This Scan wasn't completed - update the original
-						// request according to the resumeSpan and include it
-						// into the batch again.
-						origRequest.SetSpan(*resumeSpan)
-						resumeReq.reqs = append(resumeReq.reqs, origReq)
-						resumeReq.positions = append(resumeReq.positions, req.positions[i])
-					}
-				}
-			}
+			// First, we have to reconcile the memory budget. We do it
+			// separately from processing the results because we want to know
+			// how many Gets and Scans need to be allocated for the ResumeSpans,
+			// if any are present. At the moment, due to limitations of the KV
+			// layer (#75452) we cannot reuse original requests because the KV
+			// doesn't allow mutability.
+			memoryFootprintBytes, resumeReqsMemUsage, numIncompleteGets, numIncompleteScans := calculateFootprint(req, br)
 
 			// Now adjust the budget based on the actual memory footprint of
 			// non-empty responses as well as resume spans, if any.
 			respOverestimate := targetBytes - memoryFootprintBytes
-			var reqsMemUsage int64
-			if len(resumeReq.reqs) > 0 {
-				reqsMemUsage = requestsMemUsage(resumeReq.reqs)
-			}
-			reqOveraccounted := req.reqsReservedBytes - reqsMemUsage
+			reqOveraccounted := req.reqsReservedBytes - resumeReqsMemUsage
 			overaccountedTotal := respOverestimate + reqOveraccounted
 			if overaccountedTotal >= 0 {
 				w.s.budget.release(ctx, overaccountedTotal)
@@ -1169,8 +1095,6 @@ func (w *workerCoordinator) performRequestAsync(
 					return
 				}
 			}
-			// Update the resume request accordingly.
-			resumeReq.reqsReservedBytes = reqsMemUsage
 
 			// Do admission control after we've finalized the memory accounting.
 			if br != nil && w.responseAdmissionQ != nil {
@@ -1185,24 +1109,209 @@ func (w *workerCoordinator) performRequestAsync(
 				}
 			}
 
-			// If we have any results, finalize them.
-			if len(results) > 0 {
-				w.finalizeSingleRangeResults(
-					results, memoryFootprintBytes, hasNonEmptyScanResponse,
-					numCompleteGetResponses,
-				)
-			}
-
-			// If we have any incomplete requests, add them back into the work
-			// pool.
-			if len(resumeReq.reqs) > 0 {
-				w.addRequest(resumeReq)
-			}
+			// Finally, process the results and add the ResumeSpans to be
+			// processed as well.
+			w.processSingleRangeResults(
+				req, br, memoryFootprintBytes, resumeReqsMemUsage,
+				numIncompleteGets, numIncompleteScans,
+			)
 		}); err != nil {
 		// The new goroutine for the request wasn't spun up, so we have to
 		// perform the cleanup of this request ourselves.
 		w.asyncRequestCleanup()
 		w.s.setError(err)
+	}
+}
+
+// calculateFootprint calculates the memory footprint of the batch response as
+// well as of the requests that will have to be created for the ResumeSpans.
+// - memoryFootprintBytes tracks the total memory footprint of non-empty
+// responses. This will be equal to the sum of memory tokens created for all
+// Results.
+// - resumeReqsMemUsage tracks the memory usage of the requests for the
+// ResumeSpans.
+func calculateFootprint(
+	req singleRangeBatch, br *roachpb.BatchResponse,
+) (
+	memoryFootprintBytes int64,
+	resumeReqsMemUsage int64,
+	numIncompleteGets, numIncompleteScans int,
+) {
+	// Note that we cannot use Size() methods that are automatically generated
+	// by the protobuf library because they account for things differently from
+	// how the memory usage is accounted for by the KV layer for the purposes of
+	// tracking TargetBytes limit.
+
+	// getRequestScratch and scanRequestScratch are used to calculate
+	// the size of requests when we set the ResumeSpans on them.
+	var getRequestScratch roachpb.GetRequest
+	var scanRequestScratch roachpb.ScanRequest
+	for i, resp := range br.Responses {
+		reply := resp.GetInner()
+		switch req.reqs[i].GetInner().(type) {
+		case *roachpb.GetRequest:
+			get := reply.(*roachpb.GetResponse)
+			if get.ResumeSpan != nil {
+				// This Get wasn't completed.
+				getRequestScratch.SetSpan(*get.ResumeSpan)
+				resumeReqsMemUsage += int64(getRequestScratch.Size())
+				numIncompleteGets++
+			} else {
+				// This Get was completed.
+				memoryFootprintBytes += getResponseSize(get)
+			}
+		case *roachpb.ScanRequest:
+			scan := reply.(*roachpb.ScanResponse)
+			if len(scan.Rows) > 0 || len(scan.BatchResponses) > 0 {
+				memoryFootprintBytes += scanResponseSize(scan)
+			}
+			if scan.ResumeSpan != nil {
+				// This Scan wasn't completed.
+				scanRequestScratch.SetSpan(*scan.ResumeSpan)
+				resumeReqsMemUsage += int64(scanRequestScratch.Size())
+				numIncompleteScans++
+			}
+		}
+	}
+	// This addendum is the first step of requestsMemUsage() and we've already
+	// added the size of each resume request above.
+	resumeReqsMemUsage += requestUnionOverhead * int64(numIncompleteGets+numIncompleteScans)
+	return memoryFootprintBytes, resumeReqsMemUsage, numIncompleteGets, numIncompleteScans
+}
+
+// processSingleRangeResults creates a Result for each non-empty response found
+// in the BatchResponse. The ResumeSpans, if found, are added into a new
+// singleRangeBatch request that is added to be picked up by the mainLoop of the
+// worker coordinator. This method assumes that req is no longer needed by the
+// caller, so req.positions is reused for the ResumeSpans.
+//
+// It also assumes that the budget has already been reconciled with the
+// reservations for Results that will be created.
+func (w *workerCoordinator) processSingleRangeResults(
+	req singleRangeBatch,
+	br *roachpb.BatchResponse,
+	memoryFootprintBytes int64,
+	resumeReqsMemUsage int64,
+	numIncompleteGets, numIncompleteScans int,
+) {
+	numIncompleteRequests := numIncompleteGets + numIncompleteScans
+	var resumeReq singleRangeBatch
+	// We have to allocate the new slice for requests, but we can reuse the
+	// positions slice.
+	resumeReq.reqs = make([]roachpb.RequestUnion, numIncompleteRequests)
+	// numIncompleteRequests will never exceed the number of requests in req.
+	resumeReq.positions = req.positions[:numIncompleteRequests]
+	// We've already reconciled the budget with the actual reservation for the
+	// requests with the ResumeSpans.
+	resumeReq.reqsReservedBytes = resumeReqsMemUsage
+	gets := make([]struct {
+		req   roachpb.GetRequest
+		union roachpb.RequestUnion_Get
+	}, numIncompleteGets)
+	scans := make([]struct {
+		req   roachpb.ScanRequest
+		union roachpb.RequestUnion_Scan
+	}, numIncompleteScans)
+	var results []Result
+	var numCompleteGetResponses int
+	var hasNonEmptyScanResponse bool
+	var resumeReqIdx int
+	// memoryTokensBytes accumulates all reservations that are made for all
+	// Results created below. The accounting for these reservations has already
+	// been performed, and memoryTokensBytes should be exactly equal to
+	// memoryFootprintBytes, so we use it only as an additional check.
+	var memoryTokensBytes int64
+	for i, resp := range br.Responses {
+		enqueueKey := req.positions[i]
+		if w.s.enqueueKeys != nil {
+			enqueueKey = w.s.enqueueKeys[req.positions[i]]
+		}
+		reply := resp.GetInner()
+		switch origRequest := req.reqs[i].GetInner().(type) {
+		case *roachpb.GetRequest:
+			get := reply.(*roachpb.GetResponse)
+			if get.ResumeSpan != nil {
+				// This Get wasn't completed - update the original
+				// request according to the ResumeSpan and include it
+				// into the batch again.
+				newGet := gets[0]
+				gets = gets[1:]
+				newGet.req.SetSpan(*get.ResumeSpan)
+				newGet.req.KeyLocking = origRequest.KeyLocking
+				newGet.union.Get = &newGet.req
+				resumeReq.reqs[resumeReqIdx].Value = &newGet.union
+				resumeReq.positions[resumeReqIdx] = req.positions[i]
+				resumeReqIdx++
+			} else {
+				// This Get was completed.
+				result := Result{
+					GetResp: get,
+					// This currently only works because all requests
+					// are unique.
+					EnqueueKeysSatisfied: []int{enqueueKey},
+					position:             req.positions[i],
+				}
+				result.memoryTok.streamer = w.s
+				result.memoryTok.toRelease = getResponseSize(get)
+				memoryTokensBytes += result.memoryTok.toRelease
+				results = append(results, result)
+				numCompleteGetResponses++
+			}
+
+		case *roachpb.ScanRequest:
+			scan := reply.(*roachpb.ScanResponse)
+			if len(scan.Rows) > 0 || len(scan.BatchResponses) > 0 {
+				result := Result{
+					// This currently only works because all requests
+					// are unique.
+					EnqueueKeysSatisfied: []int{enqueueKey},
+					position:             req.positions[i],
+				}
+				result.memoryTok.streamer = w.s
+				result.memoryTok.toRelease = scanResponseSize(scan)
+				memoryTokensBytes += result.memoryTok.toRelease
+				result.ScanResp.ScanResponse = scan
+				// Complete field will be set below.
+				results = append(results, result)
+				hasNonEmptyScanResponse = true
+			}
+			if scan.ResumeSpan != nil {
+				// This Scan wasn't completed - update the original
+				// request according to the ResumeSpan and include it
+				// into the batch again.
+				newScan := scans[0]
+				scans = scans[1:]
+				newScan.req.SetSpan(*scan.ResumeSpan)
+				newScan.req.KeyLocking = origRequest.KeyLocking
+				newScan.union.Scan = &newScan.req
+				resumeReq.reqs[resumeReqIdx].Value = &newScan.union
+				resumeReq.positions[resumeReqIdx] = req.positions[i]
+				resumeReqIdx++
+			}
+		}
+	}
+
+	if buildutil.CrdbTestBuild {
+		if memoryFootprintBytes != memoryTokensBytes {
+			panic(errors.AssertionFailedf(
+				"different calculation of memory footprint\ncalculateFootprint: %d bytes\n"+
+					"processSingleRangeResults: %d bytes", memoryFootprintBytes, memoryTokensBytes,
+			))
+		}
+	}
+
+	// If we have any results, finalize them.
+	if len(results) > 0 {
+		w.finalizeSingleRangeResults(
+			results, memoryFootprintBytes, hasNonEmptyScanResponse,
+			numCompleteGetResponses,
+		)
+	}
+
+	// If we have any incomplete requests, add them back into the work
+	// pool.
+	if len(resumeReq.reqs) > 0 {
+		w.addRequest(resumeReq)
 	}
 }
 
@@ -1270,13 +1379,31 @@ func init() {
 	zeroIntSlice = make([]int, 1<<10)
 }
 
-const requestUnionSliceOverhead = int64(unsafe.Sizeof([]roachpb.RequestUnion{}))
+const requestUnionOverhead = int64(unsafe.Sizeof(roachpb.RequestUnion{}))
 
 func requestsMemUsage(reqs []roachpb.RequestUnion) int64 {
-	memUsage := requestUnionSliceOverhead
-	// Slice up to the capacity to account for everything.
-	for _, r := range reqs[:cap(reqs)] {
+	// RequestUnion.Size() ignores the overhead of RequestUnion object, so we'll
+	// account for it separately first.
+	memUsage := requestUnionOverhead * int64(cap(reqs))
+	// No need to account for elements past len(reqs) because those must be
+	// unset and we have already accounted for RequestUnion object above.
+	for _, r := range reqs {
 		memUsage += int64(r.Size())
 	}
 	return memUsage
+}
+
+// getResponseSize calculates the size of the GetResponse similar to how it is
+// accounted for TargetBytes parameter by the KV layer.
+func getResponseSize(get *roachpb.GetResponse) int64 {
+	if get.Value == nil {
+		return 0
+	}
+	return int64(len(get.Value.RawBytes))
+}
+
+// scanResponseSize calculates the size of the ScanResponse similar to how it is
+// accounted for TargetBytes parameter by the KV layer.
+func scanResponseSize(scan *roachpb.ScanResponse) int64 {
+	return scan.NumBytes
 }


### PR DESCRIPTION
**kvstreamer: fix rare race condition**

This commit refactors the locking logic in an error case in `Enqueue`
where previously we had a rare race condition. We divided the locking
state across two things (the mutex and a boolean indicating whether the
mutex is locked) which together were not accessed atomically. This
commit removes the boolean by forcing that the mutex is held when
`Enqueue` returns.

Release note: None

**kvstreamer: fix the case when root pool is exhausted**

Each request processed asynchronously assumes that the memory footprint
of the spans in the request has already been accounted for. This
assumption was broken in case `Enqueue` encountered an error when
consuming from the budget due to root pool being exhausted.

The sequence of steps to get into a problematic state was as follows:
- spin up the worker coordinator, it blocks until there are any requests
to serve
- populate requests to serve
- `s.mu` is unlocked to perform the memory accounting
- the worker coordinator wakes up and picks up some work
- memory reservation is denied in `Enqueue`, an error is returned; thus,
we have a drift in the memory accounting
- concurrent request is responded to, and when it attempts to reconcile
the memory accounting, a crash (in test builds) occurs because the
memory reservation in `Enqueue` was denied.

This is now fixed by not telling the worker coordinator about the
requests to serve until after the memory accounting is performed.

Fixes: #74898.

Release note: None

**kvstreamer: fix rare cases of worker coordinator being stuck forever**

Previously, it was possible for the worker coordinator to be stuck
indefinitely because we were using a separate mutex for its condition
variable waiting for more work. Namely, the following sequence of events
was possible:
1. `Enqueue` unlocks the `Streamer`'s mutex to make the memory
reservation. Then the goroutine is preempted.
2. the worker coordinator wakes up, checks that there are no requests to
serve, and before it blocks on the condition variable, it is preempted.
3. `Enqueue` goroutine wakes up, adds some requests to serve, and
signals the condition variable. But because no goroutine is currently
waiting on it, no goroutine is woken up.
4. the worker coordinator wakes up and goes into waiting on the
condition variable forever.

This problem is now fixed by using the same `Streamer`'s mutex for the
condition variable used for waiting for work.

Another scenario when the worker coordinator could get stuck was due to
the fact that we were unlocking the `Streamer`'s mutex after retrieving
no requests to proceed and before waiting on the condition variable. Thus,
previously it was possible for a new request to be added and the
condition variable to be signaled before the coordinator started waiting
(which would be forever). This is now fixed by more precise locking of
the mutex.

Release note: None

**kvstreamer: fix the streamer's behavior with a slow consumer**

This commit fixes a case when the worker coordinator could get stuck
indefinitely waiting for budget in some degenerate cases. The way
that would happen was the following:
1. the coordinator checks that there is at least one request in flight.
Its goroutine is then preempted.
2. those concurrent requests in flight finish, decrement the number of
requests in flight to zero, but don't notify the budget's `waitCh`
because the budget didn't get out of debt.
3. the coordinator wakes up, checks that the budget is in debt, and
because it earlier checked that there were some requests in flight (but
not anymore), it starts waiting for some `release` calls, but none
would ever occur.

This is now fixed by always holding the budget's mutex when checking
whether to wait for the next `release` call or until the budget gets out
of debt. The corresponding channel has been refactored to a condition
variable. The condition variable is now additionally signaled when the
last request in flight completes so that the worker coordinator doesn't
wait forever for budget to get out of debt in a degenerate case when it
never will.

Now, due to such signaling, the streamer could get in more debt than
necessary because "head-of-the-line" requests are allowed to put the
budget in more debt than it already is in. Consider a scenario when
many requests need to be responded to and the consumer is slow to
process already produced results. We might end up in a scenario where
the `Streamer` issues and receives the response one request at a time.
The results are accumulated, but every request - since there are no
other requests in flight - is treated as the "head-of-the-line", so
it is allowed to put the budget into more debt.

To improve the behavior in this scenario we introduce the notion of
requests "in progress" which include both requests that are currently
in flight in addition to already created results that haven't been
released yet. Now, the "head-of-the-line" request is such that there are
no other requests in progress.

Fixes: #75256.

Release note: None

**kvstreamer: fix the bug with corrupting request when it is put back**

When the `Streamer` realizes that its budget doesn't allow for
accounting for the received response for not head-of-the-line request,
it puts the original request back to be processed from scratch.
Previously, due to the way the code was structured, it was possible that
the request would get corrupted. Namely, this was the case because we
were updating the original request in-place to include any `ResumeSpan`s
and nilling it out too while we're calculating the total memory
footprint. Then, we'd reconcile the budget, and if the allocation is
denied, then we put the original request back to be processed; however,
at this point the request was already corrupted.

As it turns out, modifying of the original requests is not allowed by
the KV layer, so this commit fixes that as well as the corruption issue
by splitting the iteration over the results into two loops:
- in the first loop, we calculate the memory footprint only as well as
the number of new requests to be created;
- then, we reconcile the budget, and if necessary, put the original
unmodified request back to be served;
- in the second loop, when the budget is successfully reconciled, we're
allocating new requests and updating them with the `ResumeSpan`s.

Additionally, this commit adjusts the calculation of the size of the
responses to be similar to how the responses are accounted for by the KV
layer for the purposes of `TargetBytes`. This is needed because `Size`
methods generated for the protobuf messages automatically include
additional overhead, and we don't want that.

Fixes: #74853.

Release note: None