### PR TITLE
util/tracing: skip a few tests under deadlock detector

### DIFF
--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/logtags"
 	"github.com/gogo/protobuf/types"
 )
@@ -25,6 +26,7 @@ import (
 // This benchmark explicitly excludes construction of
 // the SpanOptions, which require allocations as well.
 func BenchmarkTracer_StartSpanCtx(b *testing.B) {
+	skip.UnderDeadlock(b, "span reuse triggers false-positives in the deadlock detector")
 	ctx := context.Background()
 
 	staticLogTags := logtags.Buffer{}
@@ -103,6 +105,7 @@ func BenchmarkSpan_GetRecording(b *testing.B) {
 }
 
 func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
+	skip.UnderDeadlock(b, "span reuse triggers false-positives in the deadlock detector")
 	tr := NewTracerWithOpt(context.Background(),
 		WithTracingMode(TracingModeActiveSpansRegistry),
 		WithSpanReusePercent(100))
@@ -121,6 +124,7 @@ func BenchmarkRecordingWithStructuredEvent(b *testing.B) {
 
 // BenchmarkSpanCreation creates traces with a couple of spans in them.
 func BenchmarkSpanCreation(b *testing.B) {
+	skip.UnderDeadlock(b, "span reuse triggers false-positives in the deadlock detector")
 	tr := NewTracerWithOpt(context.Background(),
 		WithTracingMode(TracingModeActiveSpansRegistry),
 		WithSpanReusePercent(100))

--- a/pkg/util/tracing/tracer_external_test.go
+++ b/pkg/util/tracing/tracer_external_test.go
@@ -32,6 +32,7 @@ import (
 func TestSpanPooling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderRace(t, "sync.Pool seems to be emptied very frequently under race, making the test unreliable")
+	skip.UnderDeadlock(t, "span reuse triggers false-positives in the deadlock detector")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	tr := tracing.NewTracerWithOpt(ctx,

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -718,6 +718,7 @@ func TestChildNeedsSameTracerAsParent(t *testing.T) {
 // one.
 func TestSpanReuse(t *testing.T) {
 	skip.UnderRace(t, "sync.Pool seems to be emptied very frequently under race, making the test unreliable")
+	skip.UnderDeadlock(t, "span reuse triggers false-positives in the deadlock detector")
 	ctx := context.Background()
 	tr := NewTracerWithOpt(ctx,
 		// Ask the tracer to always reuse spans, overriding the testing's


### PR DESCRIPTION
As explained in #75423, span reuse is incompatible with the deadlock
detector, which flags this reuse as false-positives. That patch
generally disabled reuse when running under the test detector. This
patch skips a few tests that explicitly ask for span reuse.

I'll separately try to improve the deadlock detector such that it can be
used with our code.

Fixes #75433
Fixes #75488

Release note: None