### PR TITLE
cli,rpc: don't check the active cluster version in the CLI

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1229,6 +1229,8 @@ func getClientGRPCConn(
 			Clock:    clock,
 			Stopper:  stopper,
 			Settings: cfg.Settings,
+
+			ClientOnly: true,
 		})
 	if cfg.TestingKnobs.Server != nil {
 		rpcContext.Knobs = cfg.TestingKnobs.Server.(*server.TestingKnobs).ContextTestingKnobs


### PR DESCRIPTION
This commit removes a code path that would tickle an assertion failure
if we were to later fix the context propagation in the RPC heartbeat
method (see PR #71243): there's no "active cluster version" in the CLI
and so we can't compare it in a client interceptor.

Release note: None