### PR TITLE
bazel: make the `cockroachdb/bazel` image cross-platform

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:focal-20210119
+ARG TARGETPLATFORM
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -35,8 +36,12 @@ RUN apt-get update \
 # c-deps/*-rebuild to force recreating the makefiles. This prevents
 # strange build errors caused by those makefiles depending on the
 # installed version of cmake.
-RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-linux-x86_64.tar.gz -o cmake.tar.gz \
- && echo '97bf730372f9900b2dfb9206fccbcf92f5c7f3b502148b832e77451aa0f9e0e6 cmake.tar.gz' | sha256sum -c - \
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") ARCH=x86_64; SHASUM=97bf730372f9900b2dfb9206fccbcf92f5c7f3b502148b832e77451aa0f9e0e6 ;; \
+    "linux/arm64") ARCH=aarch64; SHASUM=77620f99e9d5f39cf4a49294c6a68c89a978ecef144894618974b9958efe3c2a ;; \
+  esac \
+ && curl -fsSL "https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-linux-$ARCH.tar.gz" -o cmake.tar.gz \
+ && echo "$SHASUM cmake.tar.gz" | sha256sum -c - \
  && tar --strip-components=1 -C /usr -xzf cmake.tar.gz \
  && rm cmake.tar.gz
 
@@ -68,8 +73,12 @@ RUN apt-get purge -y \
 # awscli - roachtests
 # NB: we don't use apt-get because we need an up to date version of awscli
 # If you update the below, you should probably also update build/builder/Dockerfile.
-RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip" && \
- echo "7ee475f22c1b35cc9e53affbf96a9ffce91706e154a9441d0d39cbf8366b718e  awscliv2.zip" | sha256sum -c - && \
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") ARCH=x86_64; SHASUM=7ee475f22c1b35cc9e53affbf96a9ffce91706e154a9441d0d39cbf8366b718e ;; \
+    "linux/arm64") ARCH=aarch64; SHASUM=624ebb04705d4909eb0d56d467fe6b8b5c53a8c59375ed520e70236120125077 ;; \
+  esac && \
+ curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH-2.0.30.zip" -o "awscliv2.zip" && \
+ echo "$SHASUM awscliv2.zip" | sha256sum -c - && \
  unzip awscliv2.zip && \
  ./aws/install && \
  rm -rf aws awscliv2.zip
@@ -78,15 +87,23 @@ RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip"
 # NOTE: you should keep this in sync with build/packer/teamcity-agent.sh and
 # build/bootstrap/bootstrap-debian.sh -- if an update is necessary here, it's probably
 # necessary in the agent as well.
-RUN curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64 > /tmp/bazelisk \
- && echo '4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd /tmp/bazelisk' | sha256sum -c - \
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") ARCH=amd64; SHASUM=4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd ;; \
+    "linux/arm64") ARCH=arm64; SHASUM=c1de6860dd4f8d5e2ec270097bd46d6a211b971a0b8b38559784bd051ea950a1 ;; \
+  esac \
+ && curl -fsSL "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-$ARCH" > /tmp/bazelisk \
+ && echo "$SHASUM /tmp/bazelisk" | sha256sum -c - \
  && chmod +x /tmp/bazelisk \
  && mv /tmp/bazelisk /usr/bin/bazel
 
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 
-RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.2.0/autouseradd-1.2.0-amd64.tar.gz -o autouseradd.tar.gz \
-  && echo 'f7b0cf67564044c31ffc5e84c961726098b88b0296a57c84421659d56434a365 autouseradd.tar.gz' | sha256sum -c - \
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") ARCH=amd64; SHASUM=442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7 ;; \
+    "linux/arm64") ARCH=arm64; SHASUM=b216bebfbe30c3c156144cff07233654e23025e26ab5827058c9b284e130599e ;; \
+   esac \
+  && curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-$ARCH.tar.gz" -o autouseradd.tar.gz \
+  && echo "$SHASUM autouseradd.tar.gz" | sha256sum -c - \
   && tar xzf autouseradd.tar.gz --strip-components 1 \
   && rm autouseradd.tar.gz
 

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,7 +1,7 @@
 # FYI: You can run `./dev builder` to run this Docker image. :)
 # `dev` depends on this variable! Don't change the name or format unless you
 # also update `dev` accordingly.
-BAZEL_IMAGE=cockroachdb/bazel:20211124-095044
+BAZEL_IMAGE=cockroachdb/bazel:20220121-121551
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
 # container with the `cockroachdb/bazel` image running the given script.


### PR DESCRIPTION
Update the `Dockerfile` and corresponding instructions in
`build/README.md` to support building for both `arm64` as well as
`amd64`.

With this change, now someone running an M1 Mac can do (local,
non-cross) builds using `./dev builder`.

To do this we also update to the latest version of `autouseradd`.

Release note: None