### PR TITLE
kv: fix GenerateForcedRetryableError to return a bumped epoch

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1468,17 +1468,7 @@ func (txn *Txn) GenerateForcedRetryableError(ctx context.Context, msg string) er
 	now := txn.db.clock.NowAsClockTimestamp()
 	txn.mu.sender.ManualRestart(ctx, txn.mu.userPriority, now.ToTimestamp())
 	txn.resetDeadlineLocked()
-	return roachpb.NewTransactionRetryWithProtoRefreshError(
-		msg,
-		txn.mu.ID,
-		roachpb.MakeTransaction(
-			txn.debugNameLocked(),
-			nil, // baseKey
-			txn.mu.userPriority,
-			now.ToTimestamp(),
-			txn.db.clock.MaxOffset().Nanoseconds(),
-			int32(txn.db.ctx.NodeID.SQLInstanceID())),
-	)
+	return txn.mu.sender.PrepareRetryableError(ctx, msg)
 }
 
 // PrepareRetryableError returns a


### PR DESCRIPTION
This is needed for PR #74563, where we change how txn is reset.
Without this change GenerateForcedRetryableError returns an
error with an inner txn that has an epoch 0. With this change
the epoch is copied from the original txn.

Release note: None