### PR TITLE
*: always call Close() on http.Response.Body

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
@@ -158,6 +158,7 @@ func TestTenantGRPCServices(t *testing.T) {
 		resp, err := httpClient.Get("https://" + tenant.HTTPAddr() + "/_status/sessions")
 		defer http.DefaultClient.CloseIdleConnections()
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		require.Equal(t, 200, resp.StatusCode)
 	})
 }

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -465,9 +465,10 @@ func (s *TestDirectoryServer) startTenantLocked(
 	client := &http.Client{Transport: transport}
 	for {
 		time.Sleep(300 * time.Millisecond)
-		_, err := client.Get(fmt.Sprintf("https://%s/health", httpListener.Addr().String()))
+		resp, err := client.Get(fmt.Sprintf("https://%s/health", httpListener.Addr().String()))
 		waitTime := timeutil.Since(start)
 		if err == nil {
+			resp.Body.Close()
 			log.Infof(ctx, "tenant is healthy")
 			break
 		}

--- a/pkg/cmd/docgen/extract/extract.go
+++ b/pkg/cmd/docgen/extract/extract.go
@@ -105,11 +105,13 @@ func GenerateBNF(addr string, bnfAPITimeout time.Duration) (ebnf []byte, err err
 		if err != nil {
 			return nil, err
 		}
-		b, err = ioutil.ReadAll(resp.Body)
+		b, err = func() ([]byte, error) {
+			defer resp.Body.Close()
+			return ioutil.ReadAll(resp.Body)
+		}()
 		if err != nil {
 			return nil, err
 		}
-		resp.Body.Close()
 	} else {
 		body, err := ioutil.ReadFile(addr)
 		if err != nil {

--- a/pkg/cmd/label-merged-pr/main.go
+++ b/pkg/cmd/label-merged-pr/main.go
@@ -231,6 +231,7 @@ func apiCall(client *http.Client, url string, token string, payload interface{})
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	// Status code 422 is returned when a label already exist
 	if !(resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusUnprocessableEntity || resp.
 		StatusCode == http.StatusOK) {

--- a/pkg/cmd/roachtest/tests/rapid_restart.go
+++ b/pkg/cmd/roachtest/tests/rapid_restart.go
@@ -82,6 +82,7 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 			url := base + `/_status/vars`
 			resp, err := httpClient.Get(ctx, url)
 			if err == nil {
+				resp.Body.Close()
 				if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusOK {
 					t.Fatalf("unexpected status code from %s: %d", url, resp.StatusCode)
 				}

--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -97,6 +97,7 @@ func getEdgeURL(urlPathBase, SHA, arch string, ext string) (*url.URL, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer resp.Body.Close()
 		edgeBinaryLocation = resp.Request.URL
 	}
 

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -616,7 +616,10 @@ func TestUseWrongSplitCACerts(t *testing.T) {
 		t.Fatalf("could not create request: %v", err)
 	}
 
-	_, err = httpClient.Do(req)
+	resp, err = httpClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
+	}
 	if expected := "certificate signed by unknown authority"; !testutils.IsError(err, expected) {
 		t.Fatalf("Expected error %q, got %v", expected, err)
 	}

--- a/pkg/server/init_handshake.go
+++ b/pkg/server/init_handshake.go
@@ -351,6 +351,7 @@ func (t *tlsInitHandshaker) getPeerCACert(
 	if err != nil {
 		return nodeHostnameAndCA{}, err
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
 		return nodeHostnameAndCA{}, errors.Errorf("unexpected error returned from peer: HTTP %d", res.StatusCode)
@@ -436,8 +437,9 @@ func (t *tlsInitHandshaker) sendBundle(
 		case <-ticker.C:
 		}
 
-		_, err = client.Post(generateURLForClient(address, deliverBundleURL), "application/json; charset=utf-8", bytes.NewReader(body.Bytes()))
+		res, err := client.Post(generateURLForClient(address, deliverBundleURL), "application/json; charset=utf-8", bytes.NewReader(body.Bytes()))
 		if err == nil {
+			res.Body.Close()
 			break
 		}
 		lastError = err


### PR DESCRIPTION
Since go 1.17.6, forgetting to call Close() results in goroutine
leaks.

See: https://github.com/golang/go/issues/50652

Release note: None