### PR TITLE
kvserver: de-flake TestRangefeedCheckpointsRecoverFromLeaseExpiration

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1045,7 +1045,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 	require.Equal(t, int64(1), nudged)
 
 	// Check that n2 renewed its lease, like the test intended.
-	li, _, err := tc.FindRangeLeaseEx(ctx, desc, &n2Target)
+	li, _, err := tc.FindRangeLeaseEx(ctx, desc, nil)
 	require.NoError(t, err)
 	require.True(t, li.Current().OwnedBy(n2.GetFirstStoreID()))
 	require.Equal(t, int64(2), li.Current().Epoch)


### PR DESCRIPTION
Fixes #75098.

We didn't account for a possibly stale distsender cache earlier,
misrouting the LeaseInfo request to the last known leaseholder. By
providing a hint with the new leaseholder, we were also making an
assertion on cache freshness. We skip the hint and do just what the test
wants -- ensuring a lease renewal. Repro-ed within seconds before this
commit:

    dev test pkg/kv/kvserver \
      -f TestRangefeedCheckpointsRecoverFromLeaseExpiration --stress

Release note: None