### PR TITLE
release-21.2: ui: removed formatting to statements on the details pages

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -116,18 +116,12 @@ func collectCombinedStatements(
 				transaction_fingerprint_id,
 				app_name,
 				aggregated_ts,
-				jsonb_set(
-					metadata,
-					array['query'],
-					to_jsonb(
-						prettify_statement(metadata ->> 'query', %d, %d, %d)
-					)
-				),
+				metadata,
 				statistics,
 				sampled_plan,
 				aggregation_interval
 			FROM crdb_internal.statement_statistics
-			%s`, tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase, whereClause)
+			%s`, whereClause)
 
 	const expectedNumDatums = 8
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1961,33 +1961,17 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	thirdServerSQL := sqlutils.MakeSQLRunner(testCluster.ServerConn(2))
 
 	statements := []struct {
-		stmt                 string
-		formattedStmt        string
-		fingerprint          string
-		formattedFingerprint string
+		stmt          string
+		fingerprinted string
 	}{
+		{stmt: `CREATE DATABASE roachblog`},
+		{stmt: `SET database = roachblog`},
+		{stmt: `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`},
 		{
-			stmt:          `CREATE DATABASE roachblog`,
-			formattedStmt: "CREATE DATABASE roachblog\n",
+			stmt:          `INSERT INTO posts VALUES (1, 'foo')`,
+			fingerprinted: `INSERT INTO posts VALUES (_, '_')`,
 		},
-		{
-			stmt:          `SET database = roachblog`,
-			formattedStmt: "SET database = roachblog\n",
-		},
-		{
-			stmt:          `CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)`,
-			formattedStmt: "CREATE TABLE posts (id INT8 PRIMARY KEY, body STRING)\n",
-		},
-		{
-			stmt:                 `INSERT INTO posts VALUES (1, 'foo')`,
-			formattedStmt:        "INSERT INTO posts VALUES (1, 'foo')\n",
-			fingerprint:          `INSERT INTO posts VALUES (_, '_')`,
-			formattedFingerprint: "INSERT INTO posts VALUES (_, '_')\n",
-		},
-		{
-			stmt:          `SELECT * FROM posts`,
-			formattedStmt: "SELECT * FROM posts\n",
-		},
+		{stmt: `SELECT * FROM posts`},
 	}
 
 	for _, stmt := range statements {
@@ -2044,9 +2028,9 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 
 	var expectedStatements []string
 	for _, stmt := range statements {
-		var expectedStmt = stmt.formattedStmt
-		if stmt.fingerprint != "" {
-			expectedStmt = stmt.formattedFingerprint
+		var expectedStmt = stmt.stmt
+		if stmt.fingerprinted != "" {
+			expectedStmt = stmt.fingerprinted
 		}
 		expectedStatements = append(expectedStatements, expectedStmt)
 	}

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -111,8 +111,6 @@ type LineWidthMode int
 const (
 	// DefaultLineWidth is the line width used with the default pretty-printing configuration.
 	DefaultLineWidth LineWidthMode = 60
-	// ConsoleLineWidth is the line width used on the frontend console.
-	ConsoleLineWidth = 108
 )
 
 // keywordWithText returns a pretty.Keyword with left and/or right

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -27,6 +27,7 @@
     font-family: SFMono-Semibold;
     font-size: 14px;
     line-height: 1.57;
+    white-space: pre-line;
     word-wrap: break-word;
 
     span {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -146,14 +146,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   dateRange: [moment.utc("2021.08.08"), moment.utc("2021.08.12")],
   statement: {
     statement:
-      "CREATE TABLE IF NOT EXISTS promo_codes (\n" +
-      "  code            VARCHAR NOT NULL,\n" +
-      "  description     VARCHAR NULL,\n" +
-      "  creation_time   TIMESTAMP NULL,\n" +
-      "  expiration_time TIMESTAMP NULL,\n" +
-      "  rules           JSONB NULL,\n" +
-      "  PRIMARY KEY (code ASC)\n" +
-      ")",
+      "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
     stats: statementStats,
     database: "defaultdb",
     byNode: [

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -288,11 +288,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: "1253500548539870016",
       label:
-        "SELECT IFNULL(a, b)\n" +
-        "    FROM (\n" +
-        "          SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a,\n" +
-        "                 (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b\n" +
-        "         )",
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
       aggregationInterval,
@@ -315,11 +311,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: "13649565517143827225",
       label:
-        "SELECT IFNULL(a, b)\n" +
-        "    FROM (\n" +
-        "          SELECT (SELECT id FROM users WHERE city = $1 AND id > $2 ORDER BY id LIMIT _) AS a,\n" +
-        "                 (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b\n" +
-        "         )",
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
       aggregationInterval,
@@ -470,14 +462,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '11195381626529102926',
       label:
-        "CREATE TABLE IF NOT EXISTS promo_codes (\n" +
-        "      code            VARCHAR NOT NULL,\n" +
-        "      description     VARCHAR NULL,\n" +
-        "      creation_time   TIMESTAMP NULL,\n" +
-        "      expiration_time TIMESTAMP NULL,\n" +
-        "      rules           JSONB NULL,\n" +
-        "      PRIMARY KEY (code ASC)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
       summary:
         "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
       aggregatedTs,
@@ -525,14 +510,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '13217779306501326587',
       label:
-        'CREATE TABLE IF NOT EXISTS user_promo_codes (\n' +
-        '      city        VARCHAR NOT NULL,\n' +
-        '      user_id     UUID NOT NULL,\n' +
-        '      code        VARCHAR NOT NULL,\n' +
-        '      "timestamp" TIMESTAMP NULL,\n' +
-        '      usage_count INT8 NULL,\n' +
-        '      PRIMARY KEY (city ASC, user_id ASC, code ASC)\n' +
-        '  )',
+        'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
       summary:
         'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
       aggregatedTs,
@@ -591,22 +569,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '2695725667586429780',
       label:
-        "CREATE TABLE IF NOT EXISTS rides (\n" +
-        "      id            UUID NOT NULL,\n" +
-        "      city          VARCHAR NOT NULL,\n" +
-        "      vehicle_city  VARCHAR NULL,\n" +
-        "      rider_id      UUID NULL,\n" +
-        "      vehicle_id    UUID NULL,\n" +
-        "      start_address VARCHAR NULL,\n" +
-        "      end_address   VARCHAR NULL,\n" +
-        "      start_time    TIMESTAMP NULL,\n" +
-        "      end_time      TIMESTAMP NULL,\n" +
-        "      revenue       DECIMAL(10,2) NULL,\n" +
-        "      PRIMARY KEY (city ASC, id ASC),\n" +
-        "      INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),\n" +
-        "      INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),\n" +
-        "      CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
       summary:
         "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
       aggregatedTs,
@@ -619,18 +582,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '6754865160812330169',
       label:
-        "CREATE TABLE IF NOT EXISTS vehicles (\n" +
-        "      id               UUID NOT NULL,\n" +
-        "      city             VARCHAR NOT NULL,\n" +
-        "      type             VARCHAR NULL,\n" +
-        "      owner_id         UUID NULL,\n" +
-        "      creation_time    TIMESTAMP NULL,\n" +
-        "      status           VARCHAR NULL,\n" +
-        "      current_location VARCHAR NULL,\n" +
-        "      ext              JSONB NULL,\n" +
-        "      PRIMARY KEY (city ASC, id ASC),\n" +
-        "      INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
       summary:
         "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
       aggregatedTs,
@@ -676,14 +628,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '8695470234690735168',
       label:
-        "CREATE TABLE IF NOT EXISTS users (\n" +
-        "      id          UUID NOT NULL,\n" +
-        "      city        VARCHAR NOT NULL,\n" +
-        "      name        VARCHAR NULL,\n" +
-        "      address     VARCHAR NULL,\n" +
-        "      credit_card VARCHAR NULL,\n" +
-        "      PRIMARY KEY (city ASC, id ASC)\n" +
-        "  )",
+        "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
       summary:
         "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
       aggregatedTs,
@@ -696,14 +641,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     {
       aggregatedFingerprintID: '9261848985398568228',
       label:
-        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (\n' +
-        '      city        VARCHAR NOT NULL,\n' +
-        '      ride_id     UUID NOT NULL,\n' +
-        '      "timestamp" TIMESTAMP NOT NULL,\n' +
-        '      lat         FLOAT8 NULL,\n' +
-        '      long        FLOAT8 NULL,\n' +
-        '      PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC)\n' +
-        '  )',
+        'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
       summary:
         'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
       aggregatedTs,


### PR DESCRIPTION
Backport 2/2 commits from #75443.

/cc @cockroachdb/release

---

**ui: removed formatting to statements on the details pages**

Previously, statements displayed on the statement/transaction/index
details pages were formatted (formatting was added to allow for better
readability of statements on these detail pages). However, statements
queries from the frontend were noticeably slower due to this
implementation. This change reverts the changes to statement formatting
(updates the fixtures to show the non-formatted statements), but keeps
the change that uses statement ID as an identifier in the URL instead of
the raw statement.

Reference: [Original PR](https://github.com/cockroachdb/cockroach/pull/73853)

**Release note (ui change)**: change to replace raw
statement with statement ID in the URL.

Release justification: Category 2: Bug fixes and low-risk updates to new functionality