### PR TITLE
opt: push limit into FK and self-joins in more cases

### DIFF
--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -270,6 +270,36 @@ func TestGetJoinMultiplicity(t *testing.T) {
 			on:       ob.makeFilters(ob.makeEquality(fkCols[0], xyCols[0])),
 			expected: "left-rows(exactly-one)",
 		},
+		{ // 19
+			// SELECT *
+			// FROM fk_tab
+			// INNER JOIN (SELECT * FROM xy AS xy1 INNER JOIN xy xy2 ON xy1.x = xy2.x)
+			// ON r1 = xy1.x;
+			joinOp: opt.InnerJoinOp,
+			left:   fkScan,
+			right: ob.makeInnerJoin(
+				xyScan,
+				xyScan2,
+				ob.makeFilters(ob.makeEquality(xyCols[0], xyCols2[0])),
+			),
+			on:       ob.makeFilters(ob.makeEquality(fkCols[0], xyCols[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-more)",
+		},
+		{ // 20
+			// SELECT *
+			// FROM fk_tab
+			// INNER JOIN (SELECT * FROM xy AS xy1 INNER JOIN xy xy2 ON xy1.x = xy2.x)
+			// ON r1 = xy2.x;
+			joinOp: opt.InnerJoinOp,
+			left:   fkScan,
+			right: ob.makeInnerJoin(
+				xyScan,
+				xyScan2,
+				ob.makeFilters(ob.makeEquality(xyCols[0], xyCols2[0])),
+			),
+			on:       ob.makeFilters(ob.makeEquality(fkCols[0], xyCols2[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-more)",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -2224,7 +2224,7 @@ INNER JOIN (SELECT xysd.x, a.x AS t FROM xysd INNER JOIN xysd AS a ON xysd.x = a
 ----
 inner-join (hash)
  ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:7(int!null) t:13(int!null)
- ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── key: (1)
  ├── fd: (1)-->(2-4), (7)==(3,13), (13)==(3,7), (3)==(7,13)
  ├── prune: (1,2,4)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -2023,6 +2023,57 @@ inner-join (hash)
            ├── variable: x:7 [type=int]
            └── variable: r1:3 [type=int]
 
+# LeftJoin case with a not-null foreign key and a constant equality filter. The
+# filter pushed down on both sides of the join is redundant, so all rows on the
+# left side of the join will be preserved.
+norm
+SELECT * FROM fk LEFT JOIN xysd ON x = r1 WHERE r1 = 10
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: ()-->(3,7-10), (1)-->(2,4), (3)==(7), (7)==(3)
+ ├── prune: (1,2,4,8-10)
+ ├── interesting orderings: (+1 opt(3))
+ ├── select
+ │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2,4)
+ │    ├── prune: (1,2,4)
+ │    ├── interesting orderings: (+1 opt(3))
+ │    ├── scan fk
+ │    │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4)
+ │    │    ├── prune: (1-4)
+ │    │    ├── interesting orderings: (+1)
+ │    │    └── unfiltered-cols: (1-6)
+ │    └── filters
+ │         └── eq [type=bool, outer=(3), constraints=(/3: [/10 - /10]; tight), fd=()-->(3)]
+ │              ├── variable: r1:3 [type=int]
+ │              └── const: 10 [type=int]
+ ├── select
+ │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7-10)
+ │    ├── prune: (8-10)
+ │    ├── scan xysd
+ │    │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ │    │    ├── key: (7)
+ │    │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
+ │    │    ├── prune: (7-10)
+ │    │    ├── interesting orderings: (+7) (-9,+10,+7)
+ │    │    └── unfiltered-cols: (7-12)
+ │    └── filters
+ │         └── eq [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
+ │              ├── variable: x:7 [type=int]
+ │              └── const: 10 [type=int]
+ └── filters
+      └── eq [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+           ├── variable: x:7 [type=int]
+           └── variable: r1:3 [type=int]
 
 # LeftJoin case with a nullable foreign key. The LeftJoin cannot be simplified
 # because a nullable foreign key is not guaranteed matches.
@@ -2116,6 +2167,58 @@ inner-join (hash)
  │    ├── prune: (7-10)
  │    ├── interesting orderings: (+7) (-9,+10,+7)
  │    └── unfiltered-cols: (7-12)
+ └── filters
+      └── eq [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+           ├── variable: xysd.x:1 [type=int]
+           └── variable: a.x:7 [type=int]
+
+# Self-join case with a constant equality filter. The filter pushed down on both
+# sides of the join is redundant, so all rows on the left side of the join will
+# be preserved.
+norm
+SELECT * FROM xysd INNER JOIN xysd AS a ON xysd.x = a.x WHERE xysd.x = 10
+----
+inner-join (hash)
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ ├── cardinality: [0 - 1]
+ ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ ├── key: ()
+ ├── fd: ()-->(1-4,7-10), (7)==(1), (1)==(7)
+ ├── prune: (2-4,8-10)
+ ├── select
+ │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) xysd.s:3(string) xysd.d:4(decimal!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-4)
+ │    ├── prune: (2-4)
+ │    ├── scan xysd
+ │    │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) xysd.s:3(string) xysd.d:4(decimal!null)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
+ │    │    ├── prune: (1-4)
+ │    │    ├── interesting orderings: (+1) (-3,+4,+1)
+ │    │    └── unfiltered-cols: (1-6)
+ │    └── filters
+ │         └── eq [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
+ │              ├── variable: xysd.x:1 [type=int]
+ │              └── const: 10 [type=int]
+ ├── select
+ │    ├── columns: a.x:7(int!null) a.y:8(int) a.s:9(string) a.d:10(decimal!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7-10)
+ │    ├── prune: (8-10)
+ │    ├── scan xysd [as=a]
+ │    │    ├── columns: a.x:7(int!null) a.y:8(int) a.s:9(string) a.d:10(decimal!null)
+ │    │    ├── key: (7)
+ │    │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
+ │    │    ├── prune: (7-10)
+ │    │    ├── interesting orderings: (+7) (-9,+10,+7)
+ │    │    └── unfiltered-cols: (7-12)
+ │    └── filters
+ │         └── eq [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight), fd=()-->(7)]
+ │              ├── variable: a.x:7 [type=int]
+ │              └── const: 10 [type=int]
  └── filters
       └── eq [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
            ├── variable: xysd.x:1 [type=int]
@@ -2444,7 +2547,7 @@ inner-join (hash)
 norm
 SELECT *
 FROM ref
-INNER JOIN abc 
+INNER JOIN abc
 ON (r1, r2, r3) = (a, b, c)
 ----
 inner-join (hash)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1088,6 +1088,49 @@ left-join (hash)
  └── filters
       └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
+# Push the limit if both sides of an inner join have identical equality filters
+# on FK equality columns.
+norm expect=PushLimitIntoJoinLeft
+SELECT * FROM kvr_fk INNER JOIN uv ON r = u WHERE r = 5 LIMIT 10
+----
+inner-join (hash)
+ ├── columns: k:1!null v:2 r:3!null u:6!null v:7
+ ├── cardinality: [0 - 10]
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: ()-->(3,6,7), (1)-->(2), (3)==(6), (6)==(3)
+ ├── limit
+ │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
+ │    ├── select
+ │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(3), (1)-->(2)
+ │    │    ├── limit hint: 10.00
+ │    │    ├── scan kvr_fk
+ │    │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    └── limit hint: 1000.00
+ │    │    └── filters
+ │    │         └── r:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+ │    └── 10
+ ├── select
+ │    ├── columns: u:6!null uv.v:7
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6,7)
+ │    ├── scan uv
+ │    │    ├── columns: u:6!null uv.v:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── u:6 = 5 [outer=(6), constraints=(/6: [/5 - /5]; tight), fd=()-->(6)]
+ └── filters
+      └── r:3 = u:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
 # Don't push negative limits (or we would enter an infinite loop).
 norm expect-not=PushLimitIntoJoinLeft
 SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT -1


### PR DESCRIPTION
#### opt: more accurate join multiplicity with FKs and self-joins

When calculating join multiplicity in the presence of a foreign key, it
was previously possible for the incorrect base table to be selected from
the right expression, in the case that the right expression contained a
self-join. The base table selected was incorrect because it did not
contain the equality column from the join filter. This prevented the
optimizer from determining that these joins preserve all rows from the
left side of the join, which could prevent further optimization of a
query.

Now, only the right equality columns are passed to `checkForeignKeyCase`
which ensures that the correct base table is selected. This is safe
because `verifyFiltersAreValidEqualities` has already checked that the
right equality columns are unfiltered in the right expression, so the
same checks in `checkForeignKeyCase` are redundant.

Release note (performance improvement): The optimizer better optimizes
queries that include both foreign key joins and self-joins.

#### opt: push limit into FK and self-joins in more cases

Previously, a constant equality condition pushed into both sides of a
foreign key join or self-join would prevent a limit from being pushed
into the left side of the join. This was because the multiplicity
builder could not determine that right filter would not remove any
values also removed by the left filter. Without the join being labelled
as left-preserving, the limit could not be pushed down.

The multiplicity builder has been updated to recognize a few additional
cases where left rows are preserved in foreign key joins and self-joins,
allowing a limit to be pushed into the left side of the join. Currently,
the multiplicity builder only recognizes cases where corresponding left
and right columns are held equal to the same constant value. It is
possible to extend this to more complex inequalities and boolean
expressions, but this is left as a TODO for now.

Fixes #74419

Release note (performance improvement): A LIMIT can now be pushed below
a foreign key join or self-join in more cases, which may result in more
efficient query plans.
