### PR TITLE
util/tracing: detect use-after-Finish in all exported Span methods

### DIFF
--- a/pkg/util/log/trace_client_test.go
+++ b/pkg/util/log/trace_client_test.go
@@ -25,7 +25,7 @@ func TestTrace(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		init  func(context.Context) (context.Context, *tracing.Span)
-		check func(*testing.T, context.Context, tracing.Recording, *tracing.Tracer)
+		check func(*testing.T, context.Context, *tracing.Span, *tracing.Tracer)
 	}{
 		{
 			name: "verbose",
@@ -35,7 +35,8 @@ func TestTrace(t *testing.T) {
 				ctxWithSpan := tracing.ContextWithSpan(ctx, sp)
 				return ctxWithSpan, sp
 			},
-			check: func(t *testing.T, _ context.Context, rec tracing.Recording, _ *tracing.Tracer) {
+			check: func(t *testing.T, _ context.Context, sp *tracing.Span, _ *tracing.Tracer) {
+				rec := sp.FinishAndGetRecording(tracing.RecordingVerbose)
 				if err := tracing.CheckRecordedSpans(rec, `
 		span: s
 			tags: _verbose=1
@@ -57,7 +58,8 @@ func TestTrace(t *testing.T) {
 				tr.Configure(ctx, &st.SV)
 				return tr.StartSpanCtx(context.Background(), "foo")
 			},
-			check: func(t *testing.T, ctx context.Context, _ tracing.Recording, tr *tracing.Tracer) {
+			check: func(t *testing.T, ctx context.Context, sp *tracing.Span, tr *tracing.Tracer) {
+				defer sp.Finish()
 				// This isn't quite a real end-to-end-check, but it is good enough
 				// to give us confidence that we're really passing log events to
 				// the span, and the tracing package in turn has tests that verify
@@ -84,7 +86,7 @@ func TestTrace(t *testing.T) {
 			log.Event(ctx, "should-not-show-up")
 
 			tr := sp.Tracer()
-			tc.check(t, ctxWithSpan, sp.FinishAndGetRecording(tracing.RecordingVerbose), tr)
+			tc.check(t, ctxWithSpan, sp, tr)
 		})
 	}
 }

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -251,11 +251,11 @@ func (sp *Span) finishInternal() {
 	if sp == nil || sp.IsNoop() || sp.detectUseAfterFinish() {
 		return
 	}
-	atomic.StoreInt32(&sp.finished, 1)
-	sp.i.Finish()
 	if sp.Tracer().debugUseAfterFinish {
 		sp.finishStack = string(debug.Stack())
 	}
+	atomic.StoreInt32(&sp.finished, 1)
+	sp.i.Finish()
 	// Release the reference that the span held to itself. Unless we're racing
 	// with the finishing of the parent or one of the children, this one will be
 	// the last reference, and the span will be made available for re-allocation.

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -163,6 +163,8 @@ func (sp *Span) IsNoop() bool {
 //
 // Exported methods on Span are supposed to call this and short-circuit if true
 // is returrned.
+//
+// Note that a nil or no-op span will return true.
 func (sp *Span) detectUseAfterFinish() bool {
 	if sp == nil {
 		return true
@@ -173,7 +175,7 @@ func (sp *Span) detectUseAfterFinish() bool {
 	alreadyFinished := atomic.LoadInt32(&sp.finished) != 0
 	// In test builds, we panic on span use after Finish. This is in preparation
 	// of span pooling, at which point use-after-Finish would become corruption.
-	if alreadyFinished && sp.Tracer().PanicOnUseAfterFinish() {
+	if alreadyFinished && sp.i.tracer.PanicOnUseAfterFinish() {
 		var finishStack string
 		if sp.finishStack == "" {
 			finishStack = "<stack not captured. Set debugUseAfterFinish>"
@@ -223,6 +225,7 @@ func (sp *Span) decRef() bool {
 
 // Tracer exports the tracer this span was created using.
 func (sp *Span) Tracer() *Tracer {
+	sp.detectUseAfterFinish()
 	return sp.i.Tracer()
 }
 
@@ -235,6 +238,7 @@ func (sp *Span) Redactable() bool {
 	if sp == nil || sp.i.isNoop() {
 		return false
 	}
+	sp.detectUseAfterFinish()
 	return sp.Tracer().Redactable()
 }
 
@@ -358,12 +362,13 @@ func (sp *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
 }
 
 // Meta returns the information which needs to be propagated across process
-// boundaries in order to derive child spans from this Span. This may return
-// nil, which is a valid input to WithRemoteParentFromSpanMeta, if the Span has been
-// optimized out.
+// boundaries in order to derive child spans from this Span. This may return an
+// empty SpanMeta (which is a valid input to WithRemoteParentFromSpanMeta) if
+// the Span has been optimized out.
 func (sp *Span) Meta() SpanMeta {
-	// It shouldn't be done in practice, but it is allowed to call Meta on
-	// a finished span.
+	if sp.detectUseAfterFinish() {
+		return SpanMeta{}
+	}
 	return sp.i.Meta()
 }
 
@@ -391,6 +396,9 @@ func (sp *Span) SetVerbose(to bool) {
 
 // RecordingType returns the range's current recording mode.
 func (sp *Span) RecordingType() RecordingType {
+	if sp.detectUseAfterFinish() {
+		return RecordingOff
+	}
 	return sp.i.RecordingType()
 }
 
@@ -442,6 +450,9 @@ func (sp *Span) SetTag(key string, value attribute.Value) {
 
 // TraceID retrieves a span's trace ID.
 func (sp *Span) TraceID() tracingpb.TraceID {
+	if sp.detectUseAfterFinish() {
+		return 0
+	}
 	return sp.i.TraceID()
 }
 
@@ -459,6 +470,7 @@ func (sp *Span) OperationName() string {
 	if sp.IsNoop() {
 		return "noop"
 	}
+	sp.detectUseAfterFinish()
 	return sp.i.crdb.operation
 }
 
@@ -466,6 +478,9 @@ func (sp *Span) OperationName() string {
 // that case, trying to create a child span will result in the would-be child
 // being a root span.
 func (sp *Span) IsSterile() bool {
+	if sp.detectUseAfterFinish() {
+		return true
+	}
 	return sp.i.sterile
 }
 


### PR DESCRIPTION
Most exported Span methods already have protection for being called
after the span was Finish()ed. This patch adds the protection to the
ones that were still missing it.

Release note: None