### PR TITLE
migrations: make sure public role gets privs on public schema

### DIFF
--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
+        "//pkg/sql/privilege",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/util/log",

--- a/pkg/migration/migrations/public_schema_migration.go
+++ b/pkg/migration/migrations/public_schema_migration.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -107,6 +108,13 @@ func createPublicSchemaDescriptor(
 
 	publicSchemaDesc, _, err := sql.CreateSchemaDescriptorWithPrivileges(
 		ctx, d.DB, d.Codec, desc, tree.PublicSchema, security.AdminRoleName(), security.AdminRoleName(), true, /* allocateID */
+	)
+	// The public role has hardcoded privileges; see comment in
+	// maybeCreatePublicSchemaWithDescriptor.
+	publicSchemaDesc.Privileges.Grant(
+		security.PublicRoleName(),
+		privilege.List{privilege.CREATE, privilege.USAGE},
+		false, /* withGrantOption */
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This matches up with how the public schema gets created in a
non-migration scenario.

Release note: None