### PR TITLE
bulk: set key timestamps, SSTTimestamp in SSTBatcher

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -770,6 +770,7 @@ func (b *Batch) addSSTable(
 	stats *enginepb.MVCCStats,
 	ingestAsWrites bool,
 	writeAtRequestTimestamp bool,
+	sstTimestamp hlc.Timestamp,
 ) {
 	begin, err := marshalKey(s)
 	if err != nil {
@@ -793,6 +794,7 @@ func (b *Batch) addSSTable(
 		MVCCStats:               stats,
 		IngestAsWrites:          ingestAsWrites,
 		WriteAtRequestTimestamp: writeAtRequestTimestamp,
+		SSTTimestamp:            sstTimestamp,
 	}
 	b.appendReqs(req)
 	b.initResult(1, 0, notRaw, nil)


### PR DESCRIPTION
This changes SSTBatcher so that when it is configured to writeAtBatchTS,
it sets the key timestamps in the keys it adds to its ssts automatically
to the batch timestamp it will use when it sends, and sets that batch ts
to the current time when it adds the first key.

Release note: none.