### PR TITLE
sql: deflake TestTelemetry

### DIFF
--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -167,7 +167,6 @@ sql.plan.cte.recursive
 
 feature-allowlist
 sql.plan.lateral-join
-sql.plan.subquery.*
 ----
 
 feature-usage
@@ -179,6 +178,10 @@ feature-usage
 SELECT * FROM (VALUES (1), (2)) AS a(x) JOIN LATERAL (SELECT a.x+1 AS x) AS b ON a.x < b.x
 ----
 sql.plan.lateral-join
+
+feature-allowlist
+sql.plan.subquery.*
+----
 
 feature-usage
 SELECT 1 = (SELECT a FROM x LIMIT 1)


### PR DESCRIPTION
This commit deflakes `TestTelemetry` by adding a more precise
`feature-allowlist`.

Fixes #75138

Release note: None