### PR TITLE
vendor: bump Pebble to a5c1766b568a

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1218,10 +1218,10 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sha256 = "57d54c33bae9fd363a206b5a3ac1e2fe187213ae4edb025a1f4d4dff596fb02d",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220120213058-ec6c21662e65",
+        sha256 = "0018bcef357bf7bba06d5e3eb35277709b5fd98ee437924001531fa935d8c76d",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220126162719-a5c1766b568a",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220120213058-ec6c21662e65.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220126162719-a5c1766b568a.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220120213058-ec6c21662e65
+	github.com/cockroachdb/pebble v0.0.0-20220126162719-a5c1766b568a
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220120213058-ec6c21662e65 h1:HeWHKlheSiglFkLRB+SUnt6AU7A0XuWKrO5b7aoaZhE=
-github.com/cockroachdb/pebble v0.0.0-20220120213058-ec6c21662e65/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220126162719-a5c1766b568a h1:JY8MIjk2GyMHjCqmHkNBekLi2N/kNS3uAKheGe78huM=
+github.com/cockroachdb/pebble v0.0.0-20220126162719-a5c1766b568a/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.1/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=


### PR DESCRIPTION
```
a5c1766b compaction: use Equal in compaction iterator
060753c8 internal/rangekey: add merging, fragmenting iterator
ca9b4522 Revert "Revert "sstable: reduce allocations during index flushing""
66beca7b sstable: move checksum logic onto checksummer
176f9fbf sstable: add compressed/uncompressed fields to the dataBlockBuf
a241910a internal/manifest: fix Overlaps L0 expansion with exclusive-end
a4a6fe83 compaction: remove redundant TruncateAndFlushTo call
8540f24b sstable: re-work `TableFormat` enum values
b510eb6b db: refactor experimental writer API, expose on DB
```

Release note: None