### PR TITLE
release-21.2: distsender: fix ResumeSpan for Gets

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1705,54 +1705,100 @@ func fillSkippedResponses(
 		scratchBA.Requests[0].MustSetInner(req)
 		br.Responses[i] = scratchBA.CreateReply().Responses[0]
 	}
-	// Set the ResumeSpan for future batch requests.
+
+	// Set or correct the ResumeSpan as necessary.
 	isReverse := ba.IsReverse()
 	for i, resp := range br.Responses {
 		req := ba.Requests[i].GetInner()
-		if !roachpb.IsRange(req) {
-			continue
-		}
 		hdr := resp.GetInner().Header()
-		hdr.ResumeReason = resumeReason
-		origSpan := req.Header().Span()
+		maybeSetResumeSpan(req, &hdr, nextKey, isReverse)
+		if hdr.ResumeSpan != nil {
+			hdr.ResumeReason = resumeReason
+		}
+		br.Responses[i].GetInner().SetHeader(hdr)
+	}
+}
+
+// maybeSetResumeSpan sets or corrects the ResumeSpan in the response header, if
+// necessary.
+//
+// nextKey is the first key that was not processed.
+func maybeSetResumeSpan(
+	req roachpb.Request, hdr *roachpb.ResponseHeader, nextKey roachpb.RKey, isReverse bool,
+) {
+	if _, ok := req.(*roachpb.GetRequest); ok {
+		// This is a Get request. There are three possibilities:
+		//
+		//  1. The request was completed. In this case we don't want a ResumeSpan.
+		//
+		//  2. The request was not completed but it was part of a request that made
+		//     it to a kvserver (i.e. it was part of the last range we operated on).
+		//     In this case the ResumeSpan should be set by the kvserver and we can
+		//     leave it alone.
+		//
+		//  3. The request was not completed and was not sent to a kvserver (it was
+		//     beyond the last range we operated on). In this case we need to set
+		//     the ResumeSpan here.
+		if hdr.ResumeSpan != nil {
+			// Case 2.
+			return
+		}
+		key := req.Header().Span().Key
 		if isReverse {
-			if hdr.ResumeSpan != nil {
-				// The ResumeSpan.Key might be set to the StartKey of a range;
-				// correctly set it to the Key of the original request span.
-				hdr.ResumeSpan.Key = origSpan.Key
-			} else if roachpb.RKey(origSpan.Key).Less(nextKey) {
+			if !nextKey.Less(roachpb.RKey(key)) {
+				// key <= nextKey, so this request was not completed (case 3).
+				hdr.ResumeSpan = &roachpb.Span{Key: key}
+			}
+		} else {
+			if !roachpb.RKey(key).Less(nextKey) {
+				// key >= nextKey, so this request was not completed (case 3).
+				hdr.ResumeSpan = &roachpb.Span{Key: key}
+			}
+		}
+		return
+	}
+
+	if !roachpb.IsRange(req) {
+		return
+	}
+
+	origSpan := req.Header().Span()
+	if isReverse {
+		if hdr.ResumeSpan != nil {
+			// The ResumeSpan.Key might be set to the StartKey of a range;
+			// correctly set it to the Key of the original request span.
+			hdr.ResumeSpan.Key = origSpan.Key
+		} else if roachpb.RKey(origSpan.Key).Less(nextKey) {
+			// Some keys have yet to be processed.
+			hdr.ResumeSpan = new(roachpb.Span)
+			*hdr.ResumeSpan = origSpan
+			if nextKey.Less(roachpb.RKey(origSpan.EndKey)) {
+				// The original span has been partially processed.
+				hdr.ResumeSpan.EndKey = nextKey.AsRawKey()
+			}
+		}
+	} else {
+		if hdr.ResumeSpan != nil {
+			// The ResumeSpan.EndKey might be set to the EndKey of a range because
+			// that's what a store will set it to when the limit is reached; it
+			// doesn't know any better). In that case, we correct it to the EndKey
+			// of the original request span. Note that this doesn't touch
+			// ResumeSpan.Key, which is really the important part of the ResumeSpan.
+			hdr.ResumeSpan.EndKey = origSpan.EndKey
+		} else {
+			// The request might have been fully satisfied, in which case it doesn't
+			// need a ResumeSpan, or it might not have. Figure out if we're in the
+			// latter case.
+			if nextKey.Less(roachpb.RKey(origSpan.EndKey)) {
 				// Some keys have yet to be processed.
 				hdr.ResumeSpan = new(roachpb.Span)
 				*hdr.ResumeSpan = origSpan
-				if nextKey.Less(roachpb.RKey(origSpan.EndKey)) {
+				if roachpb.RKey(origSpan.Key).Less(nextKey) {
 					// The original span has been partially processed.
-					hdr.ResumeSpan.EndKey = nextKey.AsRawKey()
-				}
-			}
-		} else {
-			if hdr.ResumeSpan != nil {
-				// The ResumeSpan.EndKey might be set to the EndKey of a range because
-				// that's what a store will set it to when the limit is reached; it
-				// doesn't know any better). In that case, we correct it to the EndKey
-				// of the original request span. Note that this doesn't touch
-				// ResumeSpan.Key, which is really the important part of the ResumeSpan.
-				hdr.ResumeSpan.EndKey = origSpan.EndKey
-			} else {
-				// The request might have been fully satisfied, in which case it doesn't
-				// need a ResumeSpan, or it might not have. Figure out if we're in the
-				// latter case.
-				if nextKey.Less(roachpb.RKey(origSpan.EndKey)) {
-					// Some keys have yet to be processed.
-					hdr.ResumeSpan = new(roachpb.Span)
-					*hdr.ResumeSpan = origSpan
-					if roachpb.RKey(origSpan.Key).Less(nextKey) {
-						// The original span has been partially processed.
-						hdr.ResumeSpan.Key = nextKey.AsRawKey()
-					}
+					hdr.ResumeSpan.Key = nextKey.AsRawKey()
 				}
 			}
 		}
-		br.Responses[i].GetInner().SetHeader(hdr)
 	}
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -654,3 +654,31 @@ ALTER TABLE table58683_1 EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_
 CREATE TABLE table58683_2 (col2 BOOL);
 ALTER TABLE table58683_2 EXPERIMENTAL_RELOCATE SELECT ARRAY[2], 2;
 SELECT every(col2) FROM table58683_1 JOIN table58683_2 ON col1 = (table58683_2.tableoid)::INT8 GROUP BY col2 HAVING bool_and(col2);
+
+# Regression test for #74736 - missing Get results when:
+#  - multiple ranges are involved, but the scan is not distributed; and
+#  - we need to paginate; and
+#  - the cardinality of the scan is more than ParallelScanResultThreshold.
+statement ok
+CREATE TABLE table74736 (k INT PRIMARY KEY, blob STRING);
+ALTER TABLE table74736 SPLIT AT VALUES (1000000);
+ALTER TABLE table74736 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0), (ARRAY[2], 1000000);
+INSERT INTO table74736 SELECT x * 10000, repeat('a', 200000) FROM generate_series(1, 130) AS g(x);
+
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE table74736]
+----
+start_key  end_key   replicas  lease_holder
+NULL       /1000000  {1}       1
+/1000000   NULL      {2}       2
+
+statement ok
+SET DISTSQL = OFF
+
+query II
+SELECT count(*), sum_int(length(blob)) FROM table74736 WHERE (k >= 1 AND k <= 900000) OR k = 1200000 OR k = 1250000;
+----
+92  18400000
+
+statement ok
+SET DISTSQL = ON

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -558,6 +558,9 @@ func (f *txnKVFetcher) nextBatch(
 					"we're only scanning non-overlapping spans. New spans: %s",
 				catalogkeys.PrettySpans(nil, f.spans, 0 /* skip */))
 		}
+
+		// Any requests that were not fully completed will have the ResumeSpan set.
+		// Here we accumulate all of them.
 		if resumeSpan := header.ResumeSpan; resumeSpan != nil {
 			f.spansScratch[f.newFetchSpansIdx] = *resumeSpan
 			f.newFetchSpansIdx++


### PR DESCRIPTION
Backport 1/1 commits from #75475.

The test in the original PR was hitting a panic because Get and ReverseScan cannot be combined on 21.2. I added a check in the test to skip that combination.

Also, with the new code I've effectively backported the ResumeReason change in https://github.com/cockroachdb/cockroach/pull/71376/commits/46a0365f1acc3917a6dfeb7da3b81445ee015517 as well, @erikgrinaker do you see any issue with including that in this backport?

/cc @cockroachdb/release

Release justification: fixes bug that causes incorrect query results.

---

The distsender is not fully implementing the ResumeSpan contract for
Get; the promise is that a nil span is set when the operation has
successfully completed.

A Get that reaches a kvserver but that is not executed has the
ResumeSpan set on the server side. But if the requests span multiple
ranges, a subset of the requests will not make it to any kvserver.

This change fills in the missing case and improves the
TestMultiRangeScanWithPagination test to allow running mixed
operations.

Fixes #74736.

Release note (bug fix): In particular cases, some queries that involve
a scan which returns many results and which includes lookups for
individual keys were not returning all results from the table.
