### PR TITLE
sql: add builtin functions to revalidate unique constraints

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2998,6 +2998,15 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.reset_sql_stats"></a><code>crdb_internal.reset_sql_stats() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to clear the collected SQL statistics.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.revalidate_unique_constraint"></a><code>crdb_internal.revalidate_unique_constraint(table_name: <a href="string.html">string</a>, constraint_name: <a href="string.html">string</a>) &rarr; void</code></td><td><span class="funcdesc"><p>This function is used to revalidate the given unique constraint in the given
+table. Returns an error if validation fails.</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.revalidate_unique_constraints_in_all_tables"></a><code>crdb_internal.revalidate_unique_constraints_in_all_tables() &rarr; void</code></td><td><span class="funcdesc"><p>This function is used to revalidate all unique constraints in tables
+in the current database. Returns an error if validation fails.</p>
+</span></td></tr>
+<tr><td><a name="crdb_internal.revalidate_unique_constraints_in_table"></a><code>crdb_internal.revalidate_unique_constraints_in_table(table_name: <a href="string.html">string</a>) &rarr; void</code></td><td><span class="funcdesc"><p>This function is used to revalidate all unique constraints in the given
+table. Returns an error if validation fails.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.round_decimal_values"></a><code>crdb_internal.round_decimal_values(val: <a href="decimal.html">decimal</a>, scale: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>This function is used internally to round decimal values during mutations.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.round_decimal_values"></a><code>crdb_internal.round_decimal_values(val: <a href="decimal.html">decimal</a>[], scale: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>This function is used internally to round decimal array values during mutations.</p>

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -29,8 +29,10 @@ go_test(
         "regional_by_row_test.go",
         "roundtrips_test.go",
         "show_test.go",
+        "unique_test.go",
     ],
     data = glob(["testdata/**"]),
+    embed = [":multiregionccl"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/multiregionccl/unique_test.go
+++ b/pkg/ccl/multiregionccl/unique_test.go
@@ -1,0 +1,240 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package multiregionccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateUniqueConstraints tests that the builtin functions
+// crdb_internal.revalidate_unique_constraint* can find unique constraint
+// violations.
+func TestValidateUniqueConstraints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	r := sqlutils.MakeSQLRunner(db)
+
+	// Create two tables and a view.
+	_, err := db.Exec(`
+CREATE DATABASE test; USE test;
+SET experimental_enable_unique_without_index_constraints = true;
+SET experimental_enable_implicit_column_partitioning = true;
+CREATE TABLE t (k INT PRIMARY KEY, v INT UNIQUE WITHOUT INDEX);
+CREATE VIEW v AS SELECT k, v FROM t;
+CREATE TABLE u (
+  k INT PRIMARY KEY,
+  v INT UNIQUE,
+  partition_by INT
+) PARTITION ALL BY LIST (partition_by) (
+  PARTITION one VALUES IN (1),
+  PARTITION two VALUES IN (2)
+);
+`)
+	require.NoError(t, err)
+
+	// insertValuesT inserts values into table t, bypassing the SQL layer.
+	// This will allow us to insert data that violates unique constraints.
+	insertValuesT := func(values []tree.Datum) {
+		// Get the table descriptor and primary index of t.
+		tableDesc := desctestutils.TestingGetTableDescriptor(
+			kvDB, keys.SystemSQLCodec, "test", "public", "t",
+		)
+		primaryIndex := tableDesc.GetPrimaryIndex()
+
+		var colIDtoRowIndex catalog.TableColMap
+		colIDtoRowIndex.Set(tableDesc.PublicColumns()[0].GetID(), 0)
+		colIDtoRowIndex.Set(tableDesc.PublicColumns()[1].GetID(), 1)
+
+		// Construct the primary index entry to insert.
+		primaryIndexEntry, err := rowenc.EncodePrimaryIndex(
+			keys.SystemSQLCodec, tableDesc, primaryIndex, colIDtoRowIndex, values, true, /* includeEmpty */
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(primaryIndexEntry))
+
+		// Insert the entry into the index.
+		err = kvDB.Put(context.Background(), primaryIndexEntry[0].Key, &primaryIndexEntry[0].Value)
+		require.NoError(t, err)
+	}
+
+	// insertValuesU inserts values into table u, bypassing the SQL layer.
+	// This will allow us to insert data that violates unique constraints.
+	insertValuesU := func(values []tree.Datum) {
+		// Get the table descriptor and indexes of u.
+		tableDesc := desctestutils.TestingGetTableDescriptor(
+			kvDB, keys.SystemSQLCodec, "test", "public", "u",
+		)
+		primaryIndex := tableDesc.GetPrimaryIndex()
+		secondaryIndex := tableDesc.PublicNonPrimaryIndexes()[0]
+
+		var colIDtoRowIndex catalog.TableColMap
+		colIDtoRowIndex.Set(tableDesc.PublicColumns()[0].GetID(), 0)
+		colIDtoRowIndex.Set(tableDesc.PublicColumns()[1].GetID(), 1)
+		colIDtoRowIndex.Set(tableDesc.PublicColumns()[2].GetID(), 2)
+
+		// Construct the primary and secondary index entries to insert.
+		primaryIndexEntry, err := rowenc.EncodePrimaryIndex(
+			keys.SystemSQLCodec, tableDesc, primaryIndex, colIDtoRowIndex, values, true, /* includeEmpty */
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(primaryIndexEntry))
+		secondaryIndexEntry, err := rowenc.EncodeSecondaryIndex(
+			keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(secondaryIndexEntry))
+
+		// Insert the entries into the indexes.
+		err = kvDB.Put(context.Background(), primaryIndexEntry[0].Key, &primaryIndexEntry[0].Value)
+		require.NoError(t, err)
+		err = kvDB.Put(context.Background(), secondaryIndexEntry[0].Key, &secondaryIndexEntry[0].Value)
+		require.NoError(t, err)
+	}
+
+	t.Run("validate_unique_without_index", func(t *testing.T) {
+		// Insert a couple of rows into table t.
+		_, err := db.Exec(`INSERT INTO test.t VALUES (10, 10), (20, 20)`)
+		require.NoError(t, err)
+
+		// Verify that we get no validation error.
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('t')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('u')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 't_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 'unique_v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
+
+		// Insert a row into table t that has a duplicate value for v.
+		values := []tree.Datum{tree.NewDInt(30), tree.NewDInt(10)}
+		insertValuesT(values)
+		r.CheckQueryResults(
+			t, `SELECT * FROM test.t`, [][]string{{"10", "10"}, {"20", "20"}, {"30", "10"}},
+		)
+
+		// Verify that we get a validation error for table t, constraint unique_v.
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()`)
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraints_in_table('t')`)
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraint('t', 'unique_v')`)
+
+		// The other tables should not err.
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('u')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 't_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
+
+		// Clean up.
+		_, err = db.Exec(`TRUNCATE test.t`)
+		require.NoError(t, err)
+	})
+
+	t.Run("validate_implicitly_partitioned_primary_index", func(t *testing.T) {
+		// Insert a couple of rows into table u.
+		_, err := db.Exec(`INSERT INTO test.u VALUES (10, 10, 1), (20, 20, 1)`)
+		require.NoError(t, err)
+
+		// Verify that we get no validation error.
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('t')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('u')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 't_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 'unique_v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
+
+		// Insert a row into table u that has a duplicate value for k.
+		values := []tree.Datum{tree.NewDInt(10), tree.NewDInt(30), tree.NewDInt(2)}
+		insertValuesU(values)
+		r.CheckQueryResults(
+			t, `SELECT * FROM test.u`, [][]string{{"10", "10", "1"}, {"20", "20", "1"}, {"10", "30", "2"}},
+		)
+
+		// Verify that we get an error for table u, constraint u_pkey.
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()`)
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraints_in_table('u')`)
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
+
+		// The other tables should not err.
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('t')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 't_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 'unique_v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
+
+		// Clean up.
+		_, err = db.Exec(`TRUNCATE test.u`)
+		require.NoError(t, err)
+	})
+
+	t.Run("validate_implicitly_partitioned_secondary_index", func(t *testing.T) {
+		// Insert a couple of rows into table u.
+		_, err := db.Exec(`INSERT INTO test.u VALUES (100, 100, 1), (200, 200, 1)`)
+		require.NoError(t, err)
+
+		// Verify that we get no validation error.
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('t')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('u')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 't_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 'unique_v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
+
+		// Insert a row into table u that has a duplicate value for v.
+		values := []tree.Datum{tree.NewDInt(300), tree.NewDInt(100), tree.NewDInt(2)}
+		insertValuesU(values)
+		r.CheckQueryResults(
+			t, `SELECT * FROM test.u`, [][]string{{"100", "100", "1"}, {"200", "200", "1"}, {"300", "100", "2"}},
+		)
+
+		// Verify that we get an error for table u, constraint u_v_key.
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()`)
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraints_in_table('u')`)
+		r.ExpectErr(t, `failed to validate unique constraint`,
+			`SELECT crdb_internal.revalidate_unique_constraint('u', 'u_v_key')`)
+
+		// The other tables should not err.
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('t')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraints_in_table('v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 't_pkey')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('t', 'unique_v')`)
+		r.Exec(t, `SELECT crdb_internal.revalidate_unique_constraint('u', 'u_pkey')`)
+
+		// Clean up.
+		_, err = db.Exec(`TRUNCATE test.u`)
+		require.NoError(t, err)
+	})
+
+}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1709,6 +1709,7 @@ func ValidateForwardIndexes(
 							idx.GetPredicate(),
 							ie,
 							txn,
+							false, /* preExisting */
 						); err != nil {
 							return err
 						}
@@ -2263,7 +2264,9 @@ func validateUniqueWithoutIndexConstraintInTxn(
 	}
 
 	return ie.WithSyntheticDescriptors(syntheticDescs, func() error {
-		return validateUniqueConstraint(ctx, tableDesc, uc.Name, uc.ColumnIDs, uc.Predicate, ie, txn)
+		return validateUniqueConstraint(
+			ctx, tableDesc, uc.Name, uc.ColumnIDs, uc.Predicate, ie, txn, false, /* preExisting */
+		)
 	})
 }
 

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -358,11 +358,171 @@ func duplicateRowQuery(
 	), colNames, nil
 }
 
+// RevalidateUniqueConstraintsInCurrentDB verifies that all unique constraints
+// defined on tables in the current database are valid. In other words, it
+// verifies that for every table in the database with one or more unique
+// constraints, all rows in the table have unique values for every unique
+// constraint defined on the table.
+func (p *planner) RevalidateUniqueConstraintsInCurrentDB(ctx context.Context) error {
+	dbName := p.CurrentDatabase()
+	log.Infof(ctx, "validating unique constraints in database %s", dbName)
+	db, err := p.Descriptors().GetImmutableDatabaseByName(
+		ctx, p.Txn(), dbName, tree.DatabaseLookupFlags{Required: true},
+	)
+	if err != nil {
+		return err
+	}
+	tableDescs, err := p.Descriptors().GetAllTableDescriptorsInDatabase(ctx, p.Txn(), db.GetID())
+	if err != nil {
+		return err
+	}
+
+	for _, tableDesc := range tableDescs {
+		if err = p.revalidateUniqueConstraintsInTable(ctx, tableDesc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RevalidateUniqueConstraintsInTable verifies that all unique constraints
+// defined on the given table are valid. In other words, it verifies that all
+// rows in the table have unique values for every unique constraint defined on
+// the table.
+func (p *planner) RevalidateUniqueConstraintsInTable(ctx context.Context, tableID int) error {
+	tableDesc, err := p.Descriptors().GetImmutableTableByID(
+		ctx,
+		p.Txn(),
+		descpb.ID(tableID),
+		tree.ObjectLookupFlagsWithRequired(),
+	)
+	if err != nil {
+		return err
+	}
+	return p.revalidateUniqueConstraintsInTable(ctx, tableDesc)
+}
+
+// RevalidateUniqueConstraint verifies that the given unique constraint on the
+// given table is valid. In other words, it verifies that all rows in the
+// table have unique values for the columns in the constraint. Returns an
+// error if validation fails or if constraintName is not actually a unique
+// constraint on the table.
+func (p *planner) RevalidateUniqueConstraint(
+	ctx context.Context, tableID int, constraintName string,
+) error {
+	tableDesc, err := p.Descriptors().GetImmutableTableByID(
+		ctx,
+		p.Txn(),
+		descpb.ID(tableID),
+		tree.ObjectLookupFlagsWithRequired(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Check implicitly partitioned UNIQUE indexes.
+	for _, index := range tableDesc.ActiveIndexes() {
+		if index.GetName() == constraintName {
+			if !index.IsUnique() {
+				return errors.Newf("%s is not a unique constraint", constraintName)
+			}
+			if index.GetPartitioning().NumImplicitColumns() > 0 {
+				return validateUniqueConstraint(
+					ctx,
+					tableDesc,
+					index.GetName(),
+					index.IndexDesc().KeyColumnIDs[index.GetPartitioning().NumImplicitColumns():],
+					index.GetPredicate(),
+					p.ExecCfg().InternalExecutor,
+					p.Txn(),
+					true, /* preExisting */
+				)
+			}
+			// We found the unique index but we don't need to bother validating it.
+			return nil
+		}
+	}
+
+	// Check UNIQUE WITHOUT INDEX constraints.
+	for _, uc := range tableDesc.GetUniqueWithoutIndexConstraints() {
+		if uc.Name == constraintName {
+			return validateUniqueConstraint(
+				ctx,
+				tableDesc,
+				uc.Name,
+				uc.ColumnIDs,
+				uc.Predicate,
+				p.ExecCfg().InternalExecutor,
+				p.Txn(),
+				true, /* preExisting */
+			)
+		}
+	}
+
+	return errors.Newf("unique constraint %s does not exist", constraintName)
+}
+
+// revalidateUniqueConstraintsInTable verifies that all unique constraints
+// defined on the given table are valid. In other words, it verifies that all
+// rows in the table have unique values for every unique constraint defined on
+// the table.
+//
+// Note that we only need to validate UNIQUE constraints that are not already
+// enforced by an index. This includes implicitly partitioned UNIQUE indexes
+// and UNIQUE WITHOUT INDEX constraints.
+func (p *planner) revalidateUniqueConstraintsInTable(
+	ctx context.Context, tableDesc catalog.TableDescriptor,
+) error {
+	// Check implicitly partitioned UNIQUE indexes.
+	for _, index := range tableDesc.ActiveIndexes() {
+		if index.IsUnique() && index.GetPartitioning().NumImplicitColumns() > 0 {
+			if err := validateUniqueConstraint(
+				ctx,
+				tableDesc,
+				index.GetName(),
+				index.IndexDesc().KeyColumnIDs[index.GetPartitioning().NumImplicitColumns():],
+				index.GetPredicate(),
+				p.ExecCfg().InternalExecutor,
+				p.Txn(),
+				true, /* preExisting */
+			); err != nil {
+				log.Errorf(ctx, "validation of unique constraints failed for table %s: %s", tableDesc.GetName(), err)
+				return errors.Wrapf(err, "for table %s", tableDesc.GetName())
+			}
+		}
+	}
+
+	// Check UNIQUE WITHOUT INDEX constraints.
+	for _, uc := range tableDesc.GetUniqueWithoutIndexConstraints() {
+		if uc.Validity == descpb.ConstraintValidity_Validated {
+			if err := validateUniqueConstraint(
+				ctx,
+				tableDesc,
+				uc.Name,
+				uc.ColumnIDs,
+				uc.Predicate,
+				p.ExecCfg().InternalExecutor,
+				p.Txn(),
+				true, /* preExisting */
+			); err != nil {
+				log.Errorf(ctx, "validation of unique constraints failed for table %s: %s", tableDesc.GetName(), err)
+				return errors.Wrapf(err, "for table %s", tableDesc.GetName())
+			}
+		}
+	}
+
+	log.Infof(ctx, "validated all unique constraints in table %s", tableDesc.GetName())
+	return nil
+}
+
 // validateUniqueConstraint verifies that all the rows in the srcTable
 // have unique values for the given columns.
 //
 // It operates entirely on the current goroutine and is thus able to
 // reuse an existing kv.Txn safely.
+//
+// preExisting indicates whether this constraint already exists, and therefore
+// informs the error message that gets produced.
 func validateUniqueConstraint(
 	ctx context.Context,
 	srcTable catalog.TableDescriptor,
@@ -371,6 +531,7 @@ func validateUniqueConstraint(
 	pred string,
 	ie sqlutil.InternalExecutor,
 	txn *kv.Txn,
+	preExisting bool,
 ) error {
 	query, colNames, err := duplicateRowQuery(
 		srcTable, columnIDs, pred, true, /* limitResults */
@@ -398,10 +559,14 @@ func validateUniqueConstraint(
 		}
 		// Note: this error message mirrors the message produced by Postgres
 		// when it fails to add a unique index due to duplicated keys.
+		errMsg := "could not create unique constraint"
+		if preExisting {
+			errMsg = "failed to validate unique constraint"
+		}
 		return errors.WithDetail(
 			pgerror.WithConstraintName(
 				pgerror.Newf(
-					pgcode.UniqueViolation, "could not create unique constraint %q", constraintName,
+					pgcode.UniqueViolation, "%s %q", errMsg, constraintName,
 				),
 				constraintName,
 			),

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -255,6 +255,25 @@ func (*DummyEvalPlanner) ValidateSessionRevivalToken(token *tree.DBytes) (*tree.
 	return nil, errors.WithStack(errEvalPlanner)
 }
 
+// RevalidateUniqueConstraintsInCurrentDB is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) RevalidateUniqueConstraintsInCurrentDB(ctx context.Context) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
+// RevalidateUniqueConstraintsInTable is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) RevalidateUniqueConstraintsInTable(
+	ctx context.Context, tableID int,
+) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
+// RevalidateUniqueConstraint is part of the EvalPlanner interface.
+func (*DummyEvalPlanner) RevalidateUniqueConstraint(
+	ctx context.Context, tableID int, constraintName string,
+) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
 // ExecutorConfig is part of the EvalPlanner interface.
 func (*DummyEvalPlanner) ExecutorConfig() interface{} {
 	return nil

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6477,6 +6477,76 @@ table's zone configuration this will return NULL.`,
 			Volatility: tree.VolatilityVolatile,
 		},
 	),
+
+	"crdb_internal.revalidate_unique_constraints_in_all_tables": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.RevalidateUniqueConstraintsInCurrentDB(evalCtx.Ctx()); err != nil {
+					return nil, err
+				}
+				return tree.DVoidDatum, nil
+			},
+			Info: `This function is used to revalidate all unique constraints in tables
+in the current database. Returns an error if validation fails.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
+	"crdb_internal.revalidate_unique_constraints_in_table": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"table_name", types.String}},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				name := tree.MustBeDString(args[0])
+				dOid, err := tree.ParseDOid(evalCtx, string(name), types.RegClass)
+				if err != nil {
+					return nil, err
+				}
+				if err := evalCtx.Planner.RevalidateUniqueConstraintsInTable(evalCtx.Ctx(), int(dOid.DInt)); err != nil {
+					return nil, err
+				}
+				return tree.DVoidDatum, nil
+			},
+			Info: `This function is used to revalidate all unique constraints in the given
+table. Returns an error if validation fails.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
+	"crdb_internal.revalidate_unique_constraint": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"table_name", types.String}, {"constraint_name", types.String}},
+			ReturnType: tree.FixedReturnType(types.Void),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				tableName := tree.MustBeDString(args[0])
+				constraintName := tree.MustBeDString(args[1])
+				dOid, err := tree.ParseDOid(evalCtx, string(tableName), types.RegClass)
+				if err != nil {
+					return nil, err
+				}
+				if err = evalCtx.Planner.RevalidateUniqueConstraint(
+					evalCtx.Ctx(), int(dOid.DInt), string(constraintName),
+				); err != nil {
+					return nil, err
+				}
+				return tree.DVoidDatum, nil
+			},
+			Info: `This function is used to revalidate the given unique constraint in the given
+table. Returns an error if validation fails.`,
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3261,6 +3261,26 @@ type EvalPlanner interface {
 	// session revival token.
 	ValidateSessionRevivalToken(token *DBytes) (*DBool, error)
 
+	// RevalidateUniqueConstraintsInCurrentDB verifies that all unique constraints
+	// defined on tables in the current database are valid. In other words, it
+	// verifies that for every table in the database with one or more unique
+	// constraints, all rows in the table have unique values for every unique
+	// constraint defined on the table.
+	RevalidateUniqueConstraintsInCurrentDB(ctx context.Context) error
+
+	// RevalidateUniqueConstraintsInTable verifies that all unique constraints
+	// defined on the given table are valid. In other words, it verifies that all
+	// rows in the table have unique values for every unique constraint defined on
+	// the table.
+	RevalidateUniqueConstraintsInTable(ctx context.Context, tableID int) error
+
+	// RevalidateUniqueConstraint verifies that the given unique constraint on the
+	// given table is valid. In other words, it verifies that all rows in the
+	// table have unique values for the columns in the constraint. Returns an
+	// error if validation fails or if constraintName is not actually a unique
+	// constraint on the table.
+	RevalidateUniqueConstraint(ctx context.Context, tableID int, constraintName string) error
+
 	// QueryRowEx executes the supplied SQL statement and returns a single row, or
 	// nil if no row is found, or an error if more that one row is returned.
 	//


### PR DESCRIPTION
Fixes #73560

Release note (sql change): Added new builtin functions called
`crdb_internal.revalidate_unique_constraint`,
`crdb_internal.revalidate_unique_constraints_in_table`, and
`crdb_internal.revalidate_unique_constraints_in_all_tables`, which can
be used to revalidate existing unique constraints. The different
variations support validation of a single constraint, validation of
all unique constraints in a table, and validation of all unique
constraints in all tables in the current database, respectively.
If any constraint fails validation, the functions will return an
error with a hint about which data caused the constraint violation.
These violations can then be resolved manually by updating or deleting
the rows in violation. This will be useful to users who think they may
have been affected by #73024.