### PR TITLE
release-21.2: sql: fix issue with database name when converting privilege to default privilege

### DIFF
--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -56,7 +56,7 @@ func (p *planner) alterDefaultPrivileges(
 	// for the current database.
 	database := p.CurrentDatabase()
 	if n.Database != nil {
-		database = n.Database.Normalize()
+		database = string(*n.Database)
 	}
 	dbDesc, err := p.Descriptors().GetMutableDatabaseByName(ctx, p.txn, database,
 		tree.DatabaseLookupFlags{Required: true})

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -406,7 +406,7 @@ func convertPGIncompatibleDatabasePrivilegesToDefaultPrivileges(
 			if err != nil {
 				return nil, err
 			}
-			translatedStatement = fmt.Sprintf("USE %s; %s;", database.Normalize(),
+			translatedStatement = fmt.Sprintf("USE %s; %s;", database,
 				alterDefaultPrivilegesASTNode.String())
 			if err := alterDefaultPrivilegesNode.startExec(params); err != nil {
 				return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/incompatible_pg_database_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/incompatible_pg_database_privileges
@@ -113,3 +113,33 @@ SHOW DEFAULT PRIVILEGES FOR ALL ROLES
 ----
 NULL  true  tables  test-user  SELECT
 NULL  true  types   public     USAGE
+
+statement ok
+CREATE DATABASE "tEsT"
+
+statement ok
+USE "tEsT"
+
+statement ok
+GRANT SELECT ON DATABASE "tEsT" to "test-user"
+
+query TBTTT
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES
+----
+NULL  true  tables  test-user  SELECT
+NULL  true  types   public     USAGE
+
+statement ok
+CREATE DATABASE "😀"
+
+statement ok
+USE "😀"
+
+statement ok
+GRANT SELECT ON DATABASE "😀" to "test-user"
+
+query TBTTT
+SHOW DEFAULT PRIVILEGES FOR ALL ROLES
+----
+NULL  true  tables  test-user  SELECT
+NULL  true  types   public     USAGE


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/75511

No need to merge to master since the conversion function was removed.

Release note (sql change): Fix bug when granting incompatible database
privilege to default privilege with non-lowercase database names.

In a previous commit, SELECT, INSERT, UPDATE, DELETE were removed as
database privileges. They were instead automatically converted to
default privileges on the database. However the converted statement
had an issue with non-lowercase names.

Example: Grant SELECT on "AppDB" would fail because the converted
statement would look for "appdb" instead of "AppDB" because the casing
was not kept.

grant select on database "AppDB" to devuser;
ERROR: database "appdb" does not exist
SQLSTATE: 3D000