### PR TITLE
storage/metamorphic: Reduce metamorphic test operations, run more nigtly

### DIFF
--- a/pkg/storage/metamorphic/meta_nightly_test.go
+++ b/pkg/storage/metamorphic/meta_nightly_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build nightly
+// +build nightly
+
+package metamorphic
+
+func TestPebbleEquivalenceNightly(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t)
+	if *opCount < 1000000 {
+		oldOpCount := *opCount
+		// Override number of operations to at least 1 million.
+		*opCount = 1000000
+
+		defer func() {
+			*opCount = oldOpCount
+		}()
+	}
+
+	runPebbleEquivalenceTest(t)
+}

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	keep    = flag.Bool("keep", false, "keep temp directories after test")
 	check   = flag.String("check", "", "run operations in specified file and check output for equality")
-	opCount = flag.Int("operations", 100000, "number of MVCC operations to generate and run")
+	opCount = flag.Int("operations", 20000, "number of MVCC operations to generate and run")
 )
 
 type testRun struct {
@@ -164,9 +164,13 @@ func TestPebbleEquivalence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t)
+	runPebbleEquivalenceTest(t)
+}
+
+func runPebbleEquivalenceTest(t *testing.T) {
 	ctx := context.Background()
 	// This test times out with the race detector enabled.
-	skip.UnderRace(t)
 	_, seed := randutil.NewTestRand()
 
 	engineSeqs := make([]engineSequence, 0, numStandardOptions+numRandomOptions)


### PR DESCRIPTION
Ever since we slimmed the use of clearRangeOp in #74317, TestPebbleEquivalence
and TestPebbleRestarts have taken a noticeably longer amount of time. This
change reduces the number of operations in regular runs of those tests to
1/5th of the current number (100k -> 20k), while bringing the nightly
runs up to 1m operations.

Fixes #75142, #70935.

Release note: None.