### PR TITLE
vendor: bump Pebble to ec6c21662e65

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1218,10 +1218,10 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sha256 = "5c8f1cab6c2528bd9e6b832f2dfcd98538d5df2c15d8e3f1d959f6c0f8c9778a",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220118190613-20f8dd034791",
+        sha256 = "57d54c33bae9fd363a206b5a3ac1e2fe187213ae4edb025a1f4d4dff596fb02d",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220120213058-ec6c21662e65",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220118190613-20f8dd034791.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220120213058-ec6c21662e65.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220118190613-20f8dd034791
+	github.com/cockroachdb/pebble v0.0.0-20220120213058-ec6c21662e65
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220118190613-20f8dd034791 h1:g5D/E80chI50RnqWv/kZys4N1xI7wwL0J5azd2S8XYk=
-github.com/cockroachdb/pebble v0.0.0-20220118190613-20f8dd034791/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220120213058-ec6c21662e65 h1:HeWHKlheSiglFkLRB+SUnt6AU7A0XuWKrO5b7aoaZhE=
+github.com/cockroachdb/pebble v0.0.0-20220120213058-ec6c21662e65/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.1/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -427,8 +427,11 @@ const mvccWallTimeIntervalCollector = "MVCCTimeInterval"
 // BlockPropertyCollectors.
 var PebbleBlockPropertyCollectors = []func() pebble.BlockPropertyCollector{
 	func() pebble.BlockPropertyCollector {
-		return sstable.NewBlockIntervalCollector(mvccWallTimeIntervalCollector,
-			&pebbleDataBlockMVCCTimeIntervalCollector{})
+		return sstable.NewBlockIntervalCollector(
+			mvccWallTimeIntervalCollector,
+			&pebbleDataBlockMVCCTimeIntervalCollector{}, /* points */
+			nil, /* ranges */
+		)
 	},
 }
 


### PR DESCRIPTION
ec6c2166 sstable: add range key support to BlockIntervalCollector
586718d8 cmd/pebble: support testkeys comparer
b58a7bdc docs/rfcs: pebble table format versions
f3d164d8 db: save level iter debug output before closing
7f1a70dc sstable: reorganize sstable buffers and structs

Update the existing `sstable.NewBlockIntervalCollector` call site to add
the additional required parameter for the range-key collector.

Release note: none