### PR TITLE
ui: removed formatting to statements on the details pages

### DIFF
--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "//pkg/spanconfig",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/sem/tree",
         "//pkg/sql/sqlstats",
         "//pkg/sql/tests",
         "//pkg/testutils",

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -116,35 +115,19 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	tenantStatusServer := tenant.StatusServer().(serverpb.SQLStatusServer)
 
 	type testCase struct {
-		stmt                 string
-		formattedStmt        string
-		fingerprint          string
-		formattedFingerprint string
+		stmt        string
+		fingerprint string
 	}
 
 	testCaseTenant := []testCase{
+		{stmt: `CREATE DATABASE roachblog_t`},
+		{stmt: `SET database = roachblog_t`},
+		{stmt: `CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:          `CREATE DATABASE roachblog_t`,
-			formattedStmt: "CREATE DATABASE roachblog_t\n",
+			stmt:        `INSERT INTO posts_t VALUES (1, 'foo')`,
+			fingerprint: `INSERT INTO posts_t VALUES (_, '_')`,
 		},
-		{
-			stmt:          `SET database = roachblog_t`,
-			formattedStmt: "SET database = roachblog_t\n",
-		},
-		{
-			stmt:          `CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)`,
-			formattedStmt: "CREATE TABLE posts_t (id INT8 PRIMARY KEY, body STRING)\n",
-		},
-		{
-			stmt:                 `INSERT INTO posts_t VALUES (1, 'foo')`,
-			fingerprint:          `INSERT INTO posts_t VALUES (_, '_')`,
-			formattedStmt:        "INSERT INTO posts_t VALUES (1, 'foo')\n",
-			formattedFingerprint: "INSERT INTO posts_t VALUES (_, '_')\n",
-		},
-		{
-			stmt:          `SELECT * FROM posts_t`,
-			formattedStmt: "SELECT * FROM posts_t\n",
-		},
+		{stmt: `SELECT * FROM posts_t`},
 	}
 
 	for _, stmt := range testCaseTenant {
@@ -156,28 +139,14 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	require.NoError(t, err)
 
 	testCaseNonTenant := []testCase{
+		{stmt: `CREATE DATABASE roachblog_nt`},
+		{stmt: `SET database = roachblog_nt`},
+		{stmt: `CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:          `CREATE DATABASE roachblog_nt`,
-			formattedStmt: "CREATE DATABASE roachblog_nt\n",
+			stmt:        `INSERT INTO posts_nt VALUES (1, 'foo')`,
+			fingerprint: `INSERT INTO posts_nt VALUES (_, '_')`,
 		},
-		{
-			stmt:          `SET database = roachblog_nt`,
-			formattedStmt: "SET database = roachblog_nt\n",
-		},
-		{
-			stmt:          `CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)`,
-			formattedStmt: "CREATE TABLE posts_nt (id INT8 PRIMARY KEY, body STRING)\n",
-		},
-		{
-			stmt:                 `INSERT INTO posts_nt VALUES (1, 'foo')`,
-			fingerprint:          `INSERT INTO posts_nt VALUES (_, '_')`,
-			formattedStmt:        "INSERT INTO posts_nt VALUES (1, 'foo')\n",
-			formattedFingerprint: "INSERT INTO posts_nt VALUES (_, '_')\n",
-		},
-		{
-			stmt:          `SELECT * FROM posts_nt`,
-			formattedStmt: "SELECT * FROM posts_nt\n",
-		},
+		{stmt: `SELECT * FROM posts_nt`},
 	}
 
 	pgURL, cleanupGoDB := sqlutils.PGUrl(
@@ -230,22 +199,14 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	err = serverutils.GetJSONProto(nonTenant, path, &nonTenantCombinedStats)
 	require.NoError(t, err)
 
-	checkStatements := func(t *testing.T, tc []testCase, actual *serverpb.StatementsResponse, combined bool) {
+	checkStatements := func(t *testing.T, tc []testCase, actual *serverpb.StatementsResponse) {
 		t.Helper()
 		var expectedStatements []string
 		for _, stmt := range tc {
 			var expectedStmt = stmt.stmt
-			if combined {
-				expectedStmt = stmt.formattedStmt
-			}
 			if stmt.fingerprint != "" {
-				if combined {
-					expectedStmt = stmt.formattedFingerprint
-				} else {
-					expectedStmt = stmt.fingerprint
-				}
+				expectedStmt = stmt.fingerprint
 			}
-
 			expectedStatements = append(expectedStatements, expectedStmt)
 		}
 
@@ -272,14 +233,14 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 
 	// First we verify that we have expected stats from tenants.
 	t.Run("tenant-stats", func(t *testing.T) {
-		checkStatements(t, testCaseTenant, tenantStats, false)
-		checkStatements(t, testCaseTenant, tenantCombinedStats, true)
+		checkStatements(t, testCaseTenant, tenantStats)
+		checkStatements(t, testCaseTenant, tenantCombinedStats)
 	})
 
 	// Now we verify the non tenant stats are what we expected.
 	t.Run("non-tenant-stats", func(t *testing.T) {
-		checkStatements(t, testCaseNonTenant, &nonTenantStats, false)
-		checkStatements(t, testCaseNonTenant, &nonTenantCombinedStats, true)
+		checkStatements(t, testCaseNonTenant, &nonTenantStats)
+		checkStatements(t, testCaseNonTenant, &nonTenantCombinedStats)
 	})
 
 	// Now we verify that tenant and non-tenant have no visibility into each other's stats.
@@ -313,29 +274,10 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 func testResetSQLStatsRPCForTenant(
 	ctx context.Context, t *testing.T, testHelper *tenantTestHelper,
 ) {
-
-	type testCase struct {
-		stmt          string
-		formattedStmt string
-	}
-	stmts := []testCase{
-		{
-			stmt:          "SELECT 1",
-			formattedStmt: "SELECT 1\n",
-		},
-		{
-			stmt:          "SELECT 1, 1",
-			formattedStmt: "SELECT 1, 1\n",
-		},
-		{
-			stmt:          "SELECT 1, 1, 1",
-			formattedStmt: "SELECT 1, 1\n",
-		},
-	}
-
-	var expectedStatements []string
-	for _, tc := range stmts {
-		expectedStatements = append(expectedStatements, tc.formattedStmt)
+	stmts := []string{
+		"SELECT 1",
+		"SELECT 1, 1",
+		"SELECT 1, 1, 1",
 	}
 
 	testCluster := testHelper.testCluster()
@@ -365,8 +307,8 @@ func testResetSQLStatsRPCForTenant(
 			}()
 
 			for _, stmt := range stmts {
-				testCluster.tenantConn(randomServer).Exec(t, stmt.stmt)
-				controlCluster.tenantConn(randomServer).Exec(t, stmt.stmt)
+				testCluster.tenantConn(randomServer).Exec(t, stmt)
+				controlCluster.tenantConn(randomServer).Exec(t, stmt)
 			}
 
 			if flushed {
@@ -383,7 +325,7 @@ func testResetSQLStatsRPCForTenant(
 
 			require.NotEqual(t, 0, len(statsPreReset.Statements),
 				"expected to find stats for at least one statement, but found: %d", len(statsPreReset.Statements))
-			ensureExpectedStmtFingerprintExistsInRPCResponse(t, expectedStatements, statsPreReset, "test")
+			ensureExpectedStmtFingerprintExistsInRPCResponse(t, stmts, statsPreReset, "test")
 
 			_, err = status.ResetSQLStats(ctx, &serverpb.ResetSQLStatsRequest{
 				ResetPersistedStats: true,
@@ -420,7 +362,7 @@ func testResetSQLStatsRPCForTenant(
 				})
 			require.NoError(t, err)
 
-			ensureExpectedStmtFingerprintExistsInRPCResponse(t, expectedStatements, statsFromControlCluster, "control")
+			ensureExpectedStmtFingerprintExistsInRPCResponse(t, stmts, statsFromControlCluster, "control")
 		})
 	}
 }
@@ -607,10 +549,10 @@ SET DATABASE=test_db1;
 SELECT * FROM test;
 `)
 
-	getCreateStmtQuery := fmt.Sprintf(`
-		SELECT prettify_statement(indexdef, %d, %d, %d)
-		FROM pg_catalog.pg_indexes
-		WHERE tablename = 'test' AND indexname = $1`, tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase)
+	getCreateStmtQuery := `
+SELECT indexdef
+FROM pg_catalog.pg_indexes
+WHERE tablename = 'test' AND indexname = $1`
 
 	// Get index usage stats and assert expected results.
 	resp := getTableIndexStats(testHelper, "test_db1")

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -116,18 +116,12 @@ func collectCombinedStatements(
 				transaction_fingerprint_id,
 				app_name,
 				aggregated_ts,
-				jsonb_set(
-					metadata,
-					array['query'],
-					to_jsonb(
-						prettify_statement(metadata ->> 'query', %d, %d, %d)
-					)
-				),
+				metadata,
 				statistics,
 				sampled_plan,
 				aggregation_interval
 			FROM crdb_internal.statement_statistics
-			%s`, tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase, whereClause)
+			%s`, whereClause)
 
 	const expectedNumDatums = 8
 

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -223,13 +223,14 @@ func getTableIndexUsageStats(
 
 	q := makeSQLQuery()
 	// TODO(#72930): Implement virtual indexes on index_usages_statistics and table_indexes
-	q.Append(`SELECT
+	q.Append(`
+		SELECT
 			ti.index_id,
 			ti.index_name,
 			ti.index_type,
 			total_reads,
 			last_read,
-			prettify_statement(indexdef, $, $, $)
+			indexdef
 		FROM crdb_internal.index_usage_statistics AS us
   	JOIN crdb_internal.table_indexes AS ti ON us.index_id = ti.index_id 
 		AND us.table_id = ti.descriptor_id
@@ -237,9 +238,6 @@ func getTableIndexUsageStats(
   	JOIN pg_catalog.pg_indexes AS pgidxs ON pgidxs.crdb_oid = indexrelid
 		AND indexname = ti.index_name
  		WHERE ti.descriptor_id = $::REGCLASS`,
-		tree.ConsoleLineWidth,
-		tree.PrettyAlignAndDeindent,
-		tree.UpperCase,
 		tableID,
 	)
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1949,33 +1949,17 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	thirdServerSQL := sqlutils.MakeSQLRunner(testCluster.ServerConn(2))
 
 	statements := []struct {
-		stmt                 string
-		formattedStmt        string
-		fingerprint          string
-		formattedFingerprint string
+		stmt          string
+		fingerprinted string
 	}{
+		{stmt: `CREATE DATABASE roachblog`},
+		{stmt: `SET database = roachblog`},
+		{stmt: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:          `CREATE DATABASE roachblog`,
-			formattedStmt: "CREATE DATABASE roachblog\n",
+			stmt:          `INSERT INTO posts VALUES (1, 'foo')`,
+			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
 		},
-		{
-			stmt:          `SET database = roachblog`,
-			formattedStmt: "SET database = roachblog\n",
-		},
-		{
-			stmt:          `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`,
-			formattedStmt: "CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)\n",
-		},
-		{
-			stmt:                 `INSERT INTO posts VALUES (1, 'foo')`,
-			formattedStmt:        "INSERT INTO posts VALUES (1, 'foo')\n",
-			fingerprint:          `INSERT INTO posts VALUES (_, '_')`,
-			formattedFingerprint: "INSERT INTO posts VALUES (_, '_')\n",
-		},
-		{
-			stmt:          `SELECT * FROM posts`,
-			formattedStmt: "SELECT * FROM posts\n",
-		},
+		{stmt: `SELECT * FROM posts`},
 	}
 
 	for _, stmt := range statements {
@@ -2032,9 +2016,9 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 
 	var expectedStatements []string
 	for _, stmt := range statements {
-		var expectedStmt = stmt.formattedStmt
-		if stmt.fingerprint != "" {
-			expectedStmt = stmt.formattedFingerprint
+		var expectedStmt = stmt.stmt
+		if stmt.fingerprinted != "" {
+			expectedStmt = stmt.fingerprinted
 		}
 		expectedStatements = append(expectedStatements, expectedStmt)
 	}

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -27,6 +27,7 @@
     font-family: SFMono-Semibold;
     font-size: 14px;
     line-height: 1.57;
+    white-space: pre-line;
     word-wrap: break-word;
 
     span {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -151,14 +151,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   },
   statement: {
     statement:
-      "CREATE TABLE IF NOT EXISTS promo_codes (\n" +
-      "  code            VARCHAR NOT NULL,\n" +
-      "  description     VARCHAR NULL,\n" +
-      "  creation_time   TIMESTAMP NULL,\n" +
-      "  expiration_time TIMESTAMP NULL,\n" +
-      "  rules           JSONB NULL,\n" +
-      "  PRIMARY KEY (code ASC)\n" +
-      ")",
+      "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
     stats: statementStats,
     database: "defaultdb",
     byNode: [

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -288,11 +288,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: "1253500548539870016",
       label:
-        "SELECT IFNULL(a, b)\n" +
-        "    FROM (\n" +
-        "          SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a,\n" +
-        "                 (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b\n" +
-        "         )",
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
       aggregationInterval,
@@ -315,11 +311,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: "13649565517143827225",
       label:
-        "SELECT IFNULL(a, b)\n" +
-        "    FROM (\n" +
-        "          SELECT (SELECT id FROM users WHERE city = $1 AND id > $2 ORDER BY id LIMIT _) AS a,\n" +
-        "                 (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b\n" +
-        "         )",
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
       aggregationInterval,
@@ -470,14 +462,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '11195381626529102926',
       label:
-        "CREATE TABLE IF NOT EXISTS promo_codes (\n" +
-        "      code            VARCHAR NOT NULL,\n" +
-        "      description     VARCHAR NULL,\n" +
-        "      creation_time   TIMESTAMP NULL,\n" +
-        "      expiration_time TIMESTAMP NULL,\n" +
-        "      rules           JSONB NULL,\n" +
-        "      PRIMARY KEY (code ASC)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
       summary:
         "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
       aggregatedTs,
@@ -525,14 +510,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '13217779306501326587',
       label:
-        'CREATE TABLE IF NOT EXISTS user_promo_codes (\n' +
-        '      city        VARCHAR NOT NULL,\n' +
-        '      user_id     UUID NOT NULL,\n' +
-        '      code        VARCHAR NOT NULL,\n' +
-        '      "timestamp" TIMESTAMP NULL,\n' +
-        '      usage_count INT8 NULL,\n' +
-        '      PRIMARY KEY (city ASC, user_id ASC, code ASC)\n' +
-        '  )',
+        'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
       summary:
         'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
       aggregatedTs,
@@ -591,22 +569,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '2695725667586429780',
       label:
-        "CREATE TABLE IF NOT EXISTS rides (\n" +
-        "      id            UUID NOT NULL,\n" +
-        "      city          VARCHAR NOT NULL,\n" +
-        "      vehicle_city  VARCHAR NULL,\n" +
-        "      rider_id      UUID NULL,\n" +
-        "      vehicle_id    UUID NULL,\n" +
-        "      start_address VARCHAR NULL,\n" +
-        "      end_address   VARCHAR NULL,\n" +
-        "      start_time    TIMESTAMP NULL,\n" +
-        "      end_time      TIMESTAMP NULL,\n" +
-        "      revenue       DECIMAL(10,2) NULL,\n" +
-        "      PRIMARY KEY (city ASC, id ASC),\n" +
-        "      INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),\n" +
-        "      INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),\n" +
-        "      CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
       summary:
         "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
       aggregatedTs,
@@ -619,18 +582,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '6754865160812330169',
       label:
-        "CREATE TABLE IF NOT EXISTS vehicles (\n" +
-        "      id               UUID NOT NULL,\n" +
-        "      city             VARCHAR NOT NULL,\n" +
-        "      type             VARCHAR NULL,\n" +
-        "      owner_id         UUID NULL,\n" +
-        "      creation_time    TIMESTAMP NULL,\n" +
-        "      status           VARCHAR NULL,\n" +
-        "      current_location VARCHAR NULL,\n" +
-        "      ext              JSONB NULL,\n" +
-        "      PRIMARY KEY (city ASC, id ASC),\n" +
-        "      INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
       summary:
         "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
       aggregatedTs,
@@ -676,14 +628,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '8695470234690735168',
       label:
-        "CREATE TABLE IF NOT EXISTS users (\n" +
-        "      id          UUID NOT NULL,\n" +
-        "      city        VARCHAR NOT NULL,\n" +
-        "      name        VARCHAR NULL,\n" +
-        "      address     VARCHAR NULL,\n" +
-        "      credit_card VARCHAR NULL,\n" +
-        "      PRIMARY KEY (city ASC, id ASC)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
       summary:
         "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
       aggregatedTs,
@@ -696,14 +641,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '9261848985398568228',
       label:
-        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (\n' +
-        '      city        VARCHAR NOT NULL,\n' +
-        '      ride_id     UUID NOT NULL,\n' +
-        '      "timestamp" TIMESTAMP NOT NULL,\n' +
-        '      lat         FLOAT8 NULL,\n' +
-        '      long        FLOAT8 NULL,\n' +
-        '      PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC)\n' +
-        '  )',
+        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
       summary:
         'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
       aggregatedTs,


### PR DESCRIPTION
**ui: removed formatting to statements on the details pages**

Previously, statements displayed on the statement/transaction/index
details pages were formatted (formatting was added to allow for better
readability of statements on these detail pages). However, statements
queries from the frontend were noticeably slower due to this
implementation. This change reverts the changes to statement formatting
(updates the fixtures to show the non-formatted statements), but keeps
the change that uses statement ID as an identifier in the URL instead of
the raw statement.

Reference: [Original PR](https://github.com/cockroachdb/cockroach/pull/73853)

**Release note (ui change)**: change to replace raw
statement with statement ID in the URL.