### PR TITLE
server: change sqlroles api to use builtin

### DIFF
--- a/pkg/server/user.go
+++ b/pkg/server/user.go
@@ -14,8 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 )
 
 // UserSQLRoles return a list of the logged in SQL user roles.
@@ -24,46 +23,25 @@ func (s *baseStatusServer) UserSQLRoles(
 ) (_ *serverpb.UserSQLRolesResponse, retErr error) {
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
-	username, err := userFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
-	it, err := s.sqlServer.internalExecutor.QueryIteratorEx(
-		ctx, "sqlroles", nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: username},
-		"SELECT option FROM system.role_options WHERE username=$1", username,
-	)
-	if err != nil {
-		return nil, err
-	}
-	// We have to make sure to close the iterator since we might return from the
-	// for loop early (before Next() returns false).
-	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
-
-	ok, err := it.Next(ctx)
+	username, isAdmin, err := s.privilegeChecker.getUserAndRole(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var resp serverpb.UserSQLRolesResponse
-	if !ok {
-		// The query returned 0 rows.
-		return &resp, nil
-	}
-	scanner := makeResultScanner(it.Types())
-	for ; ok; ok, err = it.Next(ctx) {
-		row := it.Cur()
-		var role string
-		err = scanner.ScanIndex(row, 0, &role)
-		if err != nil {
-			return nil, err
+	if !isAdmin {
+		for name := range roleoption.ByName {
+			hasRole, err := s.privilegeChecker.hasRoleOption(ctx, username, roleoption.ByName[name])
+			if err != nil {
+				return nil, err
+			}
+			if hasRole {
+				resp.Roles = append(resp.Roles, name)
+			}
 		}
-		resp.Roles = append(resp.Roles, role)
-	}
-
-	if err != nil {
-		return nil, err
+	} else {
+		resp.Roles = append(resp.Roles, "ADMIN")
 	}
 	return &resp, nil
 }

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -13,16 +13,16 @@ package server
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
-	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -78,48 +78,42 @@ func TestSQLRolesAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	var res serverpb.UserSQLRolesResponse
 
-	params, _ := tests.CreateTestServerParams()
-	testServer, sqlDB, _ := serverutils.StartServer(t, params)
-	defer testServer.Stopper().Stop(ctx)
-
-	conn, err := testServer.RPCContext().GRPCDialNode(
-		testServer.RPCAddr(), testServer.NodeID(), rpc.DefaultClass,
-	).Connect(ctx)
+	// Admin user.
+	expRoles := []string{"ADMIN"}
+	err := getStatusJSONProtoWithAdminOption(s, "sqlroles", &res, true)
 	require.NoError(t, err)
-	client := serverpb.NewStatusClient(conn)
-	userName, err := userFromContext(ctx)
-	require.NoError(t, err)
-
-	// No roles added to the user.
-	res, err := client.UserSQLRoles(ctx, &serverpb.UserSQLRolesRequest{})
-	require.NoError(t, err)
-	if len(res.Roles) != 0 {
-		t.Errorf("Expected 0 roles, but got %v", res.Roles)
-	}
-
-	// One role added to the user.
-	_, err = sqlDB.Exec(fmt.Sprintf("ALTER USER %s VIEWACTIVITY", userName))
-	require.NoError(t, err)
-	res, err = client.UserSQLRoles(ctx, &serverpb.UserSQLRolesRequest{})
-	require.NoError(t, err)
-	expRoles := []string{"VIEWACTIVITY"}
 	require.Equal(t, expRoles, res.Roles)
 
-	// Two roles added to the user.
-	_, err = sqlDB.Exec(fmt.Sprintf("ALTER USER %s VIEWACTIVITYREDACTED", userName))
+	// No roles added to a non-admin user.
+	expRoles = []string{}
+	err = getStatusJSONProtoWithAdminOption(s, "sqlroles", &res, false)
 	require.NoError(t, err)
-	res, err = client.UserSQLRoles(ctx, &serverpb.UserSQLRolesRequest{})
+	require.Equal(t, expRoles, res.Roles)
+
+	// One role added to the non-admin user.
+	db.Exec(t, fmt.Sprintf("ALTER USER %s VIEWACTIVITY", authenticatedUserNameNoAdmin().Normalized()))
+	expRoles = []string{"VIEWACTIVITY"}
+	err = getStatusJSONProtoWithAdminOption(s, "sqlroles", &res, false)
 	require.NoError(t, err)
+	require.Equal(t, expRoles, res.Roles)
+
+	// Two roles added to the non-admin user.
+	db.Exec(t, fmt.Sprintf("ALTER USER %s VIEWACTIVITYREDACTED", authenticatedUserNameNoAdmin().Normalized()))
 	expRoles = []string{"VIEWACTIVITY", "VIEWACTIVITYREDACTED"}
+	err = getStatusJSONProtoWithAdminOption(s, "sqlroles", &res, false)
+	sort.Strings(res.Roles)
+	require.NoError(t, err)
 	require.Equal(t, expRoles, res.Roles)
 
-	// Remove one role.
-	_, err = sqlDB.Exec(fmt.Sprintf("ALTER USER %s NOVIEWACTIVITY", userName))
-	require.NoError(t, err)
-	res, err = client.UserSQLRoles(ctx, &serverpb.UserSQLRolesRequest{})
-	require.NoError(t, err)
+	// Remove one role from non-admin user.
+	db.Exec(t, fmt.Sprintf("ALTER USER %s NOVIEWACTIVITY", authenticatedUserNameNoAdmin().Normalized()))
 	expRoles = []string{"VIEWACTIVITYREDACTED"}
+	err = getStatusJSONProtoWithAdminOption(s, "sqlroles", &res, false)
+	require.NoError(t, err)
 	require.Equal(t, expRoles, res.Roles)
 }


### PR DESCRIPTION
Previously, the `/sqlroles` api was querying directly the
`system.role_options` table to return all the role options
for a user. This worked normally for users who had `SELECT`
privilege to that table, but it would fail for all other users.
This commits changes the api to use a privilege checker that
uses the `crdb_internal.has_role_option` built in instead, that
can be used by all users, independent of their permission.

Partially addresses #74817

Release note: None