### PR TITLE
kvserver: deflake a deflake attempt for ..

### DIFF
--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -269,7 +269,14 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		moveTableToNewStore(t, tc, args, tablePrefix)
 
 		// Ensure that the new replica has applied the same config.
-		waitForSpanConfig(t, tc, tablePrefix, newMax)
+		testutils.SucceedsSoon(t, func() error {
+			_, r := getFirstStoreReplica(t, tc.Server(1), tablePrefix)
+			conf := r.SpanConfig()
+			if conf.RangeMaxBytes != newMax {
+				return fmt.Errorf("expected %d, got %d", newMax, conf.RangeMaxBytes)
+			}
+			return nil
+		})
 
 		s, repl := getFirstStoreReplica(t, tc.Server(1), tablePrefix)
 		s.SetReplicateQueueActive(false)


### PR DESCRIPTION
...TestBackpressureNotAppliedWhenReducingRangeSize. Fixes #75609, a
regression we introduced in #75598. When waiting for a span config to
materialize on a given node, we were accidentally tripping up on it not
being found on the original. Not sure we this slipped CI.

Release note: None