### PR TITLE
logictest: support rewriting even for skipped tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2450,6 +2450,11 @@ func (t *logicTest) processSubtest(subtest subtestDetails, path string) error {
 					}
 				}
 			} else {
+				if *rewriteResultsInTestfiles {
+					for _, l := range query.expectedResultsRaw {
+						t.emit(l)
+					}
+				}
 				s.LogAndResetSkip(t)
 			}
 			repeat = 1


### PR DESCRIPTION
Previously, the results for skipped tests were not rewritten when the
rewrite flag was passed. Now, we rewrite the expectedResults as is if
the test was skipped.

Release note: None