### PR TITLE
row: fetcher cleanup and improvements

### DIFF
--- a/pkg/server/settingswatcher/row_decoder.go
+++ b/pkg/server/settingswatcher/row_decoder.go
@@ -57,12 +57,9 @@ func (d *RowDecoder) DecodeRow(
 	{
 		types := []*types.T{d.columns[0].GetType()}
 		nameRow := make([]rowenc.EncDatum, 1)
-		_, matches, _, err := rowenc.DecodeIndexKey(d.codec, types, nameRow, nil, kv.Key)
+		_, _, err := rowenc.DecodeIndexKey(d.codec, types, nameRow, nil, kv.Key)
 		if err != nil {
 			return "", RawValue{}, false, errors.Wrap(err, "failed to decode key")
-		}
-		if !matches {
-			return "", RawValue{}, false, errors.Errorf("unexpected non-settings KV with settings prefix: %v", kv.Key)
 		}
 		if err := nameRow[0].EnsureDecoded(types[0], &d.alloc); err != nil {
 			return "", RawValue{}, false, err

--- a/pkg/spanconfig/spanconfigkvsubscriber/span_config_decoder.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/span_config_decoder.go
@@ -47,15 +47,9 @@ func (sd *spanConfigDecoder) decode(kv roachpb.KeyValue) (entry roachpb.SpanConf
 	{
 		types := []*types.T{sd.columns[0].GetType()}
 		startKeyRow := make([]rowenc.EncDatum, 1)
-		_, matches, _, err := rowenc.DecodeIndexKey(keys.SystemSQLCodec, types, startKeyRow, nil /* colDirs */, kv.Key)
+		_, _, err := rowenc.DecodeIndexKey(keys.SystemSQLCodec, types, startKeyRow, nil /* colDirs */, kv.Key)
 		if err != nil {
 			return roachpb.SpanConfigEntry{}, errors.Wrapf(err, "failed to decode key: %v", kv.Key)
-		}
-		if !matches {
-			return roachpb.SpanConfigEntry{},
-				errors.AssertionFailedf(
-					"system.span_configurations descriptor does not match key: %v", kv.Key,
-				)
 		}
 		if err := startKeyRow[0].EnsureDecoded(types[0], &sd.alloc); err != nil {
 			return roachpb.SpanConfigEntry{}, err

--- a/pkg/spanconfig/spanconfigsqlwatcher/zonesdecoder.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/zonesdecoder.go
@@ -42,14 +42,14 @@ func (zd *zonesDecoder) DecodePrimaryKey(key roachpb.Key) (descpb.ID, error) {
 	tbl := systemschema.ZonesTable
 	types := []*types.T{tbl.PublicColumns()[0].GetType()}
 	startKeyRow := make([]rowenc.EncDatum, 1)
-	_, matches, _, err := rowenc.DecodeIndexKey(
+	_, _, err := rowenc.DecodeIndexKey(
 		zd.codec, types, startKeyRow, nil /* colDirs */, key,
 	)
-	if err != nil || !matches {
-		return descpb.InvalidID, errors.AssertionFailedf("failed to decode key in system.zones %v", key)
+	if err != nil {
+		return descpb.InvalidID, errors.NewAssertionErrorWithWrappedErrf(err, "failed to decode key in system.zones %v", key)
 	}
 	if err := startKeyRow[0].EnsureDecoded(types[0], &zd.alloc); err != nil {
-		return descpb.InvalidID, errors.AssertionFailedf("failed to decode key in system.zones %v", key)
+		return descpb.InvalidID, errors.NewAssertionErrorWithWrappedErrf(err, "failed to decode key in system.zones %v", key)
 	}
 	descID := descpb.ID(tree.MustBeDInt(startKeyRow[0].Datum))
 	return descID, nil

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -186,12 +186,9 @@ func (d *deleteRangeNode) processResults(
 				continue
 			}
 
-			after, ok, _, err := d.fetcher.ReadIndexKey(keyBytes)
+			after, _, err := d.fetcher.DecodeIndexKey(keyBytes)
 			if err != nil {
 				return nil, err
-			}
-			if !ok {
-				return nil, errors.AssertionFailedf("key did not match descriptor")
 			}
 			k := keyBytes[:len(keyBytes)-len(after)]
 			if !bytes.Equal(k, prev) {

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -650,12 +650,9 @@ func (rf *Fetcher) NextKey(ctx context.Context) (rowDone bool, _ error) {
 		rf.keyRemainingBytes = rf.kv.Key[len(rf.indexKey):]
 	} else if rf.mustDecodeIndexKey {
 		var foundNull bool
-		rf.keyRemainingBytes, moreKVs, foundNull, err = rf.ReadIndexKey(rf.kv.Key)
+		rf.keyRemainingBytes, foundNull, err = rf.DecodeIndexKey(rf.kv.Key)
 		if err != nil {
 			return false, err
-		}
-		if !moreKVs {
-			return false, errors.AssertionFailedf("key did not match any of the table descriptors")
 		}
 		// For unique secondary indexes, the index-key does not distinguish one row
 		// from the next if both rows contain identical values along with a NULL.
@@ -731,23 +728,15 @@ func (rf *Fetcher) prettyEncDatums(types []*types.T, vals []rowenc.EncDatum) str
 	return buf.String()
 }
 
-// ReadIndexKey decodes an index key for a given table.
-// It returns whether or not the key is for any of the tables initialized
-// in Fetcher, and the remaining part of the key if it is.
-// ReadIndexKey additionally returns whether or not it encountered a null while decoding.
-func (rf *Fetcher) ReadIndexKey(
-	key roachpb.Key,
-) (remaining []byte, ok bool, foundNull bool, err error) {
-	remaining, foundNull, err = rowenc.DecodeKeyVals(
+// DecodeIndexKey decodes an index key and returns the remaining key and whether
+// it encountered a null while decoding.
+func (rf *Fetcher) DecodeIndexKey(key roachpb.Key) (remaining []byte, foundNull bool, err error) {
+	return rowenc.DecodeKeyVals(
 		rf.table.keyValTypes,
 		rf.table.keyVals,
 		rf.table.indexColumnDirs,
 		key[rf.table.knownPrefixLength:],
 	)
-	if err != nil {
-		return nil, false, false, err
-	}
-	return remaining, true, foundNull, nil
 }
 
 // KeyToDesc implements the KeyToDescTranslator interface. The implementation is
@@ -756,7 +745,7 @@ func (rf *Fetcher) KeyToDesc(key roachpb.Key) (catalog.TableDescriptor, bool) {
 	if len(key) < rf.table.knownPrefixLength {
 		return nil, false
 	}
-	if _, ok, _, err := rf.ReadIndexKey(key); !ok || err != nil {
+	if _, _, err := rf.DecodeIndexKey(key); err != nil {
 		return nil, false
 	}
 	return rf.table.desc, true

--- a/pkg/sql/rowenc/BUILD.bazel
+++ b/pkg/sql/rowenc/BUILD.bazel
@@ -71,7 +71,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -464,28 +464,27 @@ func DecodeIndexKeyPrefix(
 // The remaining bytes in the index key are returned which will either be an
 // encoded column ID for the primary key index, the primary key suffix for
 // non-unique secondary indexes or unique secondary indexes containing NULL or
-// empty. If the given descriptor does not match the key, false is returned with
-// no error.
+// empty.
 func DecodeIndexKey(
 	codec keys.SQLCodec,
 	types []*types.T,
 	vals []EncDatum,
 	colDirs []descpb.IndexDescriptor_Direction,
 	key []byte,
-) (remainingKey []byte, matches bool, foundNull bool, _ error) {
+) (remainingKey []byte, foundNull bool, _ error) {
 	key, err := codec.StripTenantPrefix(key)
 	if err != nil {
-		return nil, false, false, err
+		return nil, false, err
 	}
 	key, _, _, err = DecodePartialTableIDIndexID(key)
 	if err != nil {
-		return nil, false, false, err
+		return nil, false, err
 	}
 	remainingKey, foundNull, err = DecodeKeyVals(types, vals, colDirs, key)
 	if err != nil {
-		return nil, false, false, err
+		return nil, false, err
 	}
-	return remainingKey, true, foundNull, nil
+	return remainingKey, foundNull, nil
 }
 
 // DecodeKeyVals decodes the values that are part of the key. The decoded

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,12 +92,8 @@ func decodeIndex(
 	}
 	values := make([]EncDatum, index.NumKeyColumns())
 	colDirs := index.IndexDesc().KeyColumnDirections
-	_, ok, _, err := DecodeIndexKey(codec, types, values, colDirs, key)
-	if err != nil {
+	if _, _, err := DecodeIndexKey(codec, types, values, colDirs, key); err != nil {
 		return nil, err
-	}
-	if !ok {
-		return nil, errors.Errorf("key did not match descriptor")
 	}
 
 	decodedValues := make([]tree.Datum, len(values))

--- a/pkg/sql/sqlinstance/instancestorage/row_codec.go
+++ b/pkg/sql/sqlinstance/instancestorage/row_codec.go
@@ -89,7 +89,7 @@ func (d *rowCodec) decodeRow(
 	{
 		types := []*types.T{d.columns[0].GetType()}
 		row := make([]rowenc.EncDatum, 1)
-		_, _, _, err := rowenc.DecodeIndexKey(d.codec, types, row, nil, kv.Key)
+		_, _, err := rowenc.DecodeIndexKey(d.codec, types, row, nil, kv.Key)
 		if err != nil {
 			return base.SQLInstanceID(0), "", "", hlc.Timestamp{}, false, errors.Wrap(err, "failed to decode key")
 		}

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -187,12 +187,8 @@ func decodeTableStatisticsKV(
 	types := []*types.T{types.Int, types.Int}
 	dirs := []descpb.IndexDescriptor_Direction{descpb.IndexDescriptor_ASC, descpb.IndexDescriptor_ASC}
 	keyVals := make([]rowenc.EncDatum, 2)
-	_, matches, _, err := rowenc.DecodeIndexKey(codec, types, keyVals, dirs, kv.Key)
-	if err != nil {
+	if _, _, err := rowenc.DecodeIndexKey(codec, types, keyVals, dirs, kv.Key); err != nil {
 		return 0, err
-	}
-	if !matches {
-		return 0, errors.New("descriptor does not match")
 	}
 
 	if err := keyVals[0].EnsureDecoded(types[0], da); err != nil {


### PR DESCRIPTION
#### rowenc: remove deprecated return from DecodeIndexKey

Release note: None

#### row: minor cleanup around foundNull

This moves around some code to make it clear that it's only relevant in
a specific case.

Release note: None

#### row: clean up ReadIndexKey

Renaming to DecodeIndexKey and removing return value which is no
longer useful.

Release note: None

#### row: more Fetcher cleanup

 - improve comment for `indexKey`;
 - unexport NextKey;
 - slightly change the return value of nextKey to simplify the logic
   (the semantic difference is what the first call returns, which is
   not used);
 - use numKeysPerRow instead of counting the total families; this
   enables the faster paths for more cases.

Release note: None
