### PR TITLE
compose: add bazel build targets for compose

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,7 @@ exports_files([
 #
 # gazelle:prefix github.com/cockroachdb/cockroach
 # gazelle:build_file_name BUILD.bazel
-# gazelle:build_tags bazel,fast_int_set_small,fast_int_set_large,gss
+# gazelle:build_tags bazel,compose,fast_int_set_small,fast_int_set_large,gss
 
 # Enable protobuf generation.
 #

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -438,8 +438,8 @@ ALL_TESTS = [
 ]
 
 # These suites run only the tests with the appropriate "size" (excepting those
-# tagged "broken_in_bazel" or "flaky") [1]. Note that tests have a default
-# timeout depending on the size [2].
+# tagged "broken_in_bazel", "flaky", or "integration") [1]. Note that tests have
+# a default timeout depending on the size [2].
 
 # [1] https://docs.bazel.build/versions/master/be/general.html#test_suite
 # [2] https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests
@@ -449,6 +449,7 @@ test_suite(
     tags = [
         "-broken_in_bazel",
         "-flaky",
+        "-integration",
         "small",
     ],
     tests = ALL_TESTS,
@@ -459,6 +460,7 @@ test_suite(
     tags = [
         "-broken_in_bazel",
         "-flaky",
+        "-integration",
         "medium",
     ],
     tests = ALL_TESTS,
@@ -469,6 +471,7 @@ test_suite(
     tags = [
         "-broken_in_bazel",
         "-flaky",
+        "-integration",
         "large",
     ],
     tests = ALL_TESTS,
@@ -479,6 +482,7 @@ test_suite(
     tags = [
         "-broken_in_bazel",
         "-flaky",
+        "-integration",
         "enormous",
     ],
     tests = ALL_TESTS,

--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     ],
     embed = [":acceptance"],
     gotags = ["acceptance"],
+    tags = ["integration"],
     deps = [
         "//pkg/acceptance/cluster",
         "//pkg/build/bazel",

--- a/pkg/cmd/generate-test-suites/main.go
+++ b/pkg/cmd/generate-test-suites/main.go
@@ -67,8 +67,8 @@ ALL_TESTS = [`)
 	fmt.Println(`]
 
 # These suites run only the tests with the appropriate "size" (excepting those
-# tagged "broken_in_bazel" or "flaky") [1]. Note that tests have a default
-# timeout depending on the size [2].
+# tagged "broken_in_bazel", "flaky", or "integration") [1]. Note that tests have
+# a default timeout depending on the size [2].
 
 # [1] https://docs.bazel.build/versions/master/be/general.html#test_suite
 # [2] https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests`)
@@ -80,6 +80,7 @@ test_suite(
     tags = [
         "-broken_in_bazel",
         "-flaky",
+        "-integration",
         "%[1]s",
     ],
     tests = ALL_TESTS,

--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -1,8 +1,18 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "compose",
     srcs = ["empty.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/compose",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "compose_test",
+    srcs = ["compose_test.go"],
+    data = ["//pkg/compose:compare/docker-compose.yml"],
+    embed = [":compose"],
+    gotags = ["compose"],
+    tags = ["integration"],
+    deps = ["//pkg/build/bazel"],
 )

--- a/pkg/compose/compare/compare/BUILD.bazel
+++ b/pkg/compose/compare/compare/BUILD.bazel
@@ -1,8 +1,24 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "compare",
     srcs = ["empty.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/compose/compare/compare",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "compare_test",
+    srcs = ["compare_test.go"],
+    embed = [":compare"],
+    gotags = ["compose"],
+    tags = ["integration"],
+    deps = [
+        "//pkg/cmd/cmpconn",
+        "//pkg/internal/sqlsmith",
+        "//pkg/sql/randgen",
+        "//pkg/testutils",
+        "//pkg/util/randutil",
+        "@com_github_jackc_pgx_v4//:pgx",
+    ],
 )

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 )
 
 var (
@@ -32,9 +34,19 @@ var (
 )
 
 func TestComposeCompare(t *testing.T) {
+	var dockerComposeYml string
+	if bazel.BuiltWithBazel() {
+		var err error
+		dockerComposeYml, err = bazel.Runfile("pkg/compose/compare/docker-compose.yml")
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		dockerComposeYml = filepath.Join("compare", "docker-compose.yml")
+	}
 	cmd := exec.Command(
 		"docker-compose",
-		"-f", filepath.Join("compare", "docker-compose.yml"),
+		"-f", dockerComposeYml,
 		"--no-ansi",
 		"up",
 		"--force-recreate",

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":lint"],
     gotags = ["lint"],
+    tags = ["integration"],
     visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         "//pkg/build/bazel",


### PR DESCRIPTION
Also, label integration-style tests appropriately and select them out of
the `test_suite`s in `//pkg`.

Release note: None