### PR TITLE
roachpb,kv/kvserver: skip TestReplicaUnavailableError under bazel

### DIFF
--- a/pkg/kv/kvserver/replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/redact"
@@ -25,6 +26,7 @@ import (
 
 func TestReplicaUnavailableError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderBazelWithIssue(t, 75108, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	var repls roachpb.ReplicaSet

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -169,6 +169,7 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils/buildutil",
         "//pkg/testutils/echotest",
+        "//pkg/testutils/skip",
         "//pkg/testutils/zerofields",
         "//pkg/util",
         "//pkg/util/bitarray",

--- a/pkg/roachpb/replica_unavailable_error_test.go
+++ b/pkg/roachpb/replica_unavailable_error_test.go
@@ -17,12 +17,14 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
 
 func TestReplicaUnavailableError(t *testing.T) {
 	ctx := context.Background()
+	skip.UnderBazelWithIssue(t, 75108, "flaky test")
 	var _ = (*ReplicaUnavailableError)(nil)
 	rDesc := ReplicaDescriptor{NodeID: 1, StoreID: 2, ReplicaID: 3}
 	var set ReplicaSet


### PR DESCRIPTION
Refs: #75108

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None