### PR TITLE
distsql: fix TestAggregatorAgainstProcessor

### DIFF
--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -224,7 +224,8 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 									execinfrapb.StMakeline,
 									execinfrapb.StExtent,
 									execinfrapb.StUnion,
-									execinfrapb.StCollect:
+									execinfrapb.StCollect,
+									execinfrapb.ArrayAgg:
 									for _, typ := range aggFnInputTypes {
 										if typ.Family() == types.TupleFamily || (typ.Family() == types.ArrayFamily && typ.ArrayContents().Family() == types.TupleFamily) {
 											invalid = true


### PR DESCRIPTION
Fixes #75195

TestAggregatorAgainstProcessor chooses random aggregation functions over random
types, and checks that colexec aggregation results match rowexec aggregation
results. The test uses GetAggregateInfo to check that there is an overload for
each chosen function and type, and this mostly works to verify that the
aggregation is legal. But some aggregation functions have special overloads for
tuple / array types while not actually working on those types. The test must
manually check for these.

Array_agg is another such function, so add it to the list.

Release note: None