### PR TITLE
sql: de-flake TestRecordBatchSerializerDeserializeMemoryEstimate

### DIFF
--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -341,12 +341,13 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 	newMemorySize := colmem.GetBatchMemSize(dest)
 
 	// We expect that the original and the new memory sizes are relatively close
-	// to each other (do not differ by more than a third). We cannot guarantee
-	// more precise bound here because the capacities of the underlying []byte
-	// slices is unpredictable. However, this check is sufficient to ensure that
-	// we don't double count memory under `Bytes.data`.
+	// to each other, specifically newMemorySize must less than
+	// 4/3*originalMemorySize. We cannot guarantee more precise bound here because
+	// the capacities of the underlying []byte slices is unpredictable. However,
+	// this check is sufficient to ensure that we don't double count memory under
+	// `Bytes.data`.
 	const maxDeviation = float64(0.33)
-	deviation := math.Abs(float64(originalMemorySize-newMemorySize) / (float64(originalMemorySize)))
+	deviation := float64(newMemorySize-originalMemorySize) / float64(originalMemorySize)
 	require.GreaterOrEqualf(t, maxDeviation, deviation,
 		"new memory size %d is too far away from original %d", newMemorySize, originalMemorySize)
 }


### PR DESCRIPTION
Fixes: #73781

When BatchSize was low and each buffer was much smaller than capacity
we could end up with newMemorySize more than %33 smaller than original.
However the test is just making sure we aren't double counting memory
so testing that newMemorySize - originalMemory < 4/3 original.  I.e.
its okay if it shrinks but we don't want it to be more than %33 bigger.

Release note: None