### PR TITLE
roachtest: deflake kv50/rangelookups/relocate

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -51,6 +51,7 @@ func IsExpectedRelocateError(err error) bool {
 		"descriptor changed",
 		"unable to remove replica .* which is not present",
 		"unable to add replica .* which is already present",
+		"none of the remaining voters .* are legal additions", // https://github.com/cockroachdb/cockroach/issues/74902
 		"received invalid ChangeReplicasTrigger .* to remove self",
 		"raft group deleted",
 		"snapshot failed",


### PR DESCRIPTION
Touches #74902.

Backport to 21.2 will close it.

Release note: None
