### PR TITLE
[WIP] *: use bootstrap.BootstrappedSystemIDChecker in tests

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -202,6 +202,7 @@ go_test(
         "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
@@ -4310,7 +4311,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 	gcr := roachpb.GCRequest{
 		// Bogus span to make it a valid request.
 		RequestHeader: roachpb.RequestHeader{
-			Key:    keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)),
+			Key:    keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)),
 			EndKey: keys.MaxKey,
 		},
 		Threshold: tc.Server(0).Clock().Now(),

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -205,7 +206,7 @@ CREATE TABLE data2.foo (a int);
 
 		// Check there is no data in the span that we expect user data to be imported.
 		store := tcRestore.GetFirstStoreFromServer(t, 0)
-		startKey := keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0))
+		startKey := keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0))
 		endKey := keys.SystemSQLCodec.TablePrefix(uint32(maxBackupTableID)).PrefixEnd()
 		it := store.Engine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 			UpperBound: endKey,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -749,7 +749,9 @@ func isSchemaEmpty(
 	return true, nil
 }
 
-func getTempSystemDBID(details jobspb.RestoreDetails, idChecker keys.SystemIDChecker) descpb.ID {
+func getTempSystemDBID(
+	details jobspb.RestoreDetails, idChecker *catalog.SystemIDChecker,
+) descpb.ID {
 	tempSystemDBID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(idChecker))
 	for id := range details.DescriptorRewrites {
 		if id > tempSystemDBID {

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -206,7 +207,7 @@ ORDER BY object_type, object_name`, full)
 		// Create tables with the same ID as data.tableA to ensure that comments
 		// from different tables in the restoring cluster don't appear.
 		tableA := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "data", "tablea")
-		for i := keys.TestingUserDescID(0); i < uint32(tableA.GetID()); i++ {
+		for i := bootstrap.TestingUserDescID(0); i < uint32(tableA.GetID()); i++ {
 			tableName := fmt.Sprintf("foo%d", i)
 			sqlDBRestore.Exec(t, fmt.Sprintf("CREATE TABLE %s ();", tableName))
 			sqlDBRestore.Exec(t, fmt.Sprintf("COMMENT ON TABLE %s IS 'table comment'", tableName))

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -178,6 +178,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -66,8 +67,8 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 		return nil, errors.Errorf("expected *tree.CreateTable got %T", stmt)
 	}
 	st := cluster.MakeTestingClusterSettings()
-	parentID := descpb.ID(keys.TestingUserDescID(0))
-	tableID := descpb.ID(keys.TestingUserDescID(1))
+	parentID := descpb.ID(bootstrap.TestingUserDescID(0))
+	tableID := descpb.ID(bootstrap.TestingUserDescID(1))
 	semaCtx := makeTestSemaCtx()
 	mutDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 		ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, hlc.UnixNano())

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
@@ -3542,7 +3543,7 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 	var (
 		ctx      = context.Background()
 		userSpan = roachpb.Span{
-			Key:    keys.TestingUserTableDataMin(),
+			Key:    bootstrap.TestingUserTableDataMin(),
 			EndKey: keys.TableDataMax,
 		}
 		done               = make(chan struct{})

--- a/pkg/ccl/importccl/BUILD.bazel
+++ b/pkg/ccl/importccl/BUILD.bazel
@@ -165,6 +165,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/catformat",

--- a/pkg/ccl/importccl/bench_test.go
+++ b/pkg/ccl/importccl/bench_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -55,7 +56,7 @@ func BenchmarkImportWorkload(b *testing.B) {
 	ts := timeutil.Now()
 	var tableSSTs []tableSSTable
 	for i, table := range g.Tables() {
-		tableID := descpb.ID(keys.TestingUserDescID(1 + uint32(i)))
+		tableID := descpb.ID(bootstrap.TestingUserDescID(1 + uint32(i)))
 		sst, err := format.ToSSTable(table, tableID, ts)
 		require.NoError(b, err)
 
@@ -160,7 +161,7 @@ func BenchmarkConvertToKVs(b *testing.B) {
 
 func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 	ctx := context.Background()
-	tableID := descpb.ID(keys.TestingUserDescID(0))
+	tableID := descpb.ID(bootstrap.TestingUserDescID(0))
 	ts := timeutil.Now()
 
 	var bytes int64

--- a/pkg/ccl/importccl/csv_internal_test.go
+++ b/pkg/ccl/importccl/csv_internal_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -68,7 +69,7 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			)`,
 		},
 	}
-	parentID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(keys.TestingSystemIDChecker()))
+	parentID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(bootstrap.BootstrappedSystemIDChecker()))
 	tableID := parentID + 2
 
 	ctx := context.Background()

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -447,7 +446,7 @@ func resolvePostgresFKs(
 // data. Thus, we pessimistically wait till all the verification steps in the
 // IMPORT have been completed after which we rewrite the descriptor IDs with
 // "real" unique IDs.
-func getNextPlaceholderDescID(idChecker keys.SystemIDChecker) descpb.ID {
+func getNextPlaceholderDescID(idChecker *catalog.SystemIDChecker) descpb.ID {
 	if placeholderID == 0 {
 		placeholderID = descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(idChecker) + 2)
 	}

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -146,7 +147,7 @@ func (pt *partitioningTest) parse() error {
 			return errors.Errorf("expected *tree.CreateTable got %T", stmt)
 		}
 		st := cluster.MakeTestingClusterSettings()
-		parentID, tableID := descpb.ID(keys.TestingUserDescID(0)), descpb.ID(keys.TestingUserDescID(1))
+		parentID, tableID := descpb.ID(bootstrap.TestingUserDescID(0)), descpb.ID(bootstrap.TestingUserDescID(1))
 		mutDesc, err := importccl.MakeTestingSimpleTableDescriptor(
 			ctx, &semaCtx, st, createTable, parentID, keys.PublicSchemaID, tableID, importccl.NoFKs, hlc.UnixNano())
 		if err != nil {

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -586,7 +586,7 @@ func (s *SystemConfig) systemTenantTableBoundarySplitKey(
 		if splitKey := findSplitKey(startID, endID); splitKey != nil {
 			return splitKey
 		}
-		startID = SystemTenantObjectID(keys.MinUserDescriptorID(idChecker))
+		startID = SystemTenantObjectID(keys.DeprecatedMinUserDescriptorID(idChecker))
 	}
 
 	// Find the split key in the system tenant's user space.

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -381,7 +381,7 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 	baseSql, _ /* splits */ := schema.GetInitialValues()
 	// Real system tables plus some user stuff.
 	kvs, _ /* splits */ := schema.GetInitialValues()
-	start := keys.TestingUserDescID(0)
+	start := bootstrap.TestingUserDescID(0)
 	userSQL := append(kvs, descriptor(start), descriptor(start+1), descriptor(start+5))
 	// Real system tables and partitioned user tables.
 	var subzoneSQL = make([]roachpb.KeyValue, len(userSQL))
@@ -483,7 +483,7 @@ func TestComputeSplitKeyTenantBoundaries(t *testing.T) {
 	schema := bootstrap.MakeMetadataSchema(
 		keys.SystemSQLCodec, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef(),
 	)
-	minKey := tkey(keys.TestingUserDescID(0))
+	minKey := tkey(bootstrap.TestingUserDescID(0))
 
 	// Real system tenant only.
 	baseSql, _ /* splits */ := schema.GetInitialValues()
@@ -600,15 +600,15 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{tkey(keys.LivenessRangesID), keys.SystemDatabaseID},
 
 		// User tables should refer to themselves.
-		{tkey(keys.TestingUserDescID(0)), config.SystemTenantObjectID(keys.TestingUserDescID(0))},
-		{tkey(keys.TestingUserDescID(22)), config.SystemTenantObjectID(keys.TestingUserDescID(22))},
+		{tkey(bootstrap.TestingUserDescID(0)), config.SystemTenantObjectID(bootstrap.TestingUserDescID(0))},
+		{tkey(bootstrap.TestingUserDescID(22)), config.SystemTenantObjectID(bootstrap.TestingUserDescID(22))},
 		{roachpb.RKeyMax, keys.RootNamespaceID},
 
 		// Secondary tenant tables should refer to the TenantsRangesID.
-		{tenantTkey(5, keys.TestingUserDescID(0)), keys.TenantsRangesID},
-		{tenantTkey(5, keys.TestingUserDescID(22)), keys.TenantsRangesID},
-		{tenantTkey(10, keys.TestingUserDescID(0)), keys.TenantsRangesID},
-		{tenantTkey(10, keys.TestingUserDescID(22)), keys.TenantsRangesID},
+		{tenantTkey(5, bootstrap.TestingUserDescID(0)), keys.TenantsRangesID},
+		{tenantTkey(5, bootstrap.TestingUserDescID(22)), keys.TenantsRangesID},
+		{tenantTkey(10, bootstrap.TestingUserDescID(0)), keys.TenantsRangesID},
+		{tenantTkey(10, bootstrap.TestingUserDescID(22)), keys.TenantsRangesID},
 	}
 
 	originalZoneConfigHook := config.ZoneConfigHook

--- a/pkg/keys/system.go
+++ b/pkg/keys/system.go
@@ -39,9 +39,9 @@ func (d deprecatedSystemIDChecker) IsSystemID(id uint32) bool {
 
 var _ SystemIDChecker = (*deprecatedSystemIDChecker)(nil)
 
-// MinUserDescriptorID returns the smallest possible non-system descriptor ID
-// after a cluster is bootstrapped.
-func MinUserDescriptorID(idChecker SystemIDChecker) uint32 {
+// DeprecatedMinUserDescriptorID returns the smallest possible non-system
+// descriptor ID after a cluster is bootstrapped.
+func DeprecatedMinUserDescriptorID(idChecker SystemIDChecker) uint32 {
 	id := uint32(MaxSystemConfigDescID + 1)
 	for idChecker.IsSystemID(id) {
 		id++

--- a/pkg/keys/system.go
+++ b/pkg/keys/system.go
@@ -10,8 +10,6 @@
 
 package keys
 
-import "github.com/cockroachdb/cockroach/pkg/roachpb"
-
 // SystemIDChecker determines whether a table ID corresponds to a system
 // table. In the earlier days of cockroachdb (prior to 22.1), these IDs were
 // all constants and had a value less than 50. In later versions, these IDs
@@ -49,22 +47,4 @@ func MinUserDescriptorID(idChecker SystemIDChecker) uint32 {
 		id++
 	}
 	return id
-}
-
-// TestingSystemIDChecker returns an implementation of SystemIDChecker suitable
-// for simple unit tests.
-func TestingSystemIDChecker() SystemIDChecker {
-	return &deprecatedSystemIDChecker{}
-}
-
-// TestingUserDescID is a convenience function which returns a user ID offset
-// from the minimum value allowed in a simple unit test setting.
-func TestingUserDescID(offset uint32) uint32 {
-	return MinUserDescriptorID(TestingSystemIDChecker()) + offset
-}
-
-// TestingUserTableDataMin is a convenience function which returns the first
-// user table data key in a simple unit test setting.
-func TestingUserTableDataMin() roachpb.Key {
-	return SystemSQLCodec.TablePrefix(TestingUserDescID(0))
 }

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -354,6 +354,7 @@ go_test(
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigstore",
         "//pkg/sql",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/dbdesc",

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -134,6 +134,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -58,7 +59,7 @@ func TestExportCmd(t *testing.T) {
 		t *testing.T, start hlc.Timestamp, mvccFilter roachpb.MVCCFilter, maxResponseSSTBytes int64,
 	) (roachpb.Response, *roachpb.Error) {
 		req := &roachpb.ExportRequest{
-			RequestHeader: roachpb.RequestHeader{Key: keys.TestingUserTableDataMin(), EndKey: keys.MaxKey},
+			RequestHeader: roachpb.RequestHeader{Key: bootstrap.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 			StartTime:     start,
 			Storage: roachpb.ExternalStorage{
 				Provider:  roachpb.ExternalStorageProvider_nodelocal,
@@ -423,7 +424,7 @@ func TestExportGCThreshold(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	req := &roachpb.ExportRequest{
-		RequestHeader: roachpb.RequestHeader{Key: keys.TestingUserTableDataMin(), EndKey: keys.MaxKey},
+		RequestHeader: roachpb.RequestHeader{Key: bootstrap.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 		StartTime:     hlc.Timestamp{WallTime: -1},
 	}
 	_, pErr := kv.SendWrapped(ctx, kvDB.NonTransactionalSender(), req)

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -529,7 +530,7 @@ func TestLeasePreferencesRebalance(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	key := keys.TestingUserTableDataMin()
+	key := bootstrap.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, key)
 	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 	require.NoError(t, tc.WaitForVoters(key, tc.Targets(1, 2)...))
@@ -635,7 +636,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	key := keys.TestingUserTableDataMin()
+	key := bootstrap.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, key)
 	tc.AddVotersOrFatal(t, key, tc.Targets(2, 4)...)
 	repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(key))
@@ -813,7 +814,7 @@ func TestLeasesDontThrashWhenNodeBecomesSuspect(t *testing.T) {
 	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = 'false'`)
 	require.NoError(t, err)
 
-	_, rhsDesc := tc.SplitRangeOrFatal(t, keys.TestingUserTableDataMin())
+	_, rhsDesc := tc.SplitRangeOrFatal(t, bootstrap.TestingUserTableDataMin())
 	tc.AddVotersOrFatal(t, rhsDesc.StartKey.AsRawKey(), tc.Targets(1, 2, 3)...)
 	tc.RemoveLeaseHolderOrFatal(t, rhsDesc, tc.Target(0), tc.Target(1))
 
@@ -967,7 +968,7 @@ func TestAlterRangeRelocate(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(ctx)
 
-	_, rhsDesc := tc.SplitRangeOrFatal(t, keys.TestingUserTableDataMin())
+	_, rhsDesc := tc.SplitRangeOrFatal(t, bootstrap.TestingUserTableDataMin())
 	tc.AddVotersOrFatal(t, rhsDesc.StartKey.AsRawKey(), tc.Targets(1, 2)...)
 
 	// We start with having the range under test on (1,2,3).

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -3710,7 +3711,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitKey := keys.TestingUserTableDataMin()
+	splitKey := bootstrap.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, splitKey)
 
 	tc.StopServer(0)
@@ -4213,7 +4214,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitKey := keys.TestingUserTableDataMin()
+	splitKey := bootstrap.TestingUserTableDataMin()
 	tc.SplitRangeOrFatal(t, splitKey)
 	tc.AddVotersOrFatal(t, splitKey, tc.Target(1))
 	desc := tc.LookupRangeOrFatal(t, splitKey)

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -69,7 +70,7 @@ func TestRangefeedWorksOnSystemRangesUnconditionally(t *testing.T) {
 
 		// Note: 42 is a system descriptor.
 		const junkDescriptorID = 42
-		require.True(t, keys.TestingSystemIDChecker().IsSystemID(junkDescriptorID))
+		require.True(t, bootstrap.BootstrappedSystemIDChecker().IsSystemID(junkDescriptorID))
 		junkDescriptorKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, junkDescriptorID)
 		junkDescriptor := dbdesc.NewInitial(
 			junkDescriptorID, "junk", security.AdminRoleName())

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
@@ -3825,7 +3826,7 @@ func TestTenantID(t *testing.T) {
 	t.Run("(1) initial set", func(t *testing.T) {
 		// Ensure that a normal range has the system tenant.
 		{
-			_, repl := getFirstStoreReplica(t, tc.Server(0), keys.TestingUserTableDataMin())
+			_, repl := getFirstStoreReplica(t, tc.Server(0), bootstrap.TestingUserTableDataMin())
 			ri := repl.State(ctx)
 			require.Equal(t, roachpb.SystemTenantID.ToUint64(), ri.TenantID, "%v", repl)
 		}

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -41,11 +42,11 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	kvserverbase.MergeQueueEnabled.Override(ctx, &testCtx.store.ClusterSettings().SV, true)
 
 	tableKey := func(offset uint32) []byte {
-		return keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(offset))
+		return keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(offset))
 	}
 
-	config.TestingSetZoneConfig(config.SystemTenantObjectID(keys.TestingUserDescID(0)), *zonepb.NewZoneConfig())
-	config.TestingSetZoneConfig(config.SystemTenantObjectID(keys.TestingUserDescID(1)), *zonepb.NewZoneConfig())
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(bootstrap.TestingUserDescID(0)), *zonepb.NewZoneConfig())
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(bootstrap.TestingUserDescID(1)), *zonepb.NewZoneConfig())
 
 	type testCase struct {
 		startKey, endKey []byte

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -731,7 +732,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	// which means keys.MaxReservedDescID+1.
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(1 << 20)
-	config.TestingSetZoneConfig(config.SystemTenantObjectID(keys.TestingUserDescID(1)), zoneConfig)
+	config.TestingSetZoneConfig(config.SystemTenantObjectID(bootstrap.TestingUserDescID(1)), zoneConfig)
 
 	// Check our config.
 	neverSplitsDesc = neverSplits.Desc()

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -741,7 +742,7 @@ func TestReplicaRangefeedRetryErrors(t *testing.T) {
 		}
 		// Split the range so that the RHS is not a system range and thus will
 		// respect the rangefeed_enabled cluster setting.
-		startKey := keys.TestingUserTableDataMin()
+		startKey := bootstrap.TestingUserTableDataMin()
 		tc.SplitRangeOrFatal(t, startKey)
 
 		rightRangeID := store.LookupReplica(roachpb.RKey(startKey)).RangeID

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -78,7 +79,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	const newRanges = 10
 	trackedRanges := map[roachpb.RangeID]struct{}{}
 	for i := uint32(0); i < newRanges; i++ {
-		tableID := keys.TestingUserDescID(i)
+		tableID := bootstrap.TestingUserDescID(i)
 		splitKey := keys.SystemSQLCodec.TablePrefix(tableID)
 		// Retry the splits on descriptor errors which are likely as the replicate
 		// queue is already hard at work.

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -123,7 +124,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 		tc.Servers[0].DB(),
 		zonepb.DefaultZoneConfigRef(),
 		zonepb.DefaultSystemZoneConfigRef(),
-		tc.Servers[0].SystemIDChecker().(keys.SystemIDChecker),
+		tc.Servers[0].SystemIDChecker().(*catalog.SystemIDChecker),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/reports/BUILD.bazel
+++ b/pkg/kv/kvserver/reports/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -760,7 +761,7 @@ func compileTestCase(tc baseReportTestCase) (compiledTestCase, error) {
 	// Databases and tables share the id space, so we'll use a common counter for them.
 	// And we're going to use keys in user space, otherwise there's special cases
 	// in the zone config lookup that we bump into.
-	objectCounter := int(keys.TestingUserDescID(0))
+	objectCounter := int(bootstrap.TestingUserDescID(0))
 	sysCfgBuilder := makeSystemConfigBuilder()
 	if err := sysCfgBuilder.setDefaultZoneConfig(tc.defaultZone.toZoneConfig()); err != nil {
 		return compiledTestCase{}, err

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1140,7 +1140,7 @@ func NewStore(
 		metrics:  newStoreMetrics(cfg.HistogramWindowInterval),
 		ctSender: cfg.ClosedTimestampSender,
 		systemRangeStartUpperBound: keys.SystemSQLCodec.TablePrefix(
-			keys.MinUserDescriptorID(keys.DeprecatedSystemIDChecker()),
+			keys.DeprecatedMinUserDescriptorID(keys.DeprecatedSystemIDChecker()),
 		),
 	}
 	if cfg.RPCContext != nil {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -1296,7 +1296,7 @@ func TestStoreSetRangesMaxBytes(t *testing.T) {
 		},
 		&cfg)
 
-	baseID := keys.TestingUserDescID(0)
+	baseID := bootstrap.TestingUserDescID(0)
 	testData := []struct {
 		repl        *Replica
 		expMaxBytes int64

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -2429,7 +2430,7 @@ func (s *adminServer) DataDistribution(
 		defer acct.Close(txnCtx)
 
 		kvs, err := kvclient.ScanMetaKVs(ctx, txn, roachpb.Span{
-			Key:    keys.SystemSQLCodec.TablePrefix(keys.MinUserDescriptorID(s.server.sqlServer.execCfg.SystemIDChecker)),
+			Key:    keys.SystemSQLCodec.TablePrefix(catalogkeys.MinUserDescriptorID(s.server.sqlServer.execCfg.SystemIDChecker)),
 			EndKey: keys.MaxKey,
 		})
 		if err != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -743,7 +743,7 @@ func ExpectedInitialRangeCount(
 	db *kv.DB,
 	defaultZoneConfig *zonepb.ZoneConfig,
 	defaultSystemZoneConfig *zonepb.ZoneConfig,
-	idChecker keys.SystemIDChecker,
+	idChecker *catalog.SystemIDChecker,
 ) (int, error) {
 	descriptorIDs, err := startupmigrations.ExpectedDescriptorIDs(
 		context.Background(), db, keys.SystemSQLCodec, defaultZoneConfig, defaultSystemZoneConfig,
@@ -758,7 +758,7 @@ func ExpectedInitialRangeCount(
 	// the span does not have an associated descriptor.
 	maxSystemDescriptorID := descriptorIDs[0]
 	for _, descID := range descriptorIDs {
-		if descID > maxSystemDescriptorID && catalog.IsSystemID(idChecker, descID) {
+		if descID > maxSystemDescriptorID && idChecker.IsSystemID(uint32(descID)) {
 			maxSystemDescriptorID = descID
 		}
 	}

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -582,6 +582,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/backfill",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/catconstants",

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -126,7 +126,9 @@ func (ms MetadataSchema) GetInitialValues() ([]roachpb.KeyValue, []roachpb.RKey)
 	// objects.
 	{
 		value := roachpb.Value{}
-		value.SetInt(int64(catalogkeys.MinUserDescriptorID(bootstrappedSystemIDChecker{ms})))
+		value.SetInt(int64(catalogkeys.MinUserDescriptorID(&catalog.SystemIDChecker{
+			SystemIDChecker: &bootstrappedSystemIDChecker{ms},
+		})))
 		add(ms.codec.DescIDSequenceKey(), value)
 	}
 
@@ -398,9 +400,11 @@ func (b bootstrappedSystemIDChecker) IsSystemID(id uint32) bool {
 
 // BootstrappedSystemIDChecker constructs a keys.SystemIDChecker which is valid
 // for a bootstrapped cluster.
-func BootstrappedSystemIDChecker() keys.SystemIDChecker {
+func BootstrappedSystemIDChecker() *catalog.SystemIDChecker {
 	ms := MakeMetadataSchema(keys.SystemSQLCodec, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef())
-	return bootstrappedSystemIDChecker{MetadataSchema: ms}
+	return &catalog.SystemIDChecker{
+		SystemIDChecker: &bootstrappedSystemIDChecker{MetadataSchema: ms},
+	}
 }
 
 // TestingUserDescID is a convenience function which returns a user ID offset

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -126,7 +126,7 @@ func (ms MetadataSchema) GetInitialValues() ([]roachpb.KeyValue, []roachpb.RKey)
 	// objects.
 	{
 		value := roachpb.Value{}
-		value.SetInt(int64(keys.MinUserDescriptorID(bootstrappedSystemIDChecker{ms})))
+		value.SetInt(int64(catalogkeys.MinUserDescriptorID(bootstrappedSystemIDChecker{ms})))
 		add(ms.codec.DescIDSequenceKey(), value)
 	}
 
@@ -401,4 +401,16 @@ func (b bootstrappedSystemIDChecker) IsSystemID(id uint32) bool {
 func BootstrappedSystemIDChecker() keys.SystemIDChecker {
 	ms := MakeMetadataSchema(keys.SystemSQLCodec, zonepb.DefaultZoneConfigRef(), zonepb.DefaultSystemZoneConfigRef())
 	return bootstrappedSystemIDChecker{MetadataSchema: ms}
+}
+
+// TestingUserDescID is a convenience function which returns a user ID offset
+// from the minimum value allowed in a simple unit test setting.
+func TestingUserDescID(offset uint32) uint32 {
+	return catalogkeys.MinUserDescriptorID(BootstrappedSystemIDChecker()) + offset
+}
+
+// TestingUserTableDataMin is a convenience function which returns the first
+// user table data key in a simple unit test setting.
+func TestingUserTableDataMin() roachpb.Key {
+	return keys.SystemSQLCodec.TablePrefix(TestingUserDescID(0))
 }

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -36,12 +36,22 @@ var DefaultUserDBs = []string{
 	DefaultDatabaseName, PgDatabaseName,
 }
 
+// MinUserDescriptorID returns the smallest possible non-system descriptor ID
+// after a cluster is bootstrapped.
+func MinUserDescriptorID(idChecker keys.SystemIDChecker) uint32 {
+	id := uint32(keys.MaxSystemConfigDescID + 1)
+	for idChecker.IsSystemID(id) {
+		id++
+	}
+	return id
+}
+
 // MinNonDefaultUserDescriptorID returns the smallest possible user-created
 // descriptor ID after a cluster is bootstrapped.
 func MinNonDefaultUserDescriptorID(idChecker keys.SystemIDChecker) uint32 {
 	// Each default DB comes with a public schema descriptor.
 	numDefaultDescs := len(DefaultUserDBs) * 2
-	return keys.MinUserDescriptorID(idChecker) + uint32(numDefaultDescs)
+	return MinUserDescriptorID(idChecker) + uint32(numDefaultDescs)
 }
 
 // IndexKeyValDirs returns the corresponding encoding.Directions for all the

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -38,7 +38,7 @@ var DefaultUserDBs = []string{
 
 // MinUserDescriptorID returns the smallest possible non-system descriptor ID
 // after a cluster is bootstrapped.
-func MinUserDescriptorID(idChecker keys.SystemIDChecker) uint32 {
+func MinUserDescriptorID(idChecker *catalog.SystemIDChecker) uint32 {
 	id := uint32(keys.MaxSystemConfigDescID + 1)
 	for idChecker.IsSystemID(id) {
 		id++
@@ -48,7 +48,7 @@ func MinUserDescriptorID(idChecker keys.SystemIDChecker) uint32 {
 
 // MinNonDefaultUserDescriptorID returns the smallest possible user-created
 // descriptor ID after a cluster is bootstrapped.
-func MinNonDefaultUserDescriptorID(idChecker keys.SystemIDChecker) uint32 {
+func MinNonDefaultUserDescriptorID(idChecker *catalog.SystemIDChecker) uint32 {
 	// Each default DB comes with a public schema descriptor.
 	numDefaultDescs := len(DefaultUserDBs) * 2
 	return MinUserDescriptorID(idChecker) + uint32(numDefaultDescs)

--- a/pkg/sql/catalog/catprivilege/BUILD.bazel
+++ b/pkg/sql/catalog/catprivilege/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     deps = [
         "//pkg/keys",
         "//pkg/security",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/privilege",

--- a/pkg/sql/catalog/catprivilege/fix_test.go
+++ b/pkg/sql/catalog/catprivilege/fix_test.go
@@ -8,14 +8,15 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package catprivilege
+package catprivilege_test
 
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -145,7 +146,7 @@ func TestFixPrivileges(t *testing.T) {
 			desc.Grant(u, p, false /* withGrantOption */)
 		}
 
-		MaybeFixPrivileges(
+		catprivilege.MaybeFixPrivileges(
 			&desc,
 			descpb.InvalidID,
 			descpb.InvalidID,
@@ -378,7 +379,7 @@ func TestMaybeFixUsageAndZoneConfigPrivilege(t *testing.T) {
 		for u, p := range tc.input {
 			desc.Grant(u, p, false /* withGrantOption */)
 		}
-		modified := MaybeFixUsagePrivForTablesAndDBs(&desc)
+		modified := catprivilege.MaybeFixUsagePrivForTablesAndDBs(&desc)
 
 		if tc.modified != modified {
 			t.Errorf("expected modifed to be %v, was %v", tc.modified, modified)
@@ -485,8 +486,8 @@ func TestMaybeFixSchemaPrivileges(t *testing.T) {
 		for u, p := range tc.input {
 			desc.Grant(u, p, false /* withGrantOption */)
 		}
-		testParentID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(keys.TestingSystemIDChecker()))
-		MaybeFixPrivileges(&desc,
+		testParentID := descpb.ID(catalogkeys.MinNonDefaultUserDescriptorID(bootstrap.BootstrappedSystemIDChecker()))
+		catprivilege.MaybeFixPrivileges(&desc,
 			testParentID,
 			descpb.InvalidID,
 			privilege.Schema,

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -54,6 +54,8 @@ go_test(
     deps = [
         "//pkg/keys",
         "//pkg/security",
+        "//pkg/sql/catalog/bootstrap",
+        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/privilege",
         "//pkg/testutils",
         "//pkg/util/leaktest",

--- a/pkg/sql/catalog/descpb/privilege_test.go
+++ b/pkg/sql/catalog/descpb/privilege_test.go
@@ -8,13 +8,16 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package descpb
+package descpb_test
 
 import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -22,7 +25,7 @@ import (
 
 func TestPrivilege(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
+	descriptor := descpb.NewBasePrivilegeDescriptor(security.AdminRoleName())
 
 	testUser := security.TestUserName()
 	barUser := security.MakeSQLUsernameFromPreNormalizedString("bar")
@@ -30,32 +33,32 @@ func TestPrivilege(t *testing.T) {
 	testCases := []struct {
 		grantee       security.SQLUsername // User to grant/revoke privileges on.
 		grant, revoke privilege.List
-		show          []UserPrivilegeString
+		show          []descpb.UserPrivilegeString
 		objectType    privilege.ObjectType
 	}{
 		{security.SQLUsername{}, nil, nil,
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 			},
 			privilege.Table,
 		},
 		{security.RootUserName(), privilege.List{privilege.ALL}, nil,
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 			},
 			privilege.Table,
 		},
 		{security.RootUserName(), privilege.List{privilege.INSERT, privilege.DROP}, nil,
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 			},
 			privilege.Table,
 		},
 		{testUser, privilege.List{privilege.INSERT, privilege.DROP}, nil,
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 				{testUser, []string{"DROP", "INSERT"}},
@@ -63,7 +66,7 @@ func TestPrivilege(t *testing.T) {
 			privilege.Table,
 		},
 		{barUser, nil, privilege.List{privilege.INSERT, privilege.ALL},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 				{testUser, []string{"DROP", "INSERT"}},
@@ -71,7 +74,7 @@ func TestPrivilege(t *testing.T) {
 			privilege.Table,
 		},
 		{testUser, privilege.List{privilege.ALL}, nil,
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 				{testUser, []string{"ALL"}},
@@ -79,7 +82,7 @@ func TestPrivilege(t *testing.T) {
 			privilege.Table,
 		},
 		{testUser, nil, privilege.List{privilege.SELECT, privilege.INSERT},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 				{testUser, []string{"CREATE", "DELETE", "DROP", "GRANT", "UPDATE", "ZONECONFIG"}},
@@ -87,7 +90,7 @@ func TestPrivilege(t *testing.T) {
 			privilege.Table,
 		},
 		{testUser, nil, privilege.List{privilege.ALL},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{security.RootUserName(), []string{"ALL"}},
 			},
@@ -95,7 +98,7 @@ func TestPrivilege(t *testing.T) {
 		},
 		// Validate checks that root still has ALL privileges, but we do not call it here.
 		{security.RootUserName(), nil, privilege.List{privilege.ALL},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 			},
 			privilege.Table,
@@ -103,7 +106,7 @@ func TestPrivilege(t *testing.T) {
 		// Ensure revoking USAGE from a user with ALL privilege on a type
 		// leaves the user with only GRANT privilege.
 		{testUser, privilege.List{privilege.ALL}, privilege.List{privilege.USAGE},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 				{testUser, []string{"GRANT"}},
 			},
@@ -113,7 +116,7 @@ func TestPrivilege(t *testing.T) {
 		// leaves the user with no privileges.
 		{testUser,
 			privilege.List{privilege.ALL}, privilege.List{privilege.USAGE, privilege.GRANT},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 			},
 			privilege.Type,
@@ -124,7 +127,7 @@ func TestPrivilege(t *testing.T) {
 			privilege.List{privilege.ALL}, privilege.List{privilege.CREATE, privilege.DROP,
 				privilege.GRANT, privilege.SELECT, privilege.INSERT, privilege.DELETE, privilege.UPDATE,
 				privilege.ZONECONFIG},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 			},
 			privilege.Table,
@@ -135,7 +138,7 @@ func TestPrivilege(t *testing.T) {
 			privilege.List{privilege.ALL}, privilege.List{privilege.CONNECT, privilege.CREATE,
 				privilege.DROP, privilege.GRANT, privilege.SELECT, privilege.INSERT, privilege.DELETE,
 				privilege.UPDATE, privilege.ZONECONFIG},
-			[]UserPrivilegeString{
+			[]descpb.UserPrivilegeString{
 				{security.AdminRoleName(), []string{"ALL"}},
 			},
 			privilege.Database,
@@ -172,36 +175,36 @@ func TestCheckPrivilege(t *testing.T) {
 	barUser := security.MakeSQLUsernameFromPreNormalizedString("bar")
 
 	testCases := []struct {
-		pd   *PrivilegeDescriptor
+		pd   *descpb.PrivilegeDescriptor
 		user security.SQLUsername
 		priv privilege.Kind
 		exp  bool
 	}{
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.CREATE, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			barUser, privilege.CREATE, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			barUser, privilege.DROP, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.DROP, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.CREATE, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.ALL, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.ALL, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.ALL, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.CREATE, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
 			security.AdminRoleName()),
 			testUser, privilege.UPDATE, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
 			security.AdminRoleName()),
 			testUser, privilege.DROP, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.ALL}, privilege.List{},
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.ALL}, privilege.List{},
 			security.AdminRoleName()),
 			testUser, privilege.DROP, true},
 	}
@@ -221,22 +224,22 @@ func TestAnyPrivilege(t *testing.T) {
 	barUser := security.MakeSQLUsernameFromPreNormalizedString("bar")
 
 	testCases := []struct {
-		pd   *PrivilegeDescriptor
+		pd   *descpb.PrivilegeDescriptor
 		user security.SQLUsername
 		exp  bool
 	}{
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			testUser, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			barUser, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
 			testUser, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
 			testUser, false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
 			security.AdminRoleName()),
 			testUser, true},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.DROP}, privilege.List{},
 			security.AdminRoleName()),
 			barUser, false},
 	}
@@ -255,10 +258,10 @@ func TestPrivilegeValidate(t *testing.T) {
 
 	testUser := security.TestUserName()
 
-	descriptor := NewBasePrivilegeDescriptor(security.AdminRoleName())
+	descriptor := descpb.NewBasePrivilegeDescriptor(security.AdminRoleName())
 	validate := func() error {
-		id := ID(keys.MinUserDescriptorID(keys.TestingSystemIDChecker()))
-		return descriptor.Validate(id, privilege.Table, "whatever", DefaultSuperuserPrivileges)
+		id := descpb.ID(catalogkeys.MinUserDescriptorID(bootstrap.BootstrappedSystemIDChecker()))
+		return descriptor.Validate(id, privilege.Table, "whatever", descpb.DefaultSuperuserPrivileges)
 	}
 
 	if err := validate(); err != nil {
@@ -290,7 +293,7 @@ func TestPrivilegeValidate(t *testing.T) {
 
 func TestValidPrivilegesForObjects(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	id := ID(keys.MinUserDescriptorID(keys.TestingSystemIDChecker()))
+	id := descpb.ID(catalogkeys.MinUserDescriptorID(bootstrap.BootstrappedSystemIDChecker()))
 
 	testUser := security.TestUserName()
 
@@ -306,9 +309,9 @@ func TestValidPrivilegesForObjects(t *testing.T) {
 
 	for _, tc := range testCases {
 		for _, priv := range tc.validPrivileges {
-			privDesc := NewBasePrivilegeDescriptor(security.AdminRoleName())
+			privDesc := descpb.NewBasePrivilegeDescriptor(security.AdminRoleName())
 			privDesc.Grant(testUser, privilege.List{priv}, false)
-			err := privDesc.Validate(id, tc.objectType, "whatever", DefaultSuperuserPrivileges)
+			err := privDesc.Validate(id, tc.objectType, "whatever", descpb.DefaultSuperuserPrivileges)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -323,9 +326,9 @@ func TestValidPrivilegesForObjects(t *testing.T) {
 		}
 
 		for _, priv := range invalidPrivileges {
-			privDesc := NewBasePrivilegeDescriptor(security.AdminRoleName())
+			privDesc := descpb.NewBasePrivilegeDescriptor(security.AdminRoleName())
 			privDesc.Grant(testUser, privilege.List{priv}, false)
-			err := privDesc.Validate(id, tc.objectType, "whatever", DefaultSuperuserPrivileges)
+			err := privDesc.Validate(id, tc.objectType, "whatever", descpb.DefaultSuperuserPrivileges)
 			if err == nil {
 				t.Fatalf("unexpected success, %s should not be a valid privilege for a %s",
 					priv, tc.objectType)
@@ -342,7 +345,7 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	testUser := security.TestUserName()
 
-	validate := func(descriptor *PrivilegeDescriptor) error {
+	validate := func(descriptor *descpb.PrivilegeDescriptor) error {
 		return descriptor.Validate(keys.SystemDatabaseID, privilege.Table, "whatever", privilege.ReadData)
 	}
 
@@ -353,7 +356,7 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Valid: root user has one of the allowable privilege sets.
-		descriptor := NewCustomSuperuserPrivilegeDescriptor(
+		descriptor := descpb.NewCustomSuperuserPrivilegeDescriptor(
 			privilege.List{privilege.SELECT, privilege.GRANT},
 			security.AdminRoleName(),
 		)
@@ -376,7 +379,7 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Valid: root has exactly the allowed privileges.
-		descriptor := NewCustomSuperuserPrivilegeDescriptor(
+		descriptor := descpb.NewCustomSuperuserPrivilegeDescriptor(
 			privilege.List{privilege.SELECT, privilege.GRANT},
 			security.AdminRoleName(),
 		)
@@ -403,7 +406,7 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Invalid: root has a non-allowable privilege set.
-		descriptor := NewCustomSuperuserPrivilegeDescriptor(privilege.List{privilege.UPDATE},
+		descriptor := descpb.NewCustomSuperuserPrivilegeDescriptor(privilege.List{privilege.UPDATE},
 			security.AdminRoleName())
 		if err := validate(descriptor); !testutils.IsError(err, rootWrongPrivilegesErr) {
 			t.Fatalf("expected err=%s, got err=%v", rootWrongPrivilegesErr, err)
@@ -436,22 +439,22 @@ func TestValidateOwnership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Use a non-system id.
-	id := ID(keys.MinUserDescriptorID(keys.TestingSystemIDChecker()))
-	validate := func(privs PrivilegeDescriptor) error {
-		return privs.Validate(id, privilege.Table, "whatever", DefaultSuperuserPrivileges)
+	id := descpb.ID(catalogkeys.MinUserDescriptorID(bootstrap.BootstrappedSystemIDChecker()))
+	validate := func(privs descpb.PrivilegeDescriptor) error {
+		return privs.Validate(id, privilege.Table, "whatever", descpb.DefaultSuperuserPrivileges)
 	}
 
 	// A privilege descriptor with a version before OwnerVersion can have
 	// no owner.
-	privs := PrivilegeDescriptor{
-		Users: []UserPrivileges{
+	privs := descpb.PrivilegeDescriptor{
+		Users: []descpb.UserPrivileges{
 			{
 				UserProto:  security.AdminRoleName().EncodeProto(),
-				Privileges: DefaultSuperuserPrivileges.ToBitField(),
+				Privileges: descpb.DefaultSuperuserPrivileges.ToBitField(),
 			},
 			{
 				UserProto:  security.RootUserName().EncodeProto(),
-				Privileges: DefaultSuperuserPrivileges.ToBitField(),
+				Privileges: descpb.DefaultSuperuserPrivileges.ToBitField(),
 			},
 		}}
 	err := validate(privs)
@@ -461,18 +464,18 @@ func TestValidateOwnership(t *testing.T) {
 
 	// A privilege descriptor with version OwnerVersion and onwards should
 	// have an owner.
-	privs = PrivilegeDescriptor{
-		Users: []UserPrivileges{
+	privs = descpb.PrivilegeDescriptor{
+		Users: []descpb.UserPrivileges{
 			{
 				UserProto:  security.AdminRoleName().EncodeProto(),
-				Privileges: DefaultSuperuserPrivileges.ToBitField(),
+				Privileges: descpb.DefaultSuperuserPrivileges.ToBitField(),
 			},
 			{
 				UserProto:  security.RootUserName().EncodeProto(),
-				Privileges: DefaultSuperuserPrivileges.ToBitField(),
+				Privileges: descpb.DefaultSuperuserPrivileges.ToBitField(),
 			},
 		},
-		Version: OwnerVersion,
+		Version: descpb.OwnerVersion,
 	}
 
 	err = validate(privs)
@@ -480,19 +483,19 @@ func TestValidateOwnership(t *testing.T) {
 		t.Fatal("unexpected success")
 	}
 
-	privs = PrivilegeDescriptor{
+	privs = descpb.PrivilegeDescriptor{
 		OwnerProto: security.RootUserName().EncodeProto(),
-		Users: []UserPrivileges{
+		Users: []descpb.UserPrivileges{
 			{
 				UserProto:  security.AdminRoleName().EncodeProto(),
-				Privileges: DefaultSuperuserPrivileges.ToBitField(),
+				Privileges: descpb.DefaultSuperuserPrivileges.ToBitField(),
 			},
 			{
 				UserProto:  security.RootUserName().EncodeProto(),
-				Privileges: DefaultSuperuserPrivileges.ToBitField(),
+				Privileges: descpb.DefaultSuperuserPrivileges.ToBitField(),
 			},
 		},
-		Version: OwnerVersion,
+		Version: descpb.OwnerVersion,
 	}
 
 	err = validate(privs)
@@ -509,39 +512,39 @@ func TestGrantWithGrantOption(t *testing.T) {
 	testUser := security.TestUserName()
 
 	testCases := []struct {
-		pd                  *PrivilegeDescriptor
+		pd                  *descpb.PrivilegeDescriptor
 		user                security.SQLUsername
 		objectType          privilege.ObjectType
 		grantPrivileges     privilege.List
 		expectedPrivileges  privilege.List
 		expectedGrantOption privilege.List
 	}{
-		{NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			privilege.List{privilege.SELECT, privilege.INSERT},
 			privilege.List{privilege.SELECT, privilege.INSERT},
 			privilege.List{privilege.SELECT, privilege.INSERT}},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			privilege.List{privilege.SELECT, privilege.INSERT},
 			privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT},
 			privilege.List{privilege.SELECT, privilege.INSERT}},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			privilege.List{privilege.SELECT, privilege.INSERT},
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.SELECT, privilege.INSERT}},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.INSERT}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.INSERT}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL}},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
 			testUser, privilege.Schema,
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL}},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{privilege.CREATE}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE}, privilege.List{privilege.CREATE}, security.AdminRoleName()),
 			testUser, privilege.Schema,
 			privilege.List{privilege.ALL, privilege.CREATE},
 			privilege.List{privilege.ALL},
@@ -569,7 +572,7 @@ func TestRevokeWithGrantOption(t *testing.T) {
 	testUser := security.TestUserName()
 
 	testCases := []struct {
-		pd                  *PrivilegeDescriptor
+		pd                  *descpb.PrivilegeDescriptor
 		user                security.SQLUsername
 		objectType          privilege.ObjectType
 		grantOptionFor      bool
@@ -578,56 +581,56 @@ func TestRevokeWithGrantOption(t *testing.T) {
 		expectedGrantOption privilege.List
 		shouldBeEmpty       bool
 	}{
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			true,
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL},
 			privilege.List{},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			true,
 			privilege.List{privilege.CREATE, privilege.GRANT},
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.DROP, privilege.SELECT, privilege.INSERT, privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			true,
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL},
 			privilege.List{},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			true,
 			privilege.List{privilege.ALL, privilege.CREATE, privilege.SELECT},
 			privilege.List{privilege.ALL},
 			privilege.List{},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT}, privilege.List{privilege.SELECT}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT}, privilege.List{privilege.SELECT}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			true,
 			privilege.List{privilege.CREATE, privilege.DROP, privilege.SELECT},
 			privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT},
 			privilege.List{},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT}, privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT}, privilege.List{privilege.CREATE, privilege.SELECT, privilege.INSERT}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			false,
 			privilege.List{privilege.SELECT, privilege.INSERT},
 			privilege.List{privilege.CREATE},
 			privilege.List{privilege.CREATE},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.ALL}, privilege.List{privilege.ALL}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			false,
 			privilege.List{privilege.CREATE, privilege.GRANT},
 			privilege.List{privilege.DROP, privilege.SELECT, privilege.INSERT, privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG},
 			privilege.List{privilege.DROP, privilege.SELECT, privilege.INSERT, privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG},
 			false},
-		{NewPrivilegeDescriptor(testUser, privilege.List{privilege.SELECT, privilege.INSERT}, privilege.List{privilege.INSERT}, security.AdminRoleName()),
+		{descpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.SELECT, privilege.INSERT}, privilege.List{privilege.INSERT}, security.AdminRoleName()),
 			testUser, privilege.Table,
 			false,
 			privilege.List{privilege.ALL},

--- a/pkg/sql/catalog/descriptor_id.go
+++ b/pkg/sql/catalog/descriptor_id.go
@@ -10,15 +10,7 @@
 
 package catalog
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-)
-
-// IsSystemID returns true if the ID is part of the system database.
-func IsSystemID(c keys.SystemIDChecker, id descpb.ID) bool {
-	return c.IsSystemID(uint32(id))
-}
+import "github.com/cockroachdb/cockroach/pkg/keys"
 
 // SystemIDChecker is a higher-level interface above the keys.SystemIDChecker.
 // See the comments on that interface for semantics.

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1293,7 +1293,7 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 					if idChecker.Load() == nil {
 						return
 					}
-					if !catalog.IsSystemID(idChecker.Load().(keys.SystemIDChecker), id) {
+					if !idChecker.Load().(*catalog.SystemIDChecker).IsSystemID(uint32(id)) {
 						atomic.AddInt32(&testAcquisitionBlockCount, 1)
 					}
 				},
@@ -1749,7 +1749,7 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 					if idChecker.Load() == nil {
 						return
 					}
-					if catalog.IsSystemID(idChecker.Load().(keys.SystemIDChecker), id) {
+					if idChecker.Load().(*catalog.SystemIDChecker).IsSystemID(uint32(id)) {
 						return
 					}
 					mu.Lock()
@@ -1760,7 +1760,7 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 					if idChecker.Load() == nil {
 						return
 					}
-					if !catalog.IsSystemID(idChecker.Load().(keys.SystemIDChecker), id) {
+					if !idChecker.Load().(*catalog.SystemIDChecker).IsSystemID(uint32(id)) {
 						atomic.AddInt32(&testAcquisitionBlockCount, 1)
 					}
 				},

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/catconstants",

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	. "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -54,8 +55,8 @@ func TestAllocateIDs(t *testing.T) {
 	ctx := context.Background()
 
 	desc := NewBuilder(&descpb.TableDescriptor{
-		ParentID: descpb.ID(keys.TestingUserDescID(0)),
-		ID:       descpb.ID(keys.TestingUserDescID(1)),
+		ParentID: descpb.ID(bootstrap.TestingUserDescID(0)),
+		ID:       descpb.ID(bootstrap.TestingUserDescID(1)),
 		Name:     "foo",
 		Columns: []descpb.ColumnDescriptor{
 			{Name: "a", Type: types.Int},
@@ -86,8 +87,8 @@ func TestAllocateIDs(t *testing.T) {
 	}
 
 	expected := NewBuilder(&descpb.TableDescriptor{
-		ParentID: descpb.ID(keys.TestingUserDescID(0)),
-		ID:       descpb.ID(keys.TestingUserDescID(1)),
+		ParentID: descpb.ID(bootstrap.TestingUserDescID(0)),
+		ID:       descpb.ID(bootstrap.TestingUserDescID(1)),
 		Version:  1,
 		Name:     "foo",
 		Columns: []descpb.ColumnDescriptor{

--- a/pkg/sql/catalog/typedesc/BUILD.bazel
+++ b/pkg/sql/catalog/typedesc/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemadesc",

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
@@ -377,7 +378,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	invalidPrivileges := descpb.NewBasePrivilegeDescriptor(security.RootUserName())
 	// Make the PrivilegeDescriptor invalid by granting SELECT to a type.
 	invalidPrivileges.Grant(security.TestUserName(), privilege.List{privilege.SELECT}, false)
-	typeDescID := descpb.ID(keys.TestingUserDescID(0))
+	typeDescID := descpb.ID(bootstrap.TestingUserDescID(0))
 	testData := []struct {
 		err  string
 		desc descpb.TypeDescriptor

--- a/pkg/sql/colexec/colexecspan/BUILD.bazel
+++ b/pkg/sql/colexec/colexecspan/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/security",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/colconv",

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
@@ -181,7 +182,7 @@ func spanGeneratorOracle(
 }
 
 func makeTable(useColFamilies bool) catalog.TableDescriptor {
-	tableID := keys.TestingUserDescID(0)
+	tableID := bootstrap.TestingUserDescID(0)
 	if !useColFamilies {
 		// We can prevent the span builder from splitting spans into separate column
 		// families by using a system table ID, since system tables do not have

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -271,7 +271,7 @@ func descReport(stdout io.Writer, desc catalog.Descriptor, format string, args .
 // timestamp.
 func DumpSQL(out io.Writer, descTable DescriptorTable, namespaceTable NamespaceTable) error {
 	idChecker := bootstrap.BootstrappedSystemIDChecker()
-	minUserDescID := keys.MinUserDescriptorID(idChecker)
+	minUserDescID := catalogkeys.MinUserDescriptorID(idChecker)
 	minUserCreatedDescID := catalogkeys.MinNonDefaultUserDescriptorID(idChecker)
 	// Print first transaction, which removes all predefined user descriptors.
 	fmt.Fprintln(out, `BEGIN;`)

--- a/pkg/sql/gcjob_test/BUILD.bazel
+++ b/pkg/sql/gcjob_test/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -90,9 +91,9 @@ func TestSchemaChangeGCJob(t *testing.T) {
 				sqlDB.Exec(t, "ALTER TABLE my_table CONFIGURE ZONE USING gc.ttlseconds = 1")
 				sqlDB.Exec(t, "ALTER TABLE my_other_table CONFIGURE ZONE USING gc.ttlseconds = 1")
 			}
-			myDBID := descpb.ID(keys.TestingUserDescID(2))
-			myTableID := descpb.ID(keys.TestingUserDescID(3))
-			myOtherTableID := descpb.ID(keys.TestingUserDescID(4))
+			myDBID := descpb.ID(bootstrap.TestingUserDescID(2))
+			myTableID := descpb.ID(bootstrap.TestingUserDescID(3))
+			myOtherTableID := descpb.ID(bootstrap.TestingUserDescID(4))
 
 			var myTableDesc *tabledesc.Mutable
 			var myOtherTableDesc *tabledesc.Mutable

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -99,7 +100,7 @@ func TestRevertGCThreshold(t *testing.T) {
 	kvDB := tc.Server(0).DB()
 
 	req := &roachpb.RevertRangeRequest{
-		RequestHeader:                       roachpb.RequestHeader{Key: keys.TestingUserTableDataMin(), EndKey: keys.MaxKey},
+		RequestHeader:                       roachpb.RequestHeader{Key: bootstrap.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 		TargetTime:                          hlc.Timestamp{WallTime: -1},
 		EnableTimeBoundIteratorOptimization: true,
 	}

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -43,7 +44,7 @@ func slurpUserDataKVs(t testing.TB, e storage.Engine) []roachpb.KeyValue {
 		kvs = nil
 		it := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer it.Close()
-		for it.SeekGE(storage.MVCCKey{Key: keys.TestingUserTableDataMin()}); ; it.NextKey() {
+		for it.SeekGE(storage.MVCCKey{Key: bootstrap.TestingUserTableDataMin()}); ; it.NextKey() {
 			ok, err := it.Valid()
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -487,12 +486,11 @@ func createStatsRequestFilter(
 			// Ensure that the tableID is within the expected range for a table,
 			// but is not a system table.
 
-			var c keys.SystemIDChecker
+			var c *catalog.SystemIDChecker
 			if idChecker.Load() != nil {
-				c = idChecker.Load().(keys.SystemIDChecker)
+				c = idChecker.Load().(*catalog.SystemIDChecker)
 			}
-			if tableID > 0 && tableID < 100 && c != nil &&
-				!catalog.IsSystemID(c, descpb.ID(uint32(tableID))) {
+			if tableID > 0 && tableID < 100 && c != nil && !c.IsSystemID(uint32(tableID)) {
 				// Read from the channel twice to allow jobutils.RunJob to complete
 				// even though there is only one ScanRequest.
 				<-*allowProgressIota

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -81,7 +82,7 @@ func TestSplitOnTableBoundaries(t *testing.T) {
 		kvDB,
 		&s.(*server.TestServer).Cfg.DefaultZoneConfig,
 		&s.(*server.TestServer).Cfg.DefaultSystemZoneConfig,
-		s.(*server.TestServer).SystemIDChecker().(keys.SystemIDChecker))
+		s.(*server.TestServer).SystemIDChecker().(*catalog.SystemIDChecker))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -95,7 +95,7 @@ func TestInitialKeys(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if a, e := i, int64(keys.TestingUserDescID(0)); a != e {
+		if a, e := i, int64(bootstrap.TestingUserDescID(0)); a != e {
 			t.Fatalf("Expected next descriptor ID to be %d, was %d", e, a)
 		}
 	})

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -46,7 +46,7 @@ func TestUpsertFastPath(t *testing.T) {
 	var scans uint64
 	var endTxn uint64
 	filter := func(filterArgs kvserverbase.FilterArgs) *roachpb.Error {
-		if bytes.Compare(filterArgs.Req.Header().Key, keys.TestingUserTableDataMin()) >= 0 {
+		if bytes.Compare(filterArgs.Req.Header().Key, bootstrap.TestingUserTableDataMin()) >= 0 {
 			switch filterArgs.Req.Method() {
 			case roachpb.Scan:
 				atomic.AddUint64(&scans, 1)

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
@@ -37,7 +38,7 @@ import (
 )
 
 var configID = descpb.ID(1)
-var configDescKey = catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(keys.TestingUserDescID(0)))
+var configDescKey = catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(bootstrap.TestingUserDescID(0)))
 
 // forceNewConfig forces a system config update by writing a bogus descriptor with an
 // incremented value inside. It then repeatedly fetches the gossip config until the
@@ -648,7 +649,7 @@ func BenchmarkGetZoneConfig(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)))
+		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)))
 		_, err := cfg.GetZoneConfigForKey(key)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -129,6 +129,7 @@ go_test(
         "//pkg/roachpb:with-mocks",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -4523,7 +4524,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	userID := keys.TestingUserDescID(0)
+	userID := bootstrap.TestingUserDescID(0)
 	// Manually creates rows corresponding to the schema:
 	// CREATE TABLE t (id1 STRING, id2 STRING, ... PRIMARY KEY (id1, id2, ...))
 	addTablePrefix := func(prefix roachpb.Key, id uint32, rowVals ...string) roachpb.Key {
@@ -4728,7 +4729,7 @@ func TestFindValidSplitKeys(t *testing.T) {
 				addColFam(tablePrefix(userID, "b"), 1),
 				addColFam(tablePrefix(userID, "c"), 1),
 			},
-			rangeStart: keys.SystemSQLCodec.TablePrefix(keys.TestingUserDescID(0)),
+			rangeStart: keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)),
 			expSplit:   tablePrefix(userID, "b"),
 			expError:   false,
 		},
@@ -5191,7 +5192,7 @@ func TestMVCCGarbageCollectUsesSeekLTAppropriately(t *testing.T) {
 		batch := engine.NewBatch()
 		defer batch.Close()
 		it := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-			UpperBound: keys.TestingUserTableDataMin(),
+			UpperBound: bootstrap.TestingUserTableDataMin(),
 			LowerBound: keys.MaxKey,
 		})
 		defer it.Close()


### PR DESCRIPTION
Instead of relying on hard-coded constants, tests now rely on the
bootstrapped system schema to determine which IDs belong to system
tables or not.

Release note: None