### PR TITLE
sql/rowenc: avoid panic when encoding delete preserving index

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -617,6 +617,7 @@ go_test(
         "//pkg/sql/rowinfra",
         "//pkg/sql/scrub",
         "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1335,8 +1335,12 @@ func growKey(key []byte, additionalCapacity int) []byte {
 }
 
 func getIndexValueWrapperBytes(entry *IndexEntry) ([]byte, error) {
+	var value []byte
+	if entry.Value.IsPresent() {
+		value = entry.Value.TagAndDataBytes()
+	}
 	tempKV := rowencpb.IndexValueWrapper{
-		Value:   entry.Value.TagAndDataBytes(),
+		Value:   value,
 		Deleted: false,
 	}
 


### PR DESCRIPTION
It appears, we can occasionally be asked to encode empty KVs. Notably,
this seems to happen along the delete path when multiple column
families are in play.

The included test case mirrors the case that caught this bug on an
in-progress branch. Namely, a "temporary" index used by the new index
backfiller during a primary key change.

Release note: None