### PR TITLE
ci: add `go_transition_test` support to `bazci`

### DIFF
--- a/build/teamcity/cockroach/ci/tests/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests/acceptance.sh
@@ -5,18 +5,20 @@ set -xeuo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"
 
-tc_prepare
-
 export ARTIFACTSDIR=$PWD/artifacts/acceptance
 mkdir -p "$ARTIFACTSDIR"
 
 tc_start_block "Run acceptance tests"
 status=0
-bazel run \
-  //pkg/acceptance:acceptance_test \
-  --config=crosslinux --config=test \
+
+bazel build //pkg/cmd/bazci --config=ci
+BAZCI=$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci
+
+$BAZCI run --config=crosslinux --config=test --artifacts_dir=$PWD/artifacts \
+  //pkg/acceptance:acceptance_test -- \
   --test_arg=-l="$ARTIFACTSDIR" \
   --test_env=TZ=America/New_York \
+  --test_env=GO_TEST_WRAP_TESTV=1 \
   --test_timeout=1800 || status=$?
 
 # Some unit tests test automatic ballast creation. These ballasts can be


### PR DESCRIPTION
These targets have special bespoke output directories for `testlogs`, so
we can't find them in the standard location.

Also allow `bazci run`.

Closes #75184.

Release note: None