### PR TITLE
cli: add tracing to `debug send-kv-batch`

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -69,6 +69,7 @@ func initCLIDefaults() {
 	setUserfileContextDefaults()
 	setCertContextDefaults()
 	setDebugRecoverContextDefaults()
+	setDebugSendKVBatchContextDefaults()
 
 	initPreFlagsDefaults()
 

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1700,6 +1700,14 @@ func init() {
 	f.Var(&debugTimeSeriesDumpOpts.format, "format", "output format (text, csv, tsv, raw)")
 	f.Var(&debugTimeSeriesDumpOpts.from, "from", "oldest timestamp to include (inclusive)")
 	f.Var(&debugTimeSeriesDumpOpts.to, "to", "newest timestamp to include (inclusive)")
+
+	f = debugSendKVBatchCmd.Flags()
+	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,
+		"which format to use for the trace output (off, text, jaeger)")
+	f.BoolVar(&debugSendKVBatchContext.keepCollectedSpans, "keep-collected-spans", debugSendKVBatchContext.keepCollectedSpans,
+		"whether to keep the CollectedSpans field on the response, to learn about how traces work")
+	f.StringVar(&debugSendKVBatchContext.traceFile, "trace-output", debugSendKVBatchContext.traceFile,
+		"the output file to use for the trace. If left empty, output to stderr.")
 }
 
 func initPebbleCmds(cmd *cobra.Command) {

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1220,7 +1220,11 @@ func getClientGRPCConn(
 	// cluster, so there's no need to enforce that its max offset is the same
 	// as that of nodes in the cluster.
 	clock := hlc.NewClock(hlc.UnixNano, 0)
-	stopper := stop.NewStopper()
+	tracer := cfg.Tracer
+	if tracer == nil {
+		tracer = tracing.NewTracer()
+	}
+	stopper := stop.NewStopper(stop.WithTracer(tracer))
 	rpcContext := rpc.NewContext(ctx,
 		rpc.ContextOptions{
 			TenantID: roachpb.SystemTenantID,

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2707,11 +2707,11 @@ func (s *adminServer) SendKVBatch(
 	}
 	log.StructuredEvent(ctx, event)
 
-	// Send the batch to KV.
+	ctx, finishSpan := s.server.node.setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba)
+	var br *roachpb.BatchResponse
+	defer func() { finishSpan(ctx, br) }()
 	br, pErr := s.server.db.NonTransactionalSender().Send(ctx, *ba)
-	if pErr != nil {
-		return nil, pErr.GoError()
-	}
+	br.Error = pErr
 	return br, nil
 }
 

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -90,6 +90,9 @@ func setGRPCErrorTag(sp *Span, err error) {
 // BatchMethodName is the method name of Internal.Batch RPC.
 const BatchMethodName = "/cockroach.roachpb.Internal/Batch"
 
+// SendKVBatchMethodName is the method name for adminServer.SendKVBatch.
+const SendKVBatchMethodName = "/cockroach.server.serverpb.Admin/SendKVBatch"
+
 // SetupFlowMethodName is the method name of DistSQL.SetupFlow RPC.
 const SetupFlowMethodName = "/cockroach.sql.distsqlrun.DistSQL/SetupFlow"
 const flowStreamMethodName = "/cockroach.sql.distsqlrun.DistSQL/FlowStream"
@@ -101,7 +104,9 @@ const flowStreamMethodName = "/cockroach.sql.distsqlrun.DistSQL/FlowStream"
 // interceptors deal with it. Others (DistSQL.FlowStream) are simply exempt from
 // tracing because it's not worth it.
 func methodExcludedFromTracing(method string) bool {
-	return method == BatchMethodName || method == SetupFlowMethodName ||
+	return method == BatchMethodName ||
+		method == SendKVBatchMethodName ||
+		method == SetupFlowMethodName ||
 		method == flowStreamMethodName
 }
 


### PR DESCRIPTION
This extends the `debug send-kv-batch` CLI utility to optionally
collect and print a trace of the remote processing.

(big thanks to @andreimatei for the help)

