### PR TITLE
kvserver: disable sendWithRangeID call stack

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12667,7 +12667,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 
 	// Round trip another proposal through the replica to ensure that previously
 	// committed entries have been applied.
-	_, pErr = tc.repl.sendWithRangeID(ctx, tc.repl.RangeID, &ba)
+	_, pErr = tc.repl.sendWithoutRangeID(ctx, &ba)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}


### PR DESCRIPTION
Sadly, this on longer embeds the RangeID in the stack trace (likely
culprit: Go adopting a register-based calling convention) Instead, you
get garbage values that often are obviously garbage, but this may not
always be true. We want to avoid being misled, so for now remove the
rangeID here and explain when it can come back.

See: https://cockroachlabs.slack.com/archives/G01G8LK77DK/p1641478596004700

Release note: None
