### PR TITLE
cloud: close Reader before resetting in ResumingReader

### DIFF
--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -231,6 +231,9 @@ func (r *ResumingReader) Read(p []byte) (int, error) {
 			}
 			log.Errorf(r.Ctx, "Retry IO: error %s", lastErr)
 			lastErr = nil
+			if r.Reader != nil {
+				r.Reader.Close()
+			}
 			r.Reader = nil
 		}
 	}


### PR DESCRIPTION
This change `Close()`s the Reader before resetting it when we
encounter a resumable error in the ResumingReader. This is particularly
important for the http external storage provide, since forgetting to
call Close() results in goroutine leaks from go1.17.6 onwards.

See: golang/go#50652

Fixes: #75143

Release note: None