### PR TITLE
tracing: fix span use after release when parent and child finish concurrently

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -486,6 +486,10 @@ type TracerTestingKnobs struct {
 	// MaintainAllocationCounters, if set,  configures the Tracer to maintain
 	// counters about span creation. See Tracer.GetStatsAndReset().
 	MaintainAllocationCounters bool
+	// ReleaseSpanToPool, if set, if called just before a span is put in the
+	// sync.Pool for reuse. If the hook returns false, the span will not be put in
+	// the pool.
+	ReleaseSpanToPool func(*Span) bool
 }
 
 // Redactable returns true if the tracer is configured to emit
@@ -943,7 +947,13 @@ func (t *Tracer) releaseSpanToPool(sp *Span) {
 	h.childrenAlloc = [4]childRef{}
 	h.structuredEventsAlloc = [3]interface{}{}
 
-	t.spanPool.Put(h)
+	release := true
+	if fn := t.testing.ReleaseSpanToPool; fn != nil {
+		release = fn(sp)
+	}
+	if release {
+		t.spanPool.Put(h)
+	}
 }
 
 // StartSpanCtx starts a Span and returns it alongside a wrapping Context
@@ -959,6 +969,9 @@ func (t *Tracer) StartSpanCtx(
 	// `opts` on the heap here.
 	var opts spanOptions
 	for _, o := range os {
+		if o == nil {
+			continue
+		}
 		opts = o.apply(opts)
 	}
 


### PR DESCRIPTION
Before this patch, it was possible for a span to be released to the
sync.Pool and reused while the tracing code was still holding a
reference to it. This was because a span could maintain unaccounted
references to its children even after those children were released. And
those reference could be inadvertently used, causing a data race and
trace corruption.

This race had two parts:
1) s.mu.openChildren could still hold references to children after
   s.finish() terminated. Those references were unaccounted for, so
   those children could be reused if they finish. This would be fine (or
   at least benign) by itself (since a finished span should generally
   not be accessed), if it wasn't for 2).
2) s' recording can be collected after s.Finish() ran, and that would
   call into s' child.

In order to trigger the bad behavior, I believe you need a child and a
parent to finish() concurrently, and a chain of 4 spans in parent-child
relationships. Lets call the spans ggp, gp, p, c (g=grand, p=parent,
c=child). The race scenario goes like this:

1. gp.Finish() is called; gp.mu.finished is set early.
2. p.Finish() is called; p.mu.finished is set early.
3. c.Finish() is called. c calls into p (p.childFinished(c)), asking p
   to remove c from c.mu.openChildren, and to collect its recording if
   it wants to. This call is a no-op because p.mu.finished is already set.
4. p.Finish() terminates. c remains part of c.mu.openChildren, but the
   corresponding reference count on c is decremented. Similarly, p
   remains part of gp.mu.openChildren.
5. c.Finish() terminates. c's reference count drops to zero (because p
   no longer counts a reference to it). c is release to the pool, and
   reused.
6. gp.Finish() resumes and calls into ggp (ggp.childFinished(gp)). ggp
   collects gp's recording, and recursively that calls into p, and then
   c. This is a data race, since c was already reused.

To fix this, we have p.childFinished(c) no longer automatically be a
no-op when p is already finished. Instead, if c is still part of
c.mu.openChildren, it will be removed. This way, when c.finish()
completes, we know that c is not reference any more by the parent.  We
also wipe p.mu.openChildren at the end of p.Finish(). This way, if a
child c calls p.childFinish(c) afterwards, that call will be
short-circuited and c's recording will not be needlessly collected.

Release note: None

Fixes #75495
Fixes #75414
Fixes #75334