### PR TITLE
kvserver: deflake TestBackpressureNotAppliedWhenReducingRangeSize

### DIFF
--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -102,7 +102,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		tc.SplitRangeOrFatal(t, tablePrefix)
 		require.NoError(t, tc.WaitForSplitAndInitialization(tablePrefix))
 
-		for i := 0; i < dataSize/rowSize; i++ {
+		for i := 0; i < numRows; i++ {
 			tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
 				rRand.Intn(numRows), randutil.RandBytes(rRand, rowSize))
 		}
@@ -267,6 +267,9 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 
 		// Then we'll add a new server and move the table there.
 		moveTableToNewStore(t, tc, args, tablePrefix)
+
+		// Ensure that the new replica has applied the same config.
+		waitForSpanConfig(t, tc, tablePrefix, newMax)
 
 		s, repl := getFirstStoreReplica(t, tc.Server(1), tablePrefix)
 		s.SetReplicateQueueActive(false)

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -320,7 +320,7 @@ func (s *KVSubscriber) run(ctx context.Context) error {
 		fn()
 	}
 
-	log.Info(ctx, "established range feed over span configurations table")
+	log.Infof(ctx, "established range feed over system.span_configurations starting at time %s", initialScanTS)
 
 	injectedErrCh := s.knobs.KVSubscriberErrorInjectionCh
 

--- a/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
@@ -261,7 +261,7 @@ func (s *SQLWatcher) watchForDescriptorUpdates(
 		return nil, err
 	}
 
-	log.Infof(ctx, "established range feed over system.descriptors table starting at time %s", startTS)
+	log.Infof(ctx, "established range feed over system.descriptors starting at time %s", startTS)
 	return rf, nil
 }
 
@@ -317,6 +317,6 @@ func (s *SQLWatcher) watchForZoneConfigUpdates(
 		return nil, err
 	}
 
-	log.Infof(ctx, "established range feed over system.zones table starting at time %s", startTS)
+	log.Infof(ctx, "established range feed over system.zones starting at time %s", startTS)
 	return rf, nil
 }


### PR DESCRIPTION
This test relies on a second node's span config rangefeed to have caught
up sufficiently with the global state such that a snapshot, when
applied, would construct a replica with the config this test attempts to
declare over the originating replica. Though very unlikely to occur
(repro-ed only once in hours GCE worker runs), it's possible. This patch
is a speculative fix for a failure observed only with manual stressing
on a SHA that included #75233.

(Also make some prominent span config logging a bit more consistent with
one another.)

Release note: None