### PR TITLE
cloud: add ability to specify s3 storage class for backups

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -58,6 +58,10 @@ const (
 	// KMS ID to be used for server side encryption.
 	AWSServerSideEncryptionKMSID = "AWS_SERVER_KMS_ID"
 
+	// S3StorageClassParam is the query parameter used in S3 URIs to configure the
+	// storage class for written objects.
+	S3StorageClassParam = "S3_STORAGE_CLASS"
+
 	// S3RegionParam is the query parameter for the 'endpoint' in an S3 URI.
 	S3RegionParam = "AWS_REGION"
 
@@ -145,6 +149,7 @@ func S3URI(bucket, path string, conf *roachpb.ExternalStorage_S3) string {
 	setIf(cloud.AuthParam, conf.Auth)
 	setIf(AWSServerSideEncryptionMode, conf.ServerEncMode)
 	setIf(AWSServerSideEncryptionKMSID, conf.ServerKMSID)
+	setIf(S3StorageClassParam, conf.StorageClass)
 
 	s3URL := url.URL{
 		Scheme:   "s3",
@@ -170,6 +175,7 @@ func parseS3URL(_ cloud.ExternalStorageURIContext, uri *url.URL) (roachpb.Extern
 		Auth:          uri.Query().Get(cloud.AuthParam),
 		ServerEncMode: uri.Query().Get(AWSServerSideEncryptionMode),
 		ServerKMSID:   uri.Query().Get(AWSServerSideEncryptionKMSID),
+		StorageClass:  uri.Query().Get(S3StorageClassParam),
 		/* NB: additions here should also update s3QueryParams() serializer */
 	}
 	conf.S3Config.Prefix = strings.TrimLeft(conf.S3Config.Prefix, "/")
@@ -411,6 +417,7 @@ func (s *s3Storage) Writer(ctx context.Context, basename string) (io.WriteCloser
 			Body:                 r,
 			ServerSideEncryption: nilIfEmpty(s.conf.ServerEncMode),
 			SSEKMSKeyId:          nilIfEmpty(s.conf.ServerKMSID),
+			StorageClass:         nilIfEmpty(s.conf.StorageClass),
 		})
 		return errors.Wrap(err, "upload failed")
 	}), nil

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1331,6 +1331,7 @@ message ExternalStorage {
     string auth = 8;
     string server_enc_mode  = 9;
     string server_kms_id = 10  [(gogoproto.customname) = "ServerKMSID"];
+    string storage_class = 11;
   }
   message GCS {
     string bucket = 1;


### PR DESCRIPTION
This adds the option to include '&S3_STORAGE_CLASS=some-class' to S3 URLs such as those
passed to BACKUP, to set the storage class parameter of created objects as described in
the s3 docs: https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html.

This allows, for example, adding '&S3_STORAGE_CLASS=INTELLIGENT_TIERING' to a BACKUP URI. Valid values are [listed here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-StorageClass).

```
STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | OUTPOSTS | GLACIER_IR
```

Release note (sql change): S3 URIs used for BACKUPs, EXPORTs or CHANGEFEEDs can now include the
query paramter S3_STORAGE_CLASS to configure the storage class used when that job creates objects
in the designated S3 bucket.