### PR TITLE
tree,lint: rename Format to FormatImpl and lint

### DIFF
--- a/pkg/ccl/importccl/exportcsv.go
+++ b/pkg/ccl/importccl/exportcsv.go
@@ -231,7 +231,7 @@ func (sp *csvWriter) Run(ctx context.Context) {
 					if err := ed.EnsureDecoded(typs[i], alloc); err != nil {
 						return err
 					}
-					ed.Datum.Format(f)
+					ed.Datum.FormatImpl(f)
 					csvRow[i] = f.String()
 					f.Reset()
 				}

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -523,7 +523,7 @@ func (c *transientCluster) createAndAddNode(
 	}
 	nodeID := roachpb.NodeID(idx + 1)
 	args := c.demoCtx.testServerArgsForTransientCluster(
-		c.sockForServer(nodeID), nodeID, joinAddr, c.demoDir,
+		c.sockForServer(nodeID, "" /* databaseNameOverride */), nodeID, joinAddr, c.demoDir,
 		c.sqlFirstPort,
 		c.httpFirstPort,
 		c.stickyEngineRegistry,
@@ -944,7 +944,7 @@ func (c *transientCluster) RestartNode(ctx context.Context, nodeID int32) error 
 		return errors.Errorf("restarting nodes is not supported in --%s configurations", cliflags.Global.Name)
 	}
 	args := c.demoCtx.testServerArgsForTransientCluster(
-		c.sockForServer(roachpb.NodeID(nodeID)),
+		c.sockForServer(roachpb.NodeID(nodeID), "" /* databaseNameOverride */),
 		roachpb.NodeID(nodeID),
 		c.firstServer.ServingRPCAddr(), c.demoDir,
 		c.sqlFirstPort, c.httpFirstPort, c.stickyEngineRegistry)
@@ -1137,13 +1137,17 @@ func (c *transientCluster) getNetworkURLForServer(
 		}
 	}
 	sqlAddr := c.servers[serverIdx].ServingSQLAddr()
+	database := c.defaultDB
 	if isTenant {
 		sqlAddr = c.tenantServers[serverIdx].SQLAddr()
+	}
+	if !isTenant && c.demoCtx.Multitenant {
+		database = catalogkeys.DefaultDatabaseName
 	}
 	host, port, _ := addr.SplitHostPort(sqlAddr, "")
 	u.
 		WithNet(pgurl.NetTCP(host, port)).
-		WithDatabase(c.defaultDB)
+		WithDatabase(database)
 
 	// For a demo cluster we don't use client TLS certs and instead use
 	// password-based authentication with the password pre-filled in the
@@ -1358,11 +1362,17 @@ func (c *transientCluster) AcquireDemoLicense(ctx context.Context) (chan error, 
 // sockForServer generates the metadata for a unix socket for the given node.
 // For example, node 1 gets socket /tmpdemodir/.s.PGSQL.26267,
 // node 2 gets socket /tmpdemodir/.s.PGSQL.26268, etc.
-func (c *transientCluster) sockForServer(nodeID roachpb.NodeID) unixSocketDetails {
+func (c *transientCluster) sockForServer(
+	nodeID roachpb.NodeID, databaseNameOverride string,
+) unixSocketDetails {
 	if !c.useSockets {
 		return unixSocketDetails{}
 	}
 	port := strconv.Itoa(c.sqlFirstPort + int(nodeID) - 1)
+	databaseName := c.defaultDB
+	if databaseNameOverride != "" {
+		databaseName = databaseNameOverride
+	}
 	return unixSocketDetails{
 		socketDir: c.demoDir,
 		port:      port,
@@ -1370,7 +1380,7 @@ func (c *transientCluster) sockForServer(nodeID roachpb.NodeID) unixSocketDetail
 			WithNet(pgurl.NetUnix(c.demoDir, port)).
 			WithUsername(c.adminUser.Normalized()).
 			WithAuthn(pgurl.AuthnPassword(true, c.adminPassword)).
-			WithDatabase(c.defaultDB),
+			WithDatabase(databaseName),
 	}
 }
 
@@ -1450,7 +1460,11 @@ func (c *transientCluster) ListDemoNodes(w, ew io.Writer, justOne bool) {
 		}
 		// Print unix socket if defined.
 		if c.useSockets {
-			sock := c.sockForServer(nodeID)
+			databaseNameOverride := ""
+			if c.demoCtx.Multitenant {
+				databaseNameOverride = catalogkeys.DefaultDatabaseName
+			}
+			sock := c.sockForServer(nodeID, databaseNameOverride)
 			fmt.Fprintln(w, "  (sql/unix)", sock)
 		}
 		fmt.Fprintln(w)

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -8,9 +8,25 @@ spawn $argv demo --insecure=true
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
 eexpect "your changes to data stored in the demo session will not be saved!"
-# Inform the necessary URL.
+
+# Verify the URLs for both shared and tenant server.
+eexpect "system tenant"
 eexpect "(webui)"
-eexpect "http:"
+eexpect "http://"
+eexpect ":8081"
+eexpect "(sql)"
+eexpect "root"
+eexpect ":26258/defaultdb"
+eexpect "sslmode=disable"
+eexpect "(sql/unix)"
+eexpect "root:unused@/defaultdb"
+eexpect "=26258"
+eexpect "tenant 1"
+eexpect "(sql)"
+eexpect "root"
+eexpect ":26257/movr"
+eexpect "sslmode=disable"
+
 # Ensure same messages as cockroach sql.
 eexpect "Server version"
 eexpect "Cluster ID"

--- a/pkg/cmd/cr2pg/main.go
+++ b/pkg/cmd/cr2pg/main.go
@@ -124,7 +124,7 @@ func main() {
 		w := bufio.NewWriterSize(os.Stdout, 1024*1024)
 		fmtctx := tree.NewFmtCtx(tree.FmtSimple)
 		for stmt := range writeStmts {
-			stmt.Format(fmtctx)
+			stmt.FormatImpl(fmtctx)
 			_, _ = w.WriteString(fmtctx.CloseAndGetString())
 			_, _ = w.WriteString(";\n\n")
 		}

--- a/pkg/cmd/reduce/reduce/reducesql/reducesql.go
+++ b/pkg/cmd/reduce/reduce/reducesql/reducesql.go
@@ -1089,7 +1089,7 @@ func removeValuesCol(values *tree.ValuesClause, col int) {
 
 type emptyStatement struct{}
 
-func (e emptyStatement) Format(*tree.FmtCtx) {}
+func (e emptyStatement) FormatImpl(*tree.FmtCtx) {}
 
 // SQLChunkReducer implements the reduce.ChunkReducer interface. Each SQL
 // statement in the string passed to Init is treated as a segment that can

--- a/pkg/internal/sqlsmith/tlp.go
+++ b/pkg/internal/sqlsmith/tlp.go
@@ -81,7 +81,7 @@ func (s *Smither) generateWhereTLP() (unpartitioned, partitioned string, args []
 	if !ok {
 		panic(errors.AssertionFailedf("failed to find random table"))
 	}
-	table.Format(f)
+	table.FormatImpl(f)
 	tableName := f.CloseAndGetString()
 
 	unpartitioned = fmt.Sprintf("SELECT * FROM %s", tableName)
@@ -92,7 +92,7 @@ func (s *Smither) generateWhereTLP() (unpartitioned, partitioned string, args []
 	} else {
 		pred, args = makeBoolExprWithPlaceholders(s, cols)
 	}
-	pred.Format(f)
+	pred.FormatImpl(f)
 	predicate := f.CloseAndGetString()
 
 	part1 := fmt.Sprintf("SELECT * FROM %s WHERE %s", tableName, predicate)
@@ -152,9 +152,9 @@ func (s *Smither) generateOuterJoinTLP() (unpartitioned, partitioned string) {
 	if !ok1 || !ok2 {
 		panic(errors.AssertionFailedf("failed to find random tables"))
 	}
-	table1.Format(f)
+	table1.FormatImpl(f)
 	tableName1 := f.CloseAndGetString()
-	table2.Format(f)
+	table2.FormatImpl(f)
 	tableName2 := f.CloseAndGetString()
 
 	leftJoinTrue := fmt.Sprintf(
@@ -172,7 +172,7 @@ func (s *Smither) generateOuterJoinTLP() (unpartitioned, partitioned string) {
 	)
 
 	pred := makeBoolExpr(s, cols1)
-	pred.Format(f)
+	pred.FormatImpl(f)
 	predicate := f.CloseAndGetString()
 
 	part1 := fmt.Sprintf(
@@ -230,9 +230,9 @@ func (s *Smither) generateInnerJoinTLP() (unpartitioned, partitioned string) {
 	if !ok1 || !ok2 {
 		panic(errors.AssertionFailedf("failed to find random tables"))
 	}
-	table1.Format(f)
+	table1.FormatImpl(f)
 	tableName1 := f.CloseAndGetString()
-	table2.Format(f)
+	table2.FormatImpl(f)
 	tableName2 := f.CloseAndGetString()
 
 	unpartitioned = fmt.Sprintf(
@@ -242,7 +242,7 @@ func (s *Smither) generateInnerJoinTLP() (unpartitioned, partitioned string) {
 
 	cols := cols1.extend(cols2...)
 	pred := makeBoolExpr(s, cols)
-	pred.Format(f)
+	pred.FormatImpl(f)
 	predicate := f.CloseAndGetString()
 
 	part1 := fmt.Sprintf(
@@ -307,7 +307,7 @@ func (s *Smither) generateAggregationTLP() (unpartitioned, partitioned string) {
 	if !ok {
 		panic(errors.AssertionFailedf("failed to find random table"))
 	}
-	table.Format(f)
+	table.FormatImpl(f)
 	tableName := f.CloseAndGetString()
 	tableNameAlias := strings.TrimSpace(strings.Split(tableName, "AS")[1])
 
@@ -327,7 +327,7 @@ func (s *Smither) generateAggregationTLP() (unpartitioned, partitioned string) {
 	)
 
 	pred := makeBoolExpr(s, cols)
-	pred.Format(f)
+	pred.FormatImpl(f)
 	predicate := f.CloseAndGetString()
 
 	part1 := fmt.Sprintf(

--- a/pkg/sql/catalog/colinfo/data_source.go
+++ b/pkg/sql/catalog/colinfo/data_source.go
@@ -163,8 +163,8 @@ type varFormatter struct {
 	ColumnName tree.Name
 }
 
-// Format implements the NodeFormatter interface.
-func (c *varFormatter) Format(ctx *tree.FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (c *varFormatter) FormatImpl(ctx *tree.FmtCtx) {
 	if ctx.HasFlags(tree.FmtShowTableAliases) && c.TableName.ObjectName != "" {
 		// This logic is different from (*tree.TableName).Format() with
 		// FmtAlwaysQualify, because FmtShowTableAliases only wants to

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -230,9 +230,9 @@ func (d *dummyColumn) String() string {
 	return tree.AsString(d)
 }
 
-// Format implements the NodeFormatter interface.
-func (d *dummyColumn) Format(ctx *tree.FmtCtx) {
-	d.name.Format(ctx)
+// FormatImpl implements the NodeFormatter interface.
+func (d *dummyColumn) FormatImpl(ctx *tree.FmtCtx) {
+	d.name.FormatImpl(ctx)
 }
 
 // Walk implements the Expr interface.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -781,7 +781,7 @@ func formatWithPlaceholders(ast tree.Statement, evalCtx *tree.EvalContext) strin
 					ctx.Printf("$%d", placeholder.Idx+1)
 					return
 				}
-				d.Format(ctx)
+				ctx.FormatNode(d)
 			}),
 		)
 	} else {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1118,7 +1118,7 @@ func getFinalSourceQuery(
 			if err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "failed to serialize placeholder"))
 			}
-			d.Format(ctx)
+			ctx.FormatNode(d)
 		}),
 	)
 	ctx.FormatNode(source)

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -84,7 +84,7 @@ func ExprFmtCtxBase(evalCtx *tree.EvalContext) *tree.FmtCtx {
 				if err != nil {
 					panic(errors.NewAssertionErrorWithWrappedErrf(err, "failed to serialize placeholder"))
 				}
-				d.Format(fmtCtx)
+				d.FormatImpl(fmtCtx)
 			},
 		),
 	)

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -60,7 +60,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 			ctx.WriteString(f.ColumnString(opt.ColumnID(idx + 1)))
 		}),
 	)
-	expr.Format(fmtCtx)
+	expr.FormatImpl(fmtCtx)
 	return fmtCtx.String()
 }
 

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -147,7 +147,7 @@ func TestIndexConstraints(t *testing.T) {
 							ctx.WriteString(md.ColumnMeta(opt.ColumnID(idx + 1)).Alias)
 						}),
 					)
-					expr.Format(fmtCtx)
+					expr.FormatImpl(fmtCtx)
 					fmt.Fprintf(&buf, "Remaining filter: %s\n", fmtCtx.String())
 				}
 				return buf.String()

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -141,8 +141,8 @@ func (c *scopeColumn) String() string {
 	return tree.AsString(c)
 }
 
-// Format implements the NodeFormatter interface.
-func (c *scopeColumn) Format(ctx *tree.FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (c *scopeColumn) FormatImpl(ctx *tree.FmtCtx) {
 	// FmtCheckEquivalence is used by getExprStr when comparing expressions for
 	// equivalence. If that flag is present, then use the unique column id to
 	// differentiate this column from other columns.

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -125,7 +125,7 @@ func TestImplicator(t *testing.T) {
 						ctx.WriteString(md.ColumnMeta(opt.ColumnID(idx + 1)).Alias)
 					}),
 				)
-				expr.Format(fmtCtx)
+				expr.FormatImpl(fmtCtx)
 				buf.WriteString(fmtCtx.String())
 			}
 			return buf.String()

--- a/pkg/sql/opt/testutils/testcat/create_view.go
+++ b/pkg/sql/opt/testutils/testcat/create_view.go
@@ -19,7 +19,7 @@ func (tc *Catalog) CreateView(stmt *tree.CreateView) *View {
 	tc.qualifyTableName(&stmt.Name)
 
 	fmtCtx := tree.NewFmtCtx(tree.FmtParsable)
-	stmt.AsSource.Format(fmtCtx)
+	stmt.AsSource.FormatImpl(fmtCtx)
 
 	view := &View{
 		ViewID:      tc.nextStableID(),

--- a/pkg/sql/opt/testutils/testcat/table_expr.go
+++ b/pkg/sql/opt/testutils/testcat/table_expr.go
@@ -78,8 +78,8 @@ func (c *tableCol) String() string {
 	return tree.AsString(c)
 }
 
-// Format implements the NodeFormatter interface.
-func (c *tableCol) Format(ctx *tree.FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (c *tableCol) FormatImpl(ctx *tree.FmtCtx) {
 	ctx.FormatNode(&c.name)
 }
 

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -16,8 +16,8 @@ type AlterDatabaseOwner struct {
 	Owner RoleSpec
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterDatabaseOwner) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterDatabaseOwner) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" OWNER TO ")
@@ -33,8 +33,8 @@ type AlterDatabaseAddRegion struct {
 
 var _ Statement = &AlterDatabaseAddRegion{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterDatabaseAddRegion) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterDatabaseAddRegion) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ADD REGION ")
@@ -53,8 +53,8 @@ type AlterDatabaseDropRegion struct {
 
 var _ Statement = &AlterDatabaseDropRegion{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterDatabaseDropRegion) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterDatabaseDropRegion) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" DROP REGION ")
@@ -72,12 +72,12 @@ type AlterDatabasePrimaryRegion struct {
 
 var _ Statement = &AlterDatabasePrimaryRegion{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterDatabasePrimaryRegion) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterDatabasePrimaryRegion) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" PRIMARY REGION ")
-	node.PrimaryRegion.Format(ctx)
+	node.PrimaryRegion.FormatImpl(ctx)
 }
 
 // AlterDatabaseSurvivalGoal represents a ALTER DATABASE SURVIVE ... statement.
@@ -88,12 +88,12 @@ type AlterDatabaseSurvivalGoal struct {
 
 var _ Statement = &AlterDatabaseSurvivalGoal{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterDatabaseSurvivalGoal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterDatabaseSurvivalGoal) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ")
-	node.SurvivalGoal.Format(ctx)
+	node.SurvivalGoal.FormatImpl(ctx)
 }
 
 // AlterDatabasePlacement represents a ALTER DATABASE PLACEMENT statement.
@@ -104,10 +104,10 @@ type AlterDatabasePlacement struct {
 
 var _ Statement = &AlterDatabasePlacement{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterDatabasePlacement) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterDatabasePlacement) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" ")
-	node.Placement.Format(ctx)
+	node.Placement.FormatImpl(ctx)
 }

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -36,8 +36,8 @@ type AlterDefaultPrivileges struct {
 	Revoke  AbbreviatedRevoke
 }
 
-// Format implements the NodeFormatter interface.
-func (n *AlterDefaultPrivileges) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *AlterDefaultPrivileges) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DEFAULT PRIVILEGES ")
 	if len(n.Roles) > 0 {
 		ctx.WriteString("FOR ROLE ")
@@ -55,9 +55,9 @@ func (n *AlterDefaultPrivileges) Format(ctx *FmtCtx) {
 		ctx.WriteString(" ")
 	}
 	if n.IsGrant {
-		n.Grant.Format(ctx)
+		n.Grant.FormatImpl(ctx)
 	} else {
-		n.Revoke.Format(ctx)
+		n.Revoke.FormatImpl(ctx)
 	}
 }
 
@@ -122,8 +122,8 @@ type AbbreviatedGrant struct {
 	WithGrantOption bool
 }
 
-// Format implements the NodeFormatter interface.
-func (n *AbbreviatedGrant) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *AbbreviatedGrant) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("GRANT ")
 	n.Privileges.Format(&ctx.Buffer)
 	ctx.WriteString(" ON ")
@@ -138,7 +138,7 @@ func (n *AbbreviatedGrant) Format(ctx *FmtCtx) {
 		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.WriteString("TO ")
-	n.Grantees.Format(ctx)
+	n.Grantees.FormatImpl(ctx)
 	if n.WithGrantOption {
 		ctx.WriteString(" WITH GRANT OPTION")
 	}
@@ -153,8 +153,8 @@ type AbbreviatedRevoke struct {
 	GrantOptionFor bool
 }
 
-// Format implements the NodeFormatter interface.
-func (n *AbbreviatedRevoke) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *AbbreviatedRevoke) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("REVOKE ")
 	if n.GrantOptionFor {
 		ctx.WriteString("GRANT OPTION FOR ")
@@ -172,5 +172,5 @@ func (n *AbbreviatedRevoke) Format(ctx *FmtCtx) {
 		ctx.WriteString("SCHEMAS ")
 	}
 	ctx.WriteString(" FROM ")
-	n.Grantees.Format(ctx)
+	n.Grantees.FormatImpl(ctx)
 }

--- a/pkg/sql/sem/tree/alter_index.go
+++ b/pkg/sql/sem/tree/alter_index.go
@@ -19,8 +19,8 @@ type AlterIndex struct {
 
 var _ Statement = &AlterIndex{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterIndex) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterIndex) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER INDEX ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -32,8 +32,8 @@ func (node *AlterIndex) Format(ctx *FmtCtx) {
 // AlterIndexCmds represents a list of index alterations.
 type AlterIndexCmds []AlterIndexCmd
 
-// Format implements the NodeFormatter interface.
-func (node *AlterIndexCmds) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterIndexCmds) FormatImpl(ctx *FmtCtx) {
 	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(",")
@@ -60,7 +60,7 @@ type AlterIndexPartitionBy struct {
 	*PartitionByIndex
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterIndexPartitionBy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterIndexPartitionBy) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.PartitionByIndex)
 }

--- a/pkg/sql/sem/tree/alter_range.go
+++ b/pkg/sql/sem/tree/alter_range.go
@@ -34,7 +34,7 @@ const (
 )
 
 // Format implementsthe NodeFormatter interface.
-func (n *RelocateSubject) Format(ctx *FmtCtx) {
+func (n *RelocateSubject) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(n.String())
 }
 
@@ -51,8 +51,8 @@ func (n RelocateSubject) String() string {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (n *RelocateRange) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *RelocateRange) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER RANGE RELOCATE ")
 	ctx.FormatNode(&n.SubjectReplicas)
 	// When relocating leases, the origin store is implicit.

--- a/pkg/sql/sem/tree/alter_role.go
+++ b/pkg/sql/sem/tree/alter_role.go
@@ -18,8 +18,8 @@ type AlterRole struct {
 	KVOptions KVOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterRole) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterRole) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER")
 	if node.IsRole {
 		ctx.WriteString(" ROLE ")
@@ -47,8 +47,8 @@ type AlterRoleSet struct {
 	SetOrReset   *SetVar
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterRoleSet) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterRoleSet) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER")
 	if node.IsRole {
 		ctx.WriteString(" ROLE ")

--- a/pkg/sql/sem/tree/alter_schema.go
+++ b/pkg/sql/sem/tree/alter_schema.go
@@ -18,8 +18,8 @@ type AlterSchema struct {
 
 var _ Statement = &AlterSchema{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterSchema) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterSchema) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER SCHEMA ")
 	ctx.FormatNode(&node.Schema)
 	ctx.FormatNode(node.Cmd)
@@ -38,8 +38,8 @@ type AlterSchemaRename struct {
 	NewName Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterSchemaRename) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterSchemaRename) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" RENAME TO ")
 	ctx.FormatNode(&node.NewName)
 }
@@ -51,8 +51,8 @@ type AlterSchemaOwner struct {
 	Owner RoleSpec
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterSchemaOwner) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterSchemaOwner) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" OWNER TO ")
 	ctx.FormatNode(&node.Owner)
 }

--- a/pkg/sql/sem/tree/alter_sequence.go
+++ b/pkg/sql/sem/tree/alter_sequence.go
@@ -19,8 +19,8 @@ type AlterSequence struct {
 	Options  SequenceOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterSequence) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterSequence) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER SEQUENCE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -25,8 +25,8 @@ type AlterTable struct {
 	Cmds     AlterTableCmds
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTable) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER TABLE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -38,8 +38,8 @@ func (node *AlterTable) Format(ctx *FmtCtx) {
 // AlterTableCmds represents a list of table alterations.
 type AlterTableCmds []AlterTableCmd
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableCmds) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableCmds) FormatImpl(ctx *FmtCtx) {
 	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(",")
@@ -114,8 +114,8 @@ func (node *AlterTableAddColumn) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "add_column")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableAddColumn) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableAddColumn) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ADD COLUMN ")
 	if node.IfNotExists {
 		ctx.WriteString("IF NOT EXISTS ")
@@ -210,8 +210,8 @@ func (node *AlterTableAddConstraint) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "add_constraint")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableAddConstraint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableAddConstraint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ADD ")
 	ctx.FormatNode(node.ConstraintDef)
 	if node.ValidationBehavior == ValidationSkip {
@@ -232,8 +232,8 @@ func (node *AlterTableAlterColumnType) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "alter_column_type")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableAlterColumnType) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableAlterColumnType) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" SET DATA TYPE ")
@@ -265,8 +265,8 @@ func (node *AlterTableAlterPrimaryKey) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "alter_primary_key")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableAlterPrimaryKey) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableAlterPrimaryKey) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER PRIMARY KEY USING COLUMNS (")
 	ctx.FormatNode(&node.Columns)
 	ctx.WriteString(")")
@@ -287,8 +287,8 @@ func (node *AlterTableDropColumn) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_column")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableDropColumn) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableDropColumn) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" DROP COLUMN ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -311,8 +311,8 @@ func (node *AlterTableDropConstraint) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_constraint")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableDropConstraint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableDropConstraint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" DROP CONSTRAINT ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -333,8 +333,8 @@ func (node *AlterTableValidateConstraint) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "validate_constraint")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableValidateConstraint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableValidateConstraint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" VALIDATE CONSTRAINT ")
 	ctx.FormatNode(&node.Constraint)
 }
@@ -350,8 +350,8 @@ func (node *AlterTableRenameColumn) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "rename_column")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableRenameColumn) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableRenameColumn) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" RENAME COLUMN ")
 	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" TO ")
@@ -369,8 +369,8 @@ func (node *AlterTableRenameConstraint) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "rename_constraint")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableRenameConstraint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableRenameConstraint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" RENAME CONSTRAINT ")
 	ctx.FormatNode(&node.Constraint)
 	ctx.WriteString(" TO ")
@@ -394,8 +394,8 @@ func (node *AlterTableSetDefault) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_default")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableSetDefault) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableSetDefault) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	if node.Default == nil {
@@ -423,8 +423,8 @@ func (node *AlterTableSetOnUpdate) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_on_update")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableSetOnUpdate) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableSetOnUpdate) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	if node.Expr == nil {
@@ -451,8 +451,8 @@ func (node *AlterTableSetVisible) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_visible")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableSetVisible) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableSetVisible) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" SET ")
@@ -478,8 +478,8 @@ func (node *AlterTableSetNotNull) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_not_null")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableSetNotNull) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableSetNotNull) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" SET NOT NULL")
@@ -501,8 +501,8 @@ func (node *AlterTableDropNotNull) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_not_null")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableDropNotNull) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableDropNotNull) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" DROP NOT NULL")
@@ -524,8 +524,8 @@ func (node *AlterTableDropStored) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "drop_stored")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableDropStored) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableDropStored) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER COLUMN ")
 	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" DROP STORED")
@@ -542,8 +542,8 @@ func (node *AlterTablePartitionByTable) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "partition_by")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTablePartitionByTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTablePartitionByTable) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.PartitionByTable)
 }
 
@@ -582,8 +582,8 @@ func (node *AlterTableSetAudit) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "set_audit")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableSetAudit) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableSetAudit) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" EXPERIMENTAL_AUDIT SET ")
 	ctx.WriteString(node.Mode.String())
 }
@@ -598,8 +598,8 @@ func (node *AlterTableInjectStats) TelemetryCounter() telemetry.Counter {
 	return sqltelemetry.SchemaChangeAlterCounterWithExtra("table", "inject_stats")
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableInjectStats) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableInjectStats) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" INJECT STATISTICS ")
 	ctx.FormatNode(node.Stats)
 }
@@ -613,8 +613,8 @@ type AlterTableLocality struct {
 
 var _ Statement = &AlterTableLocality{}
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableLocality) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableLocality) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER TABLE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -634,8 +634,8 @@ type AlterTableSetSchema struct {
 	IsSequence     bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableSetSchema) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableSetSchema) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER")
 	if node.IsView {
 		if node.IsMaterialized {
@@ -682,8 +682,8 @@ func (node *AlterTableOwner) TelemetryCounter() telemetry.Counter {
 	)
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTableOwner) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTableOwner) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER")
 	if node.IsView {
 		if node.IsMaterialized {

--- a/pkg/sql/sem/tree/alter_type.go
+++ b/pkg/sql/sem/tree/alter_type.go
@@ -21,8 +21,8 @@ type AlterType struct {
 	Cmd  AlterTypeCmd
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterType) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterType) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER TYPE ")
 	ctx.FormatNode(node.Type)
 	ctx.FormatNode(node.Cmd)
@@ -58,8 +58,8 @@ type AlterTypeAddValue struct {
 	Placement   *AlterTypeAddValuePlacement
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTypeAddValue) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTypeAddValue) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" ADD VALUE ")
 	if node.IfNotExists {
 		ctx.WriteString("IF NOT EXISTS ")
@@ -93,8 +93,8 @@ type AlterTypeRenameValue struct {
 	NewVal EnumValue
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTypeRenameValue) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTypeRenameValue) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" RENAME VALUE ")
 	ctx.FormatNode(&node.OldVal)
 	ctx.WriteString(" TO ")
@@ -111,8 +111,8 @@ type AlterTypeDropValue struct {
 	Val EnumValue
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTypeDropValue) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTypeDropValue) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" DROP VALUE ")
 	ctx.FormatNode(&node.Val)
 }
@@ -127,8 +127,8 @@ type AlterTypeRename struct {
 	NewName Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTypeRename) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTypeRename) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" RENAME TO ")
 	ctx.FormatNode(&node.NewName)
 }
@@ -143,8 +143,8 @@ type AlterTypeSetSchema struct {
 	Schema Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTypeSetSchema) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTypeSetSchema) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" SET SCHEMA ")
 	ctx.FormatNode(&node.Schema)
 }
@@ -159,8 +159,8 @@ type AlterTypeOwner struct {
 	Owner RoleSpec
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AlterTypeOwner) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AlterTypeOwner) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" OWNER TO ")
 	ctx.FormatNode(&node.Owner)
 }

--- a/pkg/sql/sem/tree/analyze.go
+++ b/pkg/sql/sem/tree/analyze.go
@@ -15,8 +15,8 @@ type Analyze struct {
 	Table TableExpr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Analyze) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Analyze) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ANALYZE ")
 	ctx.FormatNode(node.Table)
 }

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -76,8 +76,8 @@ type Backup struct {
 
 var _ Statement = &Backup{}
 
-// Format implements the NodeFormatter interface.
-func (node *Backup) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Backup) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("BACKUP ")
 	if node.Targets != nil {
 		ctx.FormatNode(node.Targets)
@@ -160,8 +160,8 @@ type Restore struct {
 
 var _ Statement = &Restore{}
 
-// Format implements the NodeFormatter interface.
-func (node *Restore) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Restore) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("RESTORE ")
 	if node.DescriptorCoverage == RequestedDescriptors {
 		ctx.FormatNode(&node.Targets)
@@ -197,8 +197,8 @@ type KVOption struct {
 // KVOptions is a list of KVOptions.
 type KVOptions []KVOption
 
-// Format implements the NodeFormatter interface.
-func (o *KVOptions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (o *KVOptions) FormatImpl(ctx *FmtCtx) {
 	for i := range *o {
 		n := &(*o)[i]
 		if i > 0 {
@@ -219,8 +219,8 @@ func (o *KVOptions) Format(ctx *FmtCtx) {
 // StringOrPlaceholderOptList is a list of strings or placeholders.
 type StringOrPlaceholderOptList []Expr
 
-// Format implements the NodeFormatter interface.
-func (node *StringOrPlaceholderOptList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *StringOrPlaceholderOptList) FormatImpl(ctx *FmtCtx) {
 	if len(*node) > 1 {
 		ctx.WriteString("(")
 	}
@@ -231,7 +231,7 @@ func (node *StringOrPlaceholderOptList) Format(ctx *FmtCtx) {
 }
 
 // Format implements the NodeFormatter interface
-func (o *BackupOptions) Format(ctx *FmtCtx) {
+func (o *BackupOptions) FormatImpl(ctx *FmtCtx) {
 	var addSep bool
 	maybeAddSep := func() {
 		if addSep {
@@ -321,8 +321,8 @@ func (o BackupOptions) IsDefault() bool {
 		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage)
 }
 
-// Format implements the NodeFormatter interface.
-func (o *RestoreOptions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (o *RestoreOptions) FormatImpl(ctx *FmtCtx) {
 	var addSep bool
 	maybeAddSep := func() {
 		if addSep {

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -19,8 +19,8 @@ type CreateChangefeed struct {
 
 var _ Statement = &CreateChangefeed{}
 
-// Format implements the NodeFormatter interface.
-func (node *CreateChangefeed) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateChangefeed) FormatImpl(ctx *FmtCtx) {
 	if node.SinkURI != nil {
 		ctx.WriteString("CREATE ")
 	} else {

--- a/pkg/sql/sem/tree/comment_on_column.go
+++ b/pkg/sql/sem/tree/comment_on_column.go
@@ -18,8 +18,8 @@ type CommentOnColumn struct {
 	Comment *string
 }
 
-// Format implements the NodeFormatter interface.
-func (n *CommentOnColumn) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *CommentOnColumn) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON COLUMN ")
 	ctx.FormatNode(n.ColumnItem)
 	ctx.WriteString(" IS ")

--- a/pkg/sql/sem/tree/comment_on_constraint.go
+++ b/pkg/sql/sem/tree/comment_on_constraint.go
@@ -19,8 +19,8 @@ type CommentOnConstraint struct {
 	Comment    *string
 }
 
-//Format implements the NodeFormatter interface.
-func (n *CommentOnConstraint) Format(ctx *FmtCtx) {
+//FormatImpl implements the NodeFormatter interface.
+func (n *CommentOnConstraint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON CONSTRAINT ")
 	ctx.FormatNode(&n.Constraint)
 	ctx.WriteString(" ON ")

--- a/pkg/sql/sem/tree/comment_on_database.go
+++ b/pkg/sql/sem/tree/comment_on_database.go
@@ -18,8 +18,8 @@ type CommentOnDatabase struct {
 	Comment *string
 }
 
-// Format implements the NodeFormatter interface.
-func (n *CommentOnDatabase) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *CommentOnDatabase) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON DATABASE ")
 	ctx.FormatNode(&n.Name)
 	ctx.WriteString(" IS ")

--- a/pkg/sql/sem/tree/comment_on_index.go
+++ b/pkg/sql/sem/tree/comment_on_index.go
@@ -18,8 +18,8 @@ type CommentOnIndex struct {
 	Comment *string
 }
 
-// Format implements the NodeFormatter interface.
-func (n *CommentOnIndex) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *CommentOnIndex) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON INDEX ")
 	ctx.FormatNode(&n.Index)
 	ctx.WriteString(" IS ")

--- a/pkg/sql/sem/tree/comment_on_schema.go
+++ b/pkg/sql/sem/tree/comment_on_schema.go
@@ -18,8 +18,8 @@ type CommentOnSchema struct {
 	Comment *string
 }
 
-// Format implements the NodeFormatter interface.
-func (n *CommentOnSchema) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *CommentOnSchema) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON SCHEMA ")
 	ctx.FormatNode(&n.Name)
 	ctx.WriteString(" IS ")

--- a/pkg/sql/sem/tree/comment_on_table.go
+++ b/pkg/sql/sem/tree/comment_on_table.go
@@ -18,8 +18,8 @@ type CommentOnTable struct {
 	Comment *string
 }
 
-// Format implements the NodeFormatter interface.
-func (n *CommentOnTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *CommentOnTable) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMENT ON TABLE ")
 	ctx.FormatNode(n.Table)
 	ctx.WriteString(" IS ")

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -163,8 +163,8 @@ func (expr *NumVal) Negate() {
 	expr.negative = !expr.negative
 }
 
-// Format implements the NodeFormatter interface.
-func (expr *NumVal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (expr *NumVal) FormatImpl(ctx *FmtCtx) {
 	s := expr.origString
 	if s == "" {
 		s = expr.value.String()
@@ -452,8 +452,8 @@ func (expr *StrVal) RawString() string {
 	return expr.s
 }
 
-// Format implements the NodeFormatter interface.
-func (expr *StrVal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (expr *StrVal) FormatImpl(ctx *FmtCtx) {
 	buf, f := &ctx.Buffer, ctx.flags
 	if expr.scannedAsBytes {
 		lexbase.EncodeSQLBytes(buf, expr.s)

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -30,8 +30,8 @@ type CopyOptions struct {
 
 var _ NodeFormatter = &CopyOptions{}
 
-// Format implements the NodeFormatter interface.
-func (node *CopyFrom) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CopyFrom) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COPY ")
 	ctx.FormatNode(&node.Table)
 	if len(node.Columns) > 0 {
@@ -50,7 +50,7 @@ func (node *CopyFrom) Format(ctx *FmtCtx) {
 }
 
 // Format implements the NodeFormatter interface
-func (o *CopyOptions) Format(ctx *FmtCtx) {
+func (o *CopyOptions) FormatImpl(ctx *FmtCtx) {
 	var addSep bool
 	maybeAddSep := func() {
 		if addSep {

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -51,8 +51,8 @@ type CreateDatabase struct {
 	Placement       DataPlacement
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateDatabase) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateDatabase) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE DATABASE ")
 	if node.IfNotExists {
 		ctx.WriteString("IF NOT EXISTS ")
@@ -128,8 +128,8 @@ type IndexElem struct {
 	NullsOrder NullsOrder
 }
 
-// Format implements the NodeFormatter interface.
-func (node *IndexElem) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IndexElem) FormatImpl(ctx *FmtCtx) {
 	if node.Expr == nil {
 		ctx.FormatNode(&node.Column)
 	} else {
@@ -179,8 +179,8 @@ func (node *IndexElem) doc(p *PrettyCfg) pretty.Doc {
 type IndexElemList []IndexElem
 
 // Format pretty-prints the contained names separated by commas.
-// Format implements the NodeFormatter interface.
-func (l *IndexElemList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (l *IndexElemList) FormatImpl(ctx *FmtCtx) {
 	for i := range *l {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -219,8 +219,8 @@ type CreateIndex struct {
 	Concurrently     bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateIndex) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateIndex) FormatImpl(ctx *FmtCtx) {
 	// Please also update indexForDisplay function in
 	// pkg/sql/catalog/catformat/index.go if there's any update to index
 	// definition components.
@@ -293,8 +293,8 @@ const (
 // EnumValue represents a single enum value.
 type EnumValue string
 
-// Format implements the NodeFormatter interface.
-func (n *EnumValue) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *EnumValue) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtAnonymize) {
 		ctx.WriteByte('_')
@@ -306,8 +306,8 @@ func (n *EnumValue) Format(ctx *FmtCtx) {
 // EnumValueList represents a list of enum values.
 type EnumValueList []EnumValue
 
-// Format implements the NodeFormatter interface.
-func (l *EnumValueList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (l *EnumValueList) FormatImpl(ctx *FmtCtx) {
 	for i := range *l {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -328,8 +328,8 @@ type CreateType struct {
 
 var _ Statement = &CreateType{}
 
-// Format implements the NodeFormatter interface.
-func (node *CreateType) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateType) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE TYPE ")
 	if node.IfNotExists {
 		ctx.WriteString("IF NOT EXISTS ")
@@ -367,8 +367,8 @@ func (*LikeTableDef) tableDef()                 {}
 // TableDefs represents a list of table definitions.
 type TableDefs []TableDef
 
-// Format implements the NodeFormatter interface.
-func (node *TableDefs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *TableDefs) FormatImpl(ctx *FmtCtx) {
 	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -674,8 +674,8 @@ func (node *ColumnTableDef) HasColumnFamily() bool {
 	return node.Family.Name != "" || node.Family.Create
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ColumnTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ColumnTableDef) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Name)
 
 	// ColumnTableDef node type will not be specified if it represents a CREATE
@@ -743,7 +743,7 @@ func (node *ColumnTableDef) Format(ctx *FmtCtx) {
 			ctx.WriteString(" (")
 			// TODO(janexing): remove the leading and ending space of the
 			// sequence option expression.
-			genSeqOpt.Format(ctx)
+			genSeqOpt.FormatImpl(ctx)
 			ctx.WriteString(" ) ")
 		}
 	}
@@ -931,8 +931,8 @@ type IndexTableDef struct {
 	Predicate        Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *IndexTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IndexTableDef) FormatImpl(ctx *FmtCtx) {
 	if node.Inverted {
 		ctx.WriteString("INVERTED ")
 	}
@@ -1005,8 +1005,8 @@ func (node *UniqueConstraintTableDef) SetIfNotExists() {
 	node.IfNotExists = true
 }
 
-// Format implements the NodeFormatter interface.
-func (node *UniqueConstraintTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *UniqueConstraintTableDef) FormatImpl(ctx *FmtCtx) {
 	if node.Name != "" {
 		ctx.WriteString("CONSTRAINT ")
 		if node.IfNotExists {
@@ -1075,8 +1075,8 @@ type ReferenceActions struct {
 	Update ReferenceAction
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ReferenceActions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ReferenceActions) FormatImpl(ctx *FmtCtx) {
 	if node.Delete != NoAction {
 		ctx.WriteString(" ON DELETE ")
 		ctx.WriteString(node.Delete.String())
@@ -1121,8 +1121,8 @@ type ForeignKeyConstraintTableDef struct {
 	IfNotExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ForeignKeyConstraintTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ForeignKeyConstraintTableDef) FormatImpl(ctx *FmtCtx) {
 	if node.Name != "" {
 		ctx.WriteString("CONSTRAINT ")
 		if node.IfNotExists {
@@ -1180,8 +1180,8 @@ func (node *CheckConstraintTableDef) SetIfNotExists() {
 	node.IfNotExists = true
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CheckConstraintTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CheckConstraintTableDef) FormatImpl(ctx *FmtCtx) {
 	if node.Name != "" {
 		ctx.WriteString("CONSTRAINT ")
 		if node.IfNotExists {
@@ -1202,8 +1202,8 @@ type FamilyTableDef struct {
 	Columns NameList
 }
 
-// Format implements the NodeFormatter interface.
-func (node *FamilyTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *FamilyTableDef) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("FAMILY ")
 	if node.Name != "" {
 		ctx.FormatNode(&node.Name)
@@ -1220,8 +1220,8 @@ type ShardedIndexDef struct {
 	ShardBuckets Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShardedIndexDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShardedIndexDef) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(" USING HASH WITH BUCKET_COUNT = ")
 	ctx.FormatNode(node.ShardBuckets)
 }
@@ -1263,8 +1263,8 @@ type PartitionByTable struct {
 	*PartitionBy
 }
 
-// Format implements the NodeFormatter interface.
-func (node *PartitionByTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *PartitionByTable) FormatImpl(ctx *FmtCtx) {
 	if node == nil {
 		ctx.WriteString(` PARTITION BY NOTHING`)
 		return
@@ -1300,8 +1300,8 @@ type PartitionBy struct {
 	Range []RangePartition
 }
 
-// Format implements the NodeFormatter interface.
-func (node *PartitionBy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *PartitionBy) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(` PARTITION BY `)
 	node.formatListOrRange(ctx)
 }
@@ -1340,8 +1340,8 @@ type ListPartition struct {
 	Subpartition *PartitionBy
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ListPartition) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ListPartition) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(`PARTITION `)
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(` VALUES IN (`)
@@ -1360,8 +1360,8 @@ type RangePartition struct {
 	Subpartition *PartitionBy
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RangePartition) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RangePartition) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(`PARTITION `)
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(` VALUES FROM (`)
@@ -1383,8 +1383,8 @@ type StorageParam struct {
 // StorageParams is a list of StorageParams.
 type StorageParams []StorageParam
 
-// Format implements the NodeFormatter interface.
-func (o *StorageParams) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (o *StorageParams) FormatImpl(ctx *FmtCtx) {
 	for i := range *o {
 		n := &(*o)[i]
 		if i > 0 {
@@ -1448,8 +1448,8 @@ func (node *CreateTable) AsHasUserSpecifiedPrimaryKey() bool {
 	return false
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateTable) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE ")
 	switch node.Persistence {
 	case PersistenceTemporary:
@@ -1558,8 +1558,8 @@ type CreateSchema struct {
 	Schema      ObjectNamePrefix
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateSchema) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateSchema) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE SCHEMA")
 
 	if node.IfNotExists {
@@ -1585,8 +1585,8 @@ type CreateSequence struct {
 	Options     SequenceOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateSequence) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateSequence) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE ")
 
 	if node.Persistence == PersistenceTemporary {
@@ -1605,8 +1605,8 @@ func (node *CreateSequence) Format(ctx *FmtCtx) {
 // SequenceOptions represents a list of sequence options.
 type SequenceOptions []SequenceOption
 
-// Format implements the NodeFormatter interface.
-func (node *SequenceOptions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SequenceOptions) FormatImpl(ctx *FmtCtx) {
 	for i := range *node {
 		option := &(*node)[i]
 		ctx.WriteByte(' ')
@@ -1729,8 +1729,8 @@ type LikeTableOption struct {
 	Opt      LikeTableOpt
 }
 
-// Format implements the NodeFormatter interface.
-func (def *LikeTableDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (def *LikeTableDef) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("LIKE ")
 	ctx.FormatNode(&def.Name)
 	for _, o := range def.Options {
@@ -1739,8 +1739,8 @@ func (def *LikeTableDef) Format(ctx *FmtCtx) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (l LikeTableOption) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (l LikeTableOption) FormatImpl(ctx *FmtCtx) {
 	if l.Excluded {
 		ctx.WriteString("EXCLUDING ")
 	} else {
@@ -1865,8 +1865,8 @@ type CreateRole struct {
 	KVOptions   KVOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateRole) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateRole) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE")
 	if node.IsRole {
 		ctx.WriteString(" ROLE ")
@@ -1895,8 +1895,8 @@ type CreateView struct {
 	Materialized bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateView) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateView) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE ")
 
 	if node.Replace {
@@ -1958,8 +1958,8 @@ const (
 	RefreshDataClear
 )
 
-// Format implements the NodeFormatter interface.
-func (node *RefreshMaterializedView) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RefreshMaterializedView) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("REFRESH MATERIALIZED VIEW ")
 	if node.Concurrently {
 		ctx.WriteString("CONCURRENTLY ")
@@ -1981,8 +1981,8 @@ type CreateStats struct {
 	Options     CreateStatsOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateStats) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateStats) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE STATISTICS ")
 	ctx.FormatNode(&node.Name)
 
@@ -2017,8 +2017,8 @@ func (o *CreateStatsOptions) Empty() bool {
 	return o.Throttling == 0 && o.AsOf.Expr == nil
 }
 
-// Format implements the NodeFormatter interface.
-func (o *CreateStatsOptions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (o *CreateStatsOptions) FormatImpl(ctx *FmtCtx) {
 	sep := ""
 	if o.Throttling != 0 {
 		ctx.WriteString("THROTTLING ")
@@ -2065,8 +2065,8 @@ type CreateExtension struct {
 	IfNotExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CreateExtension) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CreateExtension) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE EXTENSION ")
 	if node.IfNotExists {
 		ctx.WriteString("IF NOT EXISTS ")

--- a/pkg/sql/sem/tree/data_placement.go
+++ b/pkg/sql/sem/tree/data_placement.go
@@ -27,8 +27,8 @@ const (
 	DataPlacementRestricted
 )
 
-// Format implements the NodeFormatter interface.
-func (node *DataPlacement) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DataPlacement) FormatImpl(ctx *FmtCtx) {
 	switch *node {
 	case DataPlacementRestricted:
 		ctx.WriteString("PLACEMENT RESTRICTED")

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -165,8 +165,8 @@ type Datums []Datum
 // Len returns the number of Datum values.
 func (d Datums) Len() int { return len(d) }
 
-// Format implements the NodeFormatter interface.
-func (d *Datums) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *Datums) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	for i, v := range *d {
 		if i > 0 {
@@ -489,8 +489,8 @@ func PgwireFormatBool(d bool) byte {
 	return 'f'
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DBool) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DBool) FormatImpl(ctx *FmtCtx) {
 	if ctx.HasFlags(fmtPgwireFormat) {
 		ctx.WriteByte(PgwireFormatBool(bool(*d)))
 		return
@@ -645,8 +645,8 @@ func (d *DBitArray) Max(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DBitArray) AmbiguousFormat() bool { return false }
 
-// Format implements the NodeFormatter interface.
-func (d *DBitArray) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DBitArray) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(fmtPgwireFormat) {
 		d.BitArray.Format(&ctx.Buffer)
@@ -794,8 +794,8 @@ func (d *DInt) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DInt) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DInt) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DInt) FormatImpl(ctx *FmtCtx) {
 	// If the number is negative, we need to use parens or the `:::INT` type hint
 	// will take precedence over the negation sign.
 	disambiguate := ctx.flags.HasFlags(fmtDisambiguateDatumTypes)
@@ -950,8 +950,8 @@ func (d *DFloat) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DFloat) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DFloat) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DFloat) FormatImpl(ctx *FmtCtx) {
 	fl := float64(*d)
 
 	disambiguate := ctx.flags.HasFlags(fmtDisambiguateDatumTypes)
@@ -1125,8 +1125,8 @@ func (d *DDecimal) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DDecimal) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DDecimal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DDecimal) FormatImpl(ctx *FmtCtx) {
 	// If the number is negative, we need to use parens or the `:::INT` type hint
 	// will take precedence over the negation sign.
 	disambiguate := ctx.flags.HasFlags(fmtDisambiguateDatumTypes)
@@ -1273,8 +1273,8 @@ func (d *DString) Max(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DString) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DString) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DString) FormatImpl(ctx *FmtCtx) {
 	buf, f := &ctx.Buffer, ctx.flags
 	if f.HasFlags(fmtRawStrings) {
 		buf.WriteString(string(*d))
@@ -1353,8 +1353,8 @@ func NewDCollatedString(
 // AmbiguousFormat implements the Datum interface.
 func (*DCollatedString) AmbiguousFormat() bool { return false }
 
-// Format implements the NodeFormatter interface.
-func (d *DCollatedString) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DCollatedString) FormatImpl(ctx *FmtCtx) {
 	lexbase.EncodeSQLString(&ctx.Buffer, d.Contents)
 	ctx.WriteString(" COLLATE ")
 	lex.EncodeLocaleName(&ctx.Buffer, d.Locale)
@@ -1532,8 +1532,8 @@ func writeAsHexString(ctx *FmtCtx, d *DBytes) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DBytes) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DBytes) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(fmtPgwireFormat) {
 		ctx.WriteString(`"\\x`)
@@ -1649,8 +1649,8 @@ func (*DUuid) Max(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DUuid) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DUuid) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DUuid) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -1821,8 +1821,8 @@ func (*DIPAddr) AmbiguousFormat() bool {
 	return true
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DIPAddr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DIPAddr) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -2096,8 +2096,8 @@ func FormatDate(d pgdate.Date, ctx *FmtCtx) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DDate) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DDate) FormatImpl(ctx *FmtCtx) {
 	FormatDate(d.Date, ctx)
 }
 
@@ -2213,8 +2213,8 @@ func (d *DTime) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DTime) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DTime) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DTime) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -2347,8 +2347,8 @@ func (d *DTimeTZ) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DTimeTZ) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DTimeTZ) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DTimeTZ) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -2630,8 +2630,8 @@ func (d *DTimestamp) Max(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DTimestamp) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DTimestamp) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DTimestamp) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -2796,8 +2796,8 @@ func (d *DTimestampTZ) Max(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DTimestampTZ) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DTimestampTZ) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DTimestampTZ) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -3035,8 +3035,8 @@ func FormatDuration(d duration.Duration, ctx *FmtCtx) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DInterval) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DInterval) FormatImpl(ctx *FmtCtx) {
 	FormatDuration(d.Duration, ctx)
 }
 
@@ -3149,8 +3149,8 @@ func (d *DGeography) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DGeography) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DGeography) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DGeography) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -3271,8 +3271,8 @@ func (d *DGeometry) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DGeometry) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DGeometry) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DGeometry) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -3393,8 +3393,8 @@ func (d *DBox2D) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DBox2D) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DBox2D) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DBox2D) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	bareStrings := f.HasFlags(FmtFlags(lexbase.EncBareStrings))
 	if !bareStrings {
@@ -3611,8 +3611,8 @@ func (d *DJSON) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DJSON) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DJSON) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DJSON) FormatImpl(ctx *FmtCtx) {
 	// TODO(justin): ideally the JSON string encoder should know it needs to
 	// escape things to be inside SQL strings in order to avoid this allocation.
 	s := d.JSON.String()
@@ -3858,8 +3858,8 @@ func (d *DTuple) IsMin(ctx *EvalContext) bool {
 // AmbiguousFormat implements the Datum interface.
 func (*DTuple) AmbiguousFormat() bool { return false }
 
-// Format implements the NodeFormatter interface.
-func (d *DTuple) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DTuple) FormatImpl(ctx *FmtCtx) {
 	if ctx.HasFlags(fmtPgwireFormat) {
 		d.pgwireFormat(ctx)
 		return
@@ -4078,8 +4078,8 @@ func (dNull) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (dNull) AmbiguousFormat() bool { return false }
 
-// Format implements the NodeFormatter interface.
-func (dNull) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (dNull) FormatImpl(ctx *FmtCtx) {
 	if ctx.HasFlags(fmtPgwireFormat) {
 		// NULL sub-expressions in pgwire text values are represented with
 		// the empty string.
@@ -4257,8 +4257,8 @@ func (d *DArray) AmbiguousFormat() bool {
 	return !d.HasNonNulls
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DArray) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DArray) FormatImpl(ctx *FmtCtx) {
 	if ctx.flags.HasAnyFlags(fmtPgwireFormat | FmtPGCatalog) {
 		d.pgwireFormat(ctx)
 		return
@@ -4414,8 +4414,8 @@ func (d *DVoid) Min(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DVoid) AmbiguousFormat() bool { return true }
 
-// Format implements the NodeFormatter interface.
-func (d *DVoid) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DVoid) FormatImpl(ctx *FmtCtx) {
 	buf, f := &ctx.Buffer, ctx.flags
 	if !f.HasFlags(fmtRawStrings) {
 		// void is an empty string.
@@ -4521,8 +4521,8 @@ func MakeAllDEnumsInType(typ *types.T) []Datum {
 	return result
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DEnum) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DEnum) FormatImpl(ctx *FmtCtx) {
 	if ctx.HasFlags(fmtStaticallyFormatUserDefinedTypes) {
 		s := DBytes(d.PhysicalRep)
 		// We use the fmtFormatByteLiterals flag here so that the bytes
@@ -4533,13 +4533,13 @@ func (d *DEnum) Format(ctx *FmtCtx) {
 		// Instead, we want to emit b'\x80'::: so that '\x80' is scanned as bytes,
 		// triggering the logic to cast the bytes \x80 to t.
 		ctx.WithFlags(ctx.flags|fmtFormatByteLiterals, func() {
-			s.Format(ctx)
+			s.FormatImpl(ctx)
 		})
 	} else if ctx.HasFlags(FmtPgwireText) {
 		ctx.WriteString(d.LogicalRep)
 	} else {
 		s := DString(d.LogicalRep)
-		s.Format(ctx)
+		s.FormatImpl(ctx)
 	}
 }
 
@@ -5036,19 +5036,19 @@ func (d *DOid) CompareError(ctx *EvalContext, other Datum) (int, error) {
 }
 
 // Format implements the Datum interface.
-func (d *DOid) Format(ctx *FmtCtx) {
+func (d *DOid) FormatImpl(ctx *FmtCtx) {
 	if d.semanticType.Oid() == oid.T_oid || d.name == "" {
 		// If we call FormatNode directly when the disambiguateDatumTypes flag
 		// is set, then we get something like 123:::INT:::OID. This is the
 		// important flag set by FmtParsable which is supposed to be
 		// roundtrippable. Since in this branch, a DOid is a thin wrapper around
 		// a DInt, I _think_ it's correct to just delegate to the DInt's Format.
-		d.DInt.Format(ctx)
+		d.DInt.FormatImpl(ctx)
 	} else if ctx.HasFlags(fmtDisambiguateDatumTypes) {
 		ctx.WriteString("crdb_internal.create_")
 		ctx.WriteString(d.semanticType.SQLStandardName())
 		ctx.WriteByte('(')
-		d.DInt.Format(ctx)
+		d.DInt.FormatImpl(ctx)
 		ctx.WriteByte(',')
 		lexbase.EncodeSQLStringWithFlags(&ctx.Buffer, d.name, lexbase.EncNoFlags)
 		ctx.WriteByte(')')
@@ -5241,8 +5241,8 @@ func (d *DOidWrapper) AmbiguousFormat() bool {
 	return d.Wrapped.AmbiguousFormat()
 }
 
-// Format implements the NodeFormatter interface.
-func (d *DOidWrapper) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (d *DOidWrapper) FormatImpl(ctx *FmtCtx) {
 	// Custom formatting based on d.OID could go here.
 	ctx.FormatNode(d.Wrapped)
 }

--- a/pkg/sql/sem/tree/delete.go
+++ b/pkg/sql/sem/tree/delete.go
@@ -29,8 +29,8 @@ type Delete struct {
 	Returning ReturningClause
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Delete) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Delete) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.With)
 	ctx.WriteString("DELETE FROM ")
 	ctx.FormatNode(node.Table)

--- a/pkg/sql/sem/tree/discard.go
+++ b/pkg/sql/sem/tree/discard.go
@@ -25,8 +25,8 @@ const (
 	DiscardModeAll DiscardMode = iota
 )
 
-// Format implements the NodeFormatter interface.
-func (node *Discard) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Discard) FormatImpl(ctx *FmtCtx) {
 	switch node.Mode {
 	case DiscardModeAll:
 		ctx.WriteString("DISCARD ALL")

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -51,8 +51,8 @@ type DropDatabase struct {
 	DropBehavior DropBehavior
 }
 
-// Format implements the NodeFormatter interface.
-func (node *DropDatabase) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropDatabase) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP DATABASE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -72,8 +72,8 @@ type DropIndex struct {
 	Concurrently bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *DropIndex) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropIndex) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP INDEX ")
 	if node.Concurrently {
 		ctx.WriteString("CONCURRENTLY ")
@@ -95,8 +95,8 @@ type DropTable struct {
 	DropBehavior DropBehavior
 }
 
-// Format implements the NodeFormatter interface.
-func (node *DropTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropTable) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP TABLE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -116,8 +116,8 @@ type DropView struct {
 	IsMaterialized bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *DropView) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropView) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP ")
 	if node.IsMaterialized {
 		ctx.WriteString("MATERIALIZED ")
@@ -149,8 +149,8 @@ type DropSequence struct {
 	DropBehavior DropBehavior
 }
 
-// Format implements the NodeFormatter interface.
-func (node *DropSequence) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropSequence) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP SEQUENCE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -169,8 +169,8 @@ type DropRole struct {
 	IfExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *DropRole) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropRole) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP")
 	if node.IsRole {
 		ctx.WriteString(" ROLE ")
@@ -192,8 +192,8 @@ type DropType struct {
 
 var _ Statement = &DropType{}
 
-// Format implements the NodeFormatter interface.
-func (node *DropType) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropType) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP TYPE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -219,8 +219,8 @@ type DropSchema struct {
 
 var _ Statement = &DropSchema{}
 
-// Format implements the NodeFormatter interface.
-func (node *DropSchema) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropSchema) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP SCHEMA ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")

--- a/pkg/sql/sem/tree/drop_owned_by.go
+++ b/pkg/sql/sem/tree/drop_owned_by.go
@@ -18,14 +18,14 @@ type DropOwnedBy struct {
 
 var _ Statement = &DropOwnedBy{}
 
-// Format implements the NodeFormatter interface.
-func (node *DropOwnedBy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DropOwnedBy) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DROP OWNED BY ")
 	for i := range node.Roles {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		node.Roles[i].Format(ctx)
+		node.Roles[i].FormatImpl(ctx)
 	}
 	if node.DropBehavior != DropDefault {
 		ctx.WriteString(" ")

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -147,8 +147,8 @@ func (f ExplainFlag) String() string {
 	return explainFlagStrings[f]
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Explain) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Explain) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("EXPLAIN ")
 	b := util.MakeStringListBuilder("(", ", ", ") ")
 	if node.Mode != ExplainPlan {
@@ -185,8 +185,8 @@ func (node *Explain) doc(p *PrettyCfg) pretty.Doc {
 	return p.nestUnder(d, p.Doc(node.Statement))
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ExplainAnalyze) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ExplainAnalyze) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("EXPLAIN ANALYZE ")
 	b := util.MakeStringListBuilder("(", ", ", ") ")
 	if node.Mode != ExplainPlan {

--- a/pkg/sql/sem/tree/export.go
+++ b/pkg/sql/sem/tree/export.go
@@ -20,8 +20,8 @@ type Export struct {
 
 var _ Statement = &Export{}
 
-// Format implements the NodeFormatter interface.
-func (node *Export) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Export) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("EXPORT INTO ")
 	ctx.WriteString(node.FileFormat)
 	ctx.WriteString(" ")

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -183,8 +183,8 @@ func binExprFmtWithParenAndSubOp(ctx *FmtCtx, e1 Expr, subOp, op string, e2 Expr
 	exprFmtWithParen(ctx, e2)
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AndExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AndExpr) FormatImpl(ctx *FmtCtx) {
 	binExprFmtWithParen(ctx, node.Left, "AND", node.Right, true)
 }
 
@@ -214,8 +214,8 @@ type OrExpr struct {
 
 func (*OrExpr) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *OrExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *OrExpr) FormatImpl(ctx *FmtCtx) {
 	binExprFmtWithParen(ctx, node.Left, "OR", node.Right, true)
 }
 
@@ -245,8 +245,8 @@ type NotExpr struct {
 
 func (*NotExpr) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *NotExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *NotExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("NOT ")
 	exprFmtWithParen(ctx, node.Expr)
 }
@@ -273,8 +273,8 @@ type IsNullExpr struct {
 
 func (*IsNullExpr) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *IsNullExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IsNullExpr) FormatImpl(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
 	ctx.WriteString(" IS NULL")
 }
@@ -302,8 +302,8 @@ type IsNotNullExpr struct {
 
 func (*IsNotNullExpr) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *IsNotNullExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IsNotNullExpr) FormatImpl(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
 	ctx.WriteString(" IS NOT NULL")
 }
@@ -328,8 +328,8 @@ type ParenExpr struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ParenExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ParenExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	ctx.FormatNode(node.Expr)
 	ctx.WriteByte(')')
@@ -498,8 +498,8 @@ type ComparisonExpr struct {
 
 func (*ComparisonExpr) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *ComparisonExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ComparisonExpr) FormatImpl(ctx *FmtCtx) {
 	opStr := node.Operator.String()
 	// IS and IS NOT are equivalent to IS NOT DISTINCT FROM and IS DISTINCT
 	// FROM, respectively, when the RHS is true or false. We prefer the less
@@ -645,8 +645,8 @@ type RangeCond struct {
 
 func (*RangeCond) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *RangeCond) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RangeCond) FormatImpl(ctx *FmtCtx) {
 	notStr := " BETWEEN "
 	if node.Not {
 		notStr = " NOT BETWEEN "
@@ -704,8 +704,8 @@ func (node *IsOfTypeExpr) ResolvedTypes() []*types.T {
 	return node.resolvedTypes
 }
 
-// Format implements the NodeFormatter interface.
-func (node *IsOfTypeExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IsOfTypeExpr) FormatImpl(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
 	ctx.WriteString(" IS")
 	if node.Not {
@@ -730,8 +730,8 @@ type IfErrExpr struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *IfErrExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IfErrExpr) FormatImpl(ctx *FmtCtx) {
 	if node.Else != nil {
 		ctx.WriteString("IFERROR(")
 	} else {
@@ -773,8 +773,8 @@ func (node *IfExpr) TypedElseExpr() TypedExpr {
 	return node.Else.(TypedExpr)
 }
 
-// Format implements the NodeFormatter interface.
-func (node *IfExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IfExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("IF(")
 	ctx.FormatNode(node.Cond)
 	ctx.WriteString(", ")
@@ -792,8 +792,8 @@ type NullIfExpr struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *NullIfExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *NullIfExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("NULLIF(")
 	ctx.FormatNode(node.Expr1)
 	ctx.WriteString(", ")
@@ -839,8 +839,8 @@ func (node *CoalesceExpr) TypedExprAt(idx int) TypedExpr {
 	return node.Exprs[idx].(TypedExpr)
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CoalesceExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CoalesceExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(node.Name)
 	ctx.WriteByte('(')
 	ctx.FormatNode(&node.Exprs)
@@ -850,8 +850,8 @@ func (node *CoalesceExpr) Format(ctx *FmtCtx) {
 // DefaultVal represents the DEFAULT expression.
 type DefaultVal struct{}
 
-// Format implements the NodeFormatter interface.
-func (node DefaultVal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node DefaultVal) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DEFAULT")
 }
 
@@ -861,16 +861,16 @@ func (DefaultVal) ResolvedType() *types.T { return nil }
 // PartitionMaxVal represents the MAXVALUE expression.
 type PartitionMaxVal struct{}
 
-// Format implements the NodeFormatter interface.
-func (node PartitionMaxVal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node PartitionMaxVal) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("MAXVALUE")
 }
 
 // PartitionMinVal represents the MINVALUE expression.
 type PartitionMinVal struct{}
 
-// Format implements the NodeFormatter interface.
-func (node PartitionMinVal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node PartitionMinVal) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("MINVALUE")
 }
 
@@ -898,8 +898,8 @@ func NewPlaceholder(name string) (*Placeholder, error) {
 	return &Placeholder{Idx: PlaceholderIdx(uval - 1)}, nil
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Placeholder) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Placeholder) FormatImpl(ctx *FmtCtx) {
 	if ctx.placeholderFormat != nil {
 		ctx.placeholderFormat(ctx, node)
 		return
@@ -937,8 +937,8 @@ func NewTypedTuple(typ *types.T, typedExprs Exprs) *Tuple {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Tuple) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Tuple) FormatImpl(ctx *FmtCtx) {
 	// If there are labels, extra parentheses are required surrounding the
 	// expression.
 	if len(node.Labels) > 0 {
@@ -976,8 +976,8 @@ type Array struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Array) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Array) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ARRAY[")
 	ctx.FormatNode(&node.Exprs)
 	ctx.WriteByte(']')
@@ -998,8 +998,8 @@ type ArrayFlatten struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ArrayFlatten) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ArrayFlatten) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ARRAY ")
 	exprFmtWithParen(ctx, node.Subquery)
 	if ctx.HasFlags(FmtParsable) {
@@ -1016,8 +1016,8 @@ func (node *ArrayFlatten) Format(ctx *FmtCtx) {
 // because it's not parenthesized.
 type Exprs []Expr
 
-// Format implements the NodeFormatter interface.
-func (node *Exprs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Exprs) FormatImpl(ctx *FmtCtx) {
 	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -1064,8 +1064,8 @@ func (*Subquery) Variable() {}
 // SubqueryExpr implements the SubqueryExpr interface.
 func (*Subquery) SubqueryExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *Subquery) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Subquery) FormatImpl(ctx *FmtCtx) {
 	if ctx.HasFlags(FmtSymbolicSubqueries) {
 		ctx.Printf("@S%d", node.Idx)
 	} else {
@@ -1097,8 +1097,8 @@ func (node *TypedDummy) String() string {
 	return AsString(node)
 }
 
-// Format implements the NodeFormatter interface.
-func (node *TypedDummy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *TypedDummy) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("dummyvalof(")
 	ctx.FormatTypeReference(node.Typ)
 	ctx.WriteString(")")
@@ -1291,8 +1291,8 @@ func newBinExprIfValidOverload(op BinaryOperator, left TypedExpr, right TypedExp
 	return nil
 }
 
-// Format implements the NodeFormatter interface.
-func (node *BinaryExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *BinaryExpr) FormatImpl(ctx *FmtCtx) {
 	binExprFmtWithParen(ctx, node.Left, node.Operator.String(), node.Right, node.Operator.Symbol.isPadded())
 }
 
@@ -1359,8 +1359,8 @@ type UnaryExpr struct {
 
 func (*UnaryExpr) operatorExpr() {}
 
-// Format implements the NodeFormatter interface.
-func (node *UnaryExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *UnaryExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(node.Operator.String())
 	e := node.Expr
 	_, isOp := e.(operatorExpr)
@@ -1497,8 +1497,8 @@ const (
 	OrderedSetAgg
 )
 
-// Format implements the NodeFormatter interface.
-func (node *FuncExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *FuncExpr) FormatImpl(ctx *FmtCtx) {
 	var typ string
 	if node.Type != 0 {
 		typ = funcTypeName[node.Type] + " "
@@ -1560,8 +1560,8 @@ type CaseExpr struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CaseExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CaseExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CASE ")
 	if node.Expr != nil {
 		ctx.FormatNode(node.Expr)
@@ -1594,8 +1594,8 @@ type When struct {
 	Val  Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *When) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *When) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("WHEN ")
 	ctx.FormatNode(node.Cond)
 	ctx.WriteString(" THEN ")
@@ -1620,8 +1620,8 @@ type CastExpr struct {
 	SyntaxMode castSyntaxMode
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CastExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CastExpr) FormatImpl(ctx *FmtCtx) {
 	switch node.SyntaxMode {
 	case CastPrepend:
 		// This is a special case for things like INTERVAL '1s'. These only work
@@ -1679,8 +1679,8 @@ func NewTypedCastExpr(expr TypedExpr, typ *types.T) *CastExpr {
 // ArraySubscripts represents a sequence of one or more array subscripts.
 type ArraySubscripts []*ArraySubscript
 
-// Format implements the NodeFormatter interface.
-func (a *ArraySubscripts) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (a *ArraySubscripts) FormatImpl(ctx *FmtCtx) {
 	for _, s := range *a {
 		ctx.FormatNode(s)
 	}
@@ -1694,8 +1694,8 @@ type IndirectionExpr struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *IndirectionExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *IndirectionExpr) FormatImpl(ctx *FmtCtx) {
 	// If the sub expression is a CastExpr or an Array that has a type,
 	// we need to wrap it in a ParenExpr, otherwise the indirection
 	// will get interpreted as part of the type.
@@ -1732,8 +1732,8 @@ type AnnotateTypeExpr struct {
 	SyntaxMode annotateSyntaxMode
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AnnotateTypeExpr) FormatImpl(ctx *FmtCtx) {
 	switch node.SyntaxMode {
 	case AnnotateShort:
 		exprFmtWithParen(ctx, node.Expr)
@@ -1762,8 +1762,8 @@ type CollateExpr struct {
 	typeAnnotation
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CollateExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CollateExpr) FormatImpl(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
 	ctx.WriteString(" COLLATE ")
 	lex.EncodeLocaleName(&ctx.Buffer, node.Locale)
@@ -1778,8 +1778,8 @@ type TupleStar struct {
 // NormalizeVarName implements the VarName interface.
 func (node *TupleStar) NormalizeVarName() (VarName, error) { return node, nil }
 
-// Format implements the NodeFormatter interface.
-func (node *TupleStar) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *TupleStar) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	ctx.FormatNode(node.Expr)
 	ctx.WriteString(").*")
@@ -1822,8 +1822,8 @@ func NewTypedColumnAccessExpr(expr TypedExpr, colName Name, colIdx int) *ColumnA
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ColumnAccessExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ColumnAccessExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	ctx.FormatNode(node.Expr)
 	ctx.WriteString(").")

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -236,7 +236,7 @@ const (
 
 const flagsRequiringAnnotations FmtFlags = FmtAlwaysQualifyTableNames
 
-// FmtCtx is suitable for passing to Format() methods.
+// FmtCtx is suitable for passing to FormatImpl() methods.
 // It also exposes the underlying bytes.Buffer interface for
 // convenience.
 //
@@ -386,9 +386,10 @@ func (ctx *FmtCtx) Printf(f string, args ...interface{}) {
 
 // NodeFormatter is implemented by nodes that can be pretty-printed.
 type NodeFormatter interface {
-	// Format performs pretty-printing towards a bytes buffer. The flags member
-	// of ctx influences the results. Most callers should use FormatNode instead.
-	Format(ctx *FmtCtx)
+	// FormatImpl performs pretty-printing towards a bytes buffer. The flags
+	// member of ctx influences the results. Most callers should use FormatNode
+	// instead.
+	FormatImpl(ctx *FmtCtx)
 }
 
 // FormatName formats a string as a name.
@@ -653,10 +654,10 @@ func (ctx *FmtCtx) formatNodeMaybeMarkRedaction(n NodeFormatter) {
 			// Deliberately empty so we format as normal.
 		case Datum, Constant, *Name, *UnrestrictedName:
 			ctx.WriteString(string(redact.StartMarker()))
-			v.Format(ctx)
+			v.FormatImpl(ctx)
 			ctx.WriteString(string(redact.EndMarker()))
 			return
 		}
-		n.Format(ctx)
+		n.FormatImpl(ctx)
 	}
 }

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -183,8 +183,8 @@ var FunDefs map[string]*FunctionDefinition
 // package because of dependency issues: we can't use oidHasher from this file.
 var OidToBuiltinName map[oid.Oid]string
 
-// Format implements the NodeFormatter interface.
-func (fd *FunctionDefinition) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (fd *FunctionDefinition) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(fd.Name)
 }
 func (fd *FunctionDefinition) String() string { return AsString(fd) }

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -34,8 +34,8 @@ type ResolvableFunctionReference struct {
 	FunctionReference
 }
 
-// Format implements the NodeFormatter interface.
-func (fn *ResolvableFunctionReference) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (fn *ResolvableFunctionReference) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(fn.FunctionReference)
 }
 func (fn *ResolvableFunctionReference) String() string { return AsString(fn) }

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -52,8 +52,8 @@ type TargetList struct {
 	Roles    RoleSpecList
 }
 
-// Format implements the NodeFormatter interface.
-func (tl *TargetList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (tl *TargetList) FormatImpl(ctx *FmtCtx) {
 	if tl.Databases != nil {
 		ctx.WriteString("DATABASE ")
 		ctx.FormatNode(&tl.Databases)
@@ -79,8 +79,8 @@ func (tl *TargetList) Format(ctx *FmtCtx) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Grant) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Grant) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("GRANT ")
 	node.Privileges.Format(&ctx.Buffer)
 	ctx.WriteString(" ON ")
@@ -96,8 +96,8 @@ type GrantRole struct {
 	AdminOption bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *GrantRole) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *GrantRole) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("GRANT ")
 	ctx.FormatNode(&node.Roles)
 	ctx.WriteString(" TO ")

--- a/pkg/sql/sem/tree/hide_constants.go
+++ b/pkg/sql/sem/tree/hide_constants.go
@@ -43,7 +43,7 @@ func (ctx *FmtCtx) formatNodeOrHideConstants(n NodeFormatter) {
 			return
 		}
 	}
-	n.Format(ctx)
+	n.FormatImpl(ctx)
 }
 
 // formatHideConstants shortens multi-valued VALUES clauses to a
@@ -63,7 +63,7 @@ func (node *ValuesClause) formatHideConstants(ctx *FmtCtx) {
 func (node *Exprs) formatHideConstants(ctx *FmtCtx) {
 	exprs := *node
 	if len(exprs) < 2 {
-		node.Format(ctx)
+		node.FormatImpl(ctx)
 		return
 	}
 
@@ -83,10 +83,10 @@ func (node *Exprs) formatHideConstants(ctx *FmtCtx) {
 		if len(exprs) > 2 {
 			v2 = append(v2, arityIndicator(len(exprs)-2))
 		}
-		v2.Format(ctx)
+		v2.FormatImpl(ctx)
 		return
 	}
-	node.Format(ctx)
+	node.FormatImpl(ctx)
 }
 
 // formatHideConstants formats tuples containing only literals or
@@ -101,7 +101,7 @@ func (node *Exprs) formatHideConstants(ctx *FmtCtx) {
 //      (1+2, b, c)       -> (_ + _, b, c)
 func (node *Tuple) formatHideConstants(ctx *FmtCtx) {
 	if len(node.Exprs) < 2 {
-		node.Format(ctx)
+		node.FormatImpl(ctx)
 		return
 	}
 
@@ -125,10 +125,10 @@ func (node *Tuple) formatHideConstants(ctx *FmtCtx) {
 				v2.Labels = node.Labels[:2]
 			}
 		}
-		v2.Format(ctx)
+		v2.FormatImpl(ctx)
 		return
 	}
-	node.Format(ctx)
+	node.FormatImpl(ctx)
 }
 
 // formatHideConstants formats array expressions containing only
@@ -140,7 +140,7 @@ func (node *Tuple) formatHideConstants(ctx *FmtCtx) {
 //      array[1+2, 2+3, 3+4] -> array[_ + _, _ + _, _ + _]
 func (node *Array) formatHideConstants(ctx *FmtCtx) {
 	if len(node.Exprs) < 2 {
-		node.Format(ctx)
+		node.FormatImpl(ctx)
 		return
 	}
 
@@ -161,10 +161,10 @@ func (node *Array) formatHideConstants(ctx *FmtCtx) {
 		if len(node.Exprs) > 2 {
 			v2.Exprs = append(v2.Exprs, arityIndicator(len(node.Exprs)-2))
 		}
-		v2.Format(ctx)
+		v2.FormatImpl(ctx)
 		return
 	}
-	node.Format(ctx)
+	node.FormatImpl(ctx)
 }
 
 func arityIndicator(n int) Expr {

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -23,8 +23,8 @@ type Import struct {
 
 var _ Statement = &Import{}
 
-// Format implements the NodeFormatter interface.
-func (node *Import) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Import) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("IMPORT ")
 
 	if node.Bundle {

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -89,8 +89,8 @@ func (v *IndexedVar) ResolvedType() *types.T {
 	return v.typ
 }
 
-// Format implements the NodeFormatter interface.
-func (v *IndexedVar) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (v *IndexedVar) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if ctx.indexedVarFormat != nil {
 		ctx.indexedVarFormat(ctx, v.Idx)

--- a/pkg/sql/sem/tree/insert.go
+++ b/pkg/sql/sem/tree/insert.go
@@ -29,8 +29,8 @@ type Insert struct {
 	Returning  ReturningClause
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Insert) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Insert) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.With)
 	if node.OnConflict.IsUpsertAlias() {
 		ctx.WriteString("UPSERT")

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -29,8 +29,8 @@ import (
 // `unrestricted_name` nonterminals. See UnrestrictedName for details.
 type Name string
 
-// Format implements the NodeFormatter interface.
-func (n *Name) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *Name) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtAnonymize) && !isArityIndicatorString(string(*n)) {
 		ctx.WriteByte('_')
@@ -84,8 +84,8 @@ func (n Name) Normalize() string {
 // prefer to parse unrestricted_name nonterminals into UnrestrictedNames.
 type UnrestrictedName string
 
-// Format implements the NodeFormatter interface.
-func (u *UnrestrictedName) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (u *UnrestrictedName) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtAnonymize) {
 		ctx.WriteByte('_')
@@ -123,8 +123,8 @@ func (l NameList) ToSQLUsernames() ([]security.SQLUsername, error) {
 // A NameList is a list of identifiers.
 type NameList []Name
 
-// Format implements the NodeFormatter interface.
-func (l *NameList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (l *NameList) FormatImpl(ctx *FmtCtx) {
 	for i := range *l {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -140,8 +140,8 @@ type ArraySubscript struct {
 	Slice bool
 }
 
-// Format implements the NodeFormatter interface.
-func (a *ArraySubscript) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (a *ArraySubscript) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('[')
 	if a.Begin != nil {
 		ctx.FormatNode(a.Begin)
@@ -180,8 +180,8 @@ type UnresolvedName struct {
 // UnresolvedName.
 type NameParts = [4]string
 
-// Format implements the NodeFormatter interface.
-func (u *UnresolvedName) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (u *UnresolvedName) FormatImpl(ctx *FmtCtx) {
 	stopAt := 1
 	if u.Star {
 		stopAt = 2

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -70,8 +70,8 @@ type ObjectNamePrefix struct {
 	ExplicitSchema bool
 }
 
-// Format implements the NodeFormatter interface.
-func (tp *ObjectNamePrefix) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (tp *ObjectNamePrefix) FormatImpl(ctx *FmtCtx) {
 	alwaysFormat := ctx.alwaysFormatTablePrefix()
 	if tp.ExplicitSchema || alwaysFormat {
 		if tp.ExplicitCatalog || alwaysFormat {
@@ -97,8 +97,8 @@ func (tp *ObjectNamePrefix) Catalog() string {
 // ObjectNamePrefixList is a list of ObjectNamePrefix
 type ObjectNamePrefixList []ObjectNamePrefix
 
-// Format implements the NodeFormatter interface.
-func (tp ObjectNamePrefixList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (tp ObjectNamePrefixList) FormatImpl(ctx *FmtCtx) {
 	for idx, objectNamePrefix := range tp {
 		ctx.FormatNode(&objectNamePrefix)
 		if idx != len(tp)-1 {
@@ -169,8 +169,8 @@ func (u *UnresolvedObjectName) Resolved(ann *Annotations) ObjectName {
 	return r.(ObjectName)
 }
 
-// Format implements the NodeFormatter interface.
-func (u *UnresolvedObjectName) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (u *UnresolvedObjectName) FormatImpl(ctx *FmtCtx) {
 	// If we want to format the corresponding resolved name, look it up in the
 	// annotation.
 	if ctx.HasFlags(FmtAlwaysQualifyTableNames) || ctx.tableNameFormatter != nil {
@@ -179,12 +179,12 @@ func (u *UnresolvedObjectName) Format(ctx *FmtCtx) {
 			// unresolved names everywhere. We will need to revisit and see if we need
 			// to switch to (or add) an UnresolvedObjectName formatter.
 			tn := u.ToTableName()
-			tn.Format(ctx)
+			ctx.FormatNode(&tn)
 			return
 		}
 
 		if n := u.Resolved(ctx.ann); n != nil {
-			n.Format(ctx)
+			ctx.FormatNode(n)
 			return
 		}
 	}

--- a/pkg/sql/sem/tree/prepare.go
+++ b/pkg/sql/sem/tree/prepare.go
@@ -19,8 +19,8 @@ type Prepare struct {
 	Statement Statement
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Prepare) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Prepare) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("PREPARE ")
 	ctx.FormatNode(&node.Name)
 	if len(node.Types) > 0 {
@@ -44,8 +44,8 @@ type CannedOptPlan struct {
 	Plan string
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CannedOptPlan) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CannedOptPlan) FormatImpl(ctx *FmtCtx) {
 	// This node can only be used as the AST for a Prepare statement of the form:
 	//   PREPARE name AS OPT PLAN '...').
 	ctx.WriteString("OPT PLAN ")
@@ -61,8 +61,8 @@ type Execute struct {
 	DiscardRows bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Execute) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Execute) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("EXECUTE ")
 	ctx.FormatNode(&node.Name)
 	if len(node.Params) > 0 {
@@ -80,8 +80,8 @@ type Deallocate struct {
 	Name Name // empty for ALL
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Deallocate) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Deallocate) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DEALLOCATE ")
 	if node.Name == "" {
 		ctx.WriteString("ALL")

--- a/pkg/sql/sem/tree/reassign_owned_by.go
+++ b/pkg/sql/sem/tree/reassign_owned_by.go
@@ -18,14 +18,14 @@ type ReassignOwnedBy struct {
 
 var _ Statement = &ReassignOwnedBy{}
 
-// Format implements the NodeFormatter interface.
-func (node *ReassignOwnedBy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ReassignOwnedBy) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("REASSIGN OWNED BY ")
 	for i := range node.OldRoles {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		node.OldRoles[i].Format(ctx)
+		node.OldRoles[i].FormatImpl(ctx)
 	}
 	ctx.WriteString(" TO ")
 	ctx.FormatNode(&node.NewRole)

--- a/pkg/sql/sem/tree/region.go
+++ b/pkg/sql/sem/tree/region.go
@@ -85,8 +85,8 @@ func (node *Locality) TelemetryName() string {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Locality) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Locality) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("LOCALITY ")
 	switch node.LocalityLevel {
 	case LocalityLevelGlobal:

--- a/pkg/sql/sem/tree/rename.go
+++ b/pkg/sql/sem/tree/rename.go
@@ -25,8 +25,8 @@ type RenameDatabase struct {
 	NewName Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RenameDatabase) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RenameDatabase) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" RENAME TO ")
@@ -39,8 +39,8 @@ type ReparentDatabase struct {
 	Parent Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ReparentDatabase) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ReparentDatabase) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" CONVERT TO SCHEMA WITH PARENT ")
@@ -59,8 +59,8 @@ type RenameTable struct {
 	IsSequence     bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RenameTable) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RenameTable) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
 	if node.IsView {
 		if node.IsMaterialized {
@@ -87,8 +87,8 @@ type RenameIndex struct {
 	IfExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RenameIndex) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RenameIndex) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER INDEX ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -107,8 +107,8 @@ type RenameColumn struct {
 	IfExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RenameColumn) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RenameColumn) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER TABLE ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")

--- a/pkg/sql/sem/tree/replication_stream.go
+++ b/pkg/sql/sem/tree/replication_stream.go
@@ -21,7 +21,7 @@ type ReplicationOptions struct {
 var _ NodeFormatter = &ReplicationOptions{}
 
 // Format implements the NodeFormatter interface
-func (o *ReplicationOptions) Format(ctx *FmtCtx) {
+func (o *ReplicationOptions) FormatImpl(ctx *FmtCtx) {
 	var addSep bool
 	maybeAddSep := func() {
 		if addSep {
@@ -31,7 +31,7 @@ func (o *ReplicationOptions) Format(ctx *FmtCtx) {
 	}
 	if o.Cursor != nil {
 		ctx.WriteString("CURSOR=")
-		o.Cursor.Format(ctx)
+		ctx.FormatNode(o.Cursor)
 		addSep = true
 	}
 
@@ -78,8 +78,8 @@ type ReplicationStream struct {
 
 var _ Statement = &ReplicationStream{}
 
-// Format implements the NodeFormatter interface.
-func (n *ReplicationStream) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ReplicationStream) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE REPLICATION STREAM FOR ")
 	ctx.FormatNode(&n.Targets)
 

--- a/pkg/sql/sem/tree/returning.go
+++ b/pkg/sql/sem/tree/returning.go
@@ -26,8 +26,8 @@ var _ ReturningClause = &NoReturningClause{}
 // ReturningExprs represents RETURNING expressions.
 type ReturningExprs SelectExprs
 
-// Format implements the NodeFormatter interface.
-func (r *ReturningExprs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (r *ReturningExprs) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("RETURNING ")
 	ctx.FormatNode((*SelectExprs)(r))
 }
@@ -38,8 +38,8 @@ var ReturningNothingClause = &ReturningNothing{}
 // ReturningNothing represents RETURNING NOTHING.
 type ReturningNothing struct{}
 
-// Format implements the NodeFormatter interface.
-func (*ReturningNothing) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (*ReturningNothing) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("RETURNING NOTHING")
 }
 
@@ -50,8 +50,8 @@ var AbsentReturningClause = &NoReturningClause{}
 // NoReturningClause represents the absence of a RETURNING clause.
 type NoReturningClause struct{}
 
-// Format implements the NodeFormatter interface.
-func (*NoReturningClause) Format(_ *FmtCtx) {}
+// FormatImpl implements the NodeFormatter interface.
+func (*NoReturningClause) FormatImpl(_ *FmtCtx) {}
 
 // used by parent statements to determine their own StatementReturnType.
 func (*ReturningExprs) statementReturnType() StatementReturnType    { return Rows }

--- a/pkg/sql/sem/tree/revoke.go
+++ b/pkg/sql/sem/tree/revoke.go
@@ -30,8 +30,8 @@ type Revoke struct {
 	GrantOptionFor bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Revoke) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Revoke) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("REVOKE ")
 	// NB: we cannot use FormatNode() here because node.Privileges is
 	// not an AST node. This is OK, because a privilege list cannot
@@ -50,8 +50,8 @@ type RevokeRole struct {
 	AdminOption bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RevokeRole) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RevokeRole) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("REVOKE ")
 	if node.AdminOption {
 		ctx.WriteString("ADMIN OPTION FOR ")

--- a/pkg/sql/sem/tree/role_spec.go
+++ b/pkg/sql/sem/tree/role_spec.go
@@ -104,8 +104,8 @@ func (r RoleSpec) Undefined() bool {
 	return r.RoleSpecType == RoleName && len(r.Name) == 0
 }
 
-// Format implements the NodeFormatter interface.
-func (r *RoleSpec) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (r *RoleSpec) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtAnonymize) && !isArityIndicatorString(r.Name) {
 		ctx.WriteByte('_')
@@ -120,8 +120,8 @@ func (r *RoleSpec) Format(ctx *FmtCtx) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (l *RoleSpecList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (l *RoleSpecList) FormatImpl(ctx *FmtCtx) {
 	for i := range *l {
 		if i > 0 {
 			ctx.WriteString(", ")

--- a/pkg/sql/sem/tree/run_control.go
+++ b/pkg/sql/sem/tree/run_control.go
@@ -34,8 +34,8 @@ var JobCommandToStatement = map[JobCommand]string{
 	ResumeJob: "RESUME",
 }
 
-// Format implements the NodeFormatter interface.
-func (n *ControlJobs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ControlJobs) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(JobCommandToStatement[n.Command])
 	ctx.WriteString(" JOBS ")
 	ctx.FormatNode(n.Jobs)
@@ -51,8 +51,8 @@ type CancelQueries struct {
 	IfExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CancelQueries) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CancelQueries) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CANCEL QUERIES ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -66,8 +66,8 @@ type CancelSessions struct {
 	IfExists bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *CancelSessions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CancelSessions) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CANCEL SESSIONS ")
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
@@ -106,8 +106,8 @@ type ControlSchedules struct {
 
 var _ Statement = &ControlSchedules{}
 
-// Format implements the NodeFormatter interface.
-func (n *ControlSchedules) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ControlSchedules) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(n.Command.String())
 	ctx.WriteString(" SCHEDULES ")
 	ctx.FormatNode(n.Schedules)
@@ -127,8 +127,8 @@ type ControlJobsOfType struct {
 	Command JobCommand
 }
 
-// Format implements the NodeFormatter interface.
-func (n *ControlJobsOfType) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ControlJobsOfType) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(JobCommandToStatement[n.Command])
 	ctx.WriteString(" ALL ")
 	ctx.WriteString(n.Type)
@@ -136,7 +136,7 @@ func (n *ControlJobsOfType) Format(ctx *FmtCtx) {
 }
 
 // Format implements NodeFormatter interface.
-func (n *ControlJobsForSchedules) Format(ctx *FmtCtx) {
+func (n *ControlJobsForSchedules) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(JobCommandToStatement[n.Command])
 	ctx.WriteString(" JOBS FOR SCHEDULES ")
 	ctx.FormatNode(n.Schedules)

--- a/pkg/sql/sem/tree/schedule.go
+++ b/pkg/sql/sem/tree/schedule.go
@@ -35,8 +35,8 @@ type ScheduledBackup struct {
 
 var _ Statement = &ScheduledBackup{}
 
-// Format implements the NodeFormatter interface.
-func (node *ScheduledBackup) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ScheduledBackup) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CREATE SCHEDULE")
 
 	if node.ScheduleLabelSpec.IfNotExists {

--- a/pkg/sql/sem/tree/scrub.go
+++ b/pkg/sql/sem/tree/scrub.go
@@ -33,8 +33,8 @@ type Scrub struct {
 	AsOf     AsOfClause
 }
 
-// Format implements the NodeFormatter interface.
-func (n *Scrub) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *Scrub) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("EXPERIMENTAL SCRUB ")
 	switch n.Typ {
 	case ScrubTable:
@@ -61,8 +61,8 @@ func (n *Scrub) Format(ctx *FmtCtx) {
 // ScrubOptions corresponds to a comma-delimited list of scrub options.
 type ScrubOptions []ScrubOption
 
-// Format implements the NodeFormatter interface.
-func (n *ScrubOptions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ScrubOptions) FormatImpl(ctx *FmtCtx) {
 	for i, option := range *n {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -95,8 +95,8 @@ type ScrubOptionIndex struct {
 	IndexNames NameList
 }
 
-// Format implements the NodeFormatter interface.
-func (n *ScrubOptionIndex) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ScrubOptionIndex) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("INDEX ")
 	if n.IndexNames != nil {
 		ctx.WriteByte('(')
@@ -110,8 +110,8 @@ func (n *ScrubOptionIndex) Format(ctx *FmtCtx) {
 // ScrubOptionPhysical represents a PHYSICAL scrub check.
 type ScrubOptionPhysical struct{}
 
-// Format implements the NodeFormatter interface.
-func (n *ScrubOptionPhysical) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ScrubOptionPhysical) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("PHYSICAL")
 }
 
@@ -120,8 +120,8 @@ type ScrubOptionConstraint struct {
 	ConstraintNames NameList
 }
 
-// Format implements the NodeFormatter interface.
-func (n *ScrubOptionConstraint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ScrubOptionConstraint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("CONSTRAINT ")
 	if n.ConstraintNames != nil {
 		ctx.WriteByte('(')

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -49,8 +49,8 @@ type Select struct {
 	Locking LockingClause
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Select) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Select) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.With)
 	ctx.FormatNode(node.Select)
 	if len(node.OrderBy) > 0 {
@@ -69,8 +69,8 @@ type ParenSelect struct {
 	Select *Select
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ParenSelect) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ParenSelect) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	ctx.FormatNode(node.Select)
 	ctx.WriteByte(')')
@@ -89,8 +89,8 @@ type SelectClause struct {
 	TableSelect bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SelectClause) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SelectClause) FormatImpl(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtSummary) {
 		ctx.WriteString("SELECT")
@@ -140,8 +140,8 @@ func (node *SelectClause) Format(ctx *FmtCtx) {
 // SelectExprs represents SELECT expressions.
 type SelectExprs []SelectExpr
 
-// Format implements the NodeFormatter interface.
-func (node *SelectExprs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SelectExprs) FormatImpl(ctx *FmtCtx) {
 	for i := range *node {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -177,8 +177,8 @@ func StarSelectExpr() SelectExpr {
 	return SelectExpr{Expr: StarExpr()}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SelectExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SelectExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.Expr)
 	if node.As != "" {
 		ctx.WriteString(" AS ")
@@ -193,8 +193,8 @@ type AliasClause struct {
 	Cols  NameList
 }
 
-// Format implements the NodeFormatter interface.
-func (a *AliasClause) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (a *AliasClause) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(&a.Alias)
 	if len(a.Cols) != 0 {
 		// Format as "alias (col1, col2, ...)".
@@ -209,8 +209,8 @@ type AsOfClause struct {
 	Expr Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (a *AsOfClause) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (a *AsOfClause) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("AS OF SYSTEM TIME ")
 	ctx.FormatNode(a.Expr)
 }
@@ -221,8 +221,8 @@ type From struct {
 	AsOf   AsOfClause
 }
 
-// Format implements the NodeFormatter interface.
-func (node *From) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *From) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("FROM ")
 	ctx.FormatNode(&node.Tables)
 	if node.AsOf.Expr != nil {
@@ -234,8 +234,8 @@ func (node *From) Format(ctx *FmtCtx) {
 // TableExprs represents a list of table expressions.
 type TableExprs []TableExpr
 
-// Format implements the NodeFormatter interface.
-func (node *TableExprs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *TableExprs) FormatImpl(ctx *FmtCtx) {
 	prefix := ""
 	for _, n := range *node {
 		ctx.WriteString(prefix)
@@ -263,8 +263,8 @@ type StatementSource struct {
 	Statement Statement
 }
 
-// Format implements the NodeFormatter interface.
-func (node *StatementSource) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *StatementSource) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('[')
 	ctx.FormatNode(node.Statement)
 	ctx.WriteByte(']')
@@ -417,8 +417,8 @@ func (ih *IndexFlags) Check() error {
 	return nil
 }
 
-// Format implements the NodeFormatter interface.
-func (ih *IndexFlags) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (ih *IndexFlags) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('@')
 	if !ih.NoIndexJoin && !ih.NoZigzagJoin && !ih.NoFullScan && !ih.IgnoreForeignKeys &&
 		!ih.IgnoreUniqueWithoutIndexKeys && ih.Direction == 0 && !ih.zigzagForced() {
@@ -513,8 +513,8 @@ type AliasedTableExpr struct {
 	As         AliasClause
 }
 
-// Format implements the NodeFormatter interface.
-func (node *AliasedTableExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *AliasedTableExpr) FormatImpl(ctx *FmtCtx) {
 	if node.Lateral {
 		ctx.WriteString("LATERAL ")
 	}
@@ -536,8 +536,8 @@ type ParenTableExpr struct {
 	Expr TableExpr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ParenTableExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ParenTableExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	ctx.FormatNode(node.Expr)
 	ctx.WriteByte(')')
@@ -577,8 +577,8 @@ const (
 	AstInverted = "INVERTED"
 )
 
-// Format implements the NodeFormatter interface.
-func (node *JoinTableExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *JoinTableExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.Left)
 	ctx.WriteByte(' ')
 	if _, isNatural := node.Cond.(NaturalJoinCond); isNatural {
@@ -627,8 +627,8 @@ func (*UsingJoinCond) joinCond()  {}
 // NaturalJoinCond represents a NATURAL join condition
 type NaturalJoinCond struct{}
 
-// Format implements the NodeFormatter interface.
-func (NaturalJoinCond) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (NaturalJoinCond) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("NATURAL")
 }
 
@@ -637,8 +637,8 @@ type OnJoinCond struct {
 	Expr Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *OnJoinCond) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *OnJoinCond) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ON ")
 	ctx.FormatNode(node.Expr)
 }
@@ -648,8 +648,8 @@ type UsingJoinCond struct {
 	Cols NameList
 }
 
-// Format implements the NodeFormatter interface.
-func (node *UsingJoinCond) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *UsingJoinCond) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("USING (")
 	ctx.FormatNode(&node.Cols)
 	ctx.WriteByte(')')
@@ -676,8 +676,8 @@ func NewWhere(typ string, expr Expr) *Where {
 	return &Where{Type: typ, Expr: expr}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Where) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Where) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(node.Type)
 	ctx.WriteByte(' ')
 	ctx.FormatNode(node.Expr)
@@ -686,8 +686,8 @@ func (node *Where) Format(ctx *FmtCtx) {
 // GroupBy represents a GROUP BY clause.
 type GroupBy []Expr
 
-// Format implements the NodeFormatter interface.
-func (node *GroupBy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *GroupBy) FormatImpl(ctx *FmtCtx) {
 	prefix := "GROUP BY "
 	for _, n := range *node {
 		ctx.WriteString(prefix)
@@ -699,8 +699,8 @@ func (node *GroupBy) Format(ctx *FmtCtx) {
 // DistinctOn represents a DISTINCT ON clause.
 type DistinctOn []Expr
 
-// Format implements the NodeFormatter interface.
-func (node *DistinctOn) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *DistinctOn) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("DISTINCT ON (")
 	ctx.FormatNode((*Exprs)(node))
 	ctx.WriteByte(')')
@@ -709,8 +709,8 @@ func (node *DistinctOn) Format(ctx *FmtCtx) {
 // OrderBy represents an ORDER BY clause.
 type OrderBy []*Order
 
-// Format implements the NodeFormatter interface.
-func (node *OrderBy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *OrderBy) FormatImpl(ctx *FmtCtx) {
 	prefix := "ORDER BY "
 	for _, n := range *node {
 		ctx.WriteString(prefix)
@@ -787,8 +787,8 @@ type Order struct {
 	Index UnrestrictedName
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Order) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Order) FormatImpl(ctx *FmtCtx) {
 	if node.OrderType == OrderByColumn {
 		ctx.FormatNode(node.Expr)
 	} else {
@@ -825,8 +825,8 @@ type Limit struct {
 	LimitAll      bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Limit) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Limit) FormatImpl(ctx *FmtCtx) {
 	needSpace := false
 	if node.Count != nil {
 		ctx.WriteString("LIMIT ")
@@ -850,8 +850,8 @@ type RowsFromExpr struct {
 	Items Exprs
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RowsFromExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RowsFromExpr) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ROWS FROM (")
 	ctx.FormatNode(&node.Items)
 	ctx.WriteByte(')')
@@ -860,8 +860,8 @@ func (node *RowsFromExpr) Format(ctx *FmtCtx) {
 // Window represents a WINDOW clause.
 type Window []*WindowDef
 
-// Format implements the NodeFormatter interface.
-func (node *Window) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Window) FormatImpl(ctx *FmtCtx) {
 	prefix := "WINDOW "
 	for _, n := range *node {
 		ctx.WriteString(prefix)
@@ -881,8 +881,8 @@ type WindowDef struct {
 	Frame      *WindowFrame
 }
 
-// Format implements the NodeFormatter interface.
-func (node *WindowDef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *WindowDef) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteByte('(')
 	needSpaceSeparator := false
 	if node.RefName != "" {
@@ -1104,8 +1104,8 @@ type WindowFrame struct {
 	Exclusion WindowFrameExclusion // optional frame exclusion
 }
 
-// Format implements the NodeFormatter interface.
-func (node *WindowFrameBound) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *WindowFrameBound) FormatImpl(ctx *FmtCtx) {
 	switch node.BoundType {
 	case UnboundedPreceding:
 		ctx.WriteString("UNBOUNDED PRECEDING")
@@ -1124,8 +1124,8 @@ func (node *WindowFrameBound) Format(ctx *FmtCtx) {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (node WindowFrameExclusion) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node WindowFrameExclusion) FormatImpl(ctx *FmtCtx) {
 	if node == NoExclusion {
 		return
 	}
@@ -1156,8 +1156,8 @@ func WindowModeName(mode WindowFrameMode) string {
 	}
 }
 
-// Format implements the NodeFormatter interface.
-func (node *WindowFrame) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *WindowFrame) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString(WindowModeName(node.Mode))
 	ctx.WriteByte(' ')
 	if node.Bounds.EndBound != nil {
@@ -1177,8 +1177,8 @@ func (node *WindowFrame) Format(ctx *FmtCtx) {
 // LockingClause represents a locking clause, like FOR UPDATE.
 type LockingClause []*LockingItem
 
-// Format implements the NodeFormatter interface.
-func (node *LockingClause) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *LockingClause) FormatImpl(ctx *FmtCtx) {
 	for _, n := range *node {
 		ctx.FormatNode(n)
 	}
@@ -1194,8 +1194,8 @@ type LockingItem struct {
 	WaitPolicy LockingWaitPolicy
 }
 
-// Format implements the NodeFormatter interface.
-func (f *LockingItem) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (f *LockingItem) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(f.Strength)
 	if len(f.Targets) > 0 {
 		ctx.WriteString(" OF ")
@@ -1236,8 +1236,8 @@ func (s LockingStrength) String() string {
 	return lockingStrengthName[s]
 }
 
-// Format implements the NodeFormatter interface.
-func (s LockingStrength) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (s LockingStrength) FormatImpl(ctx *FmtCtx) {
 	if s != ForNone {
 		ctx.WriteString(" ")
 		ctx.WriteString(s.String())
@@ -1278,8 +1278,8 @@ func (p LockingWaitPolicy) String() string {
 	return lockingWaitPolicyName[p]
 }
 
-// Format implements the NodeFormatter interface.
-func (p LockingWaitPolicy) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (p LockingWaitPolicy) FormatImpl(ctx *FmtCtx) {
 	if p != LockWaitBlock {
 		ctx.WriteString(" ")
 		ctx.WriteString(p.String())

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -28,8 +28,8 @@ type SetVar struct {
 	ResetAll bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SetVar) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetVar) FormatImpl(ctx *FmtCtx) {
 	if node.ResetAll {
 		ctx.WriteString("RESET ALL")
 		return
@@ -69,8 +69,8 @@ type SetClusterSetting struct {
 	Value Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SetClusterSetting) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetClusterSetting) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SET CLUSTER SETTING ")
 	// Cluster setting names never contain PII and should be distinguished
 	// for feature tracking purposes.
@@ -95,8 +95,8 @@ type SetTransaction struct {
 	Modes TransactionModes
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SetTransaction) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetTransaction) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SET TRANSACTION")
 	ctx.FormatNode(&node.Modes)
 }
@@ -106,8 +106,8 @@ func (node *SetTransaction) Format(ctx *FmtCtx) {
 // last position.
 type SetSessionAuthorizationDefault struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *SetSessionAuthorizationDefault) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetSessionAuthorizationDefault) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SET SESSION AUTHORIZATION DEFAULT")
 }
 
@@ -116,8 +116,8 @@ type SetSessionCharacteristics struct {
 	Modes TransactionModes
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SetSessionCharacteristics) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetSessionCharacteristics) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SET SESSION CHARACTERISTICS AS TRANSACTION")
 	ctx.FormatNode(&node.Modes)
 }
@@ -127,8 +127,8 @@ type SetTracing struct {
 	Values Exprs
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SetTracing) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetTracing) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SET TRACING = ")
 	// Set tracing values never contain PII and should be distinguished
 	// for feature tracking purposes.

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -30,8 +30,8 @@ type ShowVar struct {
 	Name string
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowVar) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowVar) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	// Session var names never contain PII and should be distinguished
 	// for feature tracking purposes.
@@ -45,8 +45,8 @@ type ShowClusterSetting struct {
 	Name string
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowClusterSetting) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowClusterSetting) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CLUSTER SETTING ")
 	// Cluster setting names never contain PII and should be distinguished
 	// for feature tracking purposes.
@@ -61,8 +61,8 @@ type ShowClusterSettingList struct {
 	All bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowClusterSettingList) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowClusterSettingList) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	qual := "PUBLIC"
 	if node.All {
@@ -96,8 +96,8 @@ type ShowBackup struct {
 	Options              KVOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowBackup) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowBackup) FormatImpl(ctx *FmtCtx) {
 	if node.InCollection != nil && node.Path == nil {
 		ctx.WriteString("SHOW BACKUPS IN ")
 		ctx.FormatNode(node.InCollection)
@@ -129,8 +129,8 @@ type ShowColumns struct {
 	WithComment bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowColumns) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowColumns) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW COLUMNS FROM ")
 	ctx.FormatNode(node.Table)
 
@@ -144,8 +144,8 @@ type ShowDatabases struct {
 	WithComment bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowDatabases) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowDatabases) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW DATABASES")
 
 	if node.WithComment {
@@ -158,16 +158,16 @@ type ShowEnums struct {
 	ObjectNamePrefix
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowEnums) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowEnums) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ENUMS")
 }
 
 // ShowTypes represents a SHOW TYPES statement.
 type ShowTypes struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *ShowTypes) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowTypes) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TYPES")
 }
 
@@ -187,8 +187,8 @@ type ShowTraceForSession struct {
 	Compact   bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowTraceForSession) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowTraceForSession) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	if node.Compact {
 		ctx.WriteString("COMPACT ")
@@ -203,8 +203,8 @@ type ShowIndexes struct {
 	WithComment bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowIndexes) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowIndexes) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW INDEXES FROM ")
 	ctx.FormatNode(node.Table)
 
@@ -219,8 +219,8 @@ type ShowDatabaseIndexes struct {
 	WithComment bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowDatabaseIndexes) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowDatabaseIndexes) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW INDEXES FROM DATABASE ")
 	ctx.FormatNode(&node.Database)
 
@@ -235,8 +235,8 @@ type ShowQueries struct {
 	Cluster bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowQueries) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowQueries) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	if node.All {
 		ctx.WriteString("ALL ")
@@ -266,8 +266,8 @@ type ShowJobs struct {
 	Schedules *Select
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowJobs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowJobs) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	if node.Automatic {
 		ctx.WriteString("AUTOMATIC ")
@@ -292,8 +292,8 @@ type ShowChangefeedJobs struct {
 	Jobs *Select
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowChangefeedJobs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowChangefeedJobs) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CHANGEFEED JOBS")
 	if node.Jobs != nil {
 		ctx.WriteString(" ")
@@ -306,8 +306,8 @@ type ShowSurvivalGoal struct {
 	DatabaseName Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowSurvivalGoal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowSurvivalGoal) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SURVIVAL GOAL FROM DATABASE")
 	if node.DatabaseName != "" {
 		ctx.WriteString(" ")
@@ -335,8 +335,8 @@ type ShowRegions struct {
 	DatabaseName    Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowRegions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowRegions) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW REGIONS")
 	switch node.ShowRegionsFrom {
 	case ShowRegionsFromDefault:
@@ -361,8 +361,8 @@ type ShowSessions struct {
 	Cluster bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowSessions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowSessions) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	if node.All {
 		ctx.WriteString("ALL ")
@@ -379,8 +379,8 @@ type ShowSchemas struct {
 	Database Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowSchemas) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowSchemas) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SCHEMAS")
 	if node.Database != "" {
 		ctx.WriteString(" FROM ")
@@ -393,8 +393,8 @@ type ShowSequences struct {
 	Database Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowSequences) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowSequences) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SEQUENCES")
 	if node.Database != "" {
 		ctx.WriteString(" FROM ")
@@ -408,8 +408,8 @@ type ShowTables struct {
 	WithComment bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowTables) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowTables) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TABLES")
 	if node.ExplicitSchema {
 		ctx.WriteString(" FROM ")
@@ -427,8 +427,8 @@ type ShowTransactions struct {
 	Cluster bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowTransactions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowTransactions) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ")
 	if node.All {
 		ctx.WriteString("ALL ")
@@ -446,8 +446,8 @@ type ShowConstraints struct {
 	WithComment bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowConstraints) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowConstraints) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CONSTRAINTS FROM ")
 	ctx.FormatNode(node.Table)
 
@@ -463,8 +463,8 @@ type ShowGrants struct {
 	Grantees RoleSpecList
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowGrants) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowGrants) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW GRANTS")
 	if node.Targets != nil {
 		ctx.WriteString(" ON ")
@@ -482,8 +482,8 @@ type ShowRoleGrants struct {
 	Grantees RoleSpecList
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowRoleGrants) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowRoleGrants) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW GRANTS ON ROLE")
 	if node.Roles != nil {
 		ctx.WriteString(" ")
@@ -515,8 +515,8 @@ type ShowCreate struct {
 	Name *UnresolvedObjectName
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowCreate) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowCreate) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ")
 
 	switch node.Mode {
@@ -529,24 +529,24 @@ func (node *ShowCreate) Format(ctx *FmtCtx) {
 // ShowCreateAllSchemas represents a SHOW CREATE ALL SCHEMAS statement.
 type ShowCreateAllSchemas struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *ShowCreateAllSchemas) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowCreateAllSchemas) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ALL SCHEMAS")
 }
 
 // ShowCreateAllTables represents a SHOW CREATE ALL TABLES statement.
 type ShowCreateAllTables struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *ShowCreateAllTables) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowCreateAllTables) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ALL TABLES")
 }
 
 // ShowCreateAllTypes represents a SHOW CREATE ALL TYPES statement.
 type ShowCreateAllTypes struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *ShowCreateAllTypes) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowCreateAllTypes) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ALL TYPES")
 }
 
@@ -555,8 +555,8 @@ type ShowCreateSchedules struct {
 	ScheduleID Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowCreateSchedules) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowCreateSchedules) FormatImpl(ctx *FmtCtx) {
 	if node.ScheduleID != nil {
 		ctx.WriteString("SHOW CREATE SCHEDULE ")
 		ctx.FormatNode(node.ScheduleID)
@@ -574,8 +574,8 @@ type ShowSyntax struct {
 	Statement string
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowSyntax) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowSyntax) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SYNTAX ")
 	if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
 		ctx.WriteString("'_'")
@@ -588,8 +588,8 @@ func (node *ShowSyntax) Format(ctx *FmtCtx) {
 type ShowTransactionStatus struct {
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowTransactionStatus) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowTransactionStatus) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TRANSACTION STATUS")
 }
 
@@ -610,8 +610,8 @@ var ShowLastQueryStatisticsDefaultColumns = NameList([]Name{
 	"post_commit_jobs_latency",
 })
 
-// Format implements the NodeFormatter interface.
-func (node *ShowLastQueryStatistics) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowLastQueryStatistics) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW LAST QUERY STATISTICS RETURNING ")
 	// The column names for this statement never contain PII and should
 	// be distinguished for feature tracking purposes.
@@ -624,8 +624,8 @@ func (node *ShowLastQueryStatistics) Format(ctx *FmtCtx) {
 type ShowFullTableScans struct {
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowFullTableScans) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowFullTableScans) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW FULL TABLE SCANS")
 }
 
@@ -633,8 +633,8 @@ func (node *ShowFullTableScans) Format(ctx *FmtCtx) {
 type ShowSavepointStatus struct {
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowSavepointStatus) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowSavepointStatus) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW SAVEPOINT STATUS")
 }
 
@@ -642,8 +642,8 @@ func (node *ShowSavepointStatus) Format(ctx *FmtCtx) {
 type ShowUsers struct {
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowUsers) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowUsers) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW USERS")
 }
 
@@ -651,8 +651,8 @@ func (node *ShowUsers) Format(ctx *FmtCtx) {
 type ShowRoles struct {
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowRoles) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowRoles) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW ROLES")
 }
 
@@ -662,8 +662,8 @@ type ShowRanges struct {
 	DatabaseName Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowRanges) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowRanges) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW RANGES FROM ")
 	if node.DatabaseName != "" {
 		ctx.WriteString("DATABASE ")
@@ -683,8 +683,8 @@ type ShowRangeForRow struct {
 	Row          Exprs
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowRangeForRow) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowRangeForRow) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW RANGE FROM ")
 	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
@@ -702,8 +702,8 @@ type ShowFingerprints struct {
 	Table *UnresolvedObjectName
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowFingerprints) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowFingerprints) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
 	ctx.FormatNode(node.Table)
 }
@@ -714,8 +714,8 @@ type ShowTableStats struct {
 	UsingJSON bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowTableStats) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowTableStats) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW STATISTICS ")
 	if node.UsingJSON {
 		ctx.WriteString("USING JSON ")
@@ -729,8 +729,8 @@ type ShowHistogram struct {
 	HistogramID int64
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowHistogram) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowHistogram) FormatImpl(ctx *FmtCtx) {
 	ctx.Printf("SHOW HISTOGRAM %d", node.HistogramID)
 }
 
@@ -746,8 +746,8 @@ type ShowPartitions struct {
 	Table   *UnresolvedObjectName
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowPartitions) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowPartitions) FormatImpl(ctx *FmtCtx) {
 	if node.IsDB {
 		ctx.Printf("SHOW PARTITIONS FROM DATABASE ")
 		ctx.FormatNode(&node.Database)
@@ -817,8 +817,8 @@ const (
 	PausedSchedules
 )
 
-// Format implements the NodeFormatter interface.
-func (s ScheduleState) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (s ScheduleState) FormatImpl(ctx *FmtCtx) {
 	switch s {
 	case ActiveSchedules:
 		ctx.WriteString("RUNNING")
@@ -838,8 +838,8 @@ type ShowSchedules struct {
 
 var _ Statement = &ShowSchedules{}
 
-// Format implements the NodeFormatter interface.
-func (n *ShowSchedules) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ShowSchedules) FormatImpl(ctx *FmtCtx) {
 	if n.ScheduleID != nil {
 		ctx.WriteString("SHOW SCHEDULE ")
 		ctx.FormatNode(n.ScheduleID)
@@ -869,8 +869,8 @@ type ShowDefaultPrivileges struct {
 
 var _ Statement = &ShowDefaultPrivileges{}
 
-// Format implements the NodeFormatter interface.
-func (n *ShowDefaultPrivileges) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *ShowDefaultPrivileges) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SHOW DEFAULT PRIVILEGES ")
 	if len(n.Roles) > 0 {
 		ctx.WriteString("FOR ROLE ")

--- a/pkg/sql/sem/tree/split.go
+++ b/pkg/sql/sem/tree/split.go
@@ -21,8 +21,8 @@ type Split struct {
 	ExpireExpr Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Split) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Split) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
 	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
@@ -47,8 +47,8 @@ type Unsplit struct {
 	All  bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Unsplit) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Unsplit) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
 	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
@@ -77,8 +77,8 @@ type Relocate struct {
 	SubjectReplicas RelocateSubject
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Relocate) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Relocate) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
 	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")
@@ -102,8 +102,8 @@ type Scatter struct {
 	From, To Exprs
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Scatter) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Scatter) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
 	if node.TableOrIndex.Index != "" {
 		ctx.WriteString("INDEX ")

--- a/pkg/sql/sem/tree/stream_ingestion.go
+++ b/pkg/sql/sem/tree/stream_ingestion.go
@@ -19,8 +19,8 @@ type StreamIngestion struct {
 
 var _ Statement = &StreamIngestion{}
 
-// Format implements the NodeFormatter interface.
-func (node *StreamIngestion) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *StreamIngestion) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("RESTORE ")
 	ctx.FormatNode(&node.Targets)
 	ctx.WriteString(" ")

--- a/pkg/sql/sem/tree/survival_goal.go
+++ b/pkg/sql/sem/tree/survival_goal.go
@@ -28,8 +28,8 @@ const (
 	SurvivalGoalZoneFailure
 )
 
-// Format implements the NodeFormatter interface.
-func (node *SurvivalGoal) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SurvivalGoal) FormatImpl(ctx *FmtCtx) {
 	switch *node {
 	case SurvivalGoalRegionFailure:
 		ctx.WriteString("SURVIVE REGION FAILURE")

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -26,13 +26,13 @@ type TableName struct {
 	objName
 }
 
-// Format implements the NodeFormatter interface.
-func (t *TableName) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (t *TableName) FormatImpl(ctx *FmtCtx) {
 	if ctx.tableNameFormatter != nil {
 		ctx.tableNameFormatter(ctx, t)
 		return
 	}
-	t.ObjectNamePrefix.Format(ctx)
+	t.ObjectNamePrefix.FormatImpl(ctx)
 	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
 		ctx.WriteByte('.')
 	}
@@ -130,8 +130,8 @@ func makeObjectNamePrefixFromUnresolvedName(n *UnresolvedName) ObjectNamePrefix 
 // of table names.
 type TableNames []TableName
 
-// Format implements the NodeFormatter interface.
-func (ts *TableNames) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (ts *TableNames) FormatImpl(ctx *FmtCtx) {
 	sep := ""
 	for i := range *ts {
 		ctx.WriteString(sep)
@@ -160,8 +160,8 @@ type TableIndexName struct {
 	Index UnrestrictedName
 }
 
-// Format implements the NodeFormatter interface.
-func (n *TableIndexName) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *TableIndexName) FormatImpl(ctx *FmtCtx) {
 	if n.Index == "" {
 		ctx.FormatNode(&n.Table)
 		return
@@ -190,8 +190,8 @@ func (n *TableIndexName) String() string { return AsString(n) }
 // TableIndexNames is a list of indexes.
 type TableIndexNames []*TableIndexName
 
-// Format implements the NodeFormatter interface.
-func (n *TableIndexNames) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *TableIndexNames) FormatImpl(ctx *FmtCtx) {
 	sep := ""
 	for _, tni := range *n {
 		ctx.WriteString(sep)

--- a/pkg/sql/sem/tree/table_pattern.go
+++ b/pkg/sql/sem/tree/table_pattern.go
@@ -55,9 +55,9 @@ type AllTablesSelector struct {
 	ObjectNamePrefix
 }
 
-// Format implements the NodeFormatter interface.
-func (at *AllTablesSelector) Format(ctx *FmtCtx) {
-	at.ObjectNamePrefix.Format(ctx)
+// FormatImpl implements the NodeFormatter interface.
+func (at *AllTablesSelector) FormatImpl(ctx *FmtCtx) {
+	at.ObjectNamePrefix.FormatImpl(ctx)
 	if at.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
 		ctx.WriteByte('.')
 	}
@@ -72,8 +72,8 @@ func (at *AllTablesSelector) NormalizeTablePattern() (TablePattern, error) { ret
 // Used by e.g. the GRANT statement.
 type TablePatterns []TablePattern
 
-// Format implements the NodeFormatter interface.
-func (tt *TablePatterns) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (tt *TablePatterns) FormatImpl(ctx *FmtCtx) {
 	for i, t := range *tt {
 		if i > 0 {
 			ctx.WriteString(", ")

--- a/pkg/sql/sem/tree/table_ref.go
+++ b/pkg/sql/sem/tree/table_ref.go
@@ -35,8 +35,8 @@ type TableRef struct {
 	As AliasClause
 }
 
-// Format implements the NodeFormatter interface.
-func (n *TableRef) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (n *TableRef) FormatImpl(ctx *FmtCtx) {
 	ctx.Printf("[%d", n.TableID)
 	if n.Columns != nil {
 		ctx.WriteByte('(')

--- a/pkg/sql/sem/tree/truncate.go
+++ b/pkg/sql/sem/tree/truncate.go
@@ -25,8 +25,8 @@ type Truncate struct {
 	DropBehavior DropBehavior
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Truncate) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Truncate) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("TRUNCATE TABLE ")
 	sep := ""
 	for i := range node.Tables {

--- a/pkg/sql/sem/tree/txn.go
+++ b/pkg/sql/sem/tree/txn.go
@@ -139,8 +139,8 @@ type TransactionModes struct {
 	Deferrable    DeferrableMode
 }
 
-// Format implements the NodeFormatter interface.
-func (node *TransactionModes) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *TransactionModes) FormatImpl(ctx *FmtCtx) {
 	var sep string
 	if node.Isolation != UnspecifiedIsolation {
 		ctx.Printf(" ISOLATION LEVEL %s", node.Isolation)
@@ -224,8 +224,8 @@ type BeginTransaction struct {
 	Modes TransactionModes
 }
 
-// Format implements the NodeFormatter interface.
-func (node *BeginTransaction) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *BeginTransaction) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("BEGIN TRANSACTION")
 	ctx.FormatNode(&node.Modes)
 }
@@ -233,16 +233,16 @@ func (node *BeginTransaction) Format(ctx *FmtCtx) {
 // CommitTransaction represents a COMMIT statement.
 type CommitTransaction struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *CommitTransaction) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *CommitTransaction) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("COMMIT TRANSACTION")
 }
 
 // RollbackTransaction represents a ROLLBACK statement.
 type RollbackTransaction struct{}
 
-// Format implements the NodeFormatter interface.
-func (node *RollbackTransaction) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RollbackTransaction) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ROLLBACK TRANSACTION")
 }
 
@@ -251,8 +251,8 @@ type Savepoint struct {
 	Name Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Savepoint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Savepoint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("SAVEPOINT ")
 	ctx.FormatNode(&node.Name)
 }
@@ -262,8 +262,8 @@ type ReleaseSavepoint struct {
 	Savepoint Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ReleaseSavepoint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ReleaseSavepoint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("RELEASE SAVEPOINT ")
 	ctx.FormatNode(&node.Savepoint)
 }
@@ -273,8 +273,8 @@ type RollbackToSavepoint struct {
 	Savepoint Name
 }
 
-// Format implements the NodeFormatter interface.
-func (node *RollbackToSavepoint) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *RollbackToSavepoint) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ROLLBACK TRANSACTION TO SAVEPOINT ")
 	ctx.FormatNode(&node.Savepoint)
 }

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -40,8 +40,8 @@ func (t *TypeName) Type() string {
 	return string(t.ObjectName)
 }
 
-// Format implements the NodeFormatter interface.
-func (t *TypeName) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (t *TypeName) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(&t.ObjectNamePrefix)
 	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
 		ctx.WriteByte('.')
@@ -238,8 +238,8 @@ type ArrayTypeReference struct {
 	ElementType ResolvableTypeReference
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ArrayTypeReference) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ArrayTypeReference) FormatImpl(ctx *FmtCtx) {
 	if typ, ok := GetStaticallyKnownType(node.ElementType); ok {
 		ctx.FormatTypeReference(types.MakeArray(typ))
 	} else {

--- a/pkg/sql/sem/tree/union.go
+++ b/pkg/sql/sem/tree/union.go
@@ -51,8 +51,8 @@ func (i UnionType) String() string {
 	return unionTypeName[i]
 }
 
-// Format implements the NodeFormatter interface.
-func (node *UnionClause) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *UnionClause) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.Left)
 	ctx.WriteByte(' ')
 	ctx.WriteString(node.Type.String())

--- a/pkg/sql/sem/tree/update.go
+++ b/pkg/sql/sem/tree/update.go
@@ -31,8 +31,8 @@ type Update struct {
 	Returning ReturningClause
 }
 
-// Format implements the NodeFormatter interface.
-func (node *Update) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *Update) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(node.With)
 	ctx.WriteString("UPDATE ")
 	ctx.FormatNode(node.Table)
@@ -63,8 +63,8 @@ func (node *Update) Format(ctx *FmtCtx) {
 // UpdateExprs represents a list of update expressions.
 type UpdateExprs []*UpdateExpr
 
-// Format implements the NodeFormatter interface.
-func (node *UpdateExprs) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *UpdateExprs) FormatImpl(ctx *FmtCtx) {
 	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(", ")
@@ -80,8 +80,8 @@ type UpdateExpr struct {
 	Expr  Expr
 }
 
-// Format implements the NodeFormatter interface.
-func (node *UpdateExpr) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *UpdateExpr) FormatImpl(ctx *FmtCtx) {
 	open, close := "", ""
 	if node.Tuple {
 		open, close = "(", ")"

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -24,8 +24,8 @@ type ValuesClause struct {
 	Rows []Exprs
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ValuesClause) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ValuesClause) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("VALUES ")
 	comma := ""
 	for i := range node.Rows {

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -50,9 +50,9 @@ var _ VarName = &ColumnItem{}
 // expression.
 type UnqualifiedStar struct{}
 
-// Format implements the NodeFormatter interface.
-func (UnqualifiedStar) Format(ctx *FmtCtx) { ctx.WriteByte('*') }
-func (u UnqualifiedStar) String() string   { return AsString(u) }
+// FormatImpl implements the NodeFormatter interface.
+func (UnqualifiedStar) FormatImpl(ctx *FmtCtx) { ctx.WriteByte('*') }
+func (u UnqualifiedStar) String() string       { return AsString(u) }
 
 // NormalizeVarName implements the VarName interface.
 func (u UnqualifiedStar) NormalizeVarName() (VarName, error) { return u, nil }
@@ -96,8 +96,8 @@ type AllColumnsSelector struct {
 	TableName *UnresolvedObjectName
 }
 
-// Format implements the NodeFormatter interface.
-func (a *AllColumnsSelector) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (a *AllColumnsSelector) FormatImpl(ctx *FmtCtx) {
 	ctx.FormatNode(a.TableName)
 	ctx.WriteString(".*")
 }
@@ -130,9 +130,9 @@ type ColumnItem struct {
 	ColumnName Name
 }
 
-// Format implements the NodeFormatter interface.
+// FormatImpl implements the NodeFormatter interface.
 // If this is updated, then dummyColumnItem.Format should be updated as well.
-func (c *ColumnItem) Format(ctx *FmtCtx) {
+func (c *ColumnItem) FormatImpl(ctx *FmtCtx) {
 	if c.TableName != nil {
 		ctx.FormatNode(c.TableName)
 		ctx.WriteByte('.')

--- a/pkg/sql/sem/tree/with.go
+++ b/pkg/sql/sem/tree/with.go
@@ -32,8 +32,8 @@ type MaterializeClause struct {
 	Materialize bool
 }
 
-// Format implements the NodeFormatter interface.
-func (node *With) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *With) FormatImpl(ctx *FmtCtx) {
 	if node == nil {
 		return
 	}

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -59,8 +59,8 @@ func (node ZoneSpecifier) TargetsPartition() bool {
 	return node.TargetsTable() && node.Partition != ""
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ZoneSpecifier) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ZoneSpecifier) FormatImpl(ctx *FmtCtx) {
 	if node.NamedZone != "" {
 		ctx.WriteString("RANGE ")
 		ctx.FormatNode(&node.NamedZone)
@@ -90,8 +90,8 @@ type ShowZoneConfig struct {
 	ZoneSpecifier
 }
 
-// Format implements the NodeFormatter interface.
-func (node *ShowZoneConfig) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *ShowZoneConfig) FormatImpl(ctx *FmtCtx) {
 	if node.ZoneSpecifier == (ZoneSpecifier{}) {
 		ctx.WriteString("SHOW ZONE CONFIGURATIONS")
 	} else {
@@ -112,8 +112,8 @@ type SetZoneConfig struct {
 	Options    KVOptions
 }
 
-// Format implements the NodeFormatter interface.
-func (node *SetZoneConfig) Format(ctx *FmtCtx) {
+// FormatImpl implements the NodeFormatter interface.
+func (node *SetZoneConfig) FormatImpl(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
 	ctx.FormatNode(&node.ZoneSpecifier)
 	ctx.WriteString(" CONFIGURE ZONE ")

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -52,7 +52,7 @@ func (n *unsplitNode) Next(params runParams) (bool, error) {
 
 	if err := params.extendedEvalCtx.ExecCfg.DB.AdminUnsplit(params.ctx, rowKey); err != nil {
 		ctx := params.p.EvalContext().FmtCtx(tree.FmtSimple)
-		row.Format(ctx)
+		row.FormatImpl(ctx)
 		return false, errors.Wrapf(err, "could not UNSPLIT AT %s", ctx)
 	}
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -103,9 +103,9 @@ func (w *windowFuncHolder) samePartition(other *windowFuncHolder) bool {
 
 func (*windowFuncHolder) Variable() {}
 
-func (w *windowFuncHolder) Format(ctx *tree.FmtCtx) {
+func (w *windowFuncHolder) FormatImpl(ctx *tree.FmtCtx) {
 	// Avoid duplicating the type annotation by calling .Format directly.
-	w.expr.Format(ctx)
+	w.expr.FormatImpl(ctx)
 }
 
 func (w *windowFuncHolder) String() string { return tree.AsString(w) }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/60797

Using FormatImpl incorrectly could lead to statements not being anonymized
properly.