### PR TITLE
sql: fix logic to detect if primary index constraint name is in use

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1622,11 +1622,19 @@ func validateConstraintNameIsNotUsed(
 				name == tree.Name(defaultPKName) {
 				return false, nil
 			}
+			// If there is no active primary key, then adding one with the exact
+			// same name is allowed.
+			if !tableDesc.HasPrimaryKey() &&
+				tableDesc.PrimaryIndex.Name == name.String() {
+				return false, nil
+			}
 		}
 		if name == "" {
 			return false, nil
 		}
 		idx, _ := tableDesc.FindIndexWithName(string(name))
+		// If an index is found and its disabled, then we know it will be dropped
+		// later on.
 		if idx == nil {
 			return false, nil
 		}
@@ -1651,8 +1659,23 @@ func validateConstraintNameIsNotUsed(
 		// Unexpected error: table descriptor should be valid at this point.
 		return false, errors.WithAssertionFailure(err)
 	}
-	if _, isInUse := info[name.String()]; !isInUse {
+	constraintInfo, isInUse := info[name.String()]
+	if !isInUse {
 		return false, nil
+	}
+	// If the primary index is being replaced, then the name can be reused for
+	// another constraint.
+	if isInUse &&
+		constraintInfo.Index != nil &&
+		constraintInfo.Index.ID == tableDesc.PrimaryIndex.ID {
+		for _, mut := range tableDesc.GetMutations() {
+			if primaryKeySwap := mut.GetPrimaryKeySwap(); primaryKeySwap != nil &&
+				primaryKeySwap.OldPrimaryIndexId == tableDesc.PrimaryIndex.ID &&
+				primaryKeySwap.NewPrimaryIndexName != name.String() {
+				return false, nil
+			}
+		}
+
 	}
 	if hasIfNotExists {
 		return true, nil

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -312,10 +312,18 @@ func (desc *wrapper) collectConstraintInfo(
 			if hidden {
 				continue
 			}
+			indexName := index.Name
+			// If a primary key swap is occurring, then the primary index name can
+			// be seen as being under the new name.
+			for _, mutation := range desc.GetMutations() {
+				if mutation.GetPrimaryKeySwap() != nil {
+					indexName = mutation.GetPrimaryKeySwap().NewPrimaryIndexName
+				}
+			}
 			detail := descpb.ConstraintDetail{Kind: descpb.ConstraintTypePK}
 			detail.Columns = index.KeyColumnNames
 			detail.Index = index
-			info[index.Name] = detail
+			info[indexName] = detail
 		} else if index.Unique {
 			if _, ok := info[index.Name]; ok {
 				return nil, pgerror.Newf(pgcode.DuplicateObject,

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -622,7 +622,7 @@ ALTER TABLE t ADD CONSTRAINT "t_pkey" PRIMARY KEY (y), DROP CONSTRAINT "t_pkey"
 statement error pq: multiple primary keys for table "t" are not allowed
 ALTER TABLE t ADD CONSTRAINT "t_pkey" PRIMARY KEY (y)
 
-statement error pgcode 42710 constraint with name \"t_pkey\" already exists
+statement ok
 ALTER TABLE t DROP CONSTRAINT "t_pkey", ADD CONSTRAINT "t_pkey" PRIMARY KEY (y)
 
 statement ok
@@ -654,7 +654,7 @@ BEGIN
 statement ok
 ALTER TABLE t DROP CONSTRAINT "t_pkey"
 
-statement error pgcode 42710 constraint with name \"t_pkey\" already exists
+statement ok
 ALTER TABLE t ADD CONSTRAINT "t_pkey" PRIMARY KEY (y)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2171,3 +2171,52 @@ NOTICE: storage parameter "autovacuum_enabled = 'off'" is ignored
 
 statement error parameter "autovacuum_enabled" requires a Boolean value
 ALTER TABLE storage_param_table SET (autovacuum_enabled='11')
+
+# Fixes issue 75154 when dropping and re-creating a constraint in a transaction
+# we incorrectly detected the primary index as being used, even if its dropped
+# inside the transaction. The primary index will still exist, but will be
+# disabled via the drop constraint.
+subtest drop-and-add-constraint-primary-index
+
+statement ok
+BEGIN;
+create table const_tbl (a int, b int, constraint "bob" primary key (a, b));
+alter table const_tbl drop constraint "bob";
+alter table const_tbl add constraint "bob" primary key (a, b); -- this statement
+COMMIT;
+
+statement error relation \"const_tbl\" \(\d+\): unimplemented: primary key dropped without subsequent addition of new primary key in same transaction.*
+BEGIN;
+alter table const_tbl drop constraint "bob";
+alter table const_tbl add constraint "bob" primary key (a, b); -- this statement
+alter table const_tbl drop constraint "bob";
+COMMIT;
+
+statement ok
+BEGIN;
+alter table const_tbl drop constraint "bob";
+-- Note: Primary key must be restored first before any other command will
+-- be allowed.
+alter table const_tbl add constraint "steve" primary key (a, b); -- this statement
+
+statement error pq: relation \"const_tbl\" \(\d+\): unimplemented: cannot perform other schema changes in the same transaction as a primary key change.*
+alter table const_tbl add constraint "bob" CHECK (a > 100);
+
+statement ok
+rollback
+
+statement ok
+alter table const_tbl add constraint "steve" CHECK (a > 100);
+
+statement ok
+BEGIN;
+alter table const_tbl drop constraint "steve";
+alter table const_tbl add constraint "steve" CHECK (a > 100);
+COMMIT;
+
+statement error  pq: duplicate constraint name: "steve"
+BEGIN;
+alter table const_tbl drop constraint "steve";
+alter table const_tbl add constraint "steve" CHECK (a > 100);
+alter table const_tbl add constraint "steve" CHECK (a > 100);
+COMMIT;


### PR DESCRIPTION
Fixes: #75154

Previously, when dropping and adding a primary constraint inside
a transaction with the same name would fail since we would detect
a primary index with the same name was active. This was inadequate
because replacing an index within a transaction is supported, even
if the name is the same. To address this, this patch checks if
the index is marked for deletion via the disabled flag, in which
case the name is not currently in use because the index will be
dropped in the transaction.

Release note (bug fix): Dropping and creating a primary index constraint in the same transaction with the same name would incorrectly fail.