### PR TITLE
cmd/github-post: fix Pebble metamorphic reproduction command

### DIFF
--- a/build/teamcity-nightly-pebble-metamorphic.sh
+++ b/build/teamcity-nightly-pebble-metamorphic.sh
@@ -43,6 +43,10 @@ mkdir -p $ARTIFACTS_DIR
 # Use an `if` so that the `-e` option doesn't stop the script on error.
 pushd ./vendor/github.com/cockroachdb/pebble/internal/metamorphic
 if ! stdbuf -oL -eL \
+
+  # NB: If adjusting the metamorphic test flags below, be sure to also update
+  # pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
+  # correct flags in the reproduction command.
   go test -mod=vendor -exec "stress ${STRESSFLAGS}" -run 'TestMeta$$' \
   -timeout 0 -tags 'invariants' -test.v \
   -dir $ARTIFACTS_DIR -ops "uniform:5000-25000" 2>&1 | tee $ARTIFACTS_DIR/metamorphic.log; then

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -542,7 +542,7 @@ func formatPebbleMetamorphicIssue(
 			s = strings.TrimSpace(s[:strings.Index(s, "\n")])
 
 			repro = fmt.Sprintf("go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' "+
-				"-timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed %s", s)
+				`-timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed %s -ops "uniform:5000-25000"`, s)
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -235,7 +235,7 @@ TestXXA - 1.00s
 					testName: "TestMeta",
 					title:    "internal/metamorphic: TestMeta failed",
 					message:  "panic: induced panic",
-					expRepro: "go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000",
+					expRepro: `go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-25000"`,
 				},
 			},
 			formatter: formatPebbleMetamorphicIssue,


### PR DESCRIPTION
When posting a github issue for a Pebble metamorphic test failure, include the
correct `-ops` flag.

Discovered because cockroachdb/pebble#1459 contained a
reproduction command that contained too few ops to reproduce the issue.

Release note: none