### PR TITLE
sql: persist TTL metadata to the descriptor

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -973,20 +973,22 @@ func (n *alterTableNode) startExec(params runParams) error {
 				params.p.SemaCtx(),
 				params.EvalContext(),
 				t.StorageParams,
-				&paramparse.TableStorageParamObserver{},
+				paramparse.NewTableStorageParamObserver(n.tableDesc),
 			); err != nil {
 				return err
 			}
+			// TODO(#75428): handle TTL side effects
 
 		case *tree.AlterTableResetStorageParams:
 			if err := paramparse.ResetStorageParameters(
 				params.ctx,
 				params.EvalContext(),
 				t.Params,
-				&paramparse.TableStorageParamObserver{},
+				paramparse.NewTableStorageParamObserver(n.tableDesc),
 			); err != nil {
 				return err
 			}
+			// TODO(#75428): handle TTL side effects
 
 		case *tree.AlterTableRenameColumn:
 			descChanged, err := params.p.renameColumn(params.ctx, n.tableDesc, t.Column, t.NewName)

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1168,6 +1168,15 @@ message TableDescriptor {
   // This means that all indexes implicitly inherit all partitioning
   // from the PARTITION ALL BY clause.
   optional bool partition_all_by = 44 [(gogoproto.nullable)=false];
+
+  message RowLevelTTL {
+    option (gogoproto.equal) = true;
+
+    // DurationExpr is the automatically assigned interval for when the TTL should apply to a row.
+    optional string duration_expr = 1 [(gogoproto.nullable)=false];
+  }
+  // RowLevelTTL is set if there is a TTL set on the table.
+  optional RowLevelTTL row_level_ttl = 47 [(gogoproto.customname)="RowLevelTTL"];
 }
 
 // SurvivalGoal is the survival goal for a database.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -633,6 +633,8 @@ type TableDescriptor interface {
 	// GetRegionalByRowTableRegionColumnName returns the region column name of a
 	// REGIONAL BY ROW table.
 	GetRegionalByRowTableRegionColumnName() (tree.Name, error)
+	// GetRowLevelTTL returns the row-level TTL config for the table.
+	GetRowLevelTTL() *descpb.TableDescriptor_RowLevelTTL
 }
 
 // TypeDescriptor will eventually be called typedesc.Descriptor.

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "table.go",
         "table_desc.go",
         "table_desc_builder.go",
+        "ttl.go",
         "validate.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc",

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2409,6 +2409,11 @@ func (desc *wrapper) GetRegionalByRowTableRegionColumnName() (tree.Name, error) 
 	return tree.Name(*colName), nil
 }
 
+// GetRowLevelTTL implements the TableDescriptor interface.
+func (desc *wrapper) GetRowLevelTTL() *descpb.TableDescriptor_RowLevelTTL {
+	return desc.RowLevelTTL
+}
+
 // GetMultiRegionEnumDependency returns true if the given table has an "implicit"
 // dependency on the multi-region enum. An implicit dependency exists for
 // REGIONAL BY TABLE table's which are homed in an explicit region

--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tabledesc
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+// ValidateRowLevelTTL validates that the TTL options are valid.
+func ValidateRowLevelTTL(ttl *descpb.TableDescriptor_RowLevelTTL) error {
+	if ttl == nil {
+		return nil
+	}
+	if ttl.DurationExpr == "" {
+		return errors.AssertionFailedf("expected DurationExpr to be set on RowLevelTTL")
+	}
+	return nil
+}

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -457,6 +457,8 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 		return nil
 	})
 
+	vea.Report(ValidateRowLevelTTL(desc.GetRowLevelTTL()))
+
 	// Validate that there are no column with both a foreign key ON UPDATE and an
 	// ON UPDATE expression. This check is made to ensure that we know which ON
 	// UPDATE action to perform when a FK UPDATE happens.

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -129,6 +129,7 @@ var validationMap = []struct {
 			"LocalityConfig":                {status: iSolemnlySwearThisFieldIsValidated},
 			"PartitionAllBy":                {status: iSolemnlySwearThisFieldIsValidated},
 			"NewSchemaChangeJobID":          {status: iSolemnlySwearThisFieldIsValidated},
+			"RowLevelTTL":                   {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 	{

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1275,7 +1275,7 @@ func NewTableDesc(
 		semaCtx,
 		evalCtx,
 		n.StorageParams,
-		&paramparse.TableStorageParamObserver{},
+		paramparse.NewTableStorageParamObserver(&desc),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -21,6 +21,11 @@ tbl                                            CREATE TABLE public.tbl (
                                                FAMILY fam_0_id_text (id, text)
 ) WITH (expire_after = '00:10:00':::INTERVAL)
 
+query T
+SELECT reloptions FROM pg_class WHERE relname = 'tbl'
+----
+{expire_after='00:10:00':::INTERVAL}
+
 statement ok
 DROP TABLE tbl;
 CREATE TABLE tbl (

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1,30 +1,30 @@
-statement error value of "expire_after" must be an interval
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = ' xx invalid interval xx')
+statement error value of "ttl_expire_after" must be an interval
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = ' xx invalid interval xx')
 
-statement error value of "expire_after" must be at least zero
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '-10 minutes')
+statement error value of "ttl_expire_after" must be at least zero
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = '-10 minutes')
 
 statement ok
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
   text TEXT,
   FAMILY (id, text)
-) WITH (expire_after = '10 minutes')
+) WITH (ttl_expire_after = '10 minutes')
 
 query TT
 SHOW CREATE TABLE tbl
 ----
-tbl                                            CREATE TABLE public.tbl (
-                                               id INT8 NOT NULL,
-                                               text STRING NULL,
-                                               CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                               FAMILY fam_0_id_text (id, text)
-) WITH (expire_after = '00:10:00':::INTERVAL)
+tbl                                                CREATE TABLE public.tbl (
+                                                   id INT8 NOT NULL,
+                                                   text STRING NULL,
+                                                   CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+                                                   FAMILY fam_0_id_text (id, text)
+) WITH (ttl_expire_after = '00:10:00':::INTERVAL)
 
 query T
 SELECT reloptions FROM pg_class WHERE relname = 'tbl'
 ----
-{expire_after='00:10:00':::INTERVAL}
+{ttl_expire_after='00:10:00':::INTERVAL}
 
 statement ok
 DROP TABLE tbl;
@@ -32,14 +32,14 @@ CREATE TABLE tbl (
   id INT PRIMARY KEY,
   text TEXT,
   FAMILY (id, text)
-) WITH (expire_after = '10 minutes'::interval)
+) WITH (ttl_expire_after = '10 minutes'::interval)
 
 query TT
 SHOW CREATE TABLE tbl
 ----
-tbl                                            CREATE TABLE public.tbl (
-                                               id INT8 NOT NULL,
-                                               text STRING NULL,
-                                               CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                               FAMILY fam_0_id_text (id, text)
-) WITH (expire_after = '00:10:00':::INTERVAL)
+tbl                                                CREATE TABLE public.tbl (
+                                                   id INT8 NOT NULL,
+                                                   text STRING NULL,
+                                                   CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+                                                   FAMILY fam_0_id_text (id, text)
+) WITH (ttl_expire_after = '00:10:00':::INTERVAL)

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -5,8 +5,36 @@ statement error value of "expire_after" must be at least zero
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '-10 minutes')
 
 statement ok
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '10 minutes')
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  text TEXT,
+  FAMILY (id, text)
+) WITH (expire_after = '10 minutes')
+
+query TT
+SHOW CREATE TABLE tbl
+----
+tbl                                            CREATE TABLE public.tbl (
+                                               id INT8 NOT NULL,
+                                               text STRING NULL,
+                                               CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+                                               FAMILY fam_0_id_text (id, text)
+) WITH (expire_after = '00:10:00':::INTERVAL)
 
 statement ok
 DROP TABLE tbl;
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '10 minutes'::interval)
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  text TEXT,
+  FAMILY (id, text)
+) WITH (expire_after = '10 minutes'::interval)
+
+query TT
+SHOW CREATE TABLE tbl
+----
+tbl                                            CREATE TABLE public.tbl (
+                                               id INT8 NOT NULL,
+                                               text STRING NULL,
+                                               CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+                                               FAMILY fam_0_id_text (id, text)
+) WITH (expire_after = '00:10:00':::INTERVAL)

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1,0 +1,12 @@
+statement error value of "expire_after" must be an interval
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = ' xx invalid interval xx')
+
+statement error value of "expire_after" must be at least zero
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '-10 minutes')
+
+statement ok
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '10 minutes')
+
+statement ok
+DROP TABLE tbl;
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (expire_after = '10 minutes'::interval)

--- a/pkg/sql/paramparse/BUILD.bazel
+++ b/pkg/sql/paramparse/BUILD.bazel
@@ -11,11 +11,13 @@ go_library(
     deps = [
         "//pkg/geo/geoindex",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/paramparse/paramobserver.go
+++ b/pkg/sql/paramparse/paramobserver.go
@@ -156,7 +156,7 @@ var tableParams = map[string]tableParam{
 			return nil
 		},
 	},
-	`expire_after`: {
+	`ttl_expire_after`: {
 		onSet: func(ctx context.Context, po *TableStorageParamObserver, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, key string, datum tree.Datum) error {
 			var d *tree.DInterval
 			if stringVal, err := DatumAsString(evalCtx, key, datum); err == nil {
@@ -164,7 +164,7 @@ var tableParams = map[string]tableParam{
 				if err != nil || d == nil {
 					return pgerror.Newf(
 						pgcode.InvalidParameterValue,
-						`value of "expire_after" must be an interval`,
+						`value of "ttl_expire_after" must be an interval`,
 					)
 				}
 			} else {
@@ -173,7 +173,7 @@ var tableParams = map[string]tableParam{
 				if !ok || d == nil {
 					return pgerror.Newf(
 						pgcode.InvalidParameterValue,
-						`value of "expire_after" must be an interval`,
+						`value of "ttl_expire_after" must be an interval`,
 					)
 				}
 			}
@@ -181,7 +181,7 @@ var tableParams = map[string]tableParam{
 			if d.Duration.Compare(duration.MakeDuration(0, 0, 0)) < 0 {
 				return pgerror.Newf(
 					pgcode.InvalidParameterValue,
-					`value of "expire_after" must be at least zero`,
+					`value of "ttl_expire_after" must be at least zero`,
 				)
 			}
 			if po.tableDesc.RowLevelTTL == nil {

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -2196,10 +2196,10 @@ CREATE TABLE _ (_ INT4) LOCALITY REGIONAL BY ROW AS _ -- identifiers removed
 parse
 CREATE TABLE a (b INT) WITH (fillfactor=100)
 ----
-CREATE TABLE a (b INT8) -- normalized!
-CREATE TABLE a (b INT8) -- fully parenthesized
-CREATE TABLE a (b INT8) -- literals removed
-CREATE TABLE _ (_ INT8) -- identifiers removed
+CREATE TABLE a (b INT8) WITH (fillfactor = 100) -- normalized!
+CREATE TABLE a (b INT8) WITH (fillfactor = (100)) -- fully parenthesized
+CREATE TABLE a (b INT8) WITH (fillfactor = _) -- literals removed
+CREATE TABLE _ (_ INT8) WITH (_ = 100) -- identifiers removed
 
 parse
 CREATE TABLE arr_t (i STRING DEFAULT (('{' || 'a' || '}')::STRING[])[1]::STRING)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -626,7 +626,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 		var relOptions tree.Datum = tree.DNull
 		if ttl := table.GetRowLevelTTL(); ttl != nil {
 			relOptionsArr := tree.NewDArray(types.String)
-			if err := relOptionsArr.Append(tree.NewDString(fmt.Sprintf("expire_after=%s", ttl.DurationExpr))); err != nil {
+			if err := relOptionsArr.Append(tree.NewDString(fmt.Sprintf("ttl_expire_after=%s", ttl.DurationExpr))); err != nil {
 				return err
 			}
 			relOptions = relOptionsArr

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -623,6 +623,14 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 		if table.IsTemporary() {
 			relPersistence = relPersistenceTemporary
 		}
+		var relOptions tree.Datum = tree.DNull
+		if ttl := table.GetRowLevelTTL(); ttl != nil {
+			relOptionsArr := tree.NewDArray(types.String)
+			if err := relOptionsArr.Append(tree.NewDString(fmt.Sprintf("expire_after=%s", ttl.DurationExpr))); err != nil {
+				return err
+			}
+			relOptions = relOptionsArr
+		}
 		namespaceOid := h.NamespaceOid(db.GetID(), scName)
 		if err := addRow(
 			tableOid(table.GetID()),        // oid
@@ -652,7 +660,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			tree.DBoolFalse, // relhassubclass
 			zeroVal,         // relfrozenxid
 			tree.DNull,      // relacl
-			tree.DNull,      // reloptions
+			relOptions,      // reloptions
 			// These columns were automatically created by pg_catalog_test's missing column generator.
 			tree.DNull, // relforcerowsecurity
 			tree.DNull, // relispartition

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1489,8 +1489,11 @@ func (node *CreateTable) FormatBody(ctx *FmtCtx) {
 		if node.PartitionByTable != nil {
 			ctx.FormatNode(node.PartitionByTable)
 		}
-		// No storage parameters are implemented, so we never list the storage
-		// parameters in the output format.
+		if node.StorageParams != nil {
+			ctx.WriteString(` WITH (`)
+			ctx.FormatNode(&node.StorageParams)
+			ctx.WriteByte(')')
+		}
 		if node.Locality != nil {
 			ctx.WriteString(" ")
 			ctx.FormatNode(node.Locality)

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1265,6 +1265,15 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 	if node.PartitionByTable != nil {
 		clauses = append(clauses, p.Doc(node.PartitionByTable))
 	}
+	if node.StorageParams != nil {
+		clauses = append(
+			clauses,
+			pretty.ConcatSpace(
+				pretty.Keyword(`WITH`),
+				p.bracket(`(`, p.Doc(&node.StorageParams), `)`),
+			),
+		)
+	}
 	if node.Locality != nil {
 		clauses = append(clauses, p.Doc(node.Locality))
 	}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -175,6 +175,12 @@ func ShowCreateTable(
 		return "", err
 	}
 
+	if ttl := desc.GetRowLevelTTL(); ttl != nil {
+		f.Buffer.WriteString(` WITH (expire_after = `)
+		f.Buffer.WriteString(ttl.DurationExpr)
+		f.Buffer.WriteString(`)`)
+	}
+
 	if err := showCreateLocality(desc, f); err != nil {
 		return "", err
 	}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -176,7 +176,7 @@ func ShowCreateTable(
 	}
 
 	if ttl := desc.GetRowLevelTTL(); ttl != nil {
-		f.Buffer.WriteString(` WITH (expire_after = `)
+		f.Buffer.WriteString(` WITH (ttl_expire_after = `)
 		f.Buffer.WriteString(ttl.DurationExpr)
 		f.Buffer.WriteString(`)`)
 	}


### PR DESCRIPTION
These commits allow the WITH option in a table to symbolize TTL.
Furthermore, these values can be introspected.

Refs: #75428

See individual commits for details.