### PR TITLE
ui: make these UIConfigState properties optional

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -20,12 +20,12 @@ export type UIConfigState = {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
     };
-    sessions: {
-      showTerminateActions: boolean;
+    sessions?: {
+      showTerminateActions?: boolean;
     };
     sessionDetails: {
       showGatewayNodeLink: boolean;
-      showTerminateActions: boolean;
+      showTerminateActions?: boolean;
     };
   };
 };


### PR DESCRIPTION
This change fixes Typescript errors encountered trying to work in our
cloud code.

Codebases that load multiple versions of our cluster-ui package (read:
managed-service) need a lowest-common-denominator expression for their
default UIConfigState.

Properties like these `showTerminateActions` flags that exist only for
versions >= 21.2 must therefore be marked as optional.

Release note: None