### PR TITLE
kvserver: segregate replica metrics in the replicateQueue

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -185,6 +185,17 @@ const (
 	nonVoterTarget
 )
 
+// replicaStatus represents whether a replica is currently alive,
+// dead or decommissioning.
+type replicaStatus int
+
+const (
+	_ replicaStatus = iota
+	alive
+	dead
+	decommissioning
+)
+
 // AddChangeType returns the roachpb.ReplicaChangeType corresponding to the
 // given targetReplicaType.
 //

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -60,11 +60,22 @@ var MinLeaseTransferInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
-// TODO(aayush): Expand this metric set to include metrics about non-voting replicas.
 var (
 	metaReplicateQueueAddReplicaCount = metric.Metadata{
 		Name:        "queue.replicate.addreplica",
 		Help:        "Number of replica additions attempted by the replicate queue",
+		Measurement: "Replica Additions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueAddVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.addvoterreplica",
+		Help:        "Number of voter replica additions attempted by the replicate queue",
+		Measurement: "Replica Additions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueAddNonVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.addnonvoterreplica",
+		Help:        "Number of non-voter replica additions attempted by the replicate queue",
 		Measurement: "Replica Additions",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -74,9 +85,51 @@ var (
 		Measurement: "Replica Removals",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaReplicateQueueRemoveVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removevoterreplica",
+		Help:        "Number of voter replica removals attempted by the replicate queue (typically in response to a rebalancer-initiated addition)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRemoveNonVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removenonvoterreplica",
+		Help:        "Number of non-voter replica removals attempted by the replicate queue (typically in response to a rebalancer-initiated addition)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaReplicateQueueRemoveDeadReplicaCount = metric.Metadata{
 		Name:        "queue.replicate.removedeadreplica",
 		Help:        "Number of dead replica removals attempted by the replicate queue (typically in response to a node outage)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRemoveDeadVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removedeadvoterreplica",
+		Help:        "Number of dead voter replica removals attempted by the replicate queue (typically in response to a node outage)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRemoveDeadNonVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removedeadnonvoterreplica",
+		Help:        "Number of dead non-voter replica removals attempted by the replicate queue (typically in response to a node outage)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRemoveDecommissioningReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removedecommissioningreplica",
+		Help:        "Number of decommissioning replica removals attempted by the replicate queue (typically in response to a node outage)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRemoveDecommissioningVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removedecommissioningvoterreplica",
+		Help:        "Number of decommissioning voter replica removals attempted by the replicate queue (typically in response to a node outage)",
+		Measurement: "Replica Removals",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRemoveDecommissioningNonVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.removedecommissioningnonvoterreplica",
+		Help:        "Number of decommissioning non-voter replica removals attempted by the replicate queue (typically in response to a node outage)",
 		Measurement: "Replica Removals",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -89,6 +142,18 @@ var (
 	metaReplicateQueueRebalanceReplicaCount = metric.Metadata{
 		Name:        "queue.replicate.rebalancereplica",
 		Help:        "Number of replica rebalancer-initiated additions attempted by the replicate queue",
+		Measurement: "Replica Additions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRebalanceVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.rebalancevoterreplica",
+		Help:        "Number of voter replica rebalancer-initiated additions attempted by the replicate queue",
+		Measurement: "Replica Additions",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicateQueueRebalanceNonVoterReplicaCount = metric.Metadata{
+		Name:        "queue.replicate.rebalancenonvoterreplica",
+		Help:        "Number of non-voter replica rebalancer-initiated additions attempted by the replicate queue",
 		Measurement: "Replica Additions",
 		Unit:        metric.Unit_COUNT,
 	}
@@ -132,28 +197,140 @@ func (e *quorumError) Error() string {
 func (*quorumError) purgatoryErrorMarker() {}
 
 // ReplicateQueueMetrics is the set of metrics for the replicate queue.
-// TODO(aayush): Track metrics for non-voting replicas separately here.
 type ReplicateQueueMetrics struct {
-	AddReplicaCount           *metric.Counter
-	RemoveReplicaCount        *metric.Counter
-	RemoveDeadReplicaCount    *metric.Counter
-	RemoveLearnerReplicaCount *metric.Counter
-	RebalanceReplicaCount     *metric.Counter
-	TransferLeaseCount        *metric.Counter
-	NonVoterPromotionsCount   *metric.Counter
-	VoterDemotionsCount       *metric.Counter
+	AddReplicaCount                           *metric.Counter
+	AddVoterReplicaCount                      *metric.Counter
+	AddNonVoterReplicaCount                   *metric.Counter
+	RemoveReplicaCount                        *metric.Counter
+	RemoveVoterReplicaCount                   *metric.Counter
+	RemoveNonVoterReplicaCount                *metric.Counter
+	RemoveDeadReplicaCount                    *metric.Counter
+	RemoveDeadVoterReplicaCount               *metric.Counter
+	RemoveDeadNonVoterReplicaCount            *metric.Counter
+	RemoveDecommissioningReplicaCount         *metric.Counter
+	RemoveDecommissioningVoterReplicaCount    *metric.Counter
+	RemoveDecommissioningNonVoterReplicaCount *metric.Counter
+	RemoveLearnerReplicaCount                 *metric.Counter
+	RebalanceReplicaCount                     *metric.Counter
+	RebalanceVoterReplicaCount                *metric.Counter
+	RebalanceNonVoterReplicaCount             *metric.Counter
+	TransferLeaseCount                        *metric.Counter
+	NonVoterPromotionsCount                   *metric.Counter
+	VoterDemotionsCount                       *metric.Counter
 }
 
 func makeReplicateQueueMetrics() ReplicateQueueMetrics {
 	return ReplicateQueueMetrics{
-		AddReplicaCount:           metric.NewCounter(metaReplicateQueueAddReplicaCount),
-		RemoveReplicaCount:        metric.NewCounter(metaReplicateQueueRemoveReplicaCount),
-		RemoveDeadReplicaCount:    metric.NewCounter(metaReplicateQueueRemoveDeadReplicaCount),
-		RemoveLearnerReplicaCount: metric.NewCounter(metaReplicateQueueRemoveLearnerReplicaCount),
-		RebalanceReplicaCount:     metric.NewCounter(metaReplicateQueueRebalanceReplicaCount),
-		TransferLeaseCount:        metric.NewCounter(metaReplicateQueueTransferLeaseCount),
-		NonVoterPromotionsCount:   metric.NewCounter(metaReplicateQueueNonVoterPromotionsCount),
-		VoterDemotionsCount:       metric.NewCounter(metaReplicateQueueVoterDemotionsCount),
+		AddReplicaCount:                           metric.NewCounter(metaReplicateQueueAddReplicaCount),
+		AddVoterReplicaCount:                      metric.NewCounter(metaReplicateQueueAddVoterReplicaCount),
+		AddNonVoterReplicaCount:                   metric.NewCounter(metaReplicateQueueAddNonVoterReplicaCount),
+		RemoveReplicaCount:                        metric.NewCounter(metaReplicateQueueRemoveReplicaCount),
+		RemoveVoterReplicaCount:                   metric.NewCounter(metaReplicateQueueRemoveVoterReplicaCount),
+		RemoveNonVoterReplicaCount:                metric.NewCounter(metaReplicateQueueRemoveNonVoterReplicaCount),
+		RemoveDeadReplicaCount:                    metric.NewCounter(metaReplicateQueueRemoveDeadReplicaCount),
+		RemoveDeadVoterReplicaCount:               metric.NewCounter(metaReplicateQueueRemoveDeadVoterReplicaCount),
+		RemoveDeadNonVoterReplicaCount:            metric.NewCounter(metaReplicateQueueRemoveDeadNonVoterReplicaCount),
+		RemoveLearnerReplicaCount:                 metric.NewCounter(metaReplicateQueueRemoveLearnerReplicaCount),
+		RemoveDecommissioningReplicaCount:         metric.NewCounter(metaReplicateQueueRemoveDecommissioningReplicaCount),
+		RemoveDecommissioningVoterReplicaCount:    metric.NewCounter(metaReplicateQueueRemoveDecommissioningVoterReplicaCount),
+		RemoveDecommissioningNonVoterReplicaCount: metric.NewCounter(metaReplicateQueueRemoveDecommissioningNonVoterReplicaCount),
+		RebalanceReplicaCount:                     metric.NewCounter(metaReplicateQueueRebalanceReplicaCount),
+		RebalanceVoterReplicaCount:                metric.NewCounter(metaReplicateQueueRebalanceVoterReplicaCount),
+		RebalanceNonVoterReplicaCount:             metric.NewCounter(metaReplicateQueueRebalanceNonVoterReplicaCount),
+		TransferLeaseCount:                        metric.NewCounter(metaReplicateQueueTransferLeaseCount),
+		NonVoterPromotionsCount:                   metric.NewCounter(metaReplicateQueueNonVoterPromotionsCount),
+		VoterDemotionsCount:                       metric.NewCounter(metaReplicateQueueVoterDemotionsCount),
+	}
+}
+
+// trackAddReplicaCount increases the AddReplicaCount metric and separately
+// tracks voter/non-voter metrics given a replica targetType.
+func (metrics *ReplicateQueueMetrics) trackAddReplicaCount(targetType targetReplicaType) {
+	metrics.AddReplicaCount.Inc(1)
+	switch targetType {
+	case voterTarget:
+		metrics.AddVoterReplicaCount.Inc(1)
+	case nonVoterTarget:
+		metrics.AddNonVoterReplicaCount.Inc(1)
+	default:
+		panic(fmt.Sprintf("unsupported targetReplicaType: %v", targetType))
+	}
+}
+
+// trackRemoveMetric increases total RemoveReplicaCount metrics and
+// increments dead/decommissioning metrics depending on replicaStatus.
+func (metrics *ReplicateQueueMetrics) trackRemoveMetric(
+	targetType targetReplicaType, replicaStatus replicaStatus,
+) {
+	metrics.trackRemoveReplicaCount(targetType)
+	switch replicaStatus {
+	case dead:
+		metrics.trackRemoveDeadReplicaCount(targetType)
+	case decommissioning:
+		metrics.trackRemoveDecommissioningReplicaCount(targetType)
+	case alive:
+		return
+	default:
+		panic(fmt.Sprintf("unknown replicaStatus %v", replicaStatus))
+	}
+}
+
+// trackRemoveReplicaCount increases the RemoveReplicaCount metric and
+// separately tracks voter/non-voter metrics given a replica targetType.
+func (metrics *ReplicateQueueMetrics) trackRemoveReplicaCount(targetType targetReplicaType) {
+	metrics.RemoveReplicaCount.Inc(1)
+	switch targetType {
+	case voterTarget:
+		metrics.RemoveVoterReplicaCount.Inc(1)
+	case nonVoterTarget:
+		metrics.RemoveNonVoterReplicaCount.Inc(1)
+	default:
+		panic(fmt.Sprintf("unsupported targetReplicaType: %v", targetType))
+	}
+}
+
+// trackRemoveDeadReplicaCount increases the RemoveDeadReplicaCount metric and
+// separately tracks voter/non-voter metrics given a replica targetType.
+func (metrics *ReplicateQueueMetrics) trackRemoveDeadReplicaCount(targetType targetReplicaType) {
+	metrics.RemoveDeadReplicaCount.Inc(1)
+	switch targetType {
+	case voterTarget:
+		metrics.RemoveDeadVoterReplicaCount.Inc(1)
+	case nonVoterTarget:
+		metrics.RemoveDeadNonVoterReplicaCount.Inc(1)
+	default:
+		panic(fmt.Sprintf("unsupported targetReplicaType: %v", targetType))
+	}
+}
+
+// trackRemoveDecommissioningReplicaCount increases the
+// RemoveDecommissioningReplicaCount metric and separately tracks
+// voter/non-voter metrics given a replica targetType.
+func (metrics *ReplicateQueueMetrics) trackRemoveDecommissioningReplicaCount(
+	targetType targetReplicaType,
+) {
+	metrics.RemoveDecommissioningReplicaCount.Inc(1)
+	switch targetType {
+	case voterTarget:
+		metrics.RemoveDecommissioningVoterReplicaCount.Inc(1)
+	case nonVoterTarget:
+		metrics.RemoveDecommissioningNonVoterReplicaCount.Inc(1)
+	default:
+		panic(fmt.Sprintf("unsupported targetReplicaType: %v", targetType))
+	}
+}
+
+// trackRebalanceReplicaCount increases the RebalanceReplicaCount metric and
+// separately tracks voter/non-voter metrics given a replica targetType.
+func (metrics *ReplicateQueueMetrics) trackRebalanceReplicaCount(targetType targetReplicaType) {
+	metrics.RebalanceReplicaCount.Inc(1)
+	switch targetType {
+	case voterTarget:
+		metrics.RebalanceVoterReplicaCount.Inc(1)
+	case nonVoterTarget:
+		metrics.RebalanceNonVoterReplicaCount.Inc(1)
+	default:
+		panic(fmt.Sprintf("unsupported targetReplicaType: %v", targetType))
 	}
 }
 
@@ -398,9 +575,13 @@ func (rq *replicateQueue) processOneChange(
 
 	// Add replicas.
 	case AllocatorAddVoter:
-		return rq.addOrReplaceVoters(ctx, repl, liveVoterReplicas, liveNonVoterReplicas, -1 /* removeIdx */, dryRun)
+		return rq.addOrReplaceVoters(
+			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, -1 /* removeIdx */, alive, dryRun,
+		)
 	case AllocatorAddNonVoter:
-		return rq.addOrReplaceNonVoters(ctx, repl, liveVoterReplicas, liveNonVoterReplicas, -1 /* removeIdx */, dryRun)
+		return rq.addOrReplaceNonVoters(
+			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, -1 /* removeIdx */, alive, dryRun,
+		)
 
 	// Remove replicas.
 	case AllocatorRemoveVoter:
@@ -420,7 +601,8 @@ func (rq *replicateQueue) processOneChange(
 				"dead voter %v unexpectedly not found in %v",
 				deadVoterReplicas[0], voterReplicas)
 		}
-		return rq.addOrReplaceVoters(ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dryRun)
+		return rq.addOrReplaceVoters(
+			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dead, dryRun)
 	case AllocatorReplaceDeadNonVoter:
 		if len(deadNonVoterReplicas) == 0 {
 			// Nothing to do.
@@ -432,7 +614,8 @@ func (rq *replicateQueue) processOneChange(
 				"dead non-voter %v unexpectedly not found in %v",
 				deadNonVoterReplicas[0], nonVoterReplicas)
 		}
-		return rq.addOrReplaceNonVoters(ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dryRun)
+		return rq.addOrReplaceNonVoters(
+			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dead, dryRun)
 
 	// Replace decommissioning replicas.
 	case AllocatorReplaceDecommissioningVoter:
@@ -447,7 +630,8 @@ func (rq *replicateQueue) processOneChange(
 				"decommissioning voter %v unexpectedly not found in %v",
 				decommissioningVoterReplicas[0], voterReplicas)
 		}
-		return rq.addOrReplaceVoters(ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dryRun)
+		return rq.addOrReplaceVoters(
+			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, decommissioning, dryRun)
 	case AllocatorReplaceDecommissioningNonVoter:
 		decommissioningNonVoterReplicas := rq.allocator.storePool.decommissioningReplicas(nonVoterReplicas)
 		if len(decommissioningNonVoterReplicas) == 0 {
@@ -459,7 +643,8 @@ func (rq *replicateQueue) processOneChange(
 				"decommissioning non-voter %v unexpectedly not found in %v",
 				decommissioningNonVoterReplicas[0], nonVoterReplicas)
 		}
-		return rq.addOrReplaceNonVoters(ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, dryRun)
+		return rq.addOrReplaceNonVoters(
+			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, decommissioning, dryRun)
 
 	// Remove decommissioning replicas.
 	//
@@ -528,6 +713,7 @@ func (rq *replicateQueue) addOrReplaceVoters(
 	repl *Replica,
 	liveVoterReplicas, liveNonVoterReplicas []roachpb.ReplicaDescriptor,
 	removeIdx int,
+	replicaStatus replicaStatus,
 	dryRun bool,
 ) (requeue bool, _ error) {
 	desc, conf := repl.DescAndSpanConfig()
@@ -606,7 +792,6 @@ func (rq *replicateQueue) addOrReplaceVoters(
 			return false, errors.Wrap(err, "avoid up-replicating to fragile quorum")
 		}
 	}
-	rq.metrics.AddReplicaCount.Inc(1)
 
 	// Figure out whether we should be promoting an existing non-voting replica to
 	// a voting replica or if we ought to be adding a voter afresh.
@@ -619,16 +804,23 @@ func (rq *replicateQueue) addOrReplaceVoters(
 		}
 		// If the allocation target has a non-voter already, we will promote it to a
 		// voter.
-		rq.metrics.NonVoterPromotionsCount.Inc(1)
+		if !dryRun {
+			rq.metrics.NonVoterPromotionsCount.Inc(1)
+		}
 		ops = roachpb.ReplicationChangesForPromotion(newVoter)
 	} else {
+		if !dryRun {
+			rq.metrics.trackAddReplicaCount(voterTarget)
+		}
 		ops = roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, newVoter)
 	}
 	if removeIdx < 0 {
 		log.VEventf(ctx, 1, "adding voter %+v: %s",
 			newVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	} else {
-		rq.metrics.RemoveReplicaCount.Inc(1)
+		if !dryRun {
+			rq.metrics.trackRemoveMetric(voterTarget, replicaStatus)
+		}
 		removeVoter := existingVoters[removeIdx]
 		log.VEventf(ctx, 1, "replacing voter %s with %+v: %s",
 			removeVoter, newVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
@@ -667,6 +859,7 @@ func (rq *replicateQueue) addOrReplaceNonVoters(
 	repl *Replica,
 	liveVoterReplicas, liveNonVoterReplicas []roachpb.ReplicaDescriptor,
 	removeIdx int,
+	replicaStatus replicaStatus,
 	dryRun bool,
 ) (requeue bool, _ error) {
 	desc, conf := repl.DescAndSpanConfig()
@@ -676,14 +869,18 @@ func (rq *replicateQueue) addOrReplaceNonVoters(
 	if err != nil {
 		return false, err
 	}
-	rq.metrics.AddReplicaCount.Inc(1)
+	if !dryRun {
+		rq.metrics.trackAddReplicaCount(nonVoterTarget)
+	}
 
 	ops := roachpb.MakeReplicationChanges(roachpb.ADD_NON_VOTER, newNonVoter)
 	if removeIdx < 0 {
 		log.VEventf(ctx, 1, "adding non-voter %+v: %s",
 			newNonVoter, rangeRaftProgress(repl.RaftStatus(), existingNonVoters))
 	} else {
-		rq.metrics.RemoveReplicaCount.Inc(1)
+		if !dryRun {
+			rq.metrics.trackRemoveMetric(nonVoterTarget, replicaStatus)
+		}
 		removeNonVoter := existingNonVoters[removeIdx]
 		log.VEventf(ctx, 1, "replacing non-voter %s with %+v: %s",
 			removeNonVoter, newNonVoter, rangeRaftProgress(repl.RaftStatus(), existingNonVoters))
@@ -866,7 +1063,10 @@ func (rq *replicateQueue) removeVoter(
 	}
 
 	// Remove a replica.
-	rq.metrics.RemoveReplicaCount.Inc(1)
+	if !dryRun {
+		rq.metrics.trackRemoveMetric(voterTarget, alive)
+	}
+
 	log.VEventf(ctx, 1, "removing voting replica %+v due to over-replication: %s",
 		removeVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	desc := repl.Desc()
@@ -896,7 +1096,6 @@ func (rq *replicateQueue) removeNonVoter(
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	dryRun bool,
 ) (requeue bool, _ error) {
-	rq.metrics.RemoveReplicaCount.Inc(1)
 
 	desc, conf := repl.DescAndSpanConfig()
 	removeNonVoter, details, err := rq.allocator.RemoveNonVoter(
@@ -910,7 +1109,9 @@ func (rq *replicateQueue) removeNonVoter(
 	if err != nil {
 		return false, err
 	}
-
+	if !dryRun {
+		rq.metrics.trackRemoveMetric(nonVoterTarget, alive)
+	}
 	log.VEventf(ctx, 1, "removing non-voting replica %+v due to over-replication: %s",
 		removeNonVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	target := roachpb.ReplicationTarget{
@@ -969,7 +1170,9 @@ func (rq *replicateQueue) removeDecommissioning(
 	}
 
 	// Remove the decommissioning replica.
-	rq.metrics.RemoveReplicaCount.Inc(1)
+	if !dryRun {
+		rq.metrics.trackRemoveMetric(targetType, decommissioning)
+	}
 	log.VEventf(ctx, 1, "removing decommissioning %s %+v from store", targetType, decommissioningReplica)
 	target := roachpb.ReplicationTarget{
 		NodeID:  decommissioningReplica.NodeID,
@@ -1008,7 +1211,9 @@ func (rq *replicateQueue) removeDead(
 		return true, nil
 	}
 	deadReplica := deadReplicas[0]
-	rq.metrics.RemoveDeadReplicaCount.Inc(1)
+	if !dryRun {
+		rq.metrics.trackRemoveMetric(targetType, dead)
+	}
 	log.VEventf(ctx, 1, "removing dead %s %+v from store", targetType, deadReplica)
 	target := roachpb.ReplicationTarget{
 		NodeID:  deadReplica.NodeID,
@@ -1045,7 +1250,9 @@ func (rq *replicateQueue) removeLearner(
 		return true, nil
 	}
 	learnerReplica := learnerReplicas[0]
-	rq.metrics.RemoveLearnerReplicaCount.Inc(1)
+	if !dryRun {
+		rq.metrics.RemoveLearnerReplicaCount.Inc(1)
+	}
 	log.VEventf(ctx, 1, "removing learner replica %+v from store", learnerReplica)
 	target := roachpb.ReplicationTarget{
 		NodeID:  learnerReplica.NodeID,
@@ -1129,10 +1336,12 @@ func (rq *replicateQueue) considerRebalance(
 			if err != nil {
 				return false, err
 			}
-			rq.metrics.RebalanceReplicaCount.Inc(1)
-			if performingSwap {
-				rq.metrics.VoterDemotionsCount.Inc(1)
-				rq.metrics.NonVoterPromotionsCount.Inc(1)
+			if !dryRun {
+				rq.metrics.trackRebalanceReplicaCount(rebalanceTargetType)
+				if performingSwap {
+					rq.metrics.VoterDemotionsCount.Inc(1)
+					rq.metrics.NonVoterPromotionsCount.Inc(1)
+				}
 			}
 			log.VEventf(ctx,
 				1,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -426,6 +426,9 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 				ReplicationMode: base.ReplicationAuto,
 				ServerArgs: base.TestServerArgs{
 					Knobs: base.TestingKnobs{
+						Store: &kvserver.StoreTestingKnobs{
+							DisableReplicaRebalancing: true,
+						},
 						SpanConfig: &spanconfig.TestingKnobs{
 							ConfigureScratchRange: true,
 						},
@@ -463,6 +466,16 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		// Do a fresh look up on the range descriptor.
 		scratchRange = tc.LookupRangeOrFatal(t, scratchRange.StartKey.AsRawKey())
 		beforeNodeIDs := getNonVoterNodeIDs(scratchRange)
+		store, err := getLeaseholderStore(tc, scratchRange)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Check the value of metrics prior to replacement.
+		previousAddCount := store.ReplicateQueueMetrics().AddNonVoterReplicaCount.Count()
+		previousRemovalCount := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		previousDecommRemovals :=
+			store.ReplicateQueueMetrics().RemoveDecommissioningNonVoterReplicaCount.Count()
+
 		// Decommission each of the two nodes that have the non-voters and make sure
 		// that those non-voters are upreplicated elsewhere.
 		require.NoError(t,
@@ -490,6 +503,26 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 			}
 			return true
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
+
+		// replica replacements update the addition/removal metrics as replicas
+		// are being removed on two decommissioning stores added to other stores.
+		currentAddCount := store.ReplicateQueueMetrics().AddNonVoterReplicaCount.Count()
+		currentRemoveCount := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		currentDecommRemovals :=
+			store.ReplicateQueueMetrics().RemoveDecommissioningNonVoterReplicaCount.Count()
+
+		require.GreaterOrEqualf(
+			t, currentAddCount, previousAddCount+2,
+			"expected replica additions to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, currentRemoveCount, previousRemovalCount+2,
+			"expected total replica removals to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, currentDecommRemovals, previousDecommRemovals+2,
+			"expected decommissioning replica removals to increase by at least 2",
+		)
 	})
 
 	// Check that when we have more non-voters than needed and some of those
@@ -515,6 +548,15 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		for _, repl := range scratchRange.Replicas().NonVoterDescriptors() {
 			nonVoterNodeIDs = append(nonVoterNodeIDs, repl.NodeID)
 		}
+		// Check metrics of leaseholder store prior to removal.
+		store, err := getLeaseholderStore(tc, scratchRange)
+		if err != nil {
+			t.Fatal(err)
+		}
+		previousRemovalCount := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		previousDecommRemovals :=
+			store.ReplicateQueueMetrics().RemoveDecommissioningNonVoterReplicaCount.Count()
+
 		require.NoError(t,
 			tc.Server(0).Decommission(ctx, livenesspb.MembershipStatus_DECOMMISSIONING, nonVoterNodeIDs))
 
@@ -530,7 +572,35 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 			}
 			return ok
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
+
+		currentRemoveCount := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		currentDecommRemovals :=
+			store.ReplicateQueueMetrics().RemoveDecommissioningNonVoterReplicaCount.Count()
+		require.GreaterOrEqualf(
+			t, currentRemoveCount, previousRemovalCount+2,
+			"expected replica removals to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, currentDecommRemovals, previousDecommRemovals+2,
+			"expected replica removals to increase by at least 2",
+		)
 	})
+}
+
+// getLeaseholderStore returns the leaseholder store for the given scratchRange.
+func getLeaseholderStore(
+	tc *testcluster.TestCluster, scratchRange roachpb.RangeDescriptor,
+) (*kvserver.Store, error) {
+	leaseHolder, err := tc.FindRangeLeaseHolder(scratchRange, nil)
+	if err != nil {
+		return nil, err
+	}
+	leaseHolderSrv := tc.Servers[leaseHolder.NodeID-1]
+	store, err := leaseHolderSrv.Stores().GetStore(leaseHolder.StoreID)
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
 }
 
 // TestReplicateQueueDeadNonVoters is an end to end test ensuring that
@@ -549,7 +619,12 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			base.TestClusterArgs{
 				ReplicationMode: base.ReplicationAuto,
 				ServerArgs: base.TestServerArgs{
+					ScanMinIdleTime: time.Millisecond,
+					ScanMaxIdleTime: time.Millisecond,
 					Knobs: base.TestingKnobs{
+						Store: &kvserver.StoreTestingKnobs{
+							DisableReplicaRebalancing: true,
+						},
 						SpanConfig: &spanconfig.TestingKnobs{
 							ConfigureScratchRange: true,
 						},
@@ -612,6 +687,16 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 		tc, scratchRange := setupFn(t)
 		defer tc.Stopper().Stop(ctx)
 
+		// Check the value of non-voter metrics from leaseholder store prior to removals.
+		store, err := getLeaseholderStore(tc, scratchRange)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		prevAdditions := store.ReplicateQueueMetrics().AddNonVoterReplicaCount.Count()
+		prevRemovals := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		prevDeadRemovals := store.ReplicateQueueMetrics().RemoveDeadNonVoterReplicaCount.Count()
+
 		beforeNodeIDs := getNonVoterNodeIDs(scratchRange)
 		markDead(beforeNodeIDs)
 		require.Eventually(t, func() bool {
@@ -636,6 +721,23 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			}
 			return true
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
+
+		addCount := store.ReplicateQueueMetrics().AddNonVoterReplicaCount.Count()
+		removeNonVoterCount := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		removeDeadNonVoterCount := store.ReplicateQueueMetrics().RemoveDeadNonVoterReplicaCount.Count()
+
+		require.GreaterOrEqualf(
+			t, addCount, prevAdditions+2,
+			"expected replica removals to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, removeNonVoterCount, prevRemovals+2,
+			"expected replica removals to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, removeDeadNonVoterCount, prevDeadRemovals+2,
+			"expected replica removals to increase by at least 2",
+		)
 	})
 
 	// This subtest checks that when we have more non-voters than needed and some
@@ -661,6 +763,16 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			"ALTER RANGE default CONFIGURE ZONE USING num_replicas = 1",
 		)
 		require.NoError(t, err)
+
+		// Check the value of non-voter metrics from leaseholder store prior to removals.
+		store, err := getLeaseholderStore(tc, scratchRange)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prevRemovals := store.ReplicateQueueMetrics().RemoveReplicaCount.Count()
+		prevNonVoterRemovals := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		prevDeadRemovals := store.ReplicateQueueMetrics().RemoveDeadNonVoterReplicaCount.Count()
+
 		beforeNodeIDs := getNonVoterNodeIDs(scratchRange)
 		markDead(beforeNodeIDs)
 
@@ -673,9 +785,191 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			}
 			return ok
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
+
+		removeCount := store.ReplicateQueueMetrics().RemoveReplicaCount.Count()
+		removeNonVoterCount := store.ReplicateQueueMetrics().RemoveNonVoterReplicaCount.Count()
+		removeDeadNonVoterCount := store.ReplicateQueueMetrics().RemoveDeadNonVoterReplicaCount.Count()
+		require.GreaterOrEqualf(
+			t, removeCount, prevRemovals+2,
+			"expected replica removals to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, removeNonVoterCount, prevNonVoterRemovals+2,
+			"expected replica removals to increase by at least 2",
+		)
+		require.GreaterOrEqualf(
+			t, removeDeadNonVoterCount, prevDeadRemovals+2,
+			"expected replica removals to increase by at least 2",
+		)
 	})
 }
 
+// TestReplicateQueueMetrics is an end-to-end test ensuring the replicateQueue
+// voter replica metrics will be updated correctly during upreplication and downreplication.
+func TestReplicateQueueMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "takes a long time or times out under race")
+
+	ctx := context.Background()
+	var clusterArgs = base.TestClusterArgs{
+		ReplicationMode: base.ReplicationAuto,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					DisableReplicaRebalancing: true,
+				},
+			},
+		},
+	}
+	dbName := "testdb"
+	tableName := "kv"
+	numNodes := 3
+	tc, scratchRange := setupTestClusterWithDummyRange(t, clusterArgs, dbName, tableName, numNodes)
+	defer tc.Stopper().Stop(ctx)
+
+	// Check that the cluster is initialized correctly with 3 voters.
+	require.Eventually(t, func() bool {
+		ok, err := checkReplicaCount(
+			ctx, tc.(*testcluster.TestCluster),
+			&scratchRange, 3 /* voterCount */, 0, /* nonVoterCount */
+		)
+		if err != nil {
+			log.Errorf(ctx, "error checking replica count: %s", err)
+			return false
+		}
+		return ok
+	}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
+
+	// Get a map of voter replica store locations before the zone configuration change.
+	voterStores := getVoterStores(t, tc.(*testcluster.TestCluster), &scratchRange)
+	// Check the aggregated voter removal metrics across voter stores.
+	previousRemoveCount, previousRemoveVoterCount := getAggregateMetricCounts(
+		ctx,
+		tc.(*testcluster.TestCluster),
+		voterStores,
+		false, /* add */
+	)
+
+	_, err := tc.ServerConn(0).Exec(
+		`ALTER TABLE testdb.kv CONFIGURE ZONE USING num_replicas = 1`,
+	)
+	require.NoError(t, err)
+	require.Eventually(
+		t, func() bool {
+			ok, err := checkReplicaCount(
+				ctx, tc.(*testcluster.TestCluster), &scratchRange, 1, 0,
+			)
+			if err != nil {
+				log.Errorf(ctx, "error checking replica count: %s", err)
+				return false
+			}
+			return ok
+		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond,
+	)
+
+	// Expect the new aggregated voter removal metrics across stores which had
+	// voters removed increase by at least 2.
+	currentRemoveCount, currentRemoveVoterCount := getAggregateMetricCounts(
+		ctx,
+		tc.(*testcluster.TestCluster),
+		voterStores,
+		false, /* add */
+	)
+	require.GreaterOrEqualf(
+		t,
+		currentRemoveCount,
+		previousRemoveCount+2,
+		"expected replica removals to increase by at least 2",
+	)
+	require.GreaterOrEqualf(
+		t,
+		currentRemoveVoterCount,
+		previousRemoveVoterCount+2,
+		"expected replica removals to increase by at least 2",
+	)
+
+	scratchRange = tc.LookupRangeOrFatal(t, scratchRange.StartKey.AsRawKey())
+	store, err := getLeaseholderStore(tc.(*testcluster.TestCluster), scratchRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Track add counts on leaseholder before upreplication.
+	previousAddCount := store.ReplicateQueueMetrics().AddReplicaCount.Count()
+	previousAddVoterCount := store.ReplicateQueueMetrics().AddVoterReplicaCount.Count()
+
+	_, err = tc.ServerConn(0).Exec(
+		`ALTER TABLE testdb.kv CONFIGURE ZONE USING num_replicas = 3`,
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		ok, err := checkReplicaCount(
+			ctx, tc.(*testcluster.TestCluster), &scratchRange, 3, 0,
+		)
+		if err != nil {
+			log.Errorf(ctx, "error checking replica count: %s", err)
+			return false
+		}
+		return ok
+	}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
+
+	// Expect the aggregated voter add metrics across voter stores increase by at least 2.
+	voterMap := getVoterStores(t, tc.(*testcluster.TestCluster), &scratchRange)
+	currentAddCount, currentAddVoterCount := getAggregateMetricCounts(
+		ctx,
+		tc.(*testcluster.TestCluster),
+		voterMap,
+		true, /* add */
+	)
+	require.GreaterOrEqualf(
+		t, currentAddCount, previousAddCount+2,
+		"expected replica additions to increase by at least 2",
+	)
+	require.GreaterOrEqualf(
+		t, currentAddVoterCount, previousAddVoterCount+2,
+		"expected voter additions to increase by at least 2",
+	)
+}
+
+// getVoterStores returns a mapping of voter nodeIDs to storeIDs.
+func getVoterStores(
+	t *testing.T, tc *testcluster.TestCluster, rangeDesc *roachpb.RangeDescriptor,
+) (storeMap map[roachpb.NodeID]roachpb.StoreID) {
+	*rangeDesc = tc.LookupRangeOrFatal(t, rangeDesc.StartKey.AsRawKey())
+	voters := rangeDesc.Replicas().VoterDescriptors()
+	storeMap = make(map[roachpb.NodeID]roachpb.StoreID)
+	for i := 0; i < len(voters); i++ {
+		storeMap[voters[i].NodeID] = voters[i].StoreID
+	}
+	return storeMap
+}
+
+// getAggregateMetricCounts adds metric counts from all stores in a given map.
+// and returns the totals.
+func getAggregateMetricCounts(
+	ctx context.Context,
+	tc *testcluster.TestCluster,
+	voterMap map[roachpb.NodeID]roachpb.StoreID,
+	add bool,
+) (currentCount int64, currentVoterCount int64) {
+	for _, s := range tc.Servers {
+		if storeId, exists := voterMap[s.NodeID()]; exists {
+			store, err := s.Stores().GetStore(storeId)
+			if err != nil {
+				log.Errorf(ctx, "error finding store: %s", err)
+				continue
+			}
+			if add {
+				currentCount += store.ReplicateQueueMetrics().AddReplicaCount.Count()
+				currentVoterCount += store.ReplicateQueueMetrics().AddVoterReplicaCount.Count()
+			} else {
+				currentCount += store.ReplicateQueueMetrics().RemoveReplicaCount.Count()
+				currentVoterCount += store.ReplicateQueueMetrics().RemoveVoterReplicaCount.Count()
+			}
+		}
+	}
+	return currentCount, currentVoterCount
+}
 func getNonVoterNodeIDs(rangeDesc roachpb.RangeDescriptor) (result []roachpb.NodeID) {
 	for _, repl := range rangeDesc.Replicas().NonVoterDescriptors() {
 		result = append(result, repl.NodeID)

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -388,7 +388,7 @@ func TestReplicateQueueUpAndDownReplicateNonVoters(t *testing.T) {
 func checkReplicaCount(
 	ctx context.Context,
 	tc *testcluster.TestCluster,
-	rangeDesc roachpb.RangeDescriptor,
+	rangeDesc *roachpb.RangeDescriptor,
 	voterCount, nonVoterCount int,
 ) (bool, error) {
 	err := forceScanOnAllReplicationQueues(tc)
@@ -396,7 +396,7 @@ func checkReplicaCount(
 		log.Infof(ctx, "store.ForceReplicationScanAndProcess() failed with: %s", err)
 		return false, err
 	}
-	rangeDesc, err = tc.LookupRange(rangeDesc.StartKey.AsRawKey())
+	*rangeDesc, err = tc.LookupRange(rangeDesc.StartKey.AsRawKey())
 	if err != nil {
 		return false, err
 	}
@@ -433,15 +433,18 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 				},
 			},
 		)
+		_, err := tc.ServerConn(0).Exec(
+			`SET CLUSTER SETTING server.failed_reservation_timeout='1ms'`)
+		require.NoError(t, err)
 
 		scratchKey := tc.ScratchRange(t)
 		scratchRange := tc.LookupRangeOrFatal(t, scratchKey)
-		_, err := tc.ServerConn(0).Exec(
+		_, err = tc.ServerConn(0).Exec(
 			`ALTER RANGE DEFAULT CONFIGURE ZONE USING num_replicas = 3, num_voters = 1`,
 		)
 		require.NoError(t, err)
 		require.Eventually(t, func() bool {
-			ok, err := checkReplicaCount(ctx, tc, scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
+			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
 				log.Errorf(ctx, "error checking replica count: %s", err)
 				return false
@@ -466,7 +469,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 			tc.Server(0).Decommission(ctx, livenesspb.MembershipStatus_DECOMMISSIONING, beforeNodeIDs))
 
 		require.Eventually(t, func() bool {
-			ok, err := checkReplicaCount(ctx, tc, scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
+			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
 				log.Errorf(ctx, "error checking replica count: %s", err)
 				return false
@@ -520,7 +523,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		// replicateQueue on and ensure that these redundant non-voters are removed.
 		tc.ToggleReplicateQueues(true)
 		require.Eventually(t, func() bool {
-			ok, err := checkReplicaCount(ctx, tc, scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)
+			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)
 			if err != nil {
 				log.Errorf(ctx, "error checking replica count: %s", err)
 				return false
@@ -535,6 +538,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 func TestReplicateQueueDeadNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 76996)
 	skip.UnderRace(t, "takes a long time or times out under race")
 
 	ctx := context.Background()
@@ -564,15 +568,19 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 				},
 			},
 		)
+		_, err := tc.ServerConn(0).Exec(
+			`SET CLUSTER SETTING server.failed_reservation_timeout='1ms'`)
+		require.NoError(t, err)
+
 		// Setup a scratch range on a test cluster with 2 non-voters and 1 voter.
 		scratchKey := tc.ScratchRange(t)
 		scratchRange := tc.LookupRangeOrFatal(t, scratchKey)
-		_, err := tc.ServerConn(0).Exec(
+		_, err = tc.ServerConn(0).Exec(
 			`ALTER RANGE DEFAULT CONFIGURE ZONE USING num_replicas = 3, num_voters = 1`,
 		)
 		require.NoError(t, err)
 		require.Eventually(t, func() bool {
-			ok, err := checkReplicaCount(ctx, tc, scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
+			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
 				log.Errorf(ctx, "error checking replica count: %s", err)
 				return false
@@ -607,7 +615,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 		beforeNodeIDs := getNonVoterNodeIDs(scratchRange)
 		markDead(beforeNodeIDs)
 		require.Eventually(t, func() bool {
-			ok, err := checkReplicaCount(ctx, tc, scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
+			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 2 /* nonVoterCount */)
 			if err != nil {
 				log.Errorf(ctx, "error checking replica count: %s", err)
 				return false
@@ -658,7 +666,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 
 		toggleReplicationQueues(tc, true)
 		require.Eventually(t, func() bool {
-			ok, err := checkReplicaCount(ctx, tc, scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)
+			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)
 			if err != nil {
 				log.Errorf(ctx, "error checking replica count: %s", err)
 				return false

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2968,6 +2968,11 @@ func (s *Store) Metrics() *StoreMetrics {
 	return s.metrics
 }
 
+// ReplicateQueueMetrics returns the store's replicateQueue metric struct.
+func (s *Store) ReplicateQueueMetrics() ReplicateQueueMetrics {
+	return s.replicateQueue.metrics
+}
+
 // Descriptor returns a StoreDescriptor including current store
 // capacity information.
 func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreDescriptor, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -418,7 +418,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	registry.AddMetricStruct(nodeLiveness.Metrics())
 
 	nodeLivenessFn := kvserver.MakeStorePoolNodeLivenessFunc(nodeLiveness)
-	if nodeLivenessKnobs, ok := cfg.TestingKnobs.Store.(*kvserver.NodeLivenessTestingKnobs); ok &&
+	if nodeLivenessKnobs, ok := cfg.TestingKnobs.NodeLiveness.(kvserver.NodeLivenessTestingKnobs); ok &&
 		nodeLivenessKnobs.StorePoolNodeLivenessFn != nil {
 		nodeLivenessFn = nodeLivenessKnobs.StorePoolNodeLivenessFn
 	}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1620,8 +1620,12 @@ var charts = []sectionDescription{
 		Organization: [][]string{{ReplicationLayer, "Replicate Queue"}},
 		Charts: []chartDescription{
 			{
-				Title:   "Add Replica Count",
-				Metrics: []string{"queue.replicate.addreplica"},
+				Title: "Add Replica Count",
+				Metrics: []string{
+					"queue.replicate.addreplica",
+					"queue.replicate.addvoterreplica",
+					"queue.replicate.addnonvoterreplica",
+				},
 			},
 			{
 				Title:   "Lease Transfer Count",
@@ -1636,8 +1640,12 @@ var charts = []sectionDescription{
 				Metrics: []string{"queue.replicate.purgatory"},
 			},
 			{
-				Title:   "Rebalance Count",
-				Metrics: []string{"queue.replicate.rebalancereplica"},
+				Title: "Rebalance Count",
+				Metrics: []string{
+					"queue.replicate.rebalancereplica",
+					"queue.replicate.rebalancevoterreplica",
+					"queue.replicate.rebalancenonvoterreplica",
+				},
 			},
 			{
 				Title:   "Demotions of Voters to Non Voters",
@@ -1651,8 +1659,15 @@ var charts = []sectionDescription{
 				Title: "Remove Replica Count",
 				Metrics: []string{
 					"queue.replicate.removedeadreplica",
+					"queue.replicate.removedeadvoterreplica",
+					"queue.replicate.removedeadnonvoterreplica",
 					"queue.replicate.removereplica",
+					"queue.replicate.removevoterreplica",
+					"queue.replicate.removenonvoterreplica",
 					"queue.replicate.removelearnerreplica",
+					"queue.replicate.removedecommissioningreplica",
+					"queue.replicate.removedecommissioningvoterreplica",
+					"queue.replicate.removedecommissioningnonvoterreplica",
 				},
 			},
 			{


### PR DESCRIPTION
This commit adds separate metrics for tracking adding/removing/rebalancing of voting/non-voting replicas. For instance, the add replica count is an aggregation of voter and non-voter addition counts, which are now also separately tracked. Also added a metric for tracking adding and removing decommissioning replicas.

Fixes [#60694](https://github.com/cockroachdb/cockroach/issues/60694)
Release justification: additive change to add metrics for existing functionality