### PR TITLE
scripts: simplify (fix) `gceworker mosh`

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -100,18 +100,14 @@ case "${cmd}" in
     echo "****************************************"
     echo "Hint: you should also be able to directly invoke:"
     echo "ssh ${FQNAME}"
+    echo "  or"
+    echo "mosh ${FQNAME}"
     echo "instead of '$0 ssh'."
     echo "****************************************"
     gcloud compute ssh "${NAME}" --ssh-flag="-A" "$@"
     ;;
     mosh)
-    # An alternative solution would be to run gcloud compute config-ssh after
-    # starting or creating the vm, which adds stanzas to ~/.ssh/config that
-    # make `ssh $HOST` (and by extension, hopefully, mosh).
-    read -r -a arr <<< "$(gcloud compute ssh "${NAME}" --dry-run)"
-    host="${arr[-1]}"
-    unset 'arr[${#arr[@]}-1]'
-    mosh --ssh=$(printf '%q' "${arr}") $host
+    mosh "${FQNAME}"
     ;;
     scp)
     # Example: $0 scp gceworker-youruser:go/src/github.com/cockroachdb/cockroach/cockroach-data/logs gcelogs --recurse


### PR DESCRIPTION
At least on my machine, we need to use the $FQNAME because that has the
corresponding section in the ssh config specifying the correct public
key (maintained via `gcloud [...] config-ssh`.

Release note: None
