### PR TITLE
cmd/dev: check cmake version is new enough

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=6
+DEV_VERSION=7
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
The version automatically install on new gceworkers by bootstrap debian has been
updated but existing dev machines may have old versions. Detect this and prompt
them to update.

Release note: none.