### PR TITLE
sql: disable span-config on flakey 5node tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -1,4 +1,5 @@
 # LogicTest: 5node-default-configs !5node-metadata
+# cluster-opt: disable-span-configs
 
 # Regression test for nested tuple enum hydration (#74189)
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
@@ -1,4 +1,5 @@
 # LogicTest: 5node
+# cluster-opt: disable-span-configs
 
 statement ok
 CREATE TABLE geo_table(


### PR DESCRIPTION
Temporary fix for #72802 and 5node/distsql_enum CI failures.

Due to https://github.com/cockroachdb/cockroach/pull/73876 these tests have become flakey.
With the disable-span-configs option 70 runs of make stress on the opt logic tests pass.

Release note: None
