### PR TITLE
sql: de-flake inverted_filter_geospatial_dist

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_filter_geospatial_dist
@@ -208,7 +208,7 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUlN9v2jAQx9_3V
 #
 # TODO(treilly): What the text above claims does not square with the figure
 # generated below.
-query T
+query T retry
 EXPLAIN (DISTSQL)
 SELECT k FROM geo_table WHERE ST_CoveredBy('MULTIPOINT((2.2 2.2), (3.0 3.0))'::geometry, geom) ORDER BY k
 ----


### PR DESCRIPTION
Fixes: #75497

Add a retry to a test flaking due to distsender span config cache issues.

Release note: None