### PR TITLE
release-21.2: ui: move loading and error pages to below page settings

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -209,7 +209,6 @@ export class TransactionsPage extends React.Component<
 
   componentDidUpdate(): void {
     this.updateQueryParams();
-    this.refreshData();
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {
@@ -329,54 +328,99 @@ export class TransactionsPage extends React.Component<
   };
 
   render(): React.ReactElement {
+    const {
+      data,
+      resetSQLStats,
+      nodeRegions,
+      isTenant,
+      onColumnsChange,
+      columns: userSelectedColumnsToShow,
+      sortSetting,
+      search,
+    } = this.props;
+    const internal_app_name_prefix = data?.internal_app_name_prefix || "";
+    const statements = data?.statements || [];
+    const { filters } = this.state;
+
+    // If the cluster is a tenant cluster we don't show info
+    // about nodes/regions.
+    const nodes = isTenant
+      ? []
+      : Object.keys(nodeRegions)
+          .map(n => Number(n))
+          .sort();
+    const regions = isTenant
+      ? []
+      : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
+    // We apply the search filters and app name filters prior to aggregating across Node IDs
+    // in order to match what's done on the Statements Page.
+    //
+    // TODO(davidh): Once the redux layer for TransactionsPage is added to this repo,
+    // extract this work into the selector
+    const {
+      transactions: filteredTransactions,
+      activeFilters,
+    } = filterTransactions(
+      searchTransactionsData(search, data?.transactions || [], statements),
+      filters,
+      internal_app_name_prefix,
+      statements,
+      nodeRegions,
+      isTenant,
+    );
+
+    const appNames = getTrxAppFilterOptions(
+      data?.transactions || [],
+      internal_app_name_prefix,
+    );
+
     return (
       <div className={cx("table-area")}>
+        <PageConfig>
+          <PageConfigItem>
+            <Search
+              onSubmit={this.onSubmitSearchField as any}
+              onClear={this.onClearSearchField}
+              defaultValue={search}
+              placeholder={"Search Transactions"}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <Filter
+              onSubmitFilters={this.onSubmitFilters}
+              appNames={appNames}
+              regions={regions}
+              nodes={nodes.map(n => "n" + n)}
+              activeFilters={activeFilters}
+              filters={filters}
+              showRegions={regions.length > 1}
+              showNodes={nodes.length > 1}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <DateRange
+              start={this.props.dateRange[0]}
+              end={this.props.dateRange[1]}
+              onSubmit={this.changeDateRange}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <button className={cx("reset-btn")} onClick={this.resetTime}>
+              reset time
+            </button>
+          </PageConfigItem>
+          <PageConfigItem className={commonStyles("separator")}>
+            <ClearStats
+              resetSQLStats={resetSQLStats}
+              tooltipType="transaction"
+            />
+          </PageConfigItem>
+        </PageConfig>
         <Loading
           loading={!this.props?.data}
           error={this.props?.error}
           render={() => {
-            const {
-              data,
-              resetSQLStats,
-              nodeRegions,
-              isTenant,
-              onColumnsChange,
-              columns: userSelectedColumnsToShow,
-              sortSetting,
-              search,
-            } = this.props;
-            const { pagination, filters } = this.state;
-            const { statements, internal_app_name_prefix } = data;
-            const appNames = getTrxAppFilterOptions(
-              data.transactions,
-              internal_app_name_prefix,
-            );
-            // If the cluster is a tenant cluster we don't show info
-            // about nodes/regions.
-            const nodes = isTenant
-              ? []
-              : Object.keys(nodeRegions)
-                  .map(n => Number(n))
-                  .sort();
-            const regions = isTenant
-              ? []
-              : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
-            // We apply the search filters and app name filters prior to aggregating across Node IDs
-            // in order to match what's done on the Statements Page.
-            //
-            // TODO(davidh): Once the redux layer for TransactionsPage is added to this repo,
-            // extract this work into the selector
-            const {
-              transactions: filteredTransactions,
-              activeFilters,
-            } = filterTransactions(
-              searchTransactionsData(search, data.transactions, statements),
-              filters,
-              internal_app_name_prefix,
-              statements,
-              nodeRegions,
-              isTenant,
-            );
+            const { pagination } = this.state;
             const transactionsToDisplay: TransactionInfo[] = aggregateAcrossNodeIDs(
               filteredTransactions,
               statements,
@@ -435,49 +479,6 @@ export class TransactionsPage extends React.Component<
 
             return (
               <>
-                <PageConfig>
-                  <PageConfigItem>
-                    <Search
-                      onSubmit={this.onSubmitSearchField as any}
-                      onClear={this.onClearSearchField}
-                      defaultValue={search}
-                      placeholder={"Search Transactions"}
-                    />
-                  </PageConfigItem>
-                  <PageConfigItem>
-                    <Filter
-                      onSubmitFilters={this.onSubmitFilters}
-                      appNames={appNames}
-                      regions={regions}
-                      nodes={nodes.map(n => "n" + n)}
-                      activeFilters={activeFilters}
-                      filters={filters}
-                      showRegions={regions.length > 1}
-                      showNodes={nodes.length > 1}
-                    />
-                  </PageConfigItem>
-                  <PageConfigItem>
-                    <DateRange
-                      start={this.props.dateRange[0]}
-                      end={this.props.dateRange[1]}
-                      onSubmit={this.changeDateRange}
-                    />
-                  </PageConfigItem>
-                  <PageConfigItem>
-                    <button
-                      className={cx("reset-btn")}
-                      onClick={this.resetTime}
-                    >
-                      reset time
-                    </button>
-                  </PageConfigItem>
-                  <PageConfigItem className={commonStyles("separator")}>
-                    <ClearStats
-                      resetSQLStats={resetSQLStats}
-                      tooltipType="transaction"
-                    />
-                  </PageConfigItem>
-                </PageConfig>
                 <section className={statisticsClasses.tableContainerClass}>
                   <ColumnsSelector
                     options={tableColumns}


### PR DESCRIPTION
Backport 1/1 commits from #75458.

/cc @cockroachdb/release

Release justification: this fix allows users to issue new requests for stats from the stmt and txns pages when an error is encountered.
---

Fixes: #75247

Previously, the loading and error pages in the statement and txn
pages took up the entire page, including the settings header
used to issue new stats requests. This resulted in the user
being unable to re-issue a query after a query results in
a timeout, as we save the query parameters for re-use on
each request.

Release note (ui change): Loading and error pages are now below
page config in txns and stmts pages.

---------------
https://www.loom.com/share/e903ec74441140be98969c02ebbc7923
