### PR TITLE
ccl/importccl: skip TestImportWorkerFailure

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -5016,6 +5016,7 @@ func TestImportControlJobRBAC(t *testing.T) {
 // worker node.
 func TestImportWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 73546, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	allowResponse := make(chan struct{})


### PR DESCRIPTION
Refs: #73546

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None