### PR TITLE
ui: remove `$ internal` from apps filter option

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -61,28 +61,27 @@ export const selectApps = createSelector(sqlStatsSelector, sqlStatsState => {
   }
 
   let sawBlank = false;
-  let sawInternal = false;
   const apps: { [app: string]: boolean } = {};
   sqlStatsState.data.statements.forEach(
     (statement: ICollectedStatementStatistics) => {
-      if (
+      const isNotInternalApp =
         sqlStatsState.data.internal_app_name_prefix &&
-        statement.key.key_data.app.startsWith(
+        !statement.key.key_data.app.startsWith(
           sqlStatsState.data.internal_app_name_prefix,
-        )
+        );
+      if (
+        sqlStatsState.data.internal_app_name_prefix == undefined ||
+        isNotInternalApp
       ) {
-        sawInternal = true;
-      } else if (statement.key.key_data.app) {
-        apps[statement.key.key_data.app] = true;
-      } else {
-        sawBlank = true;
+        if (statement.key.key_data.app) {
+          apps[statement.key.key_data.app] = true;
+        } else {
+          sawBlank = true;
+        }
       }
     },
   );
-  return []
-    .concat(sawInternal ? [sqlStatsState.data.internal_app_name_prefix] : [])
-    .concat(sawBlank ? ["(unset)"] : [])
-    .concat(Object.keys(apps));
+  return [].concat(sawBlank ? ["(unset)"] : []).concat(Object.keys(apps));
 });
 
 // selectDatabases returns the array of all databases with statement statistics present

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -39,14 +39,13 @@ export const getTrxAppFilterOptions = (
   transactions: Transaction[],
   prefix: string,
 ): string[] => {
-  const defaultAppFilters = [prefix];
   const uniqueAppNames = new Set(
     transactions
       .filter(t => !t.stats_data.app.startsWith(prefix))
       .map(t => (t.stats_data.app ? t.stats_data.app : "(unset)")),
   );
 
-  return defaultAppFilters.concat(Array.from(uniqueAppNames));
+  return Array.from(uniqueAppNames);
 };
 
 export const collectStatementsText = (statements: Statement[]): string =>

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -161,28 +161,27 @@ export const selectApps = createSelector(
     }
 
     let sawBlank = false;
-    let sawInternal = false;
     const apps: { [app: string]: boolean } = {};
     state.data.statements.forEach(
       (statement: ICollectedStatementStatistics) => {
-        if (
+        const isNotInternalApp =
           state.data.internal_app_name_prefix &&
-          statement.key.key_data.app.startsWith(
+          !statement.key.key_data.app.startsWith(
             state.data.internal_app_name_prefix,
-          )
+          );
+        if (
+          state.data.internal_app_name_prefix == undefined ||
+          isNotInternalApp
         ) {
-          sawInternal = true;
-        } else if (statement.key.key_data.app) {
-          apps[statement.key.key_data.app] = true;
-        } else {
-          sawBlank = true;
+          if (statement.key.key_data.app) {
+            apps[statement.key.key_data.app] = true;
+          } else {
+            sawBlank = true;
+          }
         }
       },
     );
-    return []
-      .concat(sawInternal ? [state.data.internal_app_name_prefix] : [])
-      .concat(sawBlank ? ["(unset)"] : [])
-      .concat(Object.keys(apps));
+    return [].concat(sawBlank ? ["(unset)"] : []).concat(Object.keys(apps));
   },
 );
 


### PR DESCRIPTION
Previously, we had the option `$ internal` on the list of
Apps on filters of both Statement and Transaction pages.
We're making a change to not return internal filters anymore,
so this commit remove that option from the filter, since
it will always results on a blank table.

Release note (ui change): Remove `$ internal` as one of the apps
option under the Statements and Transactions page filters.