### PR TITLE
release-21.2: sql: check session_user can become user on deserialize_session

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -231,6 +231,13 @@ func (ep *DummyEvalPlanner) UnsafeDeleteNamespaceEntry(
 	return errors.WithStack(errEvalPlanner)
 }
 
+// CheckCanBecomeUser is part of the EvalPlanner interface.
+func (ep *DummyEvalPlanner) CheckCanBecomeUser(
+	ctx context.Context, becomeUser security.SQLUsername,
+) error {
+	return errors.WithStack(errEvalPlanner)
+}
+
 // MemberOfWithAdminOption is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
 	ctx context.Context, member security.SQLUsername,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6253,6 +6253,9 @@ table's zone configuration this will return NULL.`,
 						"can only deserialize matching session users",
 					)
 				}
+				if err := evalCtx.Planner.CheckCanBecomeUser(evalCtx.Context, sd.User()); err != nil {
+					return nil, err
+				}
 				*evalCtx.SessionData() = *sd
 				return tree.MakeDBool(true), nil
 			},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3200,6 +3200,10 @@ type EvalPlanner interface {
 		force bool,
 	) error
 
+	// CheckCanBecomeUser returns an error if the SessionUser cannot become the
+	// becomeUser.
+	CheckCanBecomeUser(ctx context.Context, becomeUser security.SQLUsername) error
+
 	// MemberOfWithAdminOption is used to collect a list of roles (direct and
 	// indirect) that the member is part of. See the comment on the planner
 	// implementation in authorization.go

--- a/pkg/sql/session_migration_test.go
+++ b/pkg/sql/session_migration_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -56,6 +58,29 @@ func TestSessionMigration(t *testing.T) {
 		defer func() {
 			_ = dbConn.Close()
 		}()
+		_, err := dbConn.Exec("CREATE USER testuser")
+		require.NoError(t, err)
+
+		openUserConnFunc := func(user string) *gosql.DB {
+
+			pgURL, cleanupGoDB, err := sqlutils.PGUrlE(
+				tc.Server(0).ServingSQLAddr(),
+				"StartServer", /* prefix */
+				url.User(user),
+			)
+			require.NoError(t, err)
+			pgURL.Path = "defaultdb"
+
+			goDB, err := gosql.Open("postgres", pgURL.String())
+			require.NoError(t, err)
+
+			tc.Server(0).Stopper().AddCloser(
+				stop.CloserFn(func() {
+					cleanupGoDB()
+				}))
+
+			return goDB
+		}
 
 		vars := make(map[string]string)
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
@@ -70,6 +95,10 @@ func TestSessionMigration(t *testing.T) {
 			case "reset":
 				require.NoError(t, dbConn.Close())
 				dbConn = openConnFunc()
+				return ""
+			case "user":
+				require.NoError(t, dbConn.Close())
+				dbConn = openUserConnFunc(d.Input)
 				return ""
 			case "exec":
 				_, err := dbConn.Exec(getQuery())

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -140,7 +140,7 @@ func (s *SessionData) GetDateStyle() pgdate.DateStyle {
 // SessionUser retrieves the session_user.
 // The SessionUser is the username that originally logged into the session.
 // If a user applies SET ROLE, the SessionUser remains the same whilst the
-// CurrentUser() changes.
+// User() changes.
 func (s *SessionData) SessionUser() security.SQLUsername {
 	if s.SessionUserProto == "" {
 		return s.User()

--- a/pkg/sql/testdata/session_migration/errors
+++ b/pkg/sql/testdata/session_migration/errors
@@ -67,3 +67,21 @@ SELECT crdb_internal.deserialize_session(
 )
 ----
 pq: crdb_internal.deserialize_session(): can only deserialize matching session users
+
+# We cannot deserialize into a current_user we do not match.
+user
+testuser
+----
+
+exec
+SELECT crdb_internal.deserialize_session(
+  decode(
+    -- minted by modifying `crdb_internal.serialize_session()` and setting
+    --   sd.SessionData.UserProto=root
+    --   sd.LocalOnlySessionData.SessionUser=testuser
+    '0a510a0964656661756c74646212102420636f636b726f6163682064656d6f1a04726f6f742204100222002802380842035554434a0524757365724a067075626c69635a0060808080207a0088010190018050124910904e3002380840026001680170017801880101d80101e00101f00101f80101900201b002808001c80201f202087465737475736572a00301a9030000000000408f40d00301e00301',
+    'hex'
+  )
+)
+----
+pq: crdb_internal.deserialize_session(): only root can become root

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -503,7 +503,7 @@ func (p *planner) setRole(ctx context.Context, local bool, s security.SQLUsernam
 		}
 	}
 
-	if err := p.checkCanBecomeUser(ctx, becomeUser); err != nil {
+	if err := p.CheckCanBecomeUser(ctx, becomeUser); err != nil {
 		return err
 	}
 
@@ -548,7 +548,8 @@ func (p *planner) setRole(ctx context.Context, local bool, s security.SQLUsernam
 
 }
 
-func (p *planner) checkCanBecomeUser(ctx context.Context, becomeUser security.SQLUsername) error {
+// CheckCanBecomeUser implements the EvalPlanner interface.
+func (p *planner) CheckCanBecomeUser(ctx context.Context, becomeUser security.SQLUsername) error {
 	sessionUser := p.SessionData().SessionUser()
 
 	// Switching to None can always succeed.


### PR DESCRIPTION
Backport 1/1 commits from #75575.

/cc @cockroachdb/release

---

Release note (bug fix): `crdb_internal.deserialize_session` now checks
the session_user has the privilege to SET ROLE to the current_user before
changing the session settings.

----

Release justification: fixes an existing bug