### PR TITLE
ccl/backupccl: skip TestScheduleBackupChainsProtectedTimestampRecords

### DIFF
--- a/pkg/ccl/backupccl/schedule_pts_chaining_test.go
+++ b/pkg/ccl/backupccl/schedule_pts_chaining_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -78,6 +79,7 @@ func checkPTSRecord(
 
 func TestScheduleBackupChainsProtectedTimestampRecords(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 71189, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	th, cleanup := newTestHelper(t)


### PR DESCRIPTION
Refs: #71189

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None