### PR TITLE
changefeedccl: store descriptors alongside cached fetchers

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -412,11 +412,6 @@ func getColumnTypes(columns []catalog.Column, outTypes []*types.T) ([]*types.T, 
 	return outTypes, nil
 }
 
-// GetTable returns the table that this Fetcher was initialized with.
-func (rf *Fetcher) GetTable() catalog.Descriptor {
-	return rf.table.desc
-}
-
 // StartScan initializes and starts the key-value scan. Can be used multiple
 // times.
 //


### PR DESCRIPTION
The row.Fetcher is being changed to no longer use a full table
descriptor. This commit removes the GetTable function and fixes up the
only user - the changefeed fetcher cache. We now store the descriptor
alongside the fetcher.

Release note: None