### PR TITLE
vendor: bump Pebble to 20f8dd034791

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1218,10 +1218,10 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sha256 = "a3dd93db0e77ac631f48db4529fcd324eeec43a732a1717ce0a1819975e3732f",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220112164547-3d0ff924d13a",
+        sha256 = "5c8f1cab6c2528bd9e6b832f2dfcd98538d5df2c15d8e3f1d959f6c0f8c9778a",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220118190613-20f8dd034791",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220112164547-3d0ff924d13a.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220118190613-20f8dd034791.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220112164547-3d0ff924d13a
+	github.com/cockroachdb/pebble v0.0.0-20220118190613-20f8dd034791
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220112164547-3d0ff924d13a h1:ZhbIEzddawjcYhWIiOLLePZawe1PT0VlIFVsJiVakB8=
-github.com/cockroachdb/pebble v0.0.0-20220112164547-3d0ff924d13a/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220118190613-20f8dd034791 h1:g5D/E80chI50RnqWv/kZys4N1xI7wwL0J5azd2S8XYk=
+github.com/cockroachdb/pebble v0.0.0-20220118190613-20f8dd034791/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.1/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
20f8dd03 sstable: reuse index block iterator in Layout
628db895 sstable: unexport BlockIntervalFilter concrete type
ea06b442 tool: constrain lsm visualizer b/w start and end version numbers
d4f0a8d4 internal/manifest: narrow Overlaps to exclude RANGEDEL sentinel keys.
```

Release note: None