### PR TITLE
sql: deflake TestTelemetry

### DIFF
--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -180,13 +180,17 @@ SELECT * FROM (VALUES (1), (2)) AS a(x) JOIN LATERAL (SELECT a.x+1 AS x) AS b ON
 sql.plan.lateral-join
 
 feature-allowlist
-sql.plan.subquery.*
+sql.plan.subquery
 ----
 
 feature-usage
 SELECT 1 = (SELECT a FROM x LIMIT 1)
 ----
 sql.plan.subquery
+
+feature-allowlist
+sql.plan.subquery.correlated
+----
 
 feature-usage
 SELECT x FROM (VALUES (1)) AS b(x) WHERE EXISTS(SELECT * FROM (VALUES (1)) AS a(x) WHERE a.x = b.x)


### PR DESCRIPTION
This commit deflakes TestTelemetry by adding a more precise
feature-allowlist.

Fixes #75190

Release note: None