### PR TITLE
util/tracing: prevent spans reuse during registry iteration

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -30,7 +30,10 @@ import (
 // crdbSpan is a span for internal crdb usage. This is used to power SQL session
 // tracing.
 type crdbSpan struct {
+	// tracer is the Tracer that created this span.
 	tracer *Tracer
+	// sp is Span that this crdbSpan is part of.
+	sp *Span
 
 	traceID      tracingpb.TraceID // probabilistically unique
 	spanID       tracingpb.SpanID  // probabilistically unique


### PR DESCRIPTION
ActiveSpansRegistry.VisitSpans() was referencing spans without
accounting for the references by incrementing the span's reference
count. This resulted in races between that use and the spans getting
Finish()ed and re-allocated.

Fixes #75380

Release note: None