### PR TITLE
sql: remove KeyToDescTranslator

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1435,29 +1435,9 @@ func (rf *cFetcher) getCurrentColumnFamilyID() (descpb.FamilyID, error) {
 // error may also undergo a mapping to make it more user friendly for SQL
 // consumers.
 func (rf *cFetcher) convertFetchError(ctx context.Context, err error) error {
-	err = row.ConvertFetchError(ctx, rf, err)
+	err = row.ConvertFetchError(ctx, rf.table.desc, err)
 	err = colexecerror.NewStorageError(err)
 	return err
-}
-
-// KeyToDesc implements the KeyToDescTranslator interface. The implementation is
-// used by convertFetchError.
-func (rf *cFetcher) KeyToDesc(key roachpb.Key) (catalog.TableDescriptor, bool) {
-	if len(key) < rf.table.knownPrefixLength {
-		return nil, false
-	}
-	nIndexCols := rf.table.index.NumKeyColumns() + rf.table.index.NumKeySuffixColumns()
-	tableKeyVals := make([]rowenc.EncDatum, nIndexCols)
-	_, _, err := rowenc.DecodeKeyVals(
-		rf.table.keyValTypes,
-		tableKeyVals,
-		rf.table.indexColumnDirs,
-		key[rf.table.knownPrefixLength:],
-	)
-	if err != nil {
-		return nil, false
-	}
-	return rf.table.desc, true
 }
 
 // getBytesRead returns the number of bytes read by the cFetcher throughout its

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -626,7 +626,7 @@ func (rf *Fetcher) setNextKV(kv roachpb.KeyValue, needsCopy bool) {
 func (rf *Fetcher) nextKey(ctx context.Context) (newRow bool, _ error) {
 	ok, kv, finalReferenceToBatch, err := rf.kvFetcher.NextKV(ctx, rf.mvccDecodeStrategy)
 	if err != nil {
-		return false, ConvertFetchError(ctx, rf, err)
+		return false, ConvertFetchError(ctx, rf.table.desc, err)
 	}
 	rf.setNextKV(kv, finalReferenceToBatch)
 
@@ -718,18 +718,6 @@ func (rf *Fetcher) DecodeIndexKey(key roachpb.Key) (remaining []byte, foundNull 
 		rf.table.indexColumnDirs,
 		key[rf.table.knownPrefixLength:],
 	)
-}
-
-// KeyToDesc implements the KeyToDescTranslator interface. The implementation is
-// used by ConvertFetchError.
-func (rf *Fetcher) KeyToDesc(key roachpb.Key) (catalog.TableDescriptor, bool) {
-	if len(key) < rf.table.knownPrefixLength {
-		return nil, false
-	}
-	if _, _, err := rf.DecodeIndexKey(key); err != nil {
-		return nil, false
-	}
-	return rf.table.desc, true
 }
 
 // processKV processes the given key/value, setting values in the row


### PR DESCRIPTION
This interface was only useful with interleaved tables.

Release note: None