### PR TITLE
Makefile,dev: include `TestTenantLogic` in `testlogic`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1112,7 +1112,7 @@ testoptlogic: bin/logictestopt
 
 logic-test-selector := $(if $(TESTCONFIG),^$(TESTCONFIG)$$)/$(if $(FILES),^$(subst $(space),$$|^,$(FILES))$$)/$(SUBTESTS)
 testbaselogic: TESTS := TestLogic/$(logic-test-selector)
-testccllogic: TESTS := TestCCLLogic/$(logic-test-selector)
+testccllogic: TESTS := Test(CCL|Tenant)Logic/$(logic-test-selector)
 testoptlogic: TESTS := TestExecBuild/$(logic-test-selector)
 
 # Note: we specify -config here in addition to the filter on TESTS

--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=7
+DEV_VERSION=8
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/logic.go
+++ b/pkg/cmd/dev/logic.go
@@ -93,7 +93,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 			selectorPrefix = "TestLogic"
 		case "ccl":
 			testTarget = "//pkg/ccl/logictestccl:logictestccl_test"
-			selectorPrefix = "TestCCLLogic"
+			selectorPrefix = "Test(CCL|Tenant)Logic"
 		case "opt":
 			testTarget = "//pkg/sql/opt/exec/execbuilder:execbuilder_test"
 			selectorPrefix = "TestExecBuild"

--- a/pkg/cmd/dev/testdata/logic.txt
+++ b/pkg/cmd/dev/testdata/logic.txt
@@ -1,7 +1,7 @@
 dev testlogic
 ----
 bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/logictest:logictest_test --test_filter TestLogic///
-bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/ccl/logictestccl:logictestccl_test --test_filter TestCCLLogic///
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///'
 bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild///
 
 dev testlogic base --files=prepare|fk --subtests=20042 --config=local

--- a/pkg/cmd/dev/testdata/recording/logic.txt
+++ b/pkg/cmd/dev/testdata/recording/logic.txt
@@ -1,7 +1,7 @@
 bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/logictest:logictest_test --test_filter TestLogic///
 ----
 
-bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/ccl/logictestccl:logictestccl_test --test_filter TestCCLLogic///
+bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/ccl/logictestccl:logictestccl_test --test_filter 'Test(CCL|Tenant)Logic///'
 ----
 
 bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/opt/exec/execbuilder:execbuilder_test --test_filter TestExecBuild///


### PR DESCRIPTION
We didn't run these before when you ran `testlogic` and that's a bummer.

Release note: None