### PR TITLE
parser: use second last token for errors when unimplemented

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -312,7 +312,7 @@ SELECT x, y, z FROM family
 1  1  NULL
 3  3  NULL
 
-statement error at or near "where": syntax error: unimplemented: this syntax
+statement error at or near "other_table": syntax error: unimplemented: this syntax
 DELETE FROM family USING family, other_table WHERE x=2
 
 # Verify that the fast path does its deletes at the expected timestamp.

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -366,16 +366,14 @@ CREATE TABLE nocols()
 statement error INSERT has more expressions than target columns, 2 expressions for 0 targets
 INSERT INTO nocols VALUES (true, default)
 
-statement error at or near "k": syntax error: unimplemented
+statement error at or near "\.": syntax error: unimplemented
 INSERT INTO kv (kv.k) VALUES ('hello')
 
-statement error at or near "\*": syntax error: unimplemented
+statement error at or near "\.": syntax error: unimplemented
 INSERT INTO kv (k.*) VALUES ('hello')
 
-statement error at or near "v": syntax error: unimplemented
+statement error at or near "\.": syntax error: unimplemented
 INSERT INTO kv (k.v) VALUES ('hello')
-
-
 
 statement ok
 CREATE TABLE insert_t (x INT, v INT)

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -53,13 +53,13 @@ SELECT * FROM kv
 statement error pgcode 42703 column "m" does not exist
 UPDATE kv SET m = 9 WHERE k IN (1, 3)
 
-statement error at or near "k": syntax error: unimplemented
+statement error at or near "\.": syntax error: unimplemented
 UPDATE kv SET kv.k = 9
 
-statement error at or near "\*": syntax error: unimplemented
+statement error at or near "\.": syntax error: unimplemented
 UPDATE kv SET k.* = 9
 
-statement error at or near "v": syntax error: unimplemented
+statement error at or near "\.": syntax error: unimplemented
 UPDATE kv SET k.v = 9
 
 statement ok

--- a/pkg/sql/parser/testdata/alter_default_privileges
+++ b/pkg/sql/parser/testdata/alter_default_privileges
@@ -50,10 +50,10 @@ error
 ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS TO foo
 ----
 ----
-at or near "to": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS TO foo
-                                                ^
+                                      ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -71,10 +71,10 @@ error
 ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS TO foo, bar
 ----
 ----
-at or near "to": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES GRANT ALL ON FUNCTIONS TO foo, bar
-                                                ^
+                                      ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -188,10 +188,10 @@ error
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON FUNCTIONS TO foo
 ----
 ----
-at or near "to": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON FUNCTIONS TO foo
-                                                             ^
+                                                   ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -305,10 +305,10 @@ error
 ALTER DEFAULT PRIVILEGES IN SCHEMA s GRANT ALL ON FUNCTIONS TO foo
 ----
 ----
-at or near "to": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES IN SCHEMA s GRANT ALL ON FUNCTIONS TO foo
-                                                            ^
+                                                  ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -422,10 +422,10 @@ error
 ALTER DEFAULT PRIVILEGES FOR ROLE foo IN SCHEMA s GRANT ALL ON FUNCTIONS TO foo
 ----
 ----
-at or near "to": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES FOR ROLE foo IN SCHEMA s GRANT ALL ON FUNCTIONS TO foo
-                                                                         ^
+                                                               ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -555,10 +555,10 @@ error
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON FUNCTIONS FROM foo
 ----
 ----
-at or near "from": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON FUNCTIONS FROM foo
-                                                 ^
+                                       ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -576,10 +576,10 @@ error
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON FUNCTIONS FROM foo, bar
 ----
 ----
-at or near "from": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON FUNCTIONS FROM foo, bar
-                                                 ^
+                                       ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -693,10 +693,10 @@ error
 ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE ALL ON FUNCTIONS FROM foo
 ----
 ----
-at or near "from": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE ALL ON FUNCTIONS FROM foo
-                                                              ^
+                                                    ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -810,10 +810,10 @@ error
 ALTER DEFAULT PRIVILEGES IN SCHEMA s REVOKE ALL ON FUNCTIONS FROM foo
 ----
 ----
-at or near "from": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES IN SCHEMA s REVOKE ALL ON FUNCTIONS FROM foo
-                                                             ^
+                                                   ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -927,10 +927,10 @@ error
 ALTER DEFAULT PRIVILEGES FOR ROLE foo IN SCHEMA s REVOKE ALL ON FUNCTIONS FROM foo
 ----
 ----
-at or near "from": syntax error: unimplemented: this syntax
+at or near "functions": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 ALTER DEFAULT PRIVILEGES FOR ROLE foo IN SCHEMA s REVOKE ALL ON FUNCTIONS FROM foo
-                                                                          ^
+                                                                ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is

--- a/pkg/sql/testdata/telemetry/trigrams
+++ b/pkg/sql/testdata/telemetry/trigrams
@@ -39,13 +39,13 @@ CREATE TABLE a(a text)
 feature-usage
 CREATE INDEX ON a USING GIST(a gin_trgm_ops)
 ----
-error: pq: at or near ")": syntax error: unimplemented: this syntax
+error: pq: at or near "gin_trgm_ops": syntax error: unimplemented: this syntax
 unimplemented.#41285.index using gin_trgm_ops
 unimplemented.syntax.#41285.index using gin_trgm_ops
 
 feature-usage
 CREATE INDEX ON a USING GIST(a gist_trgm_ops)
 ----
-error: pq: at or near ")": syntax error: unimplemented: this syntax
+error: pq: at or near "gist_trgm_ops": syntax error: unimplemented: this syntax
 unimplemented.#41285.index using gist_trgm_ops
 unimplemented.syntax.#41285.index using gist_trgm_ops


### PR DESCRIPTION
Commonly when there is an unimplemented error, the error message
displayed is not as helpful as the `lastTok` is past the obvious point
of error, e.g.:

```
-- xml unsupported
root@127.0.0.1:26257/defaultdb> create table tbl (x xml);
invalid syntax: statement ignored: at or near ")": syntax error: unimplemented: this syntax
SQLSTATE: 0A000
DETAIL: source SQL:
create table tbl (x xml)
                       ^
HINT: You have attempted to use a feature that is not yet implemented.
See: https://go.crdb.dev/issue-v/43355/v22.1

-- comment on extension unsupported
root@127.0.0.1:26257/defaultdb> comment on extension "bob";
invalid syntax: statement ignored: at or near "bob": syntax error: unimplemented: this syntax
SQLSTATE: 0A000
DETAIL: source SQL:
comment on extension "bob"
                     ^
HINT: You have attempted to use a feature that is not yet implemented.

Please check the public issue tracker to check whether this problem is
already tracked. If you cannot find it there, please report the error
with details by creating a new issue.

If you would rather not post publicly, please contact us directly
using the support form.

We appreciate your feedback.
```

This change moves the cursor back one token to make it more clear where
the error is:
```
-- xml
root@127.0.0.1:26257/defaultdb> create table tbl (x xml);
invalid syntax: statement ignored: at or near "xml": syntax error: unimplemented: this syntax
SQLSTATE: 0A000
DETAIL: source SQL:
create table tbl (x xml)
                    ^
HINT: You have attempted to use a feature that is not yet implemented.
See: https://go.crdb.dev/issue-v/43355/v22.1
-- comment on extension
root@127.0.0.1:26257/defaultdb> comment on extension "bob";
invalid syntax: statement ignored: at or near "extension": syntax error: unimplemented: this syntax
SQLSTATE: 0A000
DETAIL: source SQL:
comment on extension "bob"
           ^
HINT: You have attempted to use a feature that is not yet implemented.

Please check the public issue tracker to check whether this problem is
already tracked. If you cannot find it there, please report the error
with details by creating a new issue.

If you would rather not post publicly, please contact us directly
using the support form.

We appreciate your feedback.
```

Release note (sql change): Previously, when parsing an unimplemented SQL
syntax, we pointed the error to after the point in the syntax in which
it may be useful, e.g. for `CREATE TABLE tbl (x xml)`, we point at the
`)` and it seems as if `)` is unimplemented. The error now points at the
token beforehand - in the example this would be `xml`.