### PR TITLE
release-21.2: roachtest: pass CRDB version to sequelize test 

### DIFF
--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -140,7 +140,7 @@ func registerSequelize(r registry.Registry) {
 
 		t.Status("running Sequelize test suite")
 		rawResults, err := c.RunWithBuffer(ctx, t.L(), node,
-			fmt.Sprintf(`cd /mnt/data1/sequelize/ && CRDB_VERSION=%s npm test`, version),
+			fmt.Sprintf(`cd /mnt/data1/sequelize/ && npm test --crdb_version=%s`, version),
 		)
 		rawResultsStr := string(rawResults)
 		t.L().Printf("Test Results: %s", rawResultsStr)

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -139,7 +140,7 @@ func registerSequelize(r registry.Registry) {
 
 		t.Status("running Sequelize test suite")
 		rawResults, err := c.RunWithBuffer(ctx, t.L(), node,
-			`cd /mnt/data1/sequelize/ && npm test`,
+			fmt.Sprintf(`cd /mnt/data1/sequelize/ && CRDB_VERSION=%s npm test`, version),
 		)
 		rawResultsStr := string(rawResults)
 		t.L().Printf("Test Results: %s", rawResultsStr)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/75144

Backport:
  * 1/1 commits from "roachtest: pass CRDB version to sequelize test" (#71913)
  * 1/1 commits from "roachtest: pass option to sequelize test correctly" (#72268)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test only change