### PR TITLE
bazel: bump size of `kvserver` test to `enormous`

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -204,7 +204,7 @@ go_library(
 
 go_test(
     name = "kvserver_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "addressing_test.go",
         "allocator_scorer_test.go",


### PR DESCRIPTION
This has been timing out in CI.

Release note: None