### PR TITLE
backupccl: disable span configs for full cluster restore jobs test

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -48,6 +48,7 @@ func TestFullClusterBackup(t *testing.T) {
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			DisableSpanConfigs: true, // TODO(irfansharif): #75060.
 			Knobs: base.TestingKnobs{
 				SpanConfig: &spanconfig.TestingKnobs{
 					// We compare job progress before and after a restore. Disable


### PR DESCRIPTION
Release note: None

Related https://github.com/cockroachdb/cockroach/issues/75216