### PR TITLE
changefeedccl: more redactions in changefeed job description

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3381,7 +3381,8 @@ func TestChangefeedDescription(t *testing.T) {
 	sqlDB.QueryRow(t,
 		`SELECT description FROM [SHOW JOBS] WHERE job_id = $1`, jobID,
 	).Scan(&description)
-	expected := `CREATE CHANGEFEED FOR TABLE foo INTO '` + sink.String() +
+	redactedSink := strings.Replace(sink.String(), security.RootUser, `redacted`, 1)
+	expected := `CREATE CHANGEFEED FOR TABLE foo INTO '` + redactedSink +
 		`' WITH envelope = 'wrapped', updated`
 	require.Equal(t, expected, description)
 }


### PR DESCRIPTION
Expands the denylist for what in the sink URI gets shown in the
job description to redact ca_cert and client_cert.
Also redacts everything before an `@` symbol in the host as that
can be a user credential.

Release note (enterprise change): Redacted more potentially-sensitive URI elements from changefeed job descriptions. This is a breaking change for workflows involving copying URIs. As an alternative, the unredacted URI may be accessed from the jobs table directly.