### PR TITLE
kvserver: use EncodedError in SnapshotResponse

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverpb/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/hlc",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -38,6 +39,7 @@ proto_library(
         "//pkg/storage/enginepb:enginepb_proto",
         "//pkg/util/hlc:hlc_proto",
         "//pkg/util/tracing/tracingpb:tracingpb_proto",
+        "@com_github_cockroachdb_errors//errorspb:errorspb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@io_etcd_go_etcd_raft_v3//raftpb:raftpb_proto",
@@ -59,6 +61,7 @@ go_proto_library(
         "//pkg/util/hlc",
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",  # keep
+        "@com_github_cockroachdb_errors//errorspb",
         "@com_github_gogo_protobuf//gogoproto",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],

--- a/pkg/kv/kvserver/kvserverpb/raft.go
+++ b/pkg/kv/kvserver/kvserverpb/raft.go
@@ -10,5 +10,33 @@
 
 package kvserverpb
 
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+)
+
 // SafeValue implements the redact.SafeValue interface.
 func (SnapshotRequest_Type) SafeValue() {}
+
+// Error returns the error contained in the snapshot response, if any.
+//
+// The bool indicates whether this message uses the deprecated behavior of
+// encoding an error as a string.
+func (m *DelegateSnapshotResponse) Error() (deprecated bool, _ error) {
+	return m.SnapResponse.Error()
+}
+
+// Error returns the error contained in the snapshot response, if any.
+//
+// The bool indicates whether this message uses the deprecated behavior of
+// encoding an error as a string.
+func (m *SnapshotResponse) Error() (deprecated bool, _ error) {
+	if m.Status != SnapshotResponse_ERROR {
+		return false, nil
+	}
+	if m.EncodedError.IsSet() {
+		return false, errors.DecodeError(context.Background(), m.EncodedError)
+	}
+	return true, errors.Newf("%s", m.DeprecatedMessage)
+}

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 package cockroach.kv.kvserver.kvserverpb;
 option go_package = "kvserverpb";
 
+import "errorspb/errors.proto";
 import "roachpb/errors.proto";
 import "roachpb/internal_raft.proto";
 import "roachpb/metadata.proto";
@@ -237,11 +238,22 @@ message SnapshotResponse {
     reserved 4;
   }
   Status status = 1;
-  string message = 2;
+  // Message is a message explaining an ERROR return value. It is not set for any
+  // other status.
+  //
+  // As of 23.1, the encoded_error field is always used instead. 23.1 itself
+  // needs to populate both due to needing to be compatible with 22.2. Once
+  // the MinSupportedVersion is 23.1, this can be removed.
+  string deprecated_message = 2;
   reserved 3;
 
   // Traces from snapshot processing, returned on status APPLIED or ERROR.
   repeated util.tracing.tracingpb.RecordedSpan collected_spans = 4 [(gogoproto.nullable) = false];
+
+  // encoded_error encodes the error when the status is ERROR.
+  //
+  // MIGRATION: only guaranteed to be set when the message field is no longer there.
+  errorspb.EncodedError encoded_error = 5 [(gogoproto.nullable) = false];
 }
 
 // DelegateSnapshotRequest is the request used to delegate send snapshot requests.

--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -15,6 +15,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// errMarkSnapshotError is used as an error mark for errors that get returned
+// to the initiator of a snapshot. This generally classifies errors as transient,
+// i.e. communicates an intention for the caller to retry.
+//
 // NB: don't change the string here; this will cause cross-version issues
 // since this singleton is used as a marker.
 var errMarkSnapshotError = errors.New("snapshot failed")

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2723,11 +2723,12 @@ func (r *Replica) sendSnapshot(
 			)
 		},
 	)
-
-	if err != nil {
-		return errors.Mark(err, errMarkSnapshotError)
+	// Only mark explicitly as snapshot error (which is retriable) if we timed out.
+	// Otherwise, it's up to the remote to add this mark where appropriate.
+	if errors.HasType(err, (*contextutil.TimeoutError)(nil)) {
+		err = errors.Mark(err, errMarkSnapshotError)
 	}
-	return nil
+	return err
 }
 
 // followerSnapshotsEnabled is used to enable or disable follower snapshots.
@@ -2882,7 +2883,7 @@ func (r *Replica) followerSendSnapshot(
 		}
 	}
 
-	err = contextutil.RunWithTimeout(
+	return contextutil.RunWithTimeout(
 		ctx, "send-snapshot", sendSnapshotTimeout, func(ctx context.Context) error {
 			return r.store.cfg.Transport.SendSnapshot(
 				ctx,
@@ -2895,20 +2896,6 @@ func (r *Replica) followerSendSnapshot(
 			)
 		},
 	)
-	if err != nil {
-		if errors.Is(err, errMalformedSnapshot) {
-			tag := fmt.Sprintf("r%d_%s", r.RangeID, snap.SnapUUID.Short())
-			if dir, err := r.store.checkpoint(ctx, tag); err != nil {
-				log.Warningf(ctx, "unable to create checkpoint %s: %+v", dir, err)
-			} else {
-				log.Warningf(ctx, "created checkpoint %s", dir)
-			}
-
-			log.Fatal(ctx, "malformed snapshot generated")
-		}
-		return errors.Mark(err, errMarkSnapshotError)
-	}
-	return nil
 }
 
 // replicasCollocated is used in AdminMerge to ensure that the ranges are

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -180,10 +180,7 @@ func (s *Store) HandleDelegatedSnapshot(
 	if err := sender.followerSendSnapshot(ctx, req.RecipientReplica, req, stream); err != nil {
 		return stream.Send(
 			&kvserverpb.DelegateSnapshotResponse{
-				SnapResponse: &kvserverpb.SnapshotResponse{
-					Status:  kvserverpb.SnapshotResponse_ERROR,
-					Message: err.Error(),
-				},
+				SnapResponse:   snapRespErr(err),
 				CollectedSpans: sp.GetConfiguredRecording(),
 			},
 		)
@@ -191,8 +188,8 @@ func (s *Store) HandleDelegatedSnapshot(
 
 	resp := &kvserverpb.DelegateSnapshotResponse{
 		SnapResponse: &kvserverpb.SnapshotResponse{
-			Status:  kvserverpb.SnapshotResponse_APPLIED,
-			Message: "Snapshot successfully applied by recipient",
+			Status:            kvserverpb.SnapshotResponse_APPLIED,
+			DeprecatedMessage: "Snapshot successfully applied by recipient",
 		},
 		CollectedSpans: sp.GetConfiguredRecording(),
 	}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2911,7 +2911,8 @@ func TestSendSnapshotThrottling(t *testing.T) {
 	{
 		sp := &fakeStorePool{}
 		resp := &kvserverpb.SnapshotResponse{
-			Status: kvserverpb.SnapshotResponse_ERROR,
+			Status:       kvserverpb.SnapshotResponse_ERROR,
+			EncodedError: errors.EncodeError(ctx, errors.New("boom")),
 		}
 		c := fakeSnapshotStream{resp, nil}
 		err := sendSnapshot(


### PR DESCRIPTION
We were previously using a "Message" string to indicate details about an
error. We can do so much better now and actually encode the error. This
wasn't possible when this field was first added, but it is now, so let's
use it. As always, there's a migration concern, which means the old
field stays around & is populated as well as interpreted for one
release.

We then use this new-found freedom to improve which errors were marked
as "failed snapshot" errors. Previously, any error coming in on a
`SnapshotResponse` were considered snapshot errors and were considered
retriable. This was causing `TestLearnerSnapshotFailsRollback` to run
for 90s, as `TestCluster`'s replication changes use a [SucceedsSoon] to
retry snapshot errors - but that test actually injects an error that it
wants to fail-fast.  Now, since snapshot error marks propagate over the
wire, we can do the marking on the *sender* of the SnapshotResponse, and
we can only mark messages that correspond to an actual failure to apply
the snapshot (as opposed to an injected error, or a hard error due to a
malformed request). The test now takes around one second, for a rare 90x
speed-up.

As a drive-by, we're also removing `errMalformedSnapshot`, which became
unused when we stopped sending the raft log in raft snaps a few releases
back, and which had managed to hide from the `unused` lint.

[SucceedsSoon]: https://github.com/cockroachdb/cockroach/blob/37175f77bf374d1bcb76bc39a65149788be06134/pkg/testutils/testcluster/testcluster.go#L628-L631

Fixes #74621.
Fixes #87337.

Release note: None
