### PR TITLE
release-21.1: backupccl: allow using LATEST shorthand in RESTORE and SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -247,26 +247,11 @@ func resolveBackupCollection(
 	var chosenSuffix string
 	collectionURI := defaultURI
 	if appendToLatest {
-		collection, err := makeCloudStorage(ctx, collectionURI, user)
+		latest, err := readLatestFile(ctx, collectionURI, makeCloudStorage, user)
 		if err != nil {
 			return "", "", err
 		}
-		defer collection.Close()
-		latestFile, err := collection.ReadFile(ctx, latestFileName)
-		if err != nil {
-			if errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
-				return "", "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
-			}
-			return "", "", pgerror.WithCandidateCode(err, pgcode.Io)
-		}
-		latest, err := ioutil.ReadAll(latestFile)
-		if err != nil {
-			return "", "", err
-		}
-		if len(latest) == 0 {
-			return "", "", errors.Errorf("malformed LATEST file")
-		}
-		chosenSuffix = string(latest)
+		chosenSuffix = latest
 	} else if subdir != "" {
 		// User has specified a subdir via `BACKUP INTO 'subdir' IN...`.
 		chosenSuffix = strings.TrimPrefix(subdir, "/")
@@ -275,4 +260,32 @@ func resolveBackupCollection(
 		chosenSuffix = endTime.GoTime().Format(dateBasedIntoFolderName)
 	}
 	return collectionURI, chosenSuffix, nil
+}
+
+func readLatestFile(
+	ctx context.Context,
+	collectionURI string,
+	makeCloudStorage cloud.ExternalStorageFromURIFactory,
+	user security.SQLUsername,
+) (string, error) {
+	collection, err := makeCloudStorage(ctx, collectionURI, user)
+	if err != nil {
+		return "", err
+	}
+	defer collection.Close()
+	latestFile, err := collection.ReadFile(ctx, latestFileName)
+	if err != nil {
+		if errors.Is(err, cloudimpl.ErrFileDoesNotExist) {
+			return "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
+		}
+		return "", pgerror.WithCandidateCode(err, pgcode.Io)
+	}
+	latest, err := ioutil.ReadAll(latestFile)
+	if err != nil {
+		return "", err
+	}
+	if len(latest) == 0 {
+		return "", errors.Errorf("malformed LATEST file")
+	}
+	return string(latest), nil
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -757,6 +757,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 
+	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, $3)", collections...)
+
 	// The flavors of BACKUP and RESTORE which automatically resolve the right
 	// directory to read/write data to, have URIs with the resolved path written
 	// to the job description.
@@ -783,6 +786,10 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedCollectionURIs[0], resolvedCollectionURIs[1],
 				resolvedCollectionURIs[2])},
+			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
+				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
+				resolvedSubdirURIs[2])},
+			// and again from LATEST IN...
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
 				resolvedSubdirURIs[2])},

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -129,29 +129,41 @@ func showBackupPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		str, err := toFn()
+		dest, err := toFn()
 		if err != nil {
 			return err
 		}
 
-		if err := checkShowBackupURIPrivileges(ctx, p, str); err != nil {
+		var subdir string
+
+		if inColFn != nil {
+			subdir = dest
+			dest, err = inColFn()
+			if err != nil {
+				return err
+			}
+		}
+
+		if err := checkShowBackupURIPrivileges(ctx, p, dest); err != nil {
 			return err
 		}
 
-		if inColFn != nil {
-			collection, err := inColFn()
+		if subdir != "" {
+			parsed, err := url.Parse(dest)
 			if err != nil {
 				return err
 			}
-			parsed, err := url.Parse(collection)
-			if err != nil {
-				return err
+			if strings.EqualFold(subdir, "LATEST") {
+				subdir, err = readLatestFile(ctx, dest, p.ExecCfg().DistSQLSrv.ExternalStorageFromURI, p.User())
+				if err != nil {
+					return errors.Wrap(err, "read LATEST path")
+				}
 			}
-			parsed.Path = path.Join(parsed.Path, str)
-			str = parsed.String()
+			parsed.Path = path.Join(parsed.Path, subdir)
+			dest = parsed.String()
 		}
 
-		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, str, p.User())
+		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, dest, p.User())
 		if err != nil {
 			return errors.Wrapf(err, "make storage")
 		}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -433,6 +433,11 @@ func TestShowBackups(t *testing.T) {
 	require.Equal(t, 4, len(b1))
 	b2 := sqlDBRestore.QueryStr(t, `SELECT * FROM [SHOW BACKUP $1 IN $2] WHERE object_type='table'`, rows[1][0], full)
 	require.Equal(t, 3, len(b2))
+
+	require.Equal(t,
+		sqlDBRestore.QueryStr(t, `SHOW BACKUP $1 IN $2`, rows[2][0], full),
+		sqlDBRestore.QueryStr(t, `SHOW BACKUP LATEST IN $1`, full),
+	)
 }
 
 func TestShowBackupTenants(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #72409.

/cc @cockroachdb/release

---

We allow the alias 'LATEST' when backing up into a collection, e.g. by running
BACKUP INTO LATEST IN x, which automatically replaces 'LATEST' with the path to
most recent backup added to the collection. However for RESTORE and SHOW BACKUP
using the same alias would previously return an error, saying that the literal
'latest' path did not contain a backup. This change fixes that, doing the same
automatic expansion of the alias during RESTORE and SHOW that is done by BACKUP.

Release note (bug fix): 'RESTORE ... FROM LATEST IN' now works to restore the latest backup from a collection without needing to first inspect the collection to supply its actual path.

Release justification: low risk polish.