### PR TITLE
backupccl: call AllocateIDs after adding index mutations

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1853,6 +1853,9 @@ func (r *restoreResumer) publishDescriptors(
 				return err
 			}
 		}
+		if err := mutTable.AllocateIDs(ctx); err != nil {
+			return err
+		}
 		allMutDescs = append(allMutDescs, mutTable)
 		newTables = append(newTables, mutTable.TableDesc())
 		// For cluster restores, all the jobs are restored directly from the jobs


### PR DESCRIPTION
While we expect that all of the index mutations added here to have
fully populated IDs and columns. Changes to the AddIndexMutation API
will soon require that AllocateIDs is called after any add index
mutation.

Release note: None