### PR TITLE
kvserver: de-flake TestStoreSplitRangeLookupRace

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -3018,7 +3018,7 @@ func TestStoreSplitRangeLookupRace(t *testing.T) {
 		select {
 		case <-blockRangeLookups:
 			if kv.TestingIsRangeLookup(ba) &&
-				ba.Requests[0].GetInner().(*roachpb.ScanRequest).Key.Equal(bounds.Key.AsRawKey()) {
+				ba.Requests[0].GetInner().Header().Key.Equal(bounds.Key.AsRawKey()) {
 
 				select {
 				case rangeLookupIsBlocked <- struct{}{}:


### PR DESCRIPTION
Fixes #75198. This test was a bit brittle in expecting only one kind of
range lookup request in a testing filter -- it was always possible to
intercept a ReverseScanRequest, and after enabling span configs
(#73876), we now have an internal query ("validate-span-cfgs") that
makes use of it. See #75198 for more details.

Release note: None