### PR TITLE
ui: move loading and error pages to below page settings

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -311,7 +311,6 @@ export class StatementsPage extends React.Component<
 
   componentDidUpdate = (): void => {
     this.updateQueryParams();
-    this.refreshStatements();
     if (!this.props.isTenant && !this.props.hasViewActivityRedactedRole) {
       this.props.refreshStatementDiagnosticsRequests();
     }
@@ -481,15 +480,12 @@ export class StatementsPage extends React.Component<
       );
   };
 
-  renderStatements = (): React.ReactElement => {
+  renderStatements = (regions: string[]): React.ReactElement => {
     const { pagination, filters, activeFilters } = this.state;
     const {
       statements,
-      apps,
-      databases,
       onDiagnosticsReportDownload,
       onStatementClick,
-      resetSQLStats,
       columns: userSelectedColumnsToShow,
       onColumnsChange,
       nodeRegions,
@@ -504,14 +500,6 @@ export class StatementsPage extends React.Component<
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
     // If the cluster is a tenant cluster we don't show info
     // about nodes/regions.
-    const nodes = isTenant
-      ? []
-      : Object.keys(nodeRegions)
-          .map(n => Number(n))
-          .sort();
-    const regions = isTenant
-      ? []
-      : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
     populateRegionNodeForStatements(statements, nodeRegions, isTenant);
 
     // Creates a list of all possible columns,
@@ -560,45 +548,6 @@ export class StatementsPage extends React.Component<
 
     return (
       <div>
-        <PageConfig>
-          <PageConfigItem>
-            <Search
-              onSubmit={this.onSubmitSearchField as any}
-              onClear={this.onClearSearchField}
-              defaultValue={search}
-            />
-          </PageConfigItem>
-          <PageConfigItem>
-            <Filter
-              onSubmitFilters={this.onSubmitFilters}
-              appNames={apps}
-              dbNames={databases}
-              regions={regions}
-              nodes={nodes.map(n => "n" + n)}
-              activeFilters={activeFilters}
-              filters={filters}
-              showDB={true}
-              showSqlType={true}
-              showScan={true}
-              showRegions={regions.length > 1}
-              showNodes={nodes.length > 1}
-            />
-          </PageConfigItem>
-          <PageConfigItem className={commonStyles("separator")}>
-            <TimeScaleDropdown
-              currentScale={this.props.timeScale}
-              setTimeScale={this.changeTimeScale}
-            />
-          </PageConfigItem>
-          <PageConfigItem>
-            <button className={cx("reset-btn")} onClick={this.resetTime}>
-              reset time
-            </button>
-          </PageConfigItem>
-          <PageConfigItem className={commonStyles("separator")}>
-            <ClearStats resetSQLStats={resetSQLStats} tooltipType="statement" />
-          </PageConfigItem>
-        </PageConfig>
         <section className={sortableTableCx("cl-table-container")}>
           <div>
             <ColumnsSelector
@@ -643,13 +592,69 @@ export class StatementsPage extends React.Component<
       refreshStatementDiagnosticsRequests,
       onActivateStatementDiagnostics,
       onDiagnosticsModalOpen,
+      apps,
+      databases,
+      search,
+      isTenant,
+      nodeRegions,
+      resetSQLStats,
     } = this.props;
+
+    const nodes = isTenant
+      ? []
+      : Object.keys(nodeRegions)
+          .map(n => Number(n))
+          .sort();
+    const regions = isTenant
+      ? []
+      : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
+    const { filters, activeFilters } = this.state;
+
     return (
       <div className={cx("root", "table-area")}>
+        <PageConfig>
+          <PageConfigItem>
+            <Search
+              onSubmit={this.onSubmitSearchField as any}
+              onClear={this.onClearSearchField}
+              defaultValue={search}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <Filter
+              onSubmitFilters={this.onSubmitFilters}
+              appNames={apps}
+              dbNames={databases}
+              regions={regions}
+              nodes={nodes.map(n => "n" + n)}
+              activeFilters={activeFilters}
+              filters={filters}
+              showDB={true}
+              showSqlType={true}
+              showScan={true}
+              showRegions={regions.length > 1}
+              showNodes={nodes.length > 1}
+            />
+          </PageConfigItem>
+          <PageConfigItem className={commonStyles("separator")}>
+            <TimeScaleDropdown
+              currentScale={this.props.timeScale}
+              setTimeScale={this.changeTimeScale}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <button className={cx("reset-btn")} onClick={this.resetTime}>
+              reset time
+            </button>
+          </PageConfigItem>
+          <PageConfigItem className={commonStyles("separator")}>
+            <ClearStats resetSQLStats={resetSQLStats} tooltipType="statement" />
+          </PageConfigItem>
+        </PageConfig>
         <Loading
           loading={isNil(this.props.statements)}
           error={this.props.statementsError}
-          render={this.renderStatements}
+          render={() => this.renderStatements(regions)}
           renderError={() =>
             SQLActivityError({
               statsType: "statements",


### PR DESCRIPTION
Fixes: #75247

Previously, the loading and error pages in the statement and txn
pages took up the entire page, including the settings header
used to issue new stats requests. This resulted in the user
being unable to re-issue a query after a query results in
a timeout, as we save the query parameters for re-use on
each request.

Release note (ui change): Loading and error pages are now below
page config in txns and stmts pages.

---------------
https://www.loom.com/share/e903ec74441140be98969c02ebbc7923