### PR TITLE
sql: Remove redundant runSinglePrivilegeCheck grant check

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -163,9 +163,12 @@ func (p *planner) CheckPrivilege(
 // grant options for. Owners implicitly have all grant options, and also grant
 // options are inherited from parent roles.
 func (p *planner) CheckGrantOptionsForUser(
-	ctx context.Context, descriptor catalog.Descriptor, privList privilege.List, isGrant bool,
+	ctx context.Context,
+	descriptor catalog.Descriptor,
+	privList privilege.List,
+	user security.SQLUsername,
+	isGrant bool,
 ) error {
-	user := p.User()
 	// Always allow the command to go through if performed by a superuser or the
 	// owner of the object
 	if isAdmin, err := p.UserHasAdminRole(ctx, user); err != nil {
@@ -218,7 +221,7 @@ func getOwnerOfDesc(desc catalog.Descriptor) security.SQLUsername {
 	return owner
 }
 
-//IsOwner returns if the role has ownership on the descriptor.
+// IsOwner returns if the role has ownership on the descriptor.
 func IsOwner(desc catalog.Descriptor, role security.SQLUsername) bool {
 	return role == getOwnerOfDesc(desc)
 }
@@ -345,7 +348,7 @@ func (p *planner) RequireAdminRole(ctx context.Context, action string) error {
 		return err
 	}
 	if !ok {
-		//raise error if user is not a super-user
+		// raise error if user is not a super-user
 		return pgerror.Newf(pgcode.InsufficientPrivilege,
 			"only users with the admin role are allowed to %s", action)
 	}

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -195,7 +195,7 @@ func (n *changePrivilegesNode) startExec(params runParams) error {
 
 			noticeMessage := ""
 			if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ValidateGrantOption) {
-				err := p.CheckGrantOptionsForUser(ctx, descriptor, n.desiredprivs, n.isGrant)
+				err := p.CheckGrantOptionsForUser(ctx, descriptor, n.desiredprivs, p.User(), n.isGrant)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -317,20 +317,31 @@ func (p *planner) HasPrivilege(
 	// hasPrivilegeFunc checks whether any role has the given privilege.
 	hasPrivilegeFunc := func(priv privilege.Privilege) (bool, error) {
 		err := p.CheckPrivilegeForUser(ctx, desc, priv.Kind, user)
-		if err == nil {
-			if priv.GrantOption {
-				if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ValidateGrantOption) {
-					err = p.CheckPrivilegeForUser(ctx, desc, privilege.GRANT, user)
-				} else {
-					err = p.CheckGrantOptionsForUser(ctx, desc, []privilege.Kind{priv.Kind}, true /* isGrant */)
-				}
-			}
-		}
 		if err != nil {
 			if pgerror.GetPGCode(err) == pgcode.InsufficientPrivilege {
 				return false, nil
 			}
 			return false, err
+		}
+
+		if priv.GrantOption {
+			if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ValidateGrantOption) {
+				err := p.CheckPrivilegeForUser(ctx, desc, privilege.GRANT, user)
+				if err != nil {
+					if pgerror.GetPGCode(err) == pgcode.InsufficientPrivilege {
+						return false, nil
+					}
+					return false, err
+				}
+			} else {
+				err := p.CheckGrantOptionsForUser(ctx, desc, []privilege.Kind{priv.Kind}, user, true /* isGrant */)
+				if err != nil {
+					if pgerror.GetPGCode(err) == pgcode.WarningPrivilegeNotGranted {
+						return false, nil
+					}
+					return false, err
+				}
+			}
 		}
 
 		return true, nil


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/73129
    
HasPrivilege checks for privilege and grant permissions so runSinglePrivilegeCheck is no longer needed.