### PR TITLE
logictest: de-flake TestLogic/5node-disk/distsql_enum

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -65,7 +65,7 @@ ALTER TABLE t2 INJECT STATISTICS '[
   }
 ]'
 
-query T nodeidx=1 retry
+query T nodeidx=1,retry
 EXPLAIN (VEC)
 SELECT x from t1 WHERE EXISTS (SELECT x FROM t2 WHERE t1.x=t2.x AND t2.y='hello')
 ----


### PR DESCRIPTION
Fixes #75570. Second attempt at 83f584d, though now with the right
syntax.

Release note: None