### PR TITLE
workload: Ignore transaction restart errors.

### DIFF
--- a/pkg/workload/pgx_helpers.go
+++ b/pkg/workload/pgx_helpers.go
@@ -69,6 +69,13 @@ func (p pgxLogger) Log(
 		// are expected and noisy.
 		return
 	}
+	// data may contain error with "restart transaction" -- skip those as well.
+	if data != nil {
+		ev := data["err"]
+		if err, ok := ev.(error); ok && strings.Contains(err.Error(), "restart transaction") {
+			return
+		}
+	}
 	log.Infof(ctx, "pgx logger [%s]: %s logParams=%v", level.String(), msg, data)
 }
 


### PR DESCRIPTION
Update pgx helpers to ignore "restart transactions" errors.
Previsouly, these were sent via a "msg" portion of the Log call.
It appears that these messages may also arrive in the "data".

Release Notes: None