### PR TITLE
distsql: transition distsql physical planner to use SQLInstanceIDs instead of NodeIDs

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -11,6 +11,7 @@ package backupccl
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -39,7 +40,7 @@ func distBackupPlanSpecs(
 	encryption *jobspb.BackupEncryptionOptions,
 	mvccFilter roachpb.MVCCFilter,
 	startTime, endTime hlc.Timestamp,
-) (map[roachpb.NodeID]*execinfrapb.BackupDataSpec, error) {
+) (map[base.SQLInstanceID]*execinfrapb.BackupDataSpec, error) {
 	var span *tracing.Span
 	ctx, span = tracing.ChildSpan(ctx, "backup-plan-specs")
 	_ = ctx // ctx is currently unused, but this new ctx should be used below in the future.
@@ -88,7 +89,7 @@ func distBackupPlanSpecs(
 
 	// First construct spans based on span partitions. Then add on
 	// introducedSpans based on how those partition.
-	nodeToSpec := make(map[roachpb.NodeID]*execinfrapb.BackupDataSpec)
+	sqlInstanceIDToSpec := make(map[base.SQLInstanceID]*execinfrapb.BackupDataSpec)
 	for _, partition := range spanPartitions {
 		spec := &execinfrapb.BackupDataSpec{
 			Spans:            partition.Spans,
@@ -101,11 +102,11 @@ func distBackupPlanSpecs(
 			BackupEndTime:    endTime,
 			UserProto:        user.EncodeProto(),
 		}
-		nodeToSpec[partition.Node] = spec
+		sqlInstanceIDToSpec[partition.SQLInstanceID] = spec
 	}
 
 	for _, partition := range introducedSpanPartitions {
-		if spec, ok := nodeToSpec[partition.Node]; ok {
+		if spec, ok := sqlInstanceIDToSpec[partition.SQLInstanceID]; ok {
 			spec.IntroducedSpans = partition.Spans
 		} else {
 			// We may need to introduce a new spec in the case that there is a node
@@ -122,21 +123,21 @@ func distBackupPlanSpecs(
 				BackupEndTime:    endTime,
 				UserProto:        user.EncodeProto(),
 			}
-			nodeToSpec[partition.Node] = spec
+			sqlInstanceIDToSpec[partition.SQLInstanceID] = spec
 		}
 	}
 
 	backupPlanningTraceEvent := BackupProcessorPlanningTraceEvent{
 		NodeToNumSpans: make(map[int32]int64),
 	}
-	for node, spec := range nodeToSpec {
+	for node, spec := range sqlInstanceIDToSpec {
 		numSpans := int64(len(spec.Spans) + len(spec.IntroducedSpans))
 		backupPlanningTraceEvent.NodeToNumSpans[int32(node)] = numSpans
 		backupPlanningTraceEvent.TotalNumSpans += numSpans
 	}
 	span.RecordStructured(&backupPlanningTraceEvent)
 
-	return nodeToSpec, nil
+	return sqlInstanceIDToSpec, nil
 }
 
 // distBackup is used to plan the processors for a distributed backup. It
@@ -148,7 +149,7 @@ func distBackup(
 	planCtx *sql.PlanningCtx,
 	dsp *sql.DistSQLPlanner,
 	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
-	backupSpecs map[roachpb.NodeID]*execinfrapb.BackupDataSpec,
+	backupSpecs map[base.SQLInstanceID]*execinfrapb.BackupDataSpec,
 ) error {
 	ctx, span := tracing.ChildSpan(ctx, "backup-distsql")
 	defer span.Finish()
@@ -164,8 +165,8 @@ func distBackup(
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(backupSpecs))
 	i := 0
-	for node, spec := range backupSpecs {
-		corePlacement[i].NodeID = node
+	for sqlInstanceID, spec := range backupSpecs {
+		corePlacement[i].SQLInstanceID = sqlInstanceID
 		corePlacement[i].Core.BackupData = spec
 		i++
 	}

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -198,7 +198,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			}
 			for stream := 0; stream < c.numStreams; stream++ {
 				// In this test, nodes are 1 indexed.
-				startBytes, endBytes, err := routingSpanForNode(roachpb.NodeID(stream + 1))
+				startBytes, endBytes, err := routingSpanForSQLInstance(base.SQLInstanceID(stream + 1))
 				require.NoError(t, err)
 
 				span := execinfrapb.OutputRouterSpec_RangeRouterSpec_Span{

--- a/pkg/ccl/changefeedccl/changefeeddist/distflow.go
+++ b/pkg/ccl/changefeedccl/changefeeddist/distflow.go
@@ -52,7 +52,7 @@ func StartDistChangefeed(
 	var spanPartitions []sql.SpanPartition
 	if details.SinkURI == `` {
 		// Sinkless feeds get one ChangeAggregator on the gateway.
-		spanPartitions = []sql.SpanPartition{{Node: dsp.GatewayID(), Spans: trackedSpans}}
+		spanPartitions = []sql.SpanPartition{{SQLInstanceID: dsp.GatewayID(), Spans: trackedSpans}}
 	} else {
 		// All other feeds get a ChangeAggregator local on the leaseholder.
 		var err error
@@ -86,7 +86,7 @@ func StartDistChangefeed(
 			UserProto:  execCtx.User().EncodeProto(),
 			JobID:      jobID,
 		}
-		corePlacement[i].NodeID = sp.Node
+		corePlacement[i].SQLInstanceID = sp.SQLInstanceID
 		corePlacement[i].Core.ChangeAggregator = spec
 	}
 

--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/importccl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl/backupccl",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/utilccl",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamingest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/streamingccl",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -66,20 +66,20 @@ func ingest(
 	evalCtx := execCtx.ExtendedEvalContext()
 	dsp := execCtx.DistSQLPlanner()
 
-	planCtx, nodes, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+	planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
 	if err != nil {
 		return err
 	}
 
 	// Construct stream ingestion processor specs.
 	streamIngestionSpecs, streamIngestionFrontierSpec, err := distStreamIngestionPlanSpecs(
-		streamAddress, topology, nodes, initialHighWater, jobID)
+		streamAddress, topology, sqlInstanceIDs, initialHighWater, jobID)
 	if err != nil {
 		return err
 	}
 
 	// Plan and run the DistSQL flow.
-	return distStreamIngest(ctx, execCtx, nodes, jobID, planCtx, dsp, streamIngestionSpecs,
+	return distStreamIngest(ctx, execCtx, sqlInstanceIDs, jobID, planCtx, dsp, streamIngestionSpecs,
 		streamIngestionFrontierSpec)
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -11,6 +11,7 @@ package streamingest
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -30,20 +31,20 @@ import (
 func distStreamIngestionPlanSpecs(
 	streamAddress streamingccl.StreamAddress,
 	topology streamclient.Topology,
-	nodes []roachpb.NodeID,
+	sqlInstanceIDs []base.SQLInstanceID,
 	initialHighWater hlc.Timestamp,
 	jobID jobspb.JobID,
 ) ([]*execinfrapb.StreamIngestionDataSpec, *execinfrapb.StreamIngestionFrontierSpec, error) {
 
 	// For each stream partition in the topology, assign it to a node.
-	streamIngestionSpecs := make([]*execinfrapb.StreamIngestionDataSpec, 0, len(nodes))
+	streamIngestionSpecs := make([]*execinfrapb.StreamIngestionDataSpec, 0, len(sqlInstanceIDs))
 
 	trackedSpans := make([]roachpb.Span, 0)
 	for i, partition := range topology {
 		// Round robin assign the stream partitions to nodes. Partitions 0 through
 		// len(nodes) - 1 creates the spec. Future partitions just add themselves to
 		// the partition addresses.
-		if i < len(nodes) {
+		if i < len(sqlInstanceIDs) {
 			spec := &execinfrapb.StreamIngestionDataSpec{
 				JobID:              int64(jobID),
 				StartTime:          initialHighWater,
@@ -52,7 +53,7 @@ func distStreamIngestionPlanSpecs(
 			}
 			streamIngestionSpecs = append(streamIngestionSpecs, spec)
 		}
-		n := i % len(nodes)
+		n := i % len(sqlInstanceIDs)
 
 		streamIngestionSpecs[n].PartitionIds = append(streamIngestionSpecs[n].PartitionIds, partition.ID)
 		streamIngestionSpecs[n].PartitionSpecs = append(streamIngestionSpecs[n].PartitionSpecs,
@@ -80,7 +81,7 @@ func distStreamIngestionPlanSpecs(
 func distStreamIngest(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
-	nodes []roachpb.NodeID,
+	sqlInstanceIDs []base.SQLInstanceID,
 	jobID jobspb.JobID,
 	planCtx *sql.PlanningCtx,
 	dsp *sql.DistSQLPlanner,
@@ -98,7 +99,7 @@ func distStreamIngest(
 	// Setup a one-stage plan with one proc per input spec.
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(streamIngestionSpecs))
 	for i := range streamIngestionSpecs {
-		corePlacement[i].NodeID = nodes[i]
+		corePlacement[i].SQLInstanceID = sqlInstanceIDs[i]
 		corePlacement[i].Core.StreamIngestionData = streamIngestionSpecs[i]
 	}
 
@@ -118,7 +119,7 @@ func distStreamIngest(
 
 	// The ResultRouters from the previous stage will feed in to the
 	// StreamIngestionFrontier processor.
-	p.AddSingleGroupStage(gatewayNodeID,
+	p.AddSingleGroupStage(base.SQLInstanceID(gatewayNodeID),
 		execinfrapb.ProcessorCoreUnion{StreamIngestionFrontier: streamIngestionFrontierSpec},
 		execinfrapb.PostProcessSpec{}, streamIngestionResultTypes)
 

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
@@ -244,12 +244,12 @@ func getReplicationStreamSpec(
 		Partitions: make([]streampb.ReplicationStreamSpec_Partition, 0, len(spanPartitions)),
 	}
 	for _, sp := range spanPartitions {
-		nodeInfo, err := dsp.GetNodeInfo(sp.Node)
+		nodeInfo, err := dsp.GetSQLInstanceInfo(sp.SQLInstanceID)
 		if err != nil {
 			return nil, err
 		}
 		res.Partitions = append(res.Partitions, streampb.ReplicationStreamSpec_Partition{
-			NodeID:     sp.Node,
+			NodeID:     roachpb.NodeID(sp.SQLInstanceID),
 			SQLAddress: nodeInfo.SQLAddress,
 			Locality:   nodeInfo.Locality,
 			PartitionSpec: &streampb.StreamPartitionSpec{

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
 )
@@ -172,14 +173,14 @@ func StoreIDFromKey(storeKey string) (roachpb.StoreID, error) {
 }
 
 // MakeDistSQLNodeVersionKey returns the gossip key for the given store.
-func MakeDistSQLNodeVersionKey(nodeID roachpb.NodeID) string {
-	return MakeKey(KeyDistSQLNodeVersionKeyPrefix, nodeID.String())
+func MakeDistSQLNodeVersionKey(instanceID base.SQLInstanceID) string {
+	return MakeKey(KeyDistSQLNodeVersionKeyPrefix, instanceID.String())
 }
 
 // MakeDistSQLDrainingKey returns the gossip key for the given node's distsql
 // draining state.
-func MakeDistSQLDrainingKey(nodeID roachpb.NodeID) string {
-	return MakeKey(KeyDistSQLDrainingPrefix, nodeID.String())
+func MakeDistSQLDrainingKey(instanceID base.SQLInstanceID) string {
+	return MakeKey(KeyDistSQLDrainingPrefix, instanceID.String())
 }
 
 // removePrefixFromKey removes the key prefix and separator and returns what's

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -113,7 +113,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -1679,7 +1679,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 		s.cfg.NodeAttributes,
 		s.cfg.Locality,
 		s.cfg.LocalityAddresses,
-		s.sqlServer.execCfg.DistSQLPlanner.SetNodeInfo,
+		s.sqlServer.execCfg.DistSQLPlanner.SetSQLInstanceInfo,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -605,7 +605,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		NodeID:    cfg.nodeIDContainer,
 	}
 
-	var isAvailable func(roachpb.NodeID) bool
+	var isAvailable func(sqlInstanceID base.SQLInstanceID) bool
 	nodeLiveness, hasNodeLiveness := cfg.nodeLiveness.Optional(47900)
 	if hasNodeLiveness {
 		// TODO(erikgrinaker): We may want to use IsAvailableNotDraining instead, to
@@ -613,11 +613,13 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		// that are being drained/decommissioned. However, these nodes can still be
 		// leaseholders, and preventing processor scheduling on them can cause a
 		// performance cliff for e.g. table reads that then hit the network.
-		isAvailable = nodeLiveness.IsAvailable
+		isAvailable = func(sqlInstanceID base.SQLInstanceID) bool {
+			return nodeLiveness.IsAvailable(roachpb.NodeID(sqlInstanceID))
+		}
 	} else {
 		// We're on a SQL tenant, so this is the only node DistSQL will ever
 		// schedule on - always returning true is fine.
-		isAvailable = func(roachpb.NodeID) bool {
+		isAvailable = func(sqlInstanceID base.SQLInstanceID) bool {
 			return true
 		}
 	}
@@ -671,7 +673,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			ctx,
 			execinfra.Version,
 			cfg.Settings,
-			roachpb.NodeID(cfg.nodeIDContainer.SQLInstanceID()),
+			cfg.nodeIDContainer.SQLInstanceID(),
 			cfg.rpcContext,
 			distSQLServer,
 			cfg.distSender,
@@ -1041,7 +1043,7 @@ func (s *SQLServer) initInstanceID(ctx context.Context) error {
 		return err
 	}
 	s.sqlLivenessSessionID = sessionID
-	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: roachpb.NodeID(instanceID)})
+	s.execCfg.DistSQLPlanner.SetSQLInstanceInfo(roachpb.NodeDescriptor{NodeID: roachpb.NodeID(instanceID)})
 	return nil
 }
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -177,7 +177,7 @@ func StartTenant(
 
 	// TODO(asubiotto): remove this. Right now it is needed to initialize the
 	// SpanResolver.
-	s.execCfg.DistSQLPlanner.SetNodeInfo(roachpb.NodeDescriptor{NodeID: 0})
+	s.execCfg.DistSQLPlanner.SetSQLInstanceInfo(roachpb.NodeDescriptor{NodeID: 0})
 
 	// Register and start gRPC service on pod. This is separate from the
 	// gRPC + Gateway services configured below.

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -9,9 +9,9 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colflow/colrpc",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/col/coldata",
         "//pkg/col/colserde",
-        "//pkg/roachpb:with-mocks",
         "//pkg/sql/colexec/colexecargs",
         "//pkg/sql/colexec/colexecutils",
         "//pkg/sql/colexecerror",
@@ -46,10 +46,10 @@ go_test(
     ],
     embed = [":colrpc"],
     deps = [
+        "//pkg/base",
         "//pkg/col/coldata",
         "//pkg/col/coldatatestutils",
         "//pkg/col/colserde",
-        "//pkg/roachpb:with-mocks",
         "//pkg/settings/cluster",
         "//pkg/sql/colexec/colexecargs",
         "//pkg/sql/colexec/colexectestutils",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -136,7 +136,7 @@ func TestOutboxInbox(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticNodeID)
+	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticSQLInstanceID)
 	require.NoError(t, err)
 
 	// Generate a random cancellation scenario.
@@ -487,7 +487,7 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticNodeID)
+	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticSQLInstanceID)
 	require.NoError(t, err)
 
 	rng, _ := randutil.NewTestRand()
@@ -574,7 +574,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx,
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticNodeID,
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticSQLInstanceID,
 	)
 	require.NoError(t, err)
 
@@ -757,7 +757,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	defer stopper.Stop(ctx)
 
 	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx,
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticNodeID,
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticSQLInstanceID,
 	)
 	require.NoError(b, err)
 
@@ -830,7 +830,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx,
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticNodeID,
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticSQLInstanceID,
 	)
 	require.NoError(t, err)
 	dialer := &execinfrapb.MockDialer{Addr: addr}
@@ -861,7 +861,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 		outbox.Run(
 			ctx,
 			dialer,
-			roachpb.NodeID(0),
+			base.SQLInstanceID(0),
 			execinfrapb.FlowID{UUID: uuid.MakeV4()},
 			outboxStreamID,
 			nil, /* flowCtxCancel */

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -17,8 +17,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/colserde"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -147,7 +147,7 @@ func (o *Outbox) close(ctx context.Context) {
 func (o *Outbox) Run(
 	ctx context.Context,
 	dialer execinfra.Dialer,
-	nodeID roachpb.NodeID,
+	sqlInstanceID base.SQLInstanceID,
 	flowID execinfrapb.FlowID,
 	streamID execinfrapb.StreamID,
 	flowCtxCancel context.CancelFunc,
@@ -169,11 +169,11 @@ func (o *Outbox) Run(
 
 	o.runnerCtx = ctx
 	ctx = logtags.AddTag(ctx, "streamID", streamID)
-	log.VEventf(ctx, 2, "Outbox Dialing %s", nodeID)
+	log.VEventf(ctx, 2, "Outbox Dialing %s", sqlInstanceID)
 
 	var stream execinfrapb.DistSQL_FlowStreamClient
 	if err := func() error {
-		conn, err := execinfra.GetConnForOutbox(ctx, dialer, nodeID, connectionTimeout)
+		conn, err := execinfra.GetConnForOutbox(ctx, dialer, sqlInstanceID, connectionTimeout)
 		if err != nil {
 			log.Warningf(
 				ctx,

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -125,7 +125,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	_, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx,
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticNodeID,
+		hlc.NewClock(hlc.UnixNano, time.Nanosecond), stopper, execinfra.StaticSQLInstanceID,
 	)
 	require.NoError(t, err)
 	dialer := &execinfrapb.MockDialer{Addr: addr}
@@ -274,7 +274,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						outbox.Run(
 							outboxCtx,
 							dialer,
-							execinfra.StaticNodeID,
+							execinfra.StaticSQLInstanceID,
 							flowID,
 							execinfrapb.StreamID(id),
 							flowCtxCancel,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -292,7 +292,7 @@ func startConnExecutor(
 		},
 		Codec: keys.SystemSQLCodec,
 		DistSQLPlanner: NewDistSQLPlanner(
-			ctx, execinfra.Version, st, roachpb.NodeID(1),
+			ctx, execinfra.Version, st, 1, /* sqlInstanceID */
 			nil, /* rpcCtx */
 			distsql.NewServer(
 				ctx,
@@ -311,7 +311,7 @@ func startConnExecutor(
 			nil, /* nodeDescs */
 			gw,
 			stopper,
-			func(roachpb.NodeID) bool { return true }, // everybody is available
+			func(base.SQLInstanceID) bool { return true }, // everybody is available
 			nil, /* nodeDialer */
 		),
 		QueryCache:              querycache.New(0),

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/distsql",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/gossip",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -39,10 +39,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// staticAddressResolver maps execinfra.StaticNodeID to the given address.
+// staticAddressResolver maps execinfra.StaticSQLInstanceID to the given address.
 func staticAddressResolver(addr net.Addr) nodedialer.AddressResolver {
 	return func(nodeID roachpb.NodeID) (net.Addr, error) {
-		if nodeID == execinfra.StaticNodeID {
+		if nodeID == roachpb.NodeID(execinfra.StaticSQLInstanceID) {
 			return addr, nil
 		}
 		return nil, errors.Errorf("node %d not found", nodeID)
@@ -98,7 +98,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	}
 
 	streamID := execinfrapb.StreamID(1)
-	outbox := flowinfra.NewOutbox(&flowCtx, execinfra.StaticNodeID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+	outbox := flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 	outbox.Init(types.OneIntCol)
 
 	// WaitGroup for the outbox and inbound stream. If the WaitGroup is done, no

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -81,13 +81,11 @@ type DistSQLPlanner struct {
 	planVersion execinfrapb.DistSQLVersion
 
 	st *cluster.Settings
-	// The nodeID of the gateway node that initiated this query.
-	// TODO(asubiotto): This usage of NodeID instead of SQLInstanceID is
-	//  temporary: https://github.com/cockroachdb/cockroach/issues/49596
-	gatewayNodeID roachpb.NodeID
-	stopper       *stop.Stopper
-	distSQLSrv    *distsql.ServerImpl
-	spanResolver  physicalplan.SpanResolver
+	// The SQLInstanceID of the gateway node that initiated this query.
+	gatewaySQLInstanceID base.SQLInstanceID
+	stopper              *stop.Stopper
+	distSQLSrv           *distsql.ServerImpl
+	spanResolver         physicalplan.SpanResolver
 
 	// metadataTestTolerance is the minimum level required to plan metadata test
 	// processors.
@@ -116,11 +114,11 @@ type DistSQLPlanner struct {
 	// for the same stage of the fully local physical plans.
 	parallelLocalScansSem *quotapool.IntPool
 
-	// distSender is used to construct the spanResolver upon SetNodeInfo.
+	// distSender is used to construct the spanResolver upon SetSQLInstanceInfo.
 	distSender *kvcoord.DistSender
-	// nodeDescs is used to construct the spanResolver upon SetNodeInfo.
+	// nodeDescs is used to construct the spanResolver upon SetSQLInstanceInfo.
 	nodeDescs kvcoord.NodeDescStore
-	// rpcCtx is used to construct the spanResolver upon SetNodeInfo.
+	// rpcCtx is used to construct the spanResolver upon SetSQLInstanceInfo.
 	rpcCtx *rpc.Context
 }
 
@@ -135,34 +133,32 @@ var logPlanDiagram = envutil.EnvOrDefaultBool("COCKROACH_DISTSQL_LOG_PLAN", fals
 
 // NewDistSQLPlanner initializes a DistSQLPlanner.
 //
-// nodeID is the ID of the node on which this planner runs. It is used to favor
-// itself and other close-by nodes when planning. An invalid nodeID can be
-// passed to aid bootstrapping, but then SetNodeInfo() needs to be called
+// sqlInstanceID is the ID of the node on which this planner runs. It is used to
+// favor itself and other close-by nodes when planning. An invalid sqlInstanceID
+// can be passed to aid bootstrapping, but then SetSQLInstanceInfo() needs to be called
 // before this planner is used.
-// TODO(asubiotto): This usage of NodeID instead of SQLInstanceID is
-//  temporary: https://github.com/cockroachdb/cockroach/issues/49596
 func NewDistSQLPlanner(
 	ctx context.Context,
 	planVersion execinfrapb.DistSQLVersion,
 	st *cluster.Settings,
-	nodeID roachpb.NodeID,
+	sqlInstanceID base.SQLInstanceID,
 	rpcCtx *rpc.Context,
 	distSQLSrv *distsql.ServerImpl,
 	distSender *kvcoord.DistSender,
 	nodeDescs kvcoord.NodeDescStore,
 	gw gossip.OptionalGossip,
 	stopper *stop.Stopper,
-	isAvailable func(roachpb.NodeID) bool,
+	isAvailable func(base.SQLInstanceID) bool,
 	nodeDialer *nodedialer.Dialer,
 ) *DistSQLPlanner {
 	dsp := &DistSQLPlanner{
-		planVersion:   planVersion,
-		st:            st,
-		gatewayNodeID: nodeID,
-		stopper:       stopper,
-		distSQLSrv:    distSQLSrv,
-		gossip:        gw,
-		nodeDialer:    nodeDialer,
+		planVersion:          planVersion,
+		st:                   st,
+		gatewaySQLInstanceID: sqlInstanceID,
+		stopper:              stopper,
+		distSQLSrv:           distSQLSrv,
+		gossip:               gw,
+		nodeDialer:           nodeDialer,
 		nodeHealth: distSQLNodeHealth{
 			gossip:      gw,
 			connHealth:  nodeDialer.ConnHealthTryDial,
@@ -193,15 +189,17 @@ func (dsp *DistSQLPlanner) shouldPlanTestMetadata() bool {
 	return dsp.distSQLSrv.TestingKnobs.MetadataTestLevel >= dsp.metadataTestTolerance
 }
 
-// GetNodeInfo gets a node descriptor by node ID.
-func (dsp *DistSQLPlanner) GetNodeInfo(nodeID roachpb.NodeID) (*roachpb.NodeDescriptor, error) {
-	return dsp.nodeDescs.GetNodeDescriptor(nodeID)
+// GetSQLInstanceInfo gets a node descriptor by node ID.
+func (dsp *DistSQLPlanner) GetSQLInstanceInfo(
+	sqlInstanceID base.SQLInstanceID,
+) (*roachpb.NodeDescriptor, error) {
+	return dsp.nodeDescs.GetNodeDescriptor(roachpb.NodeID(sqlInstanceID))
 }
 
-// SetNodeInfo sets the planner's node descriptor.
-// The first call to SetNodeInfo leads to the construction of the SpanResolver.
-func (dsp *DistSQLPlanner) SetNodeInfo(desc roachpb.NodeDescriptor) {
-	dsp.gatewayNodeID = desc.NodeID
+// SetSQLInstanceInfo sets the planner's node descriptor.
+// The first call to SetSQLInstanceInfo leads to the construction of the SpanResolver.
+func (dsp *DistSQLPlanner) SetSQLInstanceInfo(desc roachpb.NodeDescriptor) {
+	dsp.gatewaySQLInstanceID = base.SQLInstanceID(desc.NodeID)
 	if dsp.spanResolver == nil {
 		sr := physicalplan.NewSpanResolver(dsp.st, dsp.distSender, dsp.nodeDescs, desc,
 			dsp.rpcCtx, ReplicaOraclePolicy)
@@ -210,8 +208,8 @@ func (dsp *DistSQLPlanner) SetNodeInfo(desc roachpb.NodeDescriptor) {
 }
 
 // GatewayID returns the ID of the gateway.
-func (dsp *DistSQLPlanner) GatewayID() roachpb.NodeID {
-	return dsp.gatewayNodeID
+func (dsp *DistSQLPlanner) GatewayID() base.SQLInstanceID {
+	return dsp.gatewaySQLInstanceID
 }
 
 // SetSpanResolver switches to a different SpanResolver. It is the caller's
@@ -659,9 +657,9 @@ type PlanningCtx struct {
 	ctx             context.Context
 	ExtendedEvalCtx *extendedEvalContext
 	spanIter        physicalplan.SpanResolverIterator
-	// NodesStatuses contains info for all NodeIDs that are referenced by any
-	// PhysicalPlan we generate with this context.
-	NodeStatuses map[roachpb.NodeID]NodeStatus
+	// NodesStatuses contains info for all SQLInstanceIDs that are referenced by
+	// any PhysicalPlan we generate with this context.
+	NodeStatuses map[base.SQLInstanceID]NodeStatus
 
 	infra physicalplan.PhysicalInfrastructure
 
@@ -681,7 +679,7 @@ type PlanningCtx struct {
 
 	// If set, the flows for the physical plan will be passed to this function.
 	// The flows are not safe for use past the lifetime of the saveFlows function.
-	saveFlows func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error
+	saveFlows func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execinfra.OpChains) error
 
 	// If set, we will record the mapping from planNode to tracing metadata to
 	// later allow associating statistics with the planNode.
@@ -735,8 +733,8 @@ func (p *PlanningCtx) IsLocal() bool {
 // plans and their diagrams.
 func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 	ctx context.Context, planner *planner, typ planComponentType,
-) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error {
-	return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec, opChains execinfra.OpChains) error {
+) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execinfra.OpChains) error {
+	return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, opChains execinfra.OpChains) error {
 		var diagram execinfrapb.FlowDiagram
 		if planner.instrumentation.shouldSaveDiagrams() {
 			diagramFlags := execinfrapb.DiagramFlags{
@@ -755,7 +753,7 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 			getExplain := func(verbose bool) []string {
 				explain, cleanup, err := colflow.ExplainVec(
 					ctx, flowCtx, flows, p.infra.LocalProcessors, opChains,
-					planner.extendedEvalCtx.DistSQLPlanner.gatewayNodeID,
+					planner.extendedEvalCtx.DistSQLPlanner.gatewaySQLInstanceID,
 					verbose, planner.curPlan.flags.IsDistributed(),
 				)
 				cleanup()
@@ -790,7 +788,7 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 // FlowDiagram using this PlanningCtx's information.
 func (p *PlanningCtx) flowSpecsToDiagram(
 	ctx context.Context,
-	flows map[roachpb.NodeID]*execinfrapb.FlowSpec,
+	flows map[base.SQLInstanceID]*execinfrapb.FlowSpec,
 	diagramFlags execinfrapb.DiagramFlags,
 ) (execinfrapb.FlowDiagram, error) {
 	log.VEvent(ctx, 1, "creating plan diagram")
@@ -880,20 +878,22 @@ func identityMapInPlace(slice []int) []int {
 	return slice
 }
 
-// SpanPartition is the intersection between a set of spans for a certain
-// operation (e.g table scan) and the set of ranges owned by a given node.
+// SpanPartition associates a subset of spans with a specific SQL instance,
+// chosen to have the most efficient access to those spans. In the single-tenant
+// case, the instance is the one running on the same node as the leaseholder for
+// those spans.
 type SpanPartition struct {
-	Node  roachpb.NodeID
-	Spans roachpb.Spans
+	SQLInstanceID base.SQLInstanceID
+	Spans         roachpb.Spans
 }
 
 type distSQLNodeHealth struct {
 	gossip      gossip.OptionalGossip
-	isAvailable func(roachpb.NodeID) bool
+	isAvailable func(base.SQLInstanceID) bool
 	connHealth  func(roachpb.NodeID, rpc.ConnectionClass) error
 }
 
-func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) error {
+func (h *distSQLNodeHealth) check(ctx context.Context, sqlInstanceID base.SQLInstanceID) error {
 	{
 		// NB: as of #22658, ConnHealth does not work as expected; see the
 		// comment within. We still keep this code for now because in
@@ -902,23 +902,23 @@ func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) er
 		// artifact of rpcContext's reconnection mechanism at the time of
 		// writing). This is better than having it used in 100% of cases
 		// (until the liveness check below kicks in).
-		err := h.connHealth(nodeID, rpc.DefaultClass)
+		err := h.connHealth(roachpb.NodeID(sqlInstanceID), rpc.DefaultClass)
 		if err != nil && !errors.Is(err, rpc.ErrNotHeartbeated) {
 			// This host is known to be unhealthy. Don't use it (use the gateway
-			// instead). Note: this can never happen for our nodeID (which
+			// instead). Note: this can never happen for our sqlInstanceID (which
 			// always has its address in the nodeMap).
-			log.VEventf(ctx, 1, "marking n%d as unhealthy for this plan: %v", nodeID, err)
+			log.VEventf(ctx, 1, "marking n%d as unhealthy for this plan: %v", sqlInstanceID, err)
 			return err
 		}
 	}
-	if !h.isAvailable(nodeID) {
-		return pgerror.Newf(pgcode.CannotConnectNow, "not using n%d since it is not available", nodeID)
+	if !h.isAvailable(sqlInstanceID) {
+		return pgerror.Newf(pgcode.CannotConnectNow, "not using n%d since it is not available", sqlInstanceID)
 	}
 
 	// Check that the node is not draining.
 	if g, ok := h.gossip.Optional(distsql.MultiTenancyIssueNo); ok {
 		drainingInfo := &execinfrapb.DistSQLDrainingInfo{}
-		if err := g.GetInfoProto(gossip.MakeDistSQLDrainingKey(nodeID), drainingInfo); err != nil {
+		if err := g.GetInfoProto(gossip.MakeDistSQLDrainingKey(sqlInstanceID), drainingInfo); err != nil {
 			// Because draining info has no expiration, an error
 			// implies that we have not yet received a node's
 			// draining information. Since this information is
@@ -930,7 +930,7 @@ func (h *distSQLNodeHealth) check(ctx context.Context, nodeID roachpb.NodeID) er
 		}
 
 		if drainingInfo.Draining {
-			err := errors.Newf("not using n%d because it is draining", nodeID)
+			err := errors.Newf("not using n%d because it is draining", sqlInstanceID)
 			log.VEventf(ctx, 1, "%v", err)
 			return err
 		}
@@ -959,11 +959,11 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 	if planCtx.isLocal {
 		// If we're planning locally, map all spans to the local node.
 		partitions = append(partitions,
-			SpanPartition{dsp.gatewayNodeID, spans})
+			SpanPartition{dsp.gatewaySQLInstanceID, spans})
 		return partitions, nil
 	}
-	// nodeMap maps a nodeID to an index inside the partitions array.
-	nodeMap := make(map[roachpb.NodeID]int)
+	// nodeMap maps a SQLInstanceID to an index inside the partitions array.
+	nodeMap := make(map[base.SQLInstanceID]int)
 	it := planCtx.spanIter
 	for i := range spans {
 
@@ -989,7 +989,7 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 			return nil, err
 		}
 
-		var lastNodeID roachpb.NodeID
+		var lastSQLInstanceID base.SQLInstanceID
 		// lastKey maintains the EndKey of the last piece of `span`.
 		lastKey := rSpan.Key
 		if log.V(1) {
@@ -1026,25 +1026,25 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 				endKey = rSpan.EndKey
 			}
 
-			nodeID := replDesc.NodeID
-			partitionIdx, inNodeMap := nodeMap[nodeID]
+			sqlInstanceID := base.SQLInstanceID(replDesc.NodeID)
+			partitionIdx, inNodeMap := nodeMap[sqlInstanceID]
 			if !inNodeMap {
-				// This is the first time we are seeing nodeID for these spans. Check
-				// its health.
-				status := dsp.CheckNodeHealthAndVersion(planCtx, nodeID)
+				// This is the first time we are seeing this sqlInstanceID for these
+				// spans. Check its health.
+				status := dsp.CheckInstanceHealthAndVersion(planCtx, sqlInstanceID)
 				// If the node is unhealthy or its DistSQL version is incompatible, use
 				// the gateway to process this span instead of the unhealthy host.
 				// An empty address indicates an unhealthy host.
 				if status != NodeOK {
-					log.Eventf(ctx, "not planning on node %d: %s", nodeID, status)
-					nodeID = dsp.gatewayNodeID
-					partitionIdx, inNodeMap = nodeMap[nodeID]
+					log.Eventf(ctx, "not planning on node %d: %s", sqlInstanceID, status)
+					sqlInstanceID = dsp.gatewaySQLInstanceID
+					partitionIdx, inNodeMap = nodeMap[sqlInstanceID]
 				}
 
 				if !inNodeMap {
 					partitionIdx = len(partitions)
-					partitions = append(partitions, SpanPartition{Node: nodeID})
-					nodeMap[nodeID] = partitionIdx
+					partitions = append(partitions, SpanPartition{SQLInstanceID: sqlInstanceID})
+					nodeMap[sqlInstanceID] = partitionIdx
 				}
 			}
 			partition := &partitions[partitionIdx]
@@ -1058,7 +1058,7 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 				break
 			}
 
-			if lastNodeID == nodeID {
+			if lastSQLInstanceID == sqlInstanceID {
 				// Two consecutive ranges on the same node, merge the spans.
 				partition.Spans[len(partition.Spans)-1].EndKey = endKey.AsRawKey()
 			} else {
@@ -1074,7 +1074,7 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 			}
 
 			lastKey = endKey
-			lastNodeID = nodeID
+			lastSQLInstanceID = sqlInstanceID
 		}
 	}
 	return partitions, nil
@@ -1083,13 +1083,13 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 // nodeVersionIsCompatible decides whether a particular node's DistSQL version
 // is compatible with dsp.planVersion. It uses gossip to find out the node's
 // version range.
-func (dsp *DistSQLPlanner) nodeVersionIsCompatible(nodeID roachpb.NodeID) bool {
+func (dsp *DistSQLPlanner) nodeVersionIsCompatible(sqlInstanceID base.SQLInstanceID) bool {
 	g, ok := dsp.gossip.Optional(distsql.MultiTenancyIssueNo)
 	if !ok {
 		return true // no gossip - always compatible; only a single gateway running in Phase 2
 	}
 	var v execinfrapb.DistSQLVersionGossipInfo
-	if err := g.GetInfoProto(gossip.MakeDistSQLNodeVersionKey(nodeID), &v); err != nil {
+	if err := g.GetInfoProto(gossip.MakeDistSQLNodeVersionKey(sqlInstanceID), &v); err != nil {
 		return false
 	}
 	return distsql.FlowVerIsCompatible(dsp.planVersion, v.MinAcceptedVersion, v.Version)
@@ -1199,13 +1199,13 @@ func (dsp *DistSQLPlanner) convertOrdering(
 	return result
 }
 
-// getNodeIDForScan retrieves the node ID where the single table reader should
-// reside for a limited scan. Ideally this is the lease holder for the first
-// range in the specified spans. But if that node is unhealthy or incompatible,
-// we use the gateway node instead.
-func (dsp *DistSQLPlanner) getNodeIDForScan(
+// getInstanceIDForScan retrieves the SQL Instance ID where the single table reader
+// should reside for a limited scan. Ideally this is the lease holder for the
+// first range in the specified spans. But if that node is unhealthy or
+// incompatible, we use the gateway node instead.
+func (dsp *DistSQLPlanner) getInstanceIDForScan(
 	planCtx *PlanningCtx, spans []roachpb.Span, reverse bool,
-) (roachpb.NodeID, error) {
+) (base.SQLInstanceID, error) {
 	if len(spans) == 0 {
 		panic("no spans")
 	}
@@ -1225,33 +1225,33 @@ func (dsp *DistSQLPlanner) getNodeIDForScan(
 		return 0, err
 	}
 
-	nodeID := replDesc.NodeID
-	status := dsp.CheckNodeHealthAndVersion(planCtx, nodeID)
+	sqlInstanceID := base.SQLInstanceID(replDesc.NodeID)
+	status := dsp.CheckInstanceHealthAndVersion(planCtx, sqlInstanceID)
 	if status != NodeOK {
-		log.Eventf(planCtx.ctx, "not planning on node %d: %s", nodeID, status)
-		return dsp.gatewayNodeID, nil
+		log.Eventf(planCtx.ctx, "not planning on node %d: %s", sqlInstanceID, status)
+		return dsp.gatewaySQLInstanceID, nil
 	}
-	return nodeID, nil
+	return sqlInstanceID, nil
 }
 
-// CheckNodeHealthAndVersion returns a information about a node's health and
+// CheckInstanceHealthAndVersion returns a information about a node's health and
 // compatibility. The info is also recorded in planCtx.Nodes.
-func (dsp *DistSQLPlanner) CheckNodeHealthAndVersion(
-	planCtx *PlanningCtx, nodeID roachpb.NodeID,
+func (dsp *DistSQLPlanner) CheckInstanceHealthAndVersion(
+	planCtx *PlanningCtx, sqlInstanceID base.SQLInstanceID,
 ) NodeStatus {
-	if status, ok := planCtx.NodeStatuses[nodeID]; ok {
+	if status, ok := planCtx.NodeStatuses[sqlInstanceID]; ok {
 		return status
 	}
 
 	var status NodeStatus
-	if err := dsp.nodeHealth.check(planCtx.ctx, nodeID); err != nil {
+	if err := dsp.nodeHealth.check(planCtx.ctx, sqlInstanceID); err != nil {
 		status = NodeUnhealthy
-	} else if !dsp.nodeVersionIsCompatible(nodeID) {
+	} else if !dsp.nodeVersionIsCompatible(sqlInstanceID) {
 		status = NodeDistSQLVersionIncompatible
 	} else {
 		status = NodeOK
 	}
-	planCtx.NodeStatuses[nodeID] = status
+	planCtx.NodeStatuses[sqlInstanceID] = status
 	return status
 }
 
@@ -1348,12 +1348,12 @@ func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
 		if err != nil {
 			// For some reason we couldn't partition the spans - fallback to
 			// having a single TableReader.
-			spanPartitions = []SpanPartition{{dsp.gatewayNodeID, info.spans}}
+			spanPartitions = []SpanPartition{{dsp.gatewaySQLInstanceID, info.spans}}
 			parallelizeLocal = false
 			return spanPartitions, parallelizeLocal
 		}
 		for i := range spanPartitions {
-			spanPartitions[i].Node = dsp.gatewayNodeID
+			spanPartitions[i].SQLInstanceID = dsp.gatewaySQLInstanceID
 		}
 		if len(spanPartitions) > 1 {
 			// We're touching ranges that have leaseholders on multiple nodes,
@@ -1401,7 +1401,7 @@ func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
 				// We weren't able to acquire the quota for any additional
 				// goroutines, so we will fallback to having a single
 				// TableReader.
-				spanPartitions = []SpanPartition{{dsp.gatewayNodeID, info.spans}}
+				spanPartitions = []SpanPartition{{dsp.gatewaySQLInstanceID, info.spans}}
 			}
 		}
 		if len(spanPartitions) == 1 {
@@ -1411,7 +1411,7 @@ func (dsp *DistSQLPlanner) maybeParallelizeLocalScans(
 			parallelizeLocal = false
 		}
 	} else {
-		spanPartitions = []SpanPartition{{dsp.gatewayNodeID, info.spans}}
+		spanPartitions = []SpanPartition{{dsp.gatewaySQLInstanceID, info.spans}}
 	}
 	return spanPartitions, parallelizeLocal
 }
@@ -1439,11 +1439,11 @@ func (dsp *DistSQLPlanner) planTableReaders(
 	} else {
 		// If the scan has a hard limit, use a single TableReader to avoid
 		// reading more rows than necessary.
-		nodeID, err := dsp.getNodeIDForScan(planCtx, info.spans, info.reverse)
+		sqlInstanceID, err := dsp.getInstanceIDForScan(planCtx, info.spans, info.reverse)
 		if err != nil {
 			return err
 		}
-		spanPartitions = []SpanPartition{{nodeID, info.spans}}
+		spanPartitions = []SpanPartition{{sqlInstanceID, info.spans}}
 	}
 
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(spanPartitions))
@@ -1469,7 +1469,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		}
 		p.TotalEstimatedScannedRows += info.estimatedRowCount
 
-		corePlacement[i].NodeID = sp.Node
+		corePlacement[i].SQLInstanceID = sp.SQLInstanceID
 		corePlacement[i].EstimatedRowCount = info.estimatedRowCount
 		corePlacement[i].Core.TableReader = tr
 	}
@@ -1486,7 +1486,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 	if parallelizeLocal {
 		// If we planned multiple table readers, we need to merge the streams
 		// into one.
-		p.AddSingleGroupStage(dsp.gatewayNodeID, execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}}, execinfrapb.PostProcessSpec{}, p.GetResultTypes())
+		p.AddSingleGroupStage(dsp.gatewaySQLInstanceID, execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}}, execinfrapb.PostProcessSpec{}, p.GetResultTypes())
 	}
 
 	return nil
@@ -1557,7 +1557,7 @@ func (dsp *DistSQLPlanner) addSorters(
 			Limit: uint64(limit),
 		}
 		p.AddSingleGroupStage(
-			p.GatewayNodeID,
+			p.GatewaySQLInstanceID,
 			execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}},
 			post,
 			p.GetResultTypes(),
@@ -1711,9 +1711,9 @@ func (dsp *DistSQLPlanner) planAggregators(
 	}
 
 	// Check if the previous stage is all on one node.
-	prevStageNode := p.Processors[p.ResultRouters[0]].Node
+	prevStageNode := p.Processors[p.ResultRouters[0]].SQLInstanceID
 	for i := 1; i < len(p.ResultRouters); i++ {
-		if n := p.Processors[p.ResultRouters[i]].Node; n != prevStageNode {
+		if n := p.Processors[p.ResultRouters[i]].SQLInstanceID; n != prevStageNode {
 			prevStageNode = 0
 			break
 		}
@@ -2076,7 +2076,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 		// No GROUP BY, or we have a single stream. Use a single final aggregator.
 		// If the previous stage was all on a single node, put the final
 		// aggregator there. Otherwise, bring the results back on this node.
-		node := dsp.gatewayNodeID
+		node := dsp.gatewaySQLInstanceID
 		if prevStageNode != 0 {
 			node = prevStageNode
 		}
@@ -2108,7 +2108,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 		prevStageResultTypes := p.GetResultTypes()
 		for _, resultProc := range p.ResultRouters {
 			proc := physicalplan.Processor{
-				Node: p.Processors[resultProc].Node,
+				SQLInstanceID: p.Processors[resultProc].SQLInstanceID,
 				Spec: execinfrapb.ProcessorSpec{
 					Input: []execinfrapb.InputSyncSpec{{
 						// The other fields will be filled in by mergeResultStreams.
@@ -2209,7 +2209,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 	} else {
 		// We have a single stream, so use a single join reader on that node.
 		plan.AddSingleGroupStage(
-			plan.Processors[plan.ResultRouters[0]].Node,
+			plan.Processors[plan.ResultRouters[0]].SQLInstanceID,
 			execinfrapb.ProcessorCoreUnion{JoinReader: &joinReaderSpec},
 			post,
 			types,
@@ -2592,8 +2592,8 @@ func (dsp *DistSQLPlanner) planZigzagJoin(
 	// processor across multiple nodes here. Until then, schedule on the current
 	// node.
 	corePlacement := []physicalplan.ProcessorCorePlacement{{
-		NodeID: dsp.gatewayNodeID,
-		Core:   execinfrapb.ProcessorCoreUnion{ZigzagJoiner: &zigzagJoinerSpec},
+		SQLInstanceID: dsp.gatewaySQLInstanceID,
+		Core:          execinfrapb.ProcessorCoreUnion{ZigzagJoiner: &zigzagJoinerSpec},
 	}}
 
 	plan.AddNoInputStage(corePlacement, post, types, execinfrapb.Ordering{})
@@ -2634,8 +2634,8 @@ func (dsp *DistSQLPlanner) createPlanForInvertedFilter(
 	//   at the next stage.
 	if len(plan.ResultRouters) == 1 {
 		// Last stage is a single processor.
-		lastNodeID := plan.Processors[plan.ResultRouters[0]].Node
-		plan.AddSingleGroupStage(lastNodeID,
+		lastSQLInstanceID := plan.Processors[plan.ResultRouters[0]].SQLInstanceID
+		plan.AddSingleGroupStage(lastSQLInstanceID,
 			execinfrapb.ProcessorCoreUnion{
 				InvertedFilterer: invertedFiltererSpec,
 			},
@@ -2664,7 +2664,7 @@ func (dsp *DistSQLPlanner) createPlanForInvertedFilter(
 		distinctColumns = append(distinctColumns, uint32(i))
 	}
 	plan.AddSingleGroupStage(
-		dsp.gatewayNodeID,
+		dsp.gatewaySQLInstanceID,
 		execinfrapb.ProcessorCoreUnion{
 			Distinct: dsp.createDistinctSpec(
 				distinctColumns,
@@ -2803,26 +2803,26 @@ func (dsp *DistSQLPlanner) planJoiners(
 	leftRouters := info.leftPlan.ResultRouters
 	rightRouters := info.rightPlan.ResultRouters
 
-	// Nodes where we will run the join processors.
-	var nodes []roachpb.NodeID
+	// Instances where we will run the join processors.
+	var sqlInstances []base.SQLInstanceID
 	if numEq := len(info.leftEqCols); numEq != 0 {
-		nodes = findJoinProcessorNodes(leftRouters, rightRouters, p.Processors)
+		sqlInstances = findJoinProcessorNodes(leftRouters, rightRouters, p.Processors)
 	} else {
 		// Without column equality, we cannot distribute the join. Run a
 		// single processor.
-		nodes = []roachpb.NodeID{dsp.gatewayNodeID}
+		sqlInstances = []base.SQLInstanceID{dsp.gatewaySQLInstanceID}
 
 		// If either side has a single stream, put the processor on that node. We
 		// prefer the left side because that is processed first by the hash joiner.
 		if len(leftRouters) == 1 {
-			nodes[0] = p.Processors[leftRouters[0]].Node
+			sqlInstances[0] = p.Processors[leftRouters[0]].SQLInstanceID
 		} else if len(rightRouters) == 1 {
-			nodes[0] = p.Processors[rightRouters[0]].Node
+			sqlInstances[0] = p.Processors[rightRouters[0]].SQLInstanceID
 		}
 	}
 
 	p.AddJoinStage(
-		nodes, info.makeCoreSpec(), info.post,
+		sqlInstances, info.makeCoreSpec(), info.post,
 		info.leftEqCols, info.rightEqCols,
 		info.leftPlan.GetResultTypes(), info.rightPlan.GetResultTypes(),
 		info.leftMergeOrd, info.rightMergeOrd,
@@ -3005,7 +3005,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		processors := make(execComponents, len(plan.ResultRouters))
 		for i, resultProcIdx := range plan.ResultRouters {
 			processors[i] = execinfrapb.ProcessorComponentID(
-				base.SQLInstanceID(plan.Processors[resultProcIdx].Node),
+				plan.Processors[resultProcIdx].SQLInstanceID,
 				execinfrapb.FlowID{UUID: planCtx.infra.FlowID},
 				int32(resultProcIdx),
 			)
@@ -3119,7 +3119,7 @@ func (dsp *DistSQLPlanner) wrapPlan(
 	}
 	name := nodeName(n)
 	proc := physicalplan.Processor{
-		Node: dsp.gatewayNodeID,
+		SQLInstanceID: dsp.gatewaySQLInstanceID,
 		Spec: execinfrapb.ProcessorSpec{
 			Input: input,
 			Core: execinfrapb.ProcessorCoreUnion{LocalPlanNode: &execinfrapb.LocalPlanNodeSpec{
@@ -3186,7 +3186,7 @@ func (dsp *DistSQLPlanner) createValuesPlan(
 
 	pIdx := p.AddProcessor(physicalplan.Processor{
 		// TODO: find a better node to place processor at
-		Node: dsp.gatewayNodeID,
+		SQLInstanceID: dsp.gatewaySQLInstanceID,
 		Spec: execinfrapb.ProcessorSpec{
 			Core:        execinfrapb.ProcessorCoreUnion{Values: spec},
 			Output:      []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
@@ -3304,9 +3304,9 @@ func (dsp *DistSQLPlanner) addDistinctProcessors(
 		return
 	}
 
-	nodes := getNodesOfRouters(plan.ResultRouters, plan.Processors)
+	sqlInstanceIDs := getSQLInstanceIDsOfRouters(plan.ResultRouters, plan.Processors)
 	plan.AddStageOnNodes(
-		nodes, distinctSpec, execinfrapb.PostProcessSpec{},
+		sqlInstanceIDs, distinctSpec, execinfrapb.PostProcessSpec{},
 		distinctSpec.Distinct.DistinctColumns, plan.GetResultTypes(),
 		plan.GetResultTypes(), plan.MergeOrdering, plan.ResultRouters,
 	)
@@ -3330,7 +3330,7 @@ func (dsp *DistSQLPlanner) createPlanForOrdinality(
 
 	// WITH ORDINALITY never gets distributed so that the gateway node can
 	// always number each row in order.
-	plan.AddSingleGroupStage(dsp.gatewayNodeID, ordinalitySpec, execinfrapb.PostProcessSpec{}, outputTypes)
+	plan.AddSingleGroupStage(dsp.gatewaySQLInstanceID, ordinalitySpec, execinfrapb.PostProcessSpec{}, outputTypes)
 
 	return plan, nil
 }
@@ -3392,7 +3392,7 @@ func (dsp *DistSQLPlanner) addProjectSet(
 	// filtered), we could try to detect these cases and use AddNoGroupingStage
 	// instead.
 	outputTypes := append(plan.GetResultTypes(), projectSetSpec.GeneratedColumns...)
-	plan.AddSingleGroupStage(dsp.gatewayNodeID, spec, execinfrapb.PostProcessSpec{}, outputTypes)
+	plan.AddSingleGroupStage(dsp.gatewaySQLInstanceID, spec, execinfrapb.PostProcessSpec{}, outputTypes)
 
 	// Add generated columns to PlanToStreamColMap.
 	for i := range projectSetSpec.GeneratedColumns {
@@ -3406,7 +3406,7 @@ func (dsp *DistSQLPlanner) addProjectSet(
 func (dsp *DistSQLPlanner) isOnlyOnGateway(plan *PhysicalPlan) bool {
 	if len(plan.ResultRouters) == 1 {
 		processorIdx := plan.ResultRouters[0]
-		if plan.Processors[processorIdx].Node == dsp.gatewayNodeID {
+		if plan.Processors[processorIdx].SQLInstanceID == dsp.gatewaySQLInstanceID {
 			return true
 		}
 	}
@@ -3579,7 +3579,7 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 					mergeOrdering,
 				),
 			}
-			p.AddSingleGroupStage(dsp.gatewayNodeID, distinctSpec, execinfrapb.PostProcessSpec{}, resultTypes)
+			p.AddSingleGroupStage(dsp.gatewaySQLInstanceID, distinctSpec, execinfrapb.PostProcessSpec{}, resultTypes)
 		} else {
 			// With UNION ALL, we can end up with multiple streams on the same node.
 			// We don't want to have unnecessary routers and cross-node streams, so
@@ -3730,26 +3730,26 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 		}
 
 		// Check if the previous stage is all on one node.
-		prevStageNode := plan.Processors[plan.ResultRouters[0]].Node
+		prevStageNode := plan.Processors[plan.ResultRouters[0]].SQLInstanceID
 		for i := 1; i < len(plan.ResultRouters); i++ {
-			if n := plan.Processors[plan.ResultRouters[i]].Node; n != prevStageNode {
+			if n := plan.Processors[plan.ResultRouters[i]].SQLInstanceID; n != prevStageNode {
 				prevStageNode = 0
 				break
 			}
 		}
 
-		// Get all nodes from the previous stage.
-		nodes := getNodesOfRouters(plan.ResultRouters, plan.Processors)
-		if len(partitionIdxs) == 0 || len(nodes) == 1 {
+		// Get all sqlInstanceIDs from the previous stage.
+		sqlInstanceIDs := getSQLInstanceIDsOfRouters(plan.ResultRouters, plan.Processors)
+		if len(partitionIdxs) == 0 || len(sqlInstanceIDs) == 1 {
 			// No PARTITION BY or we have a single node. Use a single windower.
 			// If the previous stage was all on a single node, put the windower
 			// there. Otherwise, bring the results back on this node.
-			node := dsp.gatewayNodeID
-			if len(nodes) == 1 {
-				node = nodes[0]
+			sqlInstanceID := dsp.gatewaySQLInstanceID
+			if len(sqlInstanceIDs) == 1 {
+				sqlInstanceID = sqlInstanceIDs[0]
 			}
 			plan.AddSingleGroupStage(
-				node,
+				sqlInstanceID,
 				execinfrapb.ProcessorCoreUnion{Windower: &windowerSpec},
 				execinfrapb.PostProcessSpec{},
 				newResultTypes,
@@ -3776,10 +3776,10 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 			// a node appears in nodes.
 			prevStageRouters := plan.ResultRouters
 			prevStageResultTypes := plan.GetResultTypes()
-			plan.ResultRouters = make([]physicalplan.ProcessorIdx, 0, len(nodes))
-			for bucket, nodeID := range nodes {
+			plan.ResultRouters = make([]physicalplan.ProcessorIdx, 0, len(sqlInstanceIDs))
+			for bucket, sqlInstanceID := range sqlInstanceIDs {
 				proc := physicalplan.Processor{
-					Node: nodeID,
+					SQLInstanceID: sqlInstanceID,
 					Spec: execinfrapb.ProcessorSpec{
 						Input: []execinfrapb.InputSyncSpec{{
 							Type:        execinfrapb.InputSyncSpec_PARALLEL_UNORDERED,
@@ -3988,7 +3988,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 	planCtx := &PlanningCtx{
 		ctx:             ctx,
 		ExtendedEvalCtx: evalCtx,
-		infra:           physicalplan.MakePhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewayNodeID),
+		infra:           physicalplan.MakePhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID),
 		isLocal:         !distribute,
 		planner:         planner,
 	}
@@ -4011,8 +4011,8 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 		planCtx.parallelizeScansIfLocal = true
 	}
 	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn)
-	planCtx.NodeStatuses = make(map[roachpb.NodeID]NodeStatus)
-	planCtx.NodeStatuses[dsp.gatewayNodeID] = NodeOK
+	planCtx.NodeStatuses = make(map[base.SQLInstanceID]NodeStatus)
+	planCtx.NodeStatuses[dsp.gatewaySQLInstanceID] = NodeOK
 	return planCtx
 }
 
@@ -4046,10 +4046,10 @@ func maybeMoveSingleFlowToGateway(planCtx *PlanningCtx, plan *PhysicalPlan, rowC
 		}
 		singleFlow := true
 		moveFlowToGateway := false
-		nodeID := plan.Processors[0].Node
+		sqlInstanceID := plan.Processors[0].SQLInstanceID
 		for _, p := range plan.Processors[1:] {
-			if p.Node != nodeID {
-				if p.Node != plan.GatewayNodeID || p.Spec.Core.Noop == nil {
+			if p.SQLInstanceID != sqlInstanceID {
+				if p.SQLInstanceID != plan.GatewaySQLInstanceID || p.Spec.Core.Noop == nil {
 					// We want to ignore the noop processors planned on the
 					// gateway because their job is to simply communicate the
 					// results back to the client. If, however, there is another
@@ -4070,7 +4070,7 @@ func maybeMoveSingleFlowToGateway(planCtx *PlanningCtx, plan *PhysicalPlan, rowC
 		}
 		if singleFlow && moveFlowToGateway {
 			for i := range plan.Processors {
-				plan.Processors[i].Node = plan.GatewayNodeID
+				plan.Processors[i].SQLInstanceID = plan.GatewaySQLInstanceID
 			}
 			planCtx.isLocal = true
 			planCtx.planner.curPlan.flags.Unset(planFlagFullyDistributed)
@@ -4121,7 +4121,7 @@ func (dsp *DistSQLPlanner) finalizePlanWithRowCount(
 
 	if len(metadataSenders) > 0 {
 		plan.AddSingleGroupStage(
-			dsp.gatewayNodeID,
+			dsp.gatewaySQLInstanceID,
 			execinfrapb.ProcessorCoreUnion{
 				MetadataTestReceiver: &execinfrapb.MetadataTestReceiverSpec{
 					SenderIDs: metadataSenders,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -855,16 +855,16 @@ func TestPartitionSpans(t *testing.T) {
 		testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 10; i++ {
-		nodeID := roachpb.NodeID(i)
+		sqlInstanceID := base.SQLInstanceID(i)
 		desc := &roachpb.NodeDescriptor{
-			NodeID:  nodeID,
+			NodeID:  roachpb.NodeID(sqlInstanceID),
 			Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
 		}
 		if err := mockGossip.SetNodeDescriptor(desc); err != nil {
 			t.Fatal(err)
 		}
 		if err := mockGossip.AddInfoProto(
-			gossip.MakeDistSQLNodeVersionKey(nodeID),
+			gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
 			&execinfrapb.DistSQLVersionGossipInfo{
 				MinAcceptedVersion: execinfra.MinAcceptedVersion,
 				Version:            execinfra.Version,
@@ -889,12 +889,12 @@ func TestPartitionSpans(t *testing.T) {
 
 			gw := gossip.MakeOptionalGossip(mockGossip)
 			dsp := DistSQLPlanner{
-				planVersion:   execinfra.Version,
-				st:            cluster.MakeTestingClusterSettings(),
-				gatewayNodeID: tsp.nodes[tc.gatewayNode-1].NodeID,
-				stopper:       stopper,
-				spanResolver:  tsp,
-				gossip:        gw,
+				planVersion:          execinfra.Version,
+				st:                   cluster.MakeTestingClusterSettings(),
+				gatewaySQLInstanceID: base.SQLInstanceID(tsp.nodes[tc.gatewayNode-1].NodeID),
+				stopper:              stopper,
+				spanResolver:         tsp,
+				gossip:               gw,
 				nodeHealth: distSQLNodeHealth{
 					gossip: gw,
 					connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
@@ -905,7 +905,7 @@ func TestPartitionSpans(t *testing.T) {
 						}
 						return nil
 					},
-					isAvailable: func(nodeID roachpb.NodeID) bool {
+					isAvailable: func(base.SQLInstanceID) bool {
 						return true
 					},
 				},
@@ -926,14 +926,14 @@ func TestPartitionSpans(t *testing.T) {
 
 			resMap := make(map[int][][2]string)
 			for _, p := range partitions {
-				if _, ok := resMap[int(p.Node)]; ok {
+				if _, ok := resMap[int(p.SQLInstanceID)]; ok {
 					t.Fatalf("node %d shows up in multiple partitions", p)
 				}
 				var spans [][2]string
 				for _, s := range p.Spans {
 					spans = append(spans, [2]string{string(s.Key), string(s.EndKey)})
 				}
-				resMap[int(p.Node)] = spans
+				resMap[int(p.SQLInstanceID)] = spans
 			}
 
 			if !reflect.DeepEqual(resMap, tc.partitions) {
@@ -965,21 +965,21 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 		planVersion execinfrapb.DistSQLVersion
 
 		// The versions accepted by each node.
-		nodeVersions map[roachpb.NodeID]execinfrapb.DistSQLVersionGossipInfo
+		nodeVersions map[base.SQLInstanceID]execinfrapb.DistSQLVersionGossipInfo
 
 		// nodesNotAdvertisingDistSQLVersion is the set of nodes for which gossip is
 		// not going to have information about the supported DistSQL version. This
 		// is to simulate CRDB 1.0 nodes which don't advertise this information.
-		nodesNotAdvertisingDistSQLVersion map[roachpb.NodeID]struct{}
+		nodesNotAdvertisingDistSQLVersion map[base.SQLInstanceID]struct{}
 
 		// expected result: a map of node to list of spans.
-		partitions map[roachpb.NodeID][][2]string
+		partitions map[base.SQLInstanceID][][2]string
 	}{
 		{
 			// In the first test, all nodes are compatible.
 			name:        "current_version",
 			planVersion: 2,
-			nodeVersions: map[roachpb.NodeID]execinfrapb.DistSQLVersionGossipInfo{
+			nodeVersions: map[base.SQLInstanceID]execinfrapb.DistSQLVersionGossipInfo{
 				1: {
 					MinAcceptedVersion: 1,
 					Version:            2,
@@ -989,7 +989,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 					Version:            2,
 				},
 			},
-			partitions: map[roachpb.NodeID][][2]string{
+			partitions: map[base.SQLInstanceID][][2]string{
 				1: {{"A", "B"}, {"C", "Z"}},
 				2: {{"B", "C"}},
 			},
@@ -1000,7 +1000,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			// Remember that the gateway is node 2.
 			name:        "next_version",
 			planVersion: 3,
-			nodeVersions: map[roachpb.NodeID]execinfrapb.DistSQLVersionGossipInfo{
+			nodeVersions: map[base.SQLInstanceID]execinfrapb.DistSQLVersionGossipInfo{
 				1: {
 					MinAcceptedVersion: 1,
 					Version:            2,
@@ -1010,7 +1010,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 					Version:            3,
 				},
 			},
-			partitions: map[roachpb.NodeID][][2]string{
+			partitions: map[base.SQLInstanceID][][2]string{
 				2: {{"A", "Z"}},
 			},
 		},
@@ -1019,16 +1019,16 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			// a crdb 1.0 node).
 			name:        "crdb_1.0",
 			planVersion: 3,
-			nodeVersions: map[roachpb.NodeID]execinfrapb.DistSQLVersionGossipInfo{
+			nodeVersions: map[base.SQLInstanceID]execinfrapb.DistSQLVersionGossipInfo{
 				2: {
 					MinAcceptedVersion: 3,
 					Version:            3,
 				},
 			},
-			nodesNotAdvertisingDistSQLVersion: map[roachpb.NodeID]struct{}{
+			nodesNotAdvertisingDistSQLVersion: map[base.SQLInstanceID]struct{}{
 				1: {},
 			},
-			partitions: map[roachpb.NodeID][][2]string{
+			partitions: map[base.SQLInstanceID][][2]string{
 				2: {{"A", "Z"}},
 			},
 		},
@@ -1049,18 +1049,18 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 			var nodeDescs []*roachpb.NodeDescriptor
 			for i := 1; i <= 2; i++ {
-				nodeID := roachpb.NodeID(i)
+				sqlInstanceID := base.SQLInstanceID(i)
 				desc := &roachpb.NodeDescriptor{
-					NodeID:  nodeID,
+					NodeID:  roachpb.NodeID(sqlInstanceID),
 					Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
 				}
 				if err := mockGossip.SetNodeDescriptor(desc); err != nil {
 					t.Fatal(err)
 				}
-				if _, ok := tc.nodesNotAdvertisingDistSQLVersion[nodeID]; !ok {
-					verInfo := tc.nodeVersions[nodeID]
+				if _, ok := tc.nodesNotAdvertisingDistSQLVersion[sqlInstanceID]; !ok {
+					verInfo := tc.nodeVersions[sqlInstanceID]
 					if err := mockGossip.AddInfoProto(
-						gossip.MakeDistSQLNodeVersionKey(nodeID),
+						gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
 						&verInfo,
 						0, // ttl - no expiration
 					); err != nil {
@@ -1077,19 +1077,19 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 
 			gw := gossip.MakeOptionalGossip(mockGossip)
 			dsp := DistSQLPlanner{
-				planVersion:   tc.planVersion,
-				st:            cluster.MakeTestingClusterSettings(),
-				gatewayNodeID: tsp.nodes[gatewayNode-1].NodeID,
-				stopper:       stopper,
-				spanResolver:  tsp,
-				gossip:        gw,
+				planVersion:          tc.planVersion,
+				st:                   cluster.MakeTestingClusterSettings(),
+				gatewaySQLInstanceID: base.SQLInstanceID(tsp.nodes[gatewayNode-1].NodeID),
+				stopper:              stopper,
+				spanResolver:         tsp,
+				gossip:               gw,
 				nodeHealth: distSQLNodeHealth{
 					gossip: gw,
 					connHealth: func(roachpb.NodeID, rpc.ConnectionClass) error {
 						// All the nodes are healthy.
 						return nil
 					},
-					isAvailable: func(roachpb.NodeID) bool {
+					isAvailable: func(base.SQLInstanceID) bool {
 						return true
 					},
 				},
@@ -1103,16 +1103,16 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			resMap := make(map[roachpb.NodeID][][2]string)
+			resMap := make(map[base.SQLInstanceID][][2]string)
 			for _, p := range partitions {
-				if _, ok := resMap[p.Node]; ok {
+				if _, ok := resMap[p.SQLInstanceID]; ok {
 					t.Fatalf("node %d shows up in multiple partitions", p)
 				}
 				var spans [][2]string
 				for _, s := range p.Spans {
 					spans = append(spans, [2]string{string(s.Key), string(s.EndKey)})
 				}
-				resMap[p.Node] = spans
+				resMap[p.SQLInstanceID] = spans
 			}
 
 			if !reflect.DeepEqual(resMap, tc.partitions) {
@@ -1142,9 +1142,9 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 2; i++ {
-		nodeID := roachpb.NodeID(i)
+		sqlInstanceID := base.SQLInstanceID(i)
 		desc := &roachpb.NodeDescriptor{
-			NodeID:  nodeID,
+			NodeID:  roachpb.NodeID(sqlInstanceID),
 			Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
 		}
 		if i == 2 {
@@ -1157,7 +1157,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		// the test comment - for such a node, the descriptor would be taken out of
 		// the gossip data, but other datums it advertised are left in place.
 		if err := mockGossip.AddInfoProto(
-			gossip.MakeDistSQLNodeVersionKey(nodeID),
+			gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
 			&execinfrapb.DistSQLVersionGossipInfo{
 				MinAcceptedVersion: execinfra.MinAcceptedVersion,
 				Version:            execinfra.Version,
@@ -1176,19 +1176,19 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 
 	gw := gossip.MakeOptionalGossip(mockGossip)
 	dsp := DistSQLPlanner{
-		planVersion:   execinfra.Version,
-		st:            cluster.MakeTestingClusterSettings(),
-		gatewayNodeID: tsp.nodes[gatewayNode-1].NodeID,
-		stopper:       stopper,
-		spanResolver:  tsp,
-		gossip:        gw,
+		planVersion:          execinfra.Version,
+		st:                   cluster.MakeTestingClusterSettings(),
+		gatewaySQLInstanceID: base.SQLInstanceID(tsp.nodes[gatewayNode-1].NodeID),
+		stopper:              stopper,
+		spanResolver:         tsp,
+		gossip:               gw,
 		nodeHealth: distSQLNodeHealth{
 			gossip: gw,
 			connHealth: func(node roachpb.NodeID, _ rpc.ConnectionClass) error {
 				_, err := mockGossip.GetNodeIDAddress(node)
 				return err
 			},
-			isAvailable: func(roachpb.NodeID) bool {
+			isAvailable: func(base.SQLInstanceID) bool {
 				return true
 			},
 		},
@@ -1202,20 +1202,20 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resMap := make(map[roachpb.NodeID][][2]string)
+	resMap := make(map[base.SQLInstanceID][][2]string)
 	for _, p := range partitions {
-		if _, ok := resMap[p.Node]; ok {
+		if _, ok := resMap[p.SQLInstanceID]; ok {
 			t.Fatalf("node %d shows up in multiple partitions", p)
 		}
 		var spans [][2]string
 		for _, s := range p.Spans {
 			spans = append(spans, [2]string{string(s.Key), string(s.EndKey)})
 		}
-		resMap[p.Node] = spans
+		resMap[p.SQLInstanceID] = spans
 	}
 
 	expectedPartitions :=
-		map[roachpb.NodeID][][2]string{
+		map[base.SQLInstanceID][][2]string{
 			2: {{"A", "Z"}},
 		}
 	if !reflect.DeepEqual(resMap, expectedPartitions) {
@@ -1230,20 +1230,20 @@ func TestCheckNodeHealth(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	const nodeID = roachpb.NodeID(5)
+	const sqlInstanceID = base.SQLInstanceID(5)
 
-	mockGossip := gossip.NewTest(nodeID, nil /* rpcContext */, nil, /* grpcServer */
+	mockGossip := gossip.NewTest(roachpb.NodeID(sqlInstanceID), nil /* rpcContext */, nil, /* grpcServer */
 		stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 
 	desc := &roachpb.NodeDescriptor{
-		NodeID:  nodeID,
+		NodeID:  roachpb.NodeID(sqlInstanceID),
 		Address: util.UnresolvedAddr{NetworkField: "tcp", AddressField: "testaddr"},
 	}
 	if err := mockGossip.SetNodeDescriptor(desc); err != nil {
 		t.Fatal(err)
 	}
 	if err := mockGossip.AddInfoProto(
-		gossip.MakeDistSQLNodeVersionKey(nodeID),
+		gossip.MakeDistSQLNodeVersionKey(sqlInstanceID),
 		&execinfrapb.DistSQLVersionGossipInfo{
 			MinAcceptedVersion: execinfra.MinAcceptedVersion,
 			Version:            execinfra.Version,
@@ -1253,10 +1253,10 @@ func TestCheckNodeHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	notAvailable := func(roachpb.NodeID) bool {
+	notAvailable := func(base.SQLInstanceID) bool {
 		return false
 	}
-	available := func(roachpb.NodeID) bool {
+	available := func(base.SQLInstanceID) bool {
 		return true
 	}
 
@@ -1269,7 +1269,7 @@ func TestCheckNodeHealth(t *testing.T) {
 	_ = connUnhealthy
 
 	livenessTests := []struct {
-		isAvailable func(roachpb.NodeID) bool
+		isAvailable func(id base.SQLInstanceID) bool
 		exp         string
 	}{
 		{available, ""},
@@ -1284,7 +1284,7 @@ func TestCheckNodeHealth(t *testing.T) {
 				connHealth:  connHealthy,
 				isAvailable: test.isAvailable,
 			}
-			if err := h.check(context.Background(), nodeID); !testutils.IsError(err, test.exp) {
+			if err := h.check(context.Background(), sqlInstanceID); !testutils.IsError(err, test.exp) {
 				t.Fatalf("expected %v, got %v", test.exp, err)
 			}
 		})
@@ -1305,7 +1305,7 @@ func TestCheckNodeHealth(t *testing.T) {
 				connHealth:  test.connHealth,
 				isAvailable: available,
 			}
-			if err := h.check(context.Background(), nodeID); !testutils.IsError(err, test.exp) {
+			if err := h.check(context.Background(), sqlInstanceID); !testutils.IsError(err, test.exp) {
 				t.Fatalf("expected %v, got %v", test.exp, err)
 			}
 		})

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -68,7 +68,7 @@ func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
 		ib.Spans = sp.Spans
 
 		proc := physicalplan.Processor{
-			Node: sp.Node,
+			SQLInstanceID: sp.SQLInstanceID,
 			Spec: execinfrapb.ProcessorSpec{
 				Core:        execinfrapb.ProcessorCoreUnion{Backfiller: ib},
 				Output:      []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -11,7 +11,7 @@
 package sql
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -202,25 +202,25 @@ func distsqlSetOpJoinType(setOpType tree.UnionType) descpb.JoinType {
 	}
 }
 
-// getNodesOfRouters returns all nodes that routers are put on.
-func getNodesOfRouters(
+// getSQLInstanceIDsOfRouters returns all nodes that routers are put on.
+func getSQLInstanceIDsOfRouters(
 	routers []physicalplan.ProcessorIdx, processors []physicalplan.Processor,
-) (nodes []roachpb.NodeID) {
-	seen := make(map[roachpb.NodeID]struct{})
+) (sqlInstanceIDs []base.SQLInstanceID) {
+	seen := make(map[base.SQLInstanceID]struct{})
 	for _, pIdx := range routers {
-		n := processors[pIdx].Node
+		n := processors[pIdx].SQLInstanceID
 		if _, ok := seen[n]; !ok {
 			seen[n] = struct{}{}
-			nodes = append(nodes, n)
+			sqlInstanceIDs = append(sqlInstanceIDs, n)
 		}
 	}
-	return nodes
+	return sqlInstanceIDs
 }
 
 func findJoinProcessorNodes(
 	leftRouters, rightRouters []physicalplan.ProcessorIdx, processors []physicalplan.Processor,
-) (nodes []roachpb.NodeID) {
+) (instances []base.SQLInstanceID) {
 	// TODO(radu): for now we run a join processor on every node that produces
 	// data for either source. In the future we should be smarter here.
-	return getNodesOfRouters(append(leftRouters, rightRouters...), processors)
+	return getSQLInstanceIDsOfRouters(append(leftRouters, rightRouters...), processors)
 }

--- a/pkg/sql/distsql_plan_set_op_test.go
+++ b/pkg/sql/distsql_plan_set_op_test.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -60,7 +60,7 @@ func TestMergeResultTypesForSetOp(t *testing.T) {
 			}
 		}
 	}
-	infra := physicalplan.MakePhysicalInfrastructure(uuid.FastMakeV4(), roachpb.NodeID(1))
+	infra := physicalplan.MakePhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
 	var leftPlan, rightPlan PhysicalPlan
 	leftPlan.PhysicalInfrastructure = &infra
 	rightPlan.PhysicalInfrastructure = &infra

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -232,9 +232,9 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		RowsExpected:     rowsExpected,
 	}
 	// Plan the SampleAggregator on the gateway, unless we have a single Sampler.
-	node := dsp.gatewayNodeID
+	node := dsp.gatewaySQLInstanceID
 	if len(p.ResultRouters) == 1 {
-		node = p.Processors[p.ResultRouters[0]].Node
+		node = p.Processors[p.ResultRouters[0]].SQLInstanceID
 	}
 	p.AddSingleGroupStage(
 		node,

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -11,6 +11,7 @@
 package sql
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -35,10 +36,10 @@ type distSQLSpecExecFactory struct {
 	planner *planner
 	dsp     *DistSQLPlanner
 	// planCtx should not be used directly - getPlanCtx() should be used instead.
-	planCtx       *PlanningCtx
-	singleTenant  bool
-	planningMode  distSQLPlanningMode
-	gatewayNodeID roachpb.NodeID
+	planCtx              *PlanningCtx
+	singleTenant         bool
+	planningMode         distSQLPlanningMode
+	gatewaySQLInstanceID base.SQLInstanceID
 }
 
 var _ exec.Factory = &distSQLSpecExecFactory{}
@@ -59,11 +60,11 @@ const (
 
 func newDistSQLSpecExecFactory(p *planner, planningMode distSQLPlanningMode) exec.Factory {
 	e := &distSQLSpecExecFactory{
-		planner:       p,
-		dsp:           p.extendedEvalCtx.DistSQLPlanner,
-		singleTenant:  p.execCfg.Codec.ForSystemTenant(),
-		planningMode:  planningMode,
-		gatewayNodeID: p.extendedEvalCtx.DistSQLPlanner.gatewayNodeID,
+		planner:              p,
+		dsp:                  p.extendedEvalCtx.DistSQLPlanner,
+		singleTenant:         p.execCfg.Codec.ForSystemTenant(),
+		planningMode:         planningMode,
+		gatewaySQLInstanceID: p.extendedEvalCtx.DistSQLPlanner.gatewaySQLInstanceID,
 	}
 	distribute := e.singleTenant && e.planningMode != distSQLLocalOnlyPlanning
 	evalCtx := p.ExtendedEvalContext()

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1381,7 +1381,7 @@ type ExecutorTestingKnobs struct {
 	// query (i.e. no subqueries). The physical plan is only safe for use for the
 	// lifetime of this function. Note that returning a nil function is
 	// unsupported and will lead to a panic.
-	TestingSaveFlows func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error
+	TestingSaveFlows func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execinfra.OpChains) error
 
 	// DeterministicExplain, if set, will result in overriding fields in EXPLAIN
 	// and EXPLAIN ANALYZE that can vary between runs (like elapsed times).

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -40,11 +40,11 @@ type Dialer interface {
 // user, since the receiver at the other end will hang for
 // SettingFlowStreamTimeout waiting for a successful connection attempt.
 func GetConnForOutbox(
-	ctx context.Context, dialer Dialer, nodeID roachpb.NodeID, timeout time.Duration,
+	ctx context.Context, dialer Dialer, sqlInstanceID base.SQLInstanceID, timeout time.Duration,
 ) (conn *grpc.ClientConn, err error) {
 	firstConnectionAttempt := timeutil.Now()
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
-		conn, err = dialer.DialNoBreaker(ctx, nodeID, rpc.DefaultClass)
+		conn, err = dialer.DialNoBreaker(ctx, roachpb.NodeID(sqlInstanceID), rpc.DefaultClass)
 		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
 			break
 		}

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"math"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -24,8 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
-// StaticNodeID is the default Node ID to be used in tests.
-const StaticNodeID = roachpb.NodeID(3)
+// StaticSQLInstanceID is the default Node ID to be used in tests.
+const StaticSQLInstanceID = base.SQLInstanceID(3)
 
 // RepeatableRowSource is a RowSource used in benchmarks to avoid having to
 // reinitialize a new RowSource every time during multiple passes of the input.

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -71,7 +71,7 @@ go_test(
     ],
     embed = [":execinfrapb"],
     deps = [
-        "//pkg/roachpb:with-mocks",
+        "//pkg/base",
         "//pkg/security",
         "//pkg/settings/cluster",
         "//pkg/sql",

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -41,14 +41,14 @@ message SetupFlowRequest {
   // Version of distsqlrun protocol; a server accepts a certain range of
   // versions, up to its own version. See server.go for more details.
   optional uint32 version = 5 [(gogoproto.nullable) = false,
-                               (gogoproto.casttype) = "DistSQLVersion"];
+    (gogoproto.casttype) = "DistSQLVersion"];
 
   optional FlowSpec flow = 3 [(gogoproto.nullable) = false];
 
   optional EvalContext eval_context = 6 [(gogoproto.nullable) = false];
 
   optional bool trace_kv = 8 [(gogoproto.nullable) = false,
-                              (gogoproto.customname) = "TraceKV"];
+    (gogoproto.customname) = "TraceKV"];
 
   // CollectStats specifies whether stats collection should be enabled for this
   // flow. Note that some form of tracing must be enabled for these stats to be
@@ -59,18 +59,18 @@ message SetupFlowRequest {
   // StatementSQL is the SQL statement for which this flow is executing. It
   // is populated on a best effort basis.
   optional string statement_sql = 10 [(gogoproto.nullable) = false,
-                                      (gogoproto.customname) = "StatementSQL"];
+    (gogoproto.customname) = "StatementSQL"];
 }
 
 // FlowSpec describes a "flow" which is a subgraph of a distributed SQL
 // computation consisting of processors and streams.
 message FlowSpec {
   optional bytes flow_id = 1 [(gogoproto.nullable) = false,
-                              (gogoproto.customname) = "FlowID",
-                              (gogoproto.customtype) = "FlowID"];
-  // The NodeID of the gateway that planned this Flow. Used for debugging.
+    (gogoproto.customname) = "FlowID",
+    (gogoproto.customtype) = "FlowID"];
+  // The SQLInstanceID of the gateway that planned this Flow. Used for debugging.
   optional int32 gateway = 3 [(gogoproto.nullable) = false,
-                              (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/base.SQLInstanceID"];
 
   repeated ProcessorSpec processors = 2 [(gogoproto.nullable) = false];
 }
@@ -127,9 +127,9 @@ message ConsumerHandshake {
 
   // The server's DistSQL version range.
   optional uint32 version = 3 [(gogoproto.nullable) = false,
-                               (gogoproto.casttype) = "DistSQLVersion"];
+    (gogoproto.casttype) = "DistSQLVersion"];
   optional uint32 min_accepted_version = 4 [(gogoproto.nullable) = false,
-                                            (gogoproto.casttype) = "DistSQLVersion"];
+    (gogoproto.casttype) = "DistSQLVersion"];
 }
 
 // CancelDeadFlowsRequest is a request to cancel some flows that have been
@@ -142,8 +142,8 @@ message CancelDeadFlowsRequest {
   // in the queue (i.e. it has already completed or is currently running), such
   // flow is ignored.
   repeated bytes flow_ids = 1 [(gogoproto.nullable) = false,
-                              (gogoproto.customname) = "FlowIDs",
-                              (gogoproto.customtype) = "FlowID"];
+    (gogoproto.customname) = "FlowIDs",
+    (gogoproto.customtype) = "FlowID"];
 }
 
 service DistSQL {

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -38,7 +38,7 @@ import "google/protobuf/timestamp.proto";
 message Error {
   option (gogoproto.goproto_stringer) = false;
 
-  reserved 1,2;
+  reserved 1, 2;
 
   // full_error contains a structured errors with possibly multiple
   // wrapping layers implementing the errors.Cause() interface.
@@ -103,16 +103,16 @@ message StreamEndpointSpec {
   //
   // For SYNC_RESPONSE streams, the ID is unused.
   optional int32 stream_id = 2 [(gogoproto.nullable) = false,
-                                (gogoproto.customname) = "StreamID",
-                                (gogoproto.casttype) = "StreamID"];
-  // Node ID of the target host, only used for outgoing REMOTE streams.
+    (gogoproto.customname) = "StreamID",
+    (gogoproto.casttype) = "StreamID"];
+  // SQLInstanceID of the target host, only used for outgoing REMOTE streams.
   optional int32 target_node_id = 4 [(gogoproto.nullable) = false,
-                                     (gogoproto.customname) = "TargetNodeID",
-                                     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
-  // Node ID of the origin node, only used for REMOTE streams.
+    (gogoproto.customname) = "TargetNodeID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/base.SQLInstanceID"];
+  // SQLInstanceID of the origin node, only used for REMOTE streams.
   optional int32 origin_node_id = 5 [(gogoproto.nullable) = false,
-                                    (gogoproto.customname) = "OriginNodeID",
-                                    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
+    (gogoproto.customname) = "OriginNodeID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/base.SQLInstanceID"];
   reserved 3;
 }
 
@@ -209,12 +209,12 @@ message DatumInfo {
 // ProducerHeader is a message that is sent once at the beginning of a stream.
 message ProducerHeader {
   optional bytes flow_id = 1 [(gogoproto.nullable) = false,
-                              (gogoproto.customname) = "FlowID",
-                              (gogoproto.customtype) = "FlowID"];
+    (gogoproto.customname) = "FlowID",
+    (gogoproto.customtype) = "FlowID"];
 
   optional int32 stream_id = 2 [(gogoproto.nullable) = false,
-                                (gogoproto.customname) = "StreamID",
-                                (gogoproto.casttype) = "StreamID"];
+    (gogoproto.customname) = "StreamID",
+    (gogoproto.casttype) = "StreamID"];
 }
 
 // ProducerData is a message that can be sent multiple times as part of a stream
@@ -264,7 +264,7 @@ message RemoteProducerMetadata {
   message RowNum {
     // The ID of the processor that is producing rows.
     optional string sender_id = 1 [(gogoproto.nullable) = false,
-                                   (gogoproto.customname) = "SenderID"];
+      (gogoproto.customname) = "SenderID"];
     // A running count of the number of rows emitted from the sender so far.
     optional int32 row_num = 2 [(gogoproto.nullable) = false];
     // When set, indicates that the row count contains the expected number of
@@ -317,10 +317,10 @@ message RemoteProducerMetadata {
 // distsqlrun/server.go.
 message DistSQLVersionGossipInfo {
   optional uint32 version = 1 [(gogoproto.nullable) = false,
-                               (gogoproto.casttype) = "DistSQLVersion"];
+    (gogoproto.casttype) = "DistSQLVersion"];
 
   optional uint32 min_accepted_version = 2 [(gogoproto.nullable) = false,
-                                            (gogoproto.casttype) = "DistSQLVersion"];
+    (gogoproto.casttype) = "DistSQLVersion"];
 }
 
 // DistSQLDrainingInfo represents the DistSQL draining state that gets gossiped

--- a/pkg/sql/execinfrapb/flow_diagram_external_test.go
+++ b/pkg/sql/execinfrapb/flow_diagram_external_test.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -56,7 +56,7 @@ func TestPlanDiagramTableReaderWrapColumns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	flows := make(map[roachpb.NodeID]*execinfrapb.FlowSpec)
+	flows := make(map[base.SQLInstanceID]*execinfrapb.FlowSpec)
 
 	tr := execinfrapb.TableReaderSpec{
 		Table:     *desc.TableDesc(),

--- a/pkg/sql/execinfrapb/flow_diagram_test.go
+++ b/pkg/sql/execinfrapb/flow_diagram_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -45,7 +45,7 @@ func compareDiagrams(t *testing.T, result string, expected string) {
 func TestPlanDiagramIndexJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	flows := make(map[roachpb.NodeID]*FlowSpec)
+	flows := make(map[base.SQLInstanceID]*FlowSpec)
 
 	desc := &descpb.TableDescriptor{
 		Name:    "Table",
@@ -164,7 +164,7 @@ func TestPlanDiagramIndexJoin(t *testing.T) {
 func TestPlanDiagramJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	flows := make(map[roachpb.NodeID]*FlowSpec)
+	flows := make(map[base.SQLInstanceID]*FlowSpec)
 
 	descA := &descpb.TableDescriptor{Name: "TableA"}
 	descB := &descpb.TableDescriptor{Name: "TableB"}

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -46,10 +46,10 @@ func newInsecureRPCContext(ctx context.Context, stopper *stop.Stopper) *rpc.Cont
 // StartMockDistSQLServer starts a MockDistSQLServer and returns the address on
 // which it's listening.
 func StartMockDistSQLServer(
-	ctx context.Context, clock *hlc.Clock, stopper *stop.Stopper, nodeID roachpb.NodeID,
+	ctx context.Context, clock *hlc.Clock, stopper *stop.Stopper, sqlInstanceID base.SQLInstanceID,
 ) (uuid.UUID, *MockDistSQLServer, net.Addr, error) {
 	rpcContext := newInsecureRPCContext(ctx, stopper)
-	rpcContext.NodeID.Set(context.TODO(), nodeID)
+	rpcContext.NodeID.Set(context.TODO(), roachpb.NodeID(sqlInstanceID))
 	server := rpc.NewServer(rpcContext)
 	mock := newMockDistSQLServer()
 	RegisterDistSQLServer(server, mock)

--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/roachpb:with-mocks",
         "//pkg/sql/execinfrapb",
         "//pkg/util",
         "//pkg/util/buildutil",
@@ -27,7 +26,6 @@ go_test(
     embed = [":execstats"],
     deps = [
         "//pkg/base",
-        "//pkg/roachpb:with-mocks",
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -59,11 +58,11 @@ func TestTraceAnalyzer(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					TestingSaveFlows: func(stmt string) func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error {
+					TestingSaveFlows: func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execinfra.OpChains) error {
 						if stmt != testStmt {
-							return func(map[roachpb.NodeID]*execinfrapb.FlowSpec, execinfra.OpChains) error { return nil }
+							return func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execinfra.OpChains) error { return nil }
 						}
-						return func(flows map[roachpb.NodeID]*execinfrapb.FlowSpec, _ execinfra.OpChains) error {
+						return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execinfra.OpChains) error {
 							flowsMetadata := execstats.NewFlowsMetadata(flows)
 							analyzer := execstats.NewTraceAnalyzer(flowsMetadata)
 							analyzerChan <- analyzer

--- a/pkg/sql/execstats/utils_test.go
+++ b/pkg/sql/execstats/utils_test.go
@@ -12,7 +12,6 @@ package execstats
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
@@ -27,18 +26,14 @@ func (a *TraceAnalyzer) AddComponentStats(stats *execinfrapb.ComponentStats) {
 func (m *FlowsMetadata) AddComponentStats(stats *execinfrapb.ComponentStats) {
 	switch stats.Component.Type {
 	case execinfrapb.ComponentID_PROCESSOR:
-		processorStat := &processorStats{
-			nodeID: roachpb.NodeID(stats.Component.SQLInstanceID),
-			stats:  stats,
-		}
 		if m.processorStats == nil {
-			m.processorStats = make(map[execinfrapb.ProcessorID]*processorStats)
+			m.processorStats = make(map[execinfrapb.ProcessorID]*execinfrapb.ComponentStats)
 		}
-		m.processorStats[execinfrapb.ProcessorID(stats.Component.ID)] = processorStat
+		m.processorStats[execinfrapb.ProcessorID(stats.Component.ID)] = stats
 	case execinfrapb.ComponentID_STREAM:
 		streamStat := &streamStats{
-			originNodeID: roachpb.NodeID(stats.Component.SQLInstanceID),
-			stats:        stats,
+			originSQLInstanceID: stats.Component.SQLInstanceID,
+			stats:               stats,
 		}
 		if m.streamStats == nil {
 			m.streamStats = make(map[execinfrapb.StreamID]*streamStats)

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -77,7 +77,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	willDistribute := physPlan.Distribution.WillDistribute()
 	n.run.lines, n.run.cleanup, err = colflow.ExplainVec(
 		params.ctx, flowCtx, flows, physPlan.LocalProcessors, nil, /* opChains */
-		distSQLPlanner.gatewayNodeID, verbose, willDistribute,
+		distSQLPlanner.gatewaySQLInstanceID, verbose, willDistribute,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/flowinfra",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/kv",
         "//pkg/roachpb:with-mocks",
         "//pkg/server/telemetry",

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -137,7 +137,7 @@ func TestClusterFlow(t *testing.T) {
 					Output: []execinfrapb.OutputRouterSpec{{
 						Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
 						Streams: []execinfrapb.StreamEndpointSpec{
-							{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 0, TargetNodeID: tc.Server(2).NodeID()},
+							{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 0, TargetNodeID: base.SQLInstanceID(tc.Server(2).NodeID())},
 						},
 					}},
 					ResultTypes: types.TwoIntCols,
@@ -156,7 +156,7 @@ func TestClusterFlow(t *testing.T) {
 					Output: []execinfrapb.OutputRouterSpec{{
 						Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
 						Streams: []execinfrapb.StreamEndpointSpec{
-							{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 1, TargetNodeID: tc.Server(2).NodeID()},
+							{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 1, TargetNodeID: base.SQLInstanceID(tc.Server(2).NodeID())},
 						},
 					}},
 					ResultTypes: types.TwoIntCols,
@@ -715,7 +715,7 @@ func BenchmarkInfrastructure(b *testing.B) {
 									Output: []execinfrapb.OutputRouterSpec{{
 										Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
 										Streams: []execinfrapb.StreamEndpointSpec{
-											{Type: streamType(i), StreamID: execinfrapb.StreamID(i), TargetNodeID: tc.Server(0).NodeID()},
+											{Type: streamType(i), StreamID: execinfrapb.StreamID(i), TargetNodeID: base.SQLInstanceID(tc.Server(0).NodeID())},
 										},
 									}},
 									ResultTypes: types.ThreeIntCols,

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -47,9 +47,9 @@ type Outbox struct {
 	// RowChannel implements the RowReceiver interface.
 	execinfra.RowChannel
 
-	flowCtx  *execinfra.FlowCtx
-	streamID execinfrapb.StreamID
-	nodeID   roachpb.NodeID
+	flowCtx       *execinfra.FlowCtx
+	streamID      execinfrapb.StreamID
+	sqlInstanceID base.SQLInstanceID
 	// The rows received from the RowChannel will be forwarded on this stream once
 	// it is established.
 	stream flowStream
@@ -85,12 +85,12 @@ var _ Startable = &Outbox{}
 // NewOutbox creates a new Outbox.
 func NewOutbox(
 	flowCtx *execinfra.FlowCtx,
-	nodeID roachpb.NodeID,
+	sqlInstanceID base.SQLInstanceID,
 	streamID execinfrapb.StreamID,
 	numOutboxes *int32,
 	isGatewayNode bool,
 ) *Outbox {
-	m := &Outbox{flowCtx: flowCtx, nodeID: nodeID}
+	m := &Outbox{flowCtx: flowCtx, sqlInstanceID: sqlInstanceID}
 	m.encoder.SetHeaderFields(flowCtx.ID, streamID)
 	m.streamID = streamID
 	m.numOutboxes = numOutboxes
@@ -218,7 +218,7 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 
 	if m.stream == nil {
 		conn, err := execinfra.GetConnForOutbox(
-			ctx, m.flowCtx.Cfg.NodeDialer, m.nodeID, SettingFlowStreamTimeout.Get(&m.flowCtx.Cfg.Settings.SV),
+			ctx, m.flowCtx.Cfg.NodeDialer, m.sqlInstanceID, SettingFlowStreamTimeout.Get(&m.flowCtx.Cfg.Settings.SV),
 		)
 		if err != nil {
 			// Log any Dial errors. This does not have a verbosity check due to being

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -146,7 +146,7 @@ func TestDistSQLServerGossipsVersion(t *testing.T) {
 
 	var v execinfrapb.DistSQLVersionGossipInfo
 	if err := s.GossipI().(*gossip.Gossip).GetInfoProto(
-		gossip.MakeDistSQLNodeVersionKey(s.NodeID()), &v,
+		gossip.MakeDistSQLNodeVersionKey(base.SQLInstanceID(s.NodeID())), &v,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/flowinfra/utils_test.go
+++ b/pkg/sql/flowinfra/utils_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -39,13 +40,13 @@ func createDummyStream() (
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	clusterID, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticNodeID)
+	clusterID, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticSQLInstanceID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
-	conn, err := rpcContext.GRPCDialNode(addr.String(), execinfra.StaticNodeID,
+	conn, err := rpcContext.GRPCDialNode(addr.String(), roachpb.NodeID(execinfra.StaticSQLInstanceID),
 		rpc.DefaultClass).Connect(ctx)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/sql/physicalplan/BUILD.bazel
+++ b/pkg/sql/physicalplan/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/physicalplan",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord:with-mocks",

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -17,7 +17,7 @@ package physicalplan
 import (
 	"math"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -31,7 +31,7 @@ import (
 // Processor contains the information associated with a processor in a plan.
 type Processor struct {
 	// Node where the processor must be instantiated.
-	Node roachpb.NodeID
+	SQLInstanceID base.SQLInstanceID
 
 	// Spec for the processor; note that the StreamEndpointSpecs in the input
 	// synchronizers and output routers are not set until the end of the planning
@@ -67,8 +67,8 @@ type Stream struct {
 type PhysicalInfrastructure struct {
 	// -- The following fields are immutable --
 
-	FlowID        uuid.UUID
-	GatewayNodeID roachpb.NodeID
+	FlowID               uuid.UUID
+	GatewaySQLInstanceID base.SQLInstanceID
 
 	// -- The following fields are mutable --
 
@@ -151,11 +151,11 @@ type PhysicalPlan struct {
 // MakePhysicalInfrastructure initializes a PhysicalInfrastructure that can then
 // be used with MakePhysicalPlan.
 func MakePhysicalInfrastructure(
-	flowID uuid.UUID, gatewayNodeID roachpb.NodeID,
+	flowID uuid.UUID, gatewaySQLInstanceID base.SQLInstanceID,
 ) PhysicalInfrastructure {
 	return PhysicalInfrastructure{
-		FlowID:        flowID,
-		GatewayNodeID: gatewayNodeID,
+		FlowID:               flowID,
+		GatewaySQLInstanceID: gatewaySQLInstanceID,
 	}
 }
 
@@ -198,12 +198,12 @@ func (p *PhysicalPlan) NewStage(containsRemoteProcessor bool, allowPartialDistri
 
 // NewStageOnNodes is the same as NewStage but takes in the information about
 // the nodes participating in the new stage and the gateway.
-func (p *PhysicalPlan) NewStageOnNodes(nodes []roachpb.NodeID) int32 {
+func (p *PhysicalPlan) NewStageOnNodes(sqlInstanceIDs []base.SQLInstanceID) int32 {
 	// We have a remote processor either when we have multiple nodes
 	// participating in the stage or the single processor is scheduled not on
 	// the gateway.
 	return p.NewStage(
-		len(nodes) > 1 || nodes[0] != p.GatewayNodeID, /* containsRemoteProcessor */
+		len(sqlInstanceIDs) > 1 || sqlInstanceIDs[0] != p.GatewaySQLInstanceID, /* containsRemoteProcessor */
 		false, /* allowPartialDistribution */
 	)
 }
@@ -220,8 +220,8 @@ func (p *PhysicalPlan) SetMergeOrdering(o execinfrapb.Ordering) {
 // ProcessorCorePlacement indicates on which node a particular processor core
 // needs to be planned.
 type ProcessorCorePlacement struct {
-	NodeID roachpb.NodeID
-	Core   execinfrapb.ProcessorCoreUnion
+	SQLInstanceID base.SQLInstanceID
+	Core          execinfrapb.ProcessorCoreUnion
 	// EstimatedRowCount, if set to non-zero, is the optimizer's guess of how
 	// many rows will be emitted from this processor.
 	EstimatedRowCount uint64
@@ -242,7 +242,7 @@ func (p *PhysicalPlan) AddNoInputStage(
 	// plan multiple table readers on the gateway if the plan is local.
 	containsRemoteProcessor := false
 	for i := range corePlacements {
-		if corePlacements[i].NodeID != p.GatewayNodeID {
+		if corePlacements[i].SQLInstanceID != p.GatewaySQLInstanceID {
 			containsRemoteProcessor = true
 			break
 		}
@@ -251,7 +251,7 @@ func (p *PhysicalPlan) AddNoInputStage(
 	p.ResultRouters = make([]ProcessorIdx, len(corePlacements))
 	for i := range p.ResultRouters {
 		proc := Processor{
-			Node: corePlacements[i].NodeID,
+			SQLInstanceID: corePlacements[i].SQLInstanceID,
 			Spec: execinfrapb.ProcessorSpec{
 				Core: corePlacements[i].Core,
 				Post: post,
@@ -304,7 +304,7 @@ func (p *PhysicalPlan) AddNoGroupingStageWithCoreFunc(
 		prevProc := &p.Processors[resultProc]
 
 		proc := Processor{
-			Node: prevProc.Node,
+			SQLInstanceID: prevProc.SQLInstanceID,
 			Spec: execinfrapb.ProcessorSpec{
 				Input: []execinfrapb.InputSyncSpec{{
 					Type:        execinfrapb.InputSyncSpec_PARALLEL_UNORDERED,
@@ -374,13 +374,13 @@ func (p *PhysicalPlan) MergeResultStreams(
 // parallelized) which consists of a single processor on the specified node. The
 // previous stage (ResultRouters) are all connected to this processor.
 func (p *PhysicalPlan) AddSingleGroupStage(
-	nodeID roachpb.NodeID,
+	sqlInstanceID base.SQLInstanceID,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
 	outputTypes []*types.T,
 ) {
 	proc := Processor{
-		Node: nodeID,
+		SQLInstanceID: sqlInstanceID,
 		Spec: execinfrapb.ProcessorSpec{
 			Input: []execinfrapb.InputSyncSpec{{
 				// The other fields will be filled in by mergeResultStreams.
@@ -391,10 +391,10 @@ func (p *PhysicalPlan) AddSingleGroupStage(
 			Output: []execinfrapb.OutputRouterSpec{{
 				Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
 			}},
-			// We're planning a single processor on the node nodeID, so we'll
-			// have a remote processor only when the node is different from the
+			// We're planning a single processor on the instance sqlInstanceID, so
+			// we'll have a remote processor only when the node is different from the
 			// gateway.
-			StageID:     p.NewStage(nodeID != p.GatewayNodeID, false /* allowPartialDistribution */),
+			StageID:     p.NewStage(sqlInstanceID != p.GatewaySQLInstanceID, false /* allowPartialDistribution */),
 			ResultTypes: outputTypes,
 		},
 	}
@@ -418,14 +418,14 @@ func (p *PhysicalPlan) EnsureSingleStreamOnGateway() {
 	// If we don't already have a single result router on the gateway, add a
 	// single grouping stage.
 	if len(p.ResultRouters) != 1 ||
-		p.Processors[p.ResultRouters[0]].Node != p.GatewayNodeID {
+		p.Processors[p.ResultRouters[0]].SQLInstanceID != p.GatewaySQLInstanceID {
 		p.AddSingleGroupStage(
-			p.GatewayNodeID,
+			p.GatewaySQLInstanceID,
 			execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}},
 			execinfrapb.PostProcessSpec{},
 			p.GetResultTypes(),
 		)
-		if len(p.ResultRouters) != 1 || p.Processors[p.ResultRouters[0]].Node != p.GatewayNodeID {
+		if len(p.ResultRouters) != 1 || p.Processors[p.ResultRouters[0]].SQLInstanceID != p.GatewaySQLInstanceID {
 			panic("ensuring a single stream on the gateway failed")
 		}
 	}
@@ -818,7 +818,7 @@ func (p *PhysicalPlan) AddLimit(count int64, offset int64, exprCtx ExprContext) 
 		post.Limit = uint64(count)
 	}
 	p.AddSingleGroupStage(
-		p.GatewayNodeID,
+		p.GatewaySQLInstanceID,
 		execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}},
 		post,
 		p.GetResultTypes(),
@@ -842,14 +842,14 @@ func (p *PhysicalPlan) PopulateEndpoints() {
 		p1 := &p.Processors[s.SourceProcessor]
 		p2 := &p.Processors[s.DestProcessor]
 		endpoint := execinfrapb.StreamEndpointSpec{StreamID: execinfrapb.StreamID(sIdx)}
-		if p1.Node == p2.Node {
+		if p1.SQLInstanceID == p2.SQLInstanceID {
 			endpoint.Type = execinfrapb.StreamEndpointSpec_LOCAL
 		} else {
 			endpoint.Type = execinfrapb.StreamEndpointSpec_REMOTE
 		}
 		if endpoint.Type == execinfrapb.StreamEndpointSpec_REMOTE {
-			endpoint.OriginNodeID = p1.Node
-			endpoint.TargetNodeID = p2.Node
+			endpoint.OriginNodeID = p1.SQLInstanceID
+			endpoint.TargetNodeID = p2.SQLInstanceID
 		}
 		p2.Spec.Input[s.DestInput].Streams = append(p2.Spec.Input[s.DestInput].Streams, endpoint)
 
@@ -870,18 +870,18 @@ func (p *PhysicalPlan) PopulateEndpoints() {
 // GenerateFlowSpecs takes a plan (with populated endpoints) and generates the
 // set of FlowSpecs (one per node involved in the plan).
 //
-// gateway is the current node's NodeID.
-func (p *PhysicalPlan) GenerateFlowSpecs() map[roachpb.NodeID]*execinfrapb.FlowSpec {
+// gateway is the current node's SQLInstanceID.
+func (p *PhysicalPlan) GenerateFlowSpecs() map[base.SQLInstanceID]*execinfrapb.FlowSpec {
 	flowID := execinfrapb.FlowID{
 		UUID: p.FlowID,
 	}
-	flows := make(map[roachpb.NodeID]*execinfrapb.FlowSpec, 1)
+	flows := make(map[base.SQLInstanceID]*execinfrapb.FlowSpec, 1)
 
 	for _, proc := range p.Processors {
-		flowSpec, ok := flows[proc.Node]
+		flowSpec, ok := flows[proc.SQLInstanceID]
 		if !ok {
-			flowSpec = NewFlowSpec(flowID, p.GatewayNodeID)
-			flows[proc.Node] = flowSpec
+			flowSpec = NewFlowSpec(flowID, p.GatewaySQLInstanceID)
+			flows[proc.SQLInstanceID] = flowSpec
 		}
 		flowSpec.Processors = append(flowSpec.Processors, proc.Spec)
 	}
@@ -913,7 +913,7 @@ func MergePlans(
 // AddJoinStage adds join processors at each of the specified nodes, and wires
 // the left and right-side outputs to these processors.
 func (p *PhysicalPlan) AddJoinStage(
-	nodes []roachpb.NodeID,
+	sqlInstanceIDs []base.SQLInstanceID,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
 	leftEqCols, rightEqCols []uint32,
@@ -923,15 +923,15 @@ func (p *PhysicalPlan) AddJoinStage(
 	resultTypes []*types.T,
 ) {
 	pIdxStart := ProcessorIdx(len(p.Processors))
-	stageID := p.NewStageOnNodes(nodes)
+	stageID := p.NewStageOnNodes(sqlInstanceIDs)
 
-	for _, n := range nodes {
+	for _, sqlInstanceID := range sqlInstanceIDs {
 		inputs := make([]execinfrapb.InputSyncSpec, 0, 2)
 		inputs = append(inputs, execinfrapb.InputSyncSpec{ColumnTypes: leftTypes})
 		inputs = append(inputs, execinfrapb.InputSyncSpec{ColumnTypes: rightTypes})
 
 		proc := Processor{
-			Node: n,
+			SQLInstanceID: sqlInstanceID,
 			Spec: execinfrapb.ProcessorSpec{
 				Input:       inputs,
 				Core:        core,
@@ -944,7 +944,7 @@ func (p *PhysicalPlan) AddJoinStage(
 		p.Processors = append(p.Processors, proc)
 	}
 
-	if len(nodes) > 1 {
+	if len(sqlInstanceIDs) > 1 {
 		// Parallel hash or merge join: we distribute rows (by hash of
 		// equality columns) to len(nodes) join processors.
 
@@ -967,7 +967,7 @@ func (p *PhysicalPlan) AddJoinStage(
 
 	// Connect the left and right routers to the output joiners. Each joiner
 	// corresponds to a hash bucket.
-	for bucket := 0; bucket < len(nodes); bucket++ {
+	for bucket := 0; bucket < len(sqlInstanceIDs); bucket++ {
 		pIdx := pIdxStart + ProcessorIdx(bucket)
 
 		// Connect left routers to the processor's first input. Currently the join
@@ -984,7 +984,7 @@ func (p *PhysicalPlan) AddJoinStage(
 // logical stream on the specified nodes and connects them to the previous
 // stage via a hash router.
 func (p *PhysicalPlan) AddStageOnNodes(
-	nodes []roachpb.NodeID,
+	sqlInstanceIDs []base.SQLInstanceID,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
 	hashCols []uint32,
@@ -993,11 +993,11 @@ func (p *PhysicalPlan) AddStageOnNodes(
 	routers []ProcessorIdx,
 ) {
 	pIdxStart := len(p.Processors)
-	newStageID := p.NewStageOnNodes(nodes)
+	newStageID := p.NewStageOnNodes(sqlInstanceIDs)
 
-	for _, n := range nodes {
+	for _, sqlInstanceID := range sqlInstanceIDs {
 		proc := Processor{
-			Node: n,
+			SQLInstanceID: sqlInstanceID,
 			Spec: execinfrapb.ProcessorSpec{
 				Input: []execinfrapb.InputSyncSpec{
 					{ColumnTypes: inputTypes},
@@ -1012,7 +1012,7 @@ func (p *PhysicalPlan) AddStageOnNodes(
 		p.AddProcessor(proc)
 	}
 
-	if len(nodes) > 1 {
+	if len(sqlInstanceIDs) > 1 {
 		// Set up the routers.
 		for _, resultProc := range routers {
 			p.Processors[resultProc].Spec.Output[0] = execinfrapb.OutputRouterSpec{
@@ -1023,14 +1023,14 @@ func (p *PhysicalPlan) AddStageOnNodes(
 	}
 
 	// Connect the result streams to the processors.
-	for bucket := 0; bucket < len(nodes); bucket++ {
+	for bucket := 0; bucket < len(sqlInstanceIDs); bucket++ {
 		pIdx := ProcessorIdx(pIdxStart + bucket)
 		p.MergeResultStreams(routers, bucket, mergeOrd, pIdx, 0, false /* forceSerialization */)
 	}
 
 	// Set the new result routers.
 	p.ResultRouters = p.ResultRouters[:0]
-	for i := 0; i < len(nodes); i++ {
+	for i := 0; i < len(sqlInstanceIDs); i++ {
 		p.ResultRouters = append(p.ResultRouters, ProcessorIdx(pIdxStart+i))
 	}
 }
@@ -1041,7 +1041,7 @@ func (p *PhysicalPlan) AddStageOnNodes(
 // TODO(yuzefovich): If there's a strong key on the left or right side, we
 // can elide the distinct stage on that side.
 func (p *PhysicalPlan) AddDistinctSetOpStage(
-	nodes []roachpb.NodeID,
+	sqlInstanceIDs []base.SQLInstanceID,
 	joinCore execinfrapb.ProcessorCoreUnion,
 	distinctCores []execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
@@ -1057,32 +1057,32 @@ func (p *PhysicalPlan) AddDistinctSetOpStage(
 	// produce correct results (e.g., (VALUES (1),(1),(2)) EXCEPT (VALUES (1))
 	// would return (1),(2) instead of (2) if there was no distinct processor
 	// before the EXCEPT ALL join).
-	distinctProcs := make(map[roachpb.NodeID][]ProcessorIdx)
+	distinctProcs := make(map[base.SQLInstanceID][]ProcessorIdx)
 	p.AddStageOnNodes(
-		nodes, distinctCores[0], execinfrapb.PostProcessSpec{}, eqCols,
+		sqlInstanceIDs, distinctCores[0], execinfrapb.PostProcessSpec{}, eqCols,
 		leftTypes, leftTypes, leftMergeOrd, leftRouters,
 	)
 	for _, leftDistinctProcIdx := range p.ResultRouters {
-		node := p.Processors[leftDistinctProcIdx].Node
+		node := p.Processors[leftDistinctProcIdx].SQLInstanceID
 		distinctProcs[node] = append(distinctProcs[node], leftDistinctProcIdx)
 	}
 	p.AddStageOnNodes(
-		nodes, distinctCores[1], execinfrapb.PostProcessSpec{}, eqCols,
+		sqlInstanceIDs, distinctCores[1], execinfrapb.PostProcessSpec{}, eqCols,
 		rightTypes, rightTypes, rightMergeOrd, rightRouters,
 	)
 	for _, rightDistinctProcIdx := range p.ResultRouters {
-		node := p.Processors[rightDistinctProcIdx].Node
+		node := p.Processors[rightDistinctProcIdx].SQLInstanceID
 		distinctProcs[node] = append(distinctProcs[node], rightDistinctProcIdx)
 	}
 
 	// Create a join stage, where the distinct processors on the same node are
 	// connected to a join processor.
-	joinStageID := p.NewStageOnNodes(nodes)
+	joinStageID := p.NewStageOnNodes(sqlInstanceIDs)
 	p.ResultRouters = p.ResultRouters[:0]
 
-	for _, n := range nodes {
+	for _, n := range sqlInstanceIDs {
 		proc := Processor{
-			Node: n,
+			SQLInstanceID: n,
 			Spec: execinfrapb.ProcessorSpec{
 				Input: []execinfrapb.InputSyncSpec{
 					{ColumnTypes: leftTypes},
@@ -1126,11 +1126,11 @@ func (p *PhysicalPlan) EnsureSingleStreamPerNode(
 	var foundDuplicates bool
 	for _, pIdx := range p.ResultRouters {
 		proc := &p.Processors[pIdx]
-		if nodes.Contains(int(proc.Node)) {
+		if nodes.Contains(int(proc.SQLInstanceID)) {
 			foundDuplicates = true
 			break
 		}
-		nodes.Add(int(proc.Node))
+		nodes.Add(int(proc.SQLInstanceID))
 	}
 	if !foundDuplicates {
 		return
@@ -1139,11 +1139,11 @@ func (p *PhysicalPlan) EnsureSingleStreamPerNode(
 
 	for i := 0; i < len(p.ResultRouters); i++ {
 		pIdx := p.ResultRouters[i]
-		node := p.Processors[p.ResultRouters[i]].Node
+		node := p.Processors[p.ResultRouters[i]].SQLInstanceID
 		streams = append(streams[:0], pIdx)
 		// Find all streams on the same node.
 		for j := i + 1; j < len(p.ResultRouters); {
-			if p.Processors[p.ResultRouters[j]].Node == node {
+			if p.Processors[p.ResultRouters[j]].SQLInstanceID == node {
 				streams = append(streams, p.ResultRouters[j])
 				// Remove the stream.
 				copy(p.ResultRouters[j:], p.ResultRouters[j+1:])
@@ -1159,7 +1159,7 @@ func (p *PhysicalPlan) EnsureSingleStreamPerNode(
 
 		// Merge the streams into a no-op processor.
 		proc := Processor{
-			Node: node,
+			SQLInstanceID: node,
 			Spec: execinfrapb.ProcessorSpec{
 				Input: []execinfrapb.InputSyncSpec{{
 					// The other fields will be filled in by MergeResultStreams.
@@ -1182,7 +1182,7 @@ func (p *PhysicalPlan) EnsureSingleStreamPerNode(
 // remote node, such stage is considered distributed.
 func (p *PhysicalPlan) GetLastStageDistribution() PlanDistribution {
 	for i := range p.ResultRouters {
-		if p.Processors[p.ResultRouters[i]].Node != p.GatewayNodeID {
+		if p.Processors[p.ResultRouters[i]].SQLInstanceID != p.GatewaySQLInstanceID {
 			return FullyDistributedPlan
 		}
 	}

--- a/pkg/sql/physicalplan/specs.go
+++ b/pkg/sql/physicalplan/specs.go
@@ -13,7 +13,7 @@ package physicalplan
 import (
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 )
 
@@ -25,7 +25,7 @@ var flowSpecPool = sync.Pool{
 
 // NewFlowSpec returns a new FlowSpec, which may have non-zero capacity in its
 // slice fields.
-func NewFlowSpec(flowID execinfrapb.FlowID, gateway roachpb.NodeID) *execinfrapb.FlowSpec {
+func NewFlowSpec(flowID execinfrapb.FlowID, gateway base.SQLInstanceID) *execinfrapb.FlowSpec {
 	spec := flowSpecPool.Get().(*execinfrapb.FlowSpec)
 	spec.FlowID = flowID
 	spec.Gateway = gateway


### PR DESCRIPTION
Refactors DistSQL and some related functions to use `SQLInstanceID`
instead of `NodeID` for multi-tenant support.

Fixes: #49596

Release note: None