### PR TITLE
kv: redirect on server-side RangeKeyMismatch when possible

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1187,7 +1187,13 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 	// turning single-range queries into multi-range queries for no good
 	// reason.
 	if ba.IsUnsplittable() {
-		mismatch := roachpb.NewRangeKeyMismatchError(ctx, rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), ri.Desc(), nil /* lease */)
+		mismatch := roachpb.NewRangeKeyMismatchErrorWithCTPolicy(ctx,
+			rs.Key.AsRawKey(),
+			rs.EndKey.AsRawKey(),
+			ri.Desc(),
+			nil, /* lease */
+			ri.ClosedTimestampPolicy(),
+		)
 		return nil, roachpb.NewError(mismatch)
 	}
 	// If there's no transaction and ba spans ranges, possibly re-run as part of

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -1477,7 +1477,7 @@ func TestEvictCacheOnError(t *testing.T) {
 
 	rangeMismachErr := roachpb.NewRangeKeyMismatchError(
 		context.Background(), nil, nil, &lhs, nil /* lease */)
-	rangeMismachErr.AppendRangeInfo(context.Background(), rhs, roachpb.Lease{})
+	rangeMismachErr.AppendRangeInfo(context.Background(), roachpb.RangeInfo{Desc: rhs, Lease: roachpb.Lease{}})
 
 	testCases := []struct {
 		canceledCtx            bool
@@ -1791,7 +1791,7 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 		if ba.RangeID == staleDesc.RangeID {
 			var br roachpb.BatchResponse
 			err := roachpb.NewRangeKeyMismatchError(ctx, rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), &rhsDesc, nil /* lease */)
-			err.AppendRangeInfo(ctx, lhsDesc, roachpb.Lease{})
+			err.AppendRangeInfo(ctx, roachpb.RangeInfo{Desc: lhsDesc, Lease: roachpb.Lease{}})
 			br.Error = roachpb.NewError(err)
 			return &br, nil
 		} else if ba.RangeID != lhsDesc.RangeID {
@@ -3998,7 +3998,11 @@ func TestEvictMetaRange(t *testing.T) {
 				err := roachpb.NewRangeKeyMismatchError(
 					ctx, rs.Key.AsRawKey(), rs.EndKey.AsRawKey(), &testMeta2RangeDescriptor1, nil /* lease */)
 				if hasSuggestedRange {
-					err.AppendRangeInfo(ctx, testMeta2RangeDescriptor2, roachpb.Lease{})
+					ri := roachpb.RangeInfo{
+						Desc:  testMeta2RangeDescriptor2,
+						Lease: roachpb.Lease{},
+					}
+					err.AppendRangeInfo(ctx, ri)
 				}
 				reply.Error = roachpb.NewError(err)
 				return reply, nil

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -496,11 +496,16 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	}
 	replCount := store.ReplicaCount()
 
-	// An AdminSplit request sent to the end of the old range
-	// should fail with a RangeKeyMismatchError.
-	_, pErr := kv.SendWrappedWith(ctx, store, h, args)
-	if _, ok := pErr.GetDetail().(*roachpb.RangeKeyMismatchError); !ok {
-		t.Fatalf("expected RangeKeyMismatchError, found: %v", pErr)
+	// An AdminSplit request sent to the end of the old range should be re-routed
+	// to the start of the new range, succeeding but without creating any new ranges.
+	if _, pErr := kv.SendWrappedWith(ctx, store, h, args); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	postEndSplitReplCount := store.ReplicaCount()
+	if replCount != postEndSplitReplCount {
+		t.Fatalf("splitting at the end of a range should not create a new range; before second split "+
+			"found %d ranges, after second split found %d ranges", replCount, postEndSplitReplCount)
 	}
 
 	// An AdminSplit request sent to the start of the new range
@@ -511,10 +516,10 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	newReplCount := store.ReplicaCount()
-	if replCount != newReplCount {
-		t.Fatalf("splitting at a range boundary should not create a new range; before second split "+
-			"found %d ranges, after second split found %d ranges", replCount, newReplCount)
+	postStartSplitReplCount := store.ReplicaCount()
+	if postEndSplitReplCount != postStartSplitReplCount {
+		t.Fatalf("splitting at the start boundary should not create a new range; before third split "+
+			"found %d ranges, after fourth split found %d ranges", postEndSplitReplCount, postEndSplitReplCount)
 	}
 }
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1502,9 +1502,8 @@ func (r *Replica) checkSpanInRangeRLocked(ctx context.Context, rspan roachpb.RSp
 	if desc.ContainsKeyRange(rspan.Key, rspan.EndKey) {
 		return nil
 	}
-	return roachpb.NewRangeKeyMismatchError(
-		ctx, rspan.Key.AsRawKey(), rspan.EndKey.AsRawKey(), desc, r.mu.state.Lease,
-	)
+	return roachpb.NewRangeKeyMismatchErrorWithCTPolicy(
+		ctx, rspan.Key.AsRawKey(), rspan.EndKey.AsRawKey(), desc, r.mu.state.Lease, r.closedTimestampPolicyRLocked())
 }
 
 // checkTSAboveGCThresholdRLocked returns an error if a request (identified by

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -334,8 +334,8 @@ func (r *Replica) adminSplitWithDescriptor(
 			// range's bounds, return an error for the client to try again on the
 			// correct range.
 			if !kvserverbase.ContainsKey(desc, args.Key) {
-				l, _ := r.GetLease()
-				return reply, roachpb.NewRangeKeyMismatchError(ctx, args.Key, args.Key, desc, &l)
+				ri := r.GetRangeInfo(ctx)
+				return reply, roachpb.NewRangeKeyMismatchErrorWithCTPolicy(ctx, args.Key, args.Key, desc, &ri.Lease, ri.ClosedTimestampPolicy)
 			}
 			foundSplitKey = args.SplitKey
 		}

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -186,8 +186,8 @@ func (r *Replica) protectedTimestampRecordCurrentlyApplies(
 	// correct range.
 	desc := r.descRLocked()
 	if !kvserverbase.ContainsKeyRange(desc, args.Key, args.EndKey) {
-		return false, false, "", roachpb.NewRangeKeyMismatchError(ctx, args.Key, args.EndKey, desc,
-			r.mu.state.Lease)
+		return false, false, "", roachpb.NewRangeKeyMismatchErrorWithCTPolicy(ctx, args.Key, args.EndKey, desc,
+			r.mu.state.Lease, r.closedTimestampPolicyRLocked())
 	}
 	if args.Protected.LessEq(*r.mu.state.GCThreshold) {
 		gcReason := fmt.Sprintf("protected ts: %s is less than equal to the GCThreshold: %s for the"+

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -246,7 +246,7 @@ func (s *Store) Send(
 			ris = nil // just to be safe
 		}
 		for _, ri := range ris {
-			t.AppendRangeInfo(ctx, ri.Desc, ri.Lease)
+			t.AppendRangeInfo(ctx, ri)
 		}
 		// We have to write `t` back to `pErr` so that it picks up the changes.
 		pErr = roachpb.NewError(t)

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -157,104 +157,162 @@ func (s *Store) Send(
 		log.Eventf(ctx, "executing %s", ba)
 	}
 
-	// Get range and add command to the range for execution.
-	repl, err := s.GetReplica(ba.RangeID)
-	if err != nil {
-		return nil, roachpb.NewError(err)
-	}
-	if !repl.IsInitialized() {
-		repl.mu.RLock()
-		replicaID := repl.mu.replicaID
-		repl.mu.RUnlock()
+	// Tracks suggested ranges to return to the caller. Suggested ranges are aggregated from
+	// two sources.
+	// (1): On a RangeKeyMismatchError that is retriable.
+	// (2): On a successful batch request, where suggested ranges are returned
+	//      by the replica to update the client with. This is appended before returning.
+	var rangeInfos []roachpb.RangeInfo
 
-		// If we have an uninitialized copy of the range, then we are
-		// probably a valid member of the range, we're just in the
-		// process of getting our snapshot. If we returned
-		// RangeNotFoundError, the client would invalidate its cache,
-		// but we can be smarter: the replica that caused our
-		// uninitialized replica to be created is most likely the
-		// leader.
-		return nil, roachpb.NewError(&roachpb.NotLeaseHolderError{
-			RangeID:     ba.RangeID,
-			LeaseHolder: repl.creatingReplica,
-			// The replica doesn't have a range descriptor yet, so we have to build
-			// a ReplicaDescriptor manually.
-			Replica: roachpb.ReplicaDescriptor{
-				NodeID:    repl.store.nodeDesc.NodeID,
-				StoreID:   repl.store.StoreID(),
-				ReplicaID: replicaID,
-			},
-		})
-	}
-
-	br, pErr = repl.Send(ctx, ba)
-	if pErr == nil {
-		return br, nil
-	}
-
-	// Augment error if necessary and return.
-	switch t := pErr.GetDetail().(type) {
-	case *roachpb.RangeKeyMismatchError:
-		// TODO(andrei): It seems silly that, if the client specified a RangeID that
-		// doesn't match the keys it wanted to access, but this node can serve those
-		// keys anyway, we still return a RangeKeyMismatchError to the client
-		// instead of serving the request. Particularly since we have the mechanism
-		// to communicate correct range information to the client when returning a
-		// successful response (i.e. br.RangeInfos).
-
-		// On a RangeKeyMismatchError where the batch didn't even overlap
-		// the start of the mismatched Range, try to suggest a more suitable
-		// Range from this Store.
-		rSpan, err := keys.Range(ba.Requests)
+	// Run a retry loop on retriable RangeKeyMismatchErrors, where the requested RangeID does
+	// not match any Range on this store. A BatchRequest is retriable when the correct Range
+	// for the request exists within this store.
+	for {
+		// Get range and add command to the range for execution.
+		repl, err := s.GetReplica(ba.RangeID)
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
+		if !repl.IsInitialized() {
+			repl.mu.RLock()
+			replicaID := repl.mu.replicaID
+			repl.mu.RUnlock()
 
-		// The kvclient thought that a particular range id covers rSpans. It was
-		// wrong; the respective range doesn't cover all of rSpan, or perhaps it
-		// doesn't even overlap it. Clearly the client has a stale range cache.
-		// We'll return info on the range that the request ended up being routed to
-		// and, to the extent that we have the info, the ranges containing the keys
-		// that the client requested, and all the ranges in between.
-		ri, err := t.MismatchedRange()
-		if err != nil {
-			return nil, roachpb.NewError(err)
+			// If we have an uninitialized copy of the range, then we are
+			// probably a valid member of the range, we're just in the
+			// process of getting our snapshot. If we returned
+			// RangeNotFoundError, the client would invalidate its cache,
+			// but we can be smarter: the replica that caused our
+			// uninitialized replica to be created is most likely the
+			// leader.
+			return nil, roachpb.NewError(&roachpb.NotLeaseHolderError{
+				RangeID:     ba.RangeID,
+				LeaseHolder: repl.creatingReplica,
+				// The replica doesn't have a range descriptor yet, so we have to build
+				// a ReplicaDescriptor manually.
+				Replica: roachpb.ReplicaDescriptor{
+					NodeID:    repl.store.nodeDesc.NodeID,
+					StoreID:   repl.store.StoreID(),
+					ReplicaID: replicaID,
+				},
+			})
 		}
-		skipRID := ri.Desc.RangeID // We already have info on one range, so don't add it again below.
-		startKey := ri.Desc.StartKey
-		if rSpan.Key.Less(startKey) {
-			startKey = rSpan.Key
-		}
-		endKey := ri.Desc.EndKey
-		if endKey.Less(rSpan.EndKey) {
-			endKey = rSpan.EndKey
-		}
-		var ris []roachpb.RangeInfo
-		if err := s.visitReplicasByKey(ctx, startKey, endKey, AscendingKeyOrder, func(ctx context.Context, repl *Replica) error {
-			// Note that we return the lease even if it's expired. The kvclient can
-			// use it as it sees fit.
-			ri := repl.GetRangeInfo(ctx)
-			if ri.Desc.RangeID == skipRID {
-				return nil
+
+		br, pErr = repl.Send(ctx, ba)
+		if pErr == nil {
+			// If any retries occurred, we should include the RangeInfos accumulated
+			// and pass these to the client, to invalidate their cache. This is
+			// otherwise empty. The order is kept in LILO, such that the most recent data
+			// is considered last by the RangeCache.
+			if len(rangeInfos) > 0 {
+				br.RangeInfos = append(rangeInfos, br.RangeInfos...)
 			}
-			ris = append(ris, ri)
-			return nil
-		}); err != nil {
-			// Errors here should not be possible, but if there is one, it is ignored
-			// as attaching RangeInfo is optional.
-			log.Warningf(ctx, "unexpected error visiting replicas: %s", err)
-			ris = nil // just to be safe
+
+			return br, nil
 		}
-		for _, ri := range ris {
-			t.AppendRangeInfo(ctx, ri)
+
+		// Augment error if necessary and return.
+		switch t := pErr.GetDetail().(type) {
+		case *roachpb.RangeKeyMismatchError:
+			// TODO(andrei): It seems silly that, if the client specified a RangeID that
+			// doesn't match the keys it wanted to access, but this node can serve those
+			// keys anyway, we still return a RangeKeyMismatchError to the client
+			// instead of serving the request. Particularly since we have the mechanism
+			// to communicate correct range information to the client when returning a
+			// successful response (i.e. br.RangeInfos).
+
+			// On a RangeKeyMismatchError where the batch didn't even overlap
+			// the start of the mismatched Range, try to suggest a more suitable
+			// Range from this Store.
+			rSpan, err := keys.Range(ba.Requests)
+			if err != nil {
+				return nil, roachpb.NewError(err)
+			}
+
+			// The kvclient thought that a particular range id covers rSpans. It was
+			// wrong; the respective range doesn't cover all of rSpan, or perhaps it
+			// doesn't even overlap it. Clearly the client has a stale range cache.
+			// We'll return info on the range that the request ended up being routed to
+			// and, to the extent that we have the info, the ranges containing the keys
+			// that the client requested, and all the ranges in between.
+			ri, err := t.MismatchedRange()
+			if err != nil {
+				return nil, roachpb.NewError(err)
+			}
+			skipRID := ri.Desc.RangeID // We already have info on one range, so don't add it again below.
+			startKey := ri.Desc.StartKey
+			if rSpan.Key.Less(startKey) {
+				startKey = rSpan.Key
+			}
+			endKey := ri.Desc.EndKey
+			if endKey.Less(rSpan.EndKey) {
+				endKey = rSpan.EndKey
+			}
+			var ris []roachpb.RangeInfo
+			if err := s.visitReplicasByKey(ctx, startKey, endKey, AscendingKeyOrder, func(ctx context.Context, repl *Replica) error {
+				// Note that we return the lease even if it's expired. The kvclient can use it as it sees fit.
+				ri := repl.GetRangeInfo(ctx)
+				if ri.Desc.RangeID == skipRID {
+					return nil
+				}
+				ris = append(ris, ri)
+				return nil
+			}); err != nil {
+				// Errors here should not be possible, but if there is one, it is ignored
+				// as attaching RangeInfo is optional.
+				log.Warningf(ctx, "unexpected error visiting replicas: %s", err)
+				ris = nil // just to be safe
+			}
+
+			// Update the suggested ranges, if returned from the replica. Note here that newer ranges are
+			// always appended, so that the oldest RangeInfo is processed by the Client's RangeCache first,
+			// which is then invalidated on conflict by newer data (LILO).
+			t.AppendRangeInfo(ctx, ris...)
+
+			isRetriableMismatch := false
+			for _, ri := range ris {
+				// Check if the original batch request rSpan exists entirely within any known
+				// ranges stored on this replica, if so update repl and set retriable to true.
+				if ri.Desc.RSpan().ContainsKeyRange(rSpan.Key, rSpan.EndKey) {
+					// Retry this request: Update BatchRequest to reflect re-routing the request
+					// to ri. ClientRangeInfo is also updated here to avoid the replica providing
+					// duplicate BatchResponse.RangeInfos upon a successful retry for the client
+					// to invalidate their RangeCache with.
+					ba.RangeID = ri.Desc.RangeID
+					ba.ClientRangeInfo = roachpb.ClientRangeInfo{
+						ClosedTimestampPolicy: ri.ClosedTimestampPolicy,
+						DescriptorGeneration:  ri.Desc.Generation,
+						LeaseSequence:         ri.Lease.Sequence,
+					}
+
+					rangeInfos = append(rangeInfos, t.Ranges...)
+					isRetriableMismatch = true
+					break
+				}
+			}
+
+			if isRetriableMismatch {
+				continue
+			}
+
+			// The request is not retriable and an error will be returned to the client,
+			// to invalidate their RangeCache and update the request headers. Include all
+			// RangeInfos that have been accumulated so far first, so that stale data is
+			// resolved by later entries; as the header is processes in a last-in-last-out
+			// manner.
+			t.Ranges = append(rangeInfos, t.Ranges...)
+
+			// We have to write `t` back to `pErr` so that it picks up the changes.
+			pErr = roachpb.NewError(t)
+		case *roachpb.RaftGroupDeletedError:
+			// This error needs to be converted appropriately so that clients
+			// will retry.
+			err := roachpb.NewRangeNotFoundError(repl.RangeID, repl.store.StoreID())
+			pErr = roachpb.NewError(err)
 		}
-		// We have to write `t` back to `pErr` so that it picks up the changes.
-		pErr = roachpb.NewError(t)
-	case *roachpb.RaftGroupDeletedError:
-		// This error needs to be converted appropriately so that clients
-		// will retry.
-		err := roachpb.NewRangeNotFoundError(repl.RangeID, repl.store.StoreID())
-		pErr = roachpb.NewError(err)
+
+		// Unable to retry, exit the retry loop and return an error.
+		break
 	}
 	return nil, pErr
 }

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -603,7 +603,7 @@ func NewRangeKeyMismatchError(
 		end,
 		desc,
 		lease,
-		LAG_BY_CLUSTER_SETTING, /* defaut closed timestsamp policy*/
+		LAG_BY_CLUSTER_SETTING, /* default closed timestsamp policy*/
 	)
 }
 

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -547,17 +547,14 @@ func IsRangeNotFoundError(err error) bool {
 	return errors.HasType(err, (*RangeNotFoundError)(nil))
 }
 
-// NewRangeKeyMismatchError initializes a new RangeKeyMismatchError.
-//
-// desc and lease represent info about the range that the request was
-// erroneously routed to. lease can be nil. If it's not nil but the leaseholder
-// is not part of desc, it is ignored. This allows callers to read the
-// descriptor and lease non-atomically without worrying about incoherence.
-//
-// Note that more range info is commonly added to the error after the error is
-// created.
-func NewRangeKeyMismatchError(
-	ctx context.Context, start, end Key, desc *RangeDescriptor, lease *Lease,
+// NewRangeKeyMismatchErrorWithCTPolicy initializes a new RangeKeyMismatchError.
+// identical to NewRangeKeyMismatchError, with the given ClosedTimestampPolicy.
+func NewRangeKeyMismatchErrorWithCTPolicy(
+	ctx context.Context,
+	start, end Key,
+	desc *RangeDescriptor,
+	lease *Lease,
+	ctPolicy RangeClosedTimestampPolicy,
 ) *RangeKeyMismatchError {
 	if desc == nil {
 		panic("NewRangeKeyMismatchError with nil descriptor")
@@ -579,9 +576,35 @@ func NewRangeKeyMismatchError(
 		RequestStartKey: start,
 		RequestEndKey:   end,
 	}
+	ri := RangeInfo{
+		Desc:                  *desc,
+		Lease:                 l,
+		ClosedTimestampPolicy: ctPolicy,
+	}
 	// More ranges are sometimes added to rangesInternal later.
-	e.AppendRangeInfo(ctx, *desc, l)
+	e.AppendRangeInfo(ctx, ri)
 	return e
+}
+
+// NewRangeKeyMismatchError initializes a new RangeKeyMismatchError.
+//
+// desc and lease represent info about the range that the request was
+// erroneously routed to. lease can be nil. If it's not nil but the leaseholder
+// is not part of desc, it is ignored. This allows callers to read the
+// descriptor and lease non-atomically without worrying about incoherence.
+//
+// Note that more range info is commonly added to the error after the error is
+// created.
+func NewRangeKeyMismatchError(
+	ctx context.Context, start, end Key, desc *RangeDescriptor, lease *Lease,
+) *RangeKeyMismatchError {
+	return NewRangeKeyMismatchErrorWithCTPolicy(ctx,
+		start,
+		end,
+		desc,
+		lease,
+		LAG_BY_CLUSTER_SETTING, /* defaut closed timestsamp policy*/
+	)
 }
 
 func (e *RangeKeyMismatchError) Error() string {
@@ -613,23 +636,20 @@ func (e *RangeKeyMismatchError) MismatchedRange() (RangeInfo, error) {
 	return e.Ranges[0], nil
 }
 
-// AppendRangeInfo appends info about one range to the set returned to the
+// AppendRangeInfo appends info about a group of ranges to the set returned to the
 // kvclient.
 //
 // l can be empty. Otherwise, the leaseholder is asserted to be a replica in
 // desc.
-func (e *RangeKeyMismatchError) AppendRangeInfo(
-	ctx context.Context, desc RangeDescriptor, l Lease,
-) {
-	if !l.Empty() {
-		if _, ok := desc.GetReplicaDescriptorByID(l.Replica.ReplicaID); !ok {
-			log.Fatalf(ctx, "lease names missing replica; lease: %s, desc: %s", l, desc)
+func (e *RangeKeyMismatchError) AppendRangeInfo(ctx context.Context, ris ...RangeInfo) {
+	for _, ri := range ris {
+		if !ri.Lease.Empty() {
+			if _, ok := ri.Desc.GetReplicaDescriptorByID(ri.Lease.Replica.ReplicaID); !ok {
+				log.Fatalf(ctx, "lease names missing replica; lease: %s, desc: %s", ri.Lease, ri.Desc)
+			}
 		}
+		e.Ranges = append(e.Ranges, ri)
 	}
-	e.Ranges = append(e.Ranges, RangeInfo{
-		Desc:  desc,
-		Lease: l,
-	})
 }
 
 var _ ErrorDetailInterface = &RangeKeyMismatchError{}


### PR DESCRIPTION
Previously, `RangeKeyMismatchError` would construct a `RangeInfo`
without a `ClosedTimestampPolicy`. This caused `ClosedTimestampPolicy`
to default to `LAG_CLUSTER_BY_SETTING` when there may be a different
policy currently. To address this, this patch adds `ClosedTimestampPolicy`
as an argument for constructing `RangeKeyMismatchError`. This change is
extended to include the entire `RangeInfo`, containing `ClosedTimestampPolicy`
in `RangeKeyMismatchError.AppendRangeInfo()`.

Previously, `RangekeyMismatchError` would be returned when a
`BatchRequest` was directed at the wrong Range. This caused client side retries,
even if the replica existed on the store servicing the `BatchRequest`.
`store_send` will now check and retry locally when possible, instead of returning
a `RangekeyMismatchError`. Updated `RangeInfos` are now returned in the
`BatchResponse`, not modifying client `RangeDescriptiorCache` invalidation
behavior upon response. This change consolidates tests which assume server side
retries are not possible on kv requests.

resolves cockroachdb#72400

Release note (performance improvement): Stores will now server side
retry requests that are directed at the incorrect Range, however
still within the store. This commonly occurs following a Range split,
where the RHS has not yet been rebalanced away. In which case, the RHS
Range will be sitting adjacent to the LHS Range, on the same store.
Server side retries reduce KV hops, following a mismatch from 2 to 1.
This has the effect of reducing tail latency in the retriable case.
If the requested Range straddles both the LHS and RHS, no server
side retry is attempted.