### PR TITLE
sql: Fix bug in Scanner::allocBytes

### DIFF
--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -84,9 +84,9 @@ func (s *Scanner) Cleanup() {
 }
 
 func (s *Scanner) allocBytes(length int) []byte {
-	if len(s.bytesPrealloc) >= length {
+	if cap(s.bytesPrealloc) >= length {
 		res := s.bytesPrealloc[:length:length]
-		s.bytesPrealloc = s.bytesPrealloc[length:]
+		s.bytesPrealloc = s.bytesPrealloc[length:cap(s.bytesPrealloc)]
 		return res
 	}
 	return make([]byte, length)

--- a/pkg/sql/scanner/scan_test.go
+++ b/pkg/sql/scanner/scan_test.go
@@ -149,3 +149,31 @@ func TestLastLexicalToken(t *testing.T) {
 		})
 	}
 }
+
+func TestScannerBuffer(t *testing.T) {
+	scanner := makeScanner("pretty long initial query string")
+
+	// get one buffer and return it
+	initialBuffer := scanner.buffer()
+	b := append(initialBuffer, []byte("abc")...)
+	s := scanner.finishString(b)
+	require.Equal(t, "abc", s)
+
+	// append some bytes with allocBytes()
+	b = scanner.allocBytes(4)
+	copy(b, []byte("defg"))
+	require.Equal(t, []byte("abcdefg"), initialBuffer[:7])
+
+	// append other bytes with buffer()+finishString()
+	b = scanner.buffer()
+	b = append(b, []byte("hi")...)
+	s = scanner.finishString(b)
+	require.Equal(t, "hi", s)
+	require.Equal(t, []byte("abcdefghi"), initialBuffer[:9])
+}
+
+func makeScanner(str string) Scanner {
+	var s Scanner
+	s.Init(str)
+	return s
+}


### PR DESCRIPTION
The scanner buffer is supposed to be reused while scanning the query.
However when the buffer is partially used the left part is returned
to be reused with the length set to zero.
We must use all the buffer, up to the capability.

Release note: None