### PR TITLE
roachtest: heap profile tpccbench every 15s

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -845,6 +845,9 @@ func (s tpccBenchSpec) startOpts() (option.StartOpts, install.ClusterSettings) {
 	startOpts := option.DefaultStartOpts()
 	startOpts.RoachtestOpts.DontEncrypt = true
 	settings := install.MakeClusterSettings()
+	// Facilitate diagnosing out-of-memory conditions in tpccbench runs.
+	// See https://github.com/cockroachdb/cockroach/issues/75071.
+	settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=15s")
 	if s.LoadConfig == singlePartitionedLoadgen {
 		settings.NumRacks = s.partitions()
 	}


### PR DESCRIPTION
Can hopefully help understand
https://github.com/cockroachdb/cockroach/issues/75071.

Release note: None
