### PR TITLE
flowinfra: clean up the flow if the server is quiescing

### DIFF
--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -127,9 +127,11 @@ type Flow interface {
 	// GetID returns the flow ID.
 	GetID() execinfrapb.FlowID
 
-	// Cleanup should be called when the flow completes (after all processors
-	// and mailboxes exited). The implementations must be safe to execute in
-	// case the Flow is never Run() or Start()ed.
+	// Cleanup must be called whenever the flow is done (meaning it either
+	// completes gracefully after all processors and mailboxes exited or an
+	// error is encountered that stops the flow from making progress). The
+	// implementations must be safe to execute in case the Flow is never Run()
+	// or Start()ed.
 	Cleanup(context.Context)
 
 	// ConcurrentTxnUse returns true if multiple processors/operators in the flow
@@ -423,10 +425,7 @@ func (f *FlowBase) IsVectorized() bool {
 
 // Start is part of the Flow interface.
 func (f *FlowBase) Start(ctx context.Context, doneFn func()) error {
-	if err := f.StartInternal(ctx, f.processors, doneFn); err != nil {
-		return err
-	}
-	return nil
+	return f.StartInternal(ctx, f.processors, doneFn)
 }
 
 // Run is part of the Flow interface.

--- a/pkg/sql/flowinfra/flow_scheduler.go
+++ b/pkg/sql/flowinfra/flow_scheduler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 )
 
 const flowDoneChanSize = 8
@@ -177,6 +178,7 @@ func (fs *FlowScheduler) runFlowNow(ctx context.Context, f Flow, locked bool) er
 		fs.mu.Unlock()
 	}
 	if err := f.Start(ctx, func() { fs.flowDoneCh <- f }); err != nil {
+		f.Cleanup(ctx)
 		return err
 	}
 	// TODO(radu): we could replace the WaitGroup with a structure that keeps a
@@ -192,12 +194,13 @@ func (fs *FlowScheduler) runFlowNow(ctx context.Context, f Flow, locked bool) er
 }
 
 // ScheduleFlow is the main interface of the flow scheduler: it runs or enqueues
-// the given flow.
+// the given flow. If the flow is not enqueued, it is guaranteed to be cleaned
+// up when this function returns.
 //
 // If the flow can start immediately, errors encountered when starting the flow
 // are returned. If the flow is enqueued, these error will be later ignored.
 func (fs *FlowScheduler) ScheduleFlow(ctx context.Context, f Flow) error {
-	return fs.stopper.RunTaskWithErr(
+	err := fs.stopper.RunTaskWithErr(
 		ctx, "flowinfra.FlowScheduler: scheduling flow", func(ctx context.Context) error {
 			fs.metrics.FlowsScheduled.Inc(1)
 			telemetry.Inc(sqltelemetry.DistSQLFlowsScheduled)
@@ -217,6 +220,11 @@ func (fs *FlowScheduler) ScheduleFlow(ctx context.Context, f Flow) error {
 			return nil
 
 		})
+	if err != nil && errors.Is(err, stop.ErrUnavailable) {
+		// If the server is quiescing, we have to explicitly clean up the flow.
+		f.Cleanup(ctx)
+	}
+	return err
 }
 
 // NumFlowsInQueue returns the number of flows currently in the queue to be


### PR DESCRIPTION
Previously, there were some edge cases when `Flow.Cleanup` was never
called (although it was expected to be). In particular, this could
happen on the remote node if the server is quiescing when `ScheduleFlow`
is called. This would lead to the tracing span created in `setupFlow` be
unfinished. This commit audits all the code paths where we're creating
flows and where we're done with them to make sure that all created flows
are always cleaned up.

Fixes: #75432.

Release note: None