### PR TITLE
catalog: add Index.InvertedColumnKeyType

### DIFF
--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	types "github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
 
@@ -111,4 +112,15 @@ func (desc *IndexDescriptor) InvertedColumnName() string {
 		panic(errors.AssertionFailedf("index is not inverted"))
 	}
 	return desc.KeyColumnNames[len(desc.KeyColumnNames)-1]
+}
+
+// InvertedColumnKeyType returns the type of the data element that is encoded
+// as the inverted index key. This is currently always Bytes.
+//
+// Panics if the index is not inverted.
+func (desc *IndexDescriptor) InvertedColumnKeyType() *types.T {
+	if desc.Type != IndexDescriptor_INVERTED {
+		panic(errors.AssertionFailedf("index is not inverted"))
+	}
+	return types.Bytes
 }

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -152,8 +152,23 @@ type Index interface {
 	CollectSecondaryStoredColumnIDs() TableColSet
 	CollectCompositeColumnIDs() TableColSet
 
+	// InvertedColumnID returns the ColumnID of the inverted column of the
+	// inverted index.
+	//
+	// Panics if the index is not inverted.
 	InvertedColumnID() descpb.ColumnID
+
+	// InvertedColumnName returns the name of the inverted column of the inverted
+	// index.
+	//
+	// Panics if the index is not inverted.
 	InvertedColumnName() string
+
+	// InvertedColumnKeyType returns the type of the data element that is encoded
+	// as the inverted index key. This is currently always Bytes.
+	//
+	// Panics if the index is not inverted.
+	InvertedColumnKeyType() *types.T
 
 	NumPrimaryStoredColumns() int
 	NumSecondaryStoredColumns() int

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
@@ -158,6 +159,14 @@ func (w index) InvertedColumnID() descpb.ColumnID {
 // not inverted.
 func (w index) InvertedColumnName() string {
 	return w.desc.InvertedColumnName()
+}
+
+// InvertedColumnKeyType returns the type of the data element that is encoded
+// as the inverted index key. This is currently always Bytes.
+//
+// Panics if the index is not inverted.
+func (w index) InvertedColumnKeyType() *types.T {
+	return w.desc.InvertedColumnKeyType()
 }
 
 // CollectKeyColumnIDs creates a new set containing the column IDs in the key

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -806,22 +806,25 @@ func newOptTable(
 			}
 		}
 		if idx.GetType() == descpb.IndexDescriptor_INVERTED {
-			// The last column of an inverted index is special: in the
+			// The inverted column of an inverted index is special: in the
 			// descriptors, it looks as if the table column is part of the
 			// index; in fact the key contains values *derived* from that
 			// column. In the catalog, we refer to this key as a separate,
 			// inverted column.
-			invertedSourceColOrdinal, _ := ot.lookupColumnOrdinal(idx.GetKeyColumnID(idx.NumKeyColumns() - 1))
+			invertedColumnID := idx.InvertedColumnID()
+			invertedColumnName := idx.InvertedColumnName()
+			invertedColumnType := idx.InvertedColumnKeyType()
+
+			invertedSourceColOrdinal, _ := ot.lookupColumnOrdinal(invertedColumnID)
 
 			// Add a inverted column that refers to the inverted index key.
 			invertedCol, invertedColOrd := newColumn()
 
 			// All inverted columns have type bytes.
-			typ := types.Bytes
 			invertedCol.InitInverted(
 				invertedColOrd,
-				tree.Name(string(ot.Column(invertedSourceColOrdinal).ColName())+"_inverted_key"),
-				typ,
+				tree.Name(invertedColumnName+"_inverted_key"),
+				invertedColumnType,
 				false, /* nullable */
 				invertedSourceColOrdinal,
 			)


### PR DESCRIPTION
In an inverted index, the encoded key is treated as a Bytes datum.
This is currently hardcoded in the opt catalog.

This commit moves this into the index descriptor.

Release note: None