### PR TITLE
kvserver: fix closed timestamp regression on clock jump

### DIFF
--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -236,6 +236,13 @@ func (r *Replica) loadRaftMuLockedReplicaMuLocked(desc *roachpb.RangeDescriptor)
 	}
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.Engine())
 
+	// Initialize the propBuf's closed timestamp info from the loaded replica
+	// state. This prevents the replica from proposing commands with carrying a
+	// closed timestamp below what was previously closed. This is relevant after a
+	// restart, in case the clock went backwards since the node was previously
+	// stopped.
+	r.mu.proposalBuf.forwardClosedTimestampLocked(r.mu.state.RaftClosedTimestamp)
+
 	r.sideTransportClosedTimestamp.init(r.store.cfg.ClosedTimestampReceiver, desc.RangeID)
 
 	return nil


### PR DESCRIPTION
Before this patch, the following scenario was possible:
- a node is stopped
- the clock jumps backwards
- the node is restarted
- a replica from the node proposes a command with a closed timestamp
  lower than timestamps closed before the restart. This causes an
  assertion to fire on application.

The problem is that, after the restart, the propBuf, which is in charge
of assigning closed timestamps to proposals, doesn't have info on what
had been closed prior to the restart. The propBuf maintains the
b.assignedClosedTimestamp field, which is supposed to be in advance of
r.mu.state.RaftClosedTimestamp on leaseholder replicas, but nobody
initializes that field on restart. For ranges with epoch-based leases, I
believe we don't have a problem because the range will need to acquire a
new lease after restart before proposing any commands - and lease
acquisitions initialize b.assignedClosedTimestamp. But for
expiration-based leases, I believe a lease from before the restart
might be used(*).

(*) This is probably a bad thing which we should discuss separately. I
think we don't want leases to be used after a restart for multiple
reasons and we have the r.minLeaseProposedTS[1] guard that supposed to
protect against using them (in addition to the epoch protection we have
for epoch-based leases, I think). But I believe this protection can be
elided by a backwards clock jump - we refuse to use leases acquired
*before* minLeaseProposedTS, and minLPTS is assigned to time.Now() on
start; if the clock went backwards, the leases will appear to be good.

[1] https://github.com/cockroachdb/cockroach/blob/6664d0c34df0fea61de4fff1e97987b7de609b9e/pkg/kv/kvserver/replica.go#L468

Release note: A bug causing nodes to repeatedly crash with a "raft
closed timestamp regression" was fixed. The bug occurred when the node
in question had been stopped and the machine clock jumped backwards
before the node was restarted.

Fixes #70894