### PR TITLE
partitionccl,logictestccl: rewrite flaky test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_enum
@@ -86,13 +86,5 @@ create table tbl (i INT, k t,  PRIMARY KEY (i, k), INDEX idx (k) PARTITION BY RA
 statement error pgcode 2BP01 could not remove enum value "a" as it is being used in the partitioning of index tbl@idx
 alter type t drop value 'a';
 
-# We want to fail even if the index is being dropped. The reason is that it
-# would be bad if we rolled back the dropping of the index.
-statement error pgcode XXA00 could not remove enum value "a" as it is being used in the partitioning of index tbl@idx
-begin;
-drop index tbl@idx;
-alter type t drop value 'a';
-commit
-
 statement ok
 alter type t drop value 'c';

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -79,8 +79,10 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
+        "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -18,11 +18,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -49,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -1536,4 +1540,101 @@ func TestRemovePartitioningExpiredLicense(t *testing.T) {
 	expectErr(`ALTER INDEX t@i PARTITION BY RANGE (a) (PARTITION p45 VALUES FROM (4) TO (5))`, partitionErr)
 	expectErr(`ALTER INDEX t@t_pkey CONFIGURE ZONE USING DEFAULT`, zoneErr)
 	expectErr(`ALTER INDEX t@i CONFIGURE ZONE USING DEFAULT`, zoneErr)
+}
+
+// Test that dropping an enum value fails if there's a concurrent index drop
+// for an index partitioned by that enum value. The reason is that it
+// would be bad if we rolled back the dropping of the index.
+func TestDropEnumValueWithConcurrentPartitionedIndexDrop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var s serverutils.TestServerInterface
+	var sqlDB *gosql.DB
+
+	// Use the dropCh to block any DROP INDEX job until the channel is closed.
+	dropCh := make(chan chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	s, sqlDB, _ = serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				RunBeforeResume: func(jobID jobspb.JobID) error {
+					var isDropJob bool
+					if err := sqlDB.QueryRow(`
+SELECT count(*) > 0
+  FROM [SHOW JOB $1]
+ WHERE description LIKE 'DROP INDEX %'
+`, jobID).Scan(&isDropJob); err != nil {
+						return err
+					}
+					if !isDropJob {
+						return nil
+					}
+					ch := make(chan struct{})
+					select {
+					case dropCh <- ch:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					select {
+					case <-ch:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					return nil
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(context.Background())
+	defer cancel()
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Set up the table to have an index which is partitioned by the enum value
+	// we're going to drop.
+	for _, stmt := range []string{
+		`CREATE TYPE t AS ENUM ('a', 'b', 'c')`,
+		`CREATE TABLE tbl (
+    i INT8, k t,
+    PRIMARY KEY (i, k),
+    INDEX idx (k)
+        PARTITION BY RANGE (k)
+            (PARTITION a VALUES FROM ('a') TO ('b'))
+)`,
+	} {
+		tdb.Exec(t, stmt)
+	}
+	// Run a transaction to drop the index and the enum value.
+	errCh := make(chan error)
+	go func() {
+		errCh <- crdb.ExecuteTx(ctx, sqlDB, nil, func(tx *gosql.Tx) error {
+			if _, err := tx.Exec("drop index tbl@idx;"); err != nil {
+				return err
+			}
+			_, err := tx.Exec("alter type t drop value 'a';")
+			return err
+		})
+	}()
+	// Wait until the dropping of the enum value has finished.
+	ch := <-dropCh
+	testutils.SucceedsSoon(t, func() error {
+		var done bool
+		tdb.QueryRow(t, `
+SELECT bool_and(done)
+  FROM (
+        SELECT status NOT IN `+jobs.NonTerminalStatusTupleString+` AS done
+          FROM [SHOW JOBS]
+         WHERE job_type = 'TYPEDESC SCHEMA CHANGE'
+       );`).
+			Scan(&done)
+		if done {
+			return nil
+		}
+		return errors.Errorf("not done")
+	})
+	// Allow the dropping of the index to proceed.
+	close(ch)
+	// Ensure we got the right error.
+	require.Regexp(t,
+		`could not remove enum value "a" as it is being used in the partitioning of index tbl@idx`,
+		<-errCh)
 }


### PR DESCRIPTION
The test in question would flake if the drop index job ran to completion
before the type change ran. This was flakey. We instead make it a real go test
and use a testing knob to prevent this from happening.

Fixes #68395

Release note: None