### PR TITLE
ui: add circuit breaker metrics on Replication metrics page

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -901,7 +901,7 @@ var charts = []sectionDescription{
 			},
 			{
 				Title:       "Replicas with tripped circuit breakers",
-				Downsampler: DescribeAggregator_MAX,
+				Downsampler: DescribeAggregator_SUM,
 				Metrics:     []string{"kv.replica_circuit_breaker.num_tripped_replicas"},
 			},
 			{

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -151,3 +151,17 @@ export const TransactionRestartsToolTip: React.FC<{
     for more details.
   </div>
 );
+
+export const CircuitBreakerTrippedReplicasTooltip: React.FC = () => (
+  <div>
+    Number of Replicas for which the per-Replica circuit breaker is currently
+    tripped.
+  </div>
+);
+
+export const CircuitBreakerTrippedEventsTooltip: React.FC = () => (
+  <div>
+    Number of times the per-Replica circuit breakers tripped since process
+    start.
+  </div>
+);

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -13,9 +13,9 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import {
-  Metric,
   Axis,
   AxisUnits,
+  Metric,
 } from "src/views/shared/components/metricQuery";
 
 import {
@@ -23,7 +23,13 @@ import {
   nodeDisplayName,
   storeIDsForNode,
 } from "./dashboardUtils";
-import { LogicalBytesGraphTooltip } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
+import {
+  CircuitBreakerTrippedEventsTooltip,
+  CircuitBreakerTrippedReplicasTooltip,
+  LogicalBytesGraphTooltip,
+} from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
+import { cockroach } from "src/js/protos";
+import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function(props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, storeSources } = props;
@@ -170,6 +176,39 @@ export default function(props: GraphDashboardProps) {
           title="Reserved"
           nonNegativeRate
         />
+      </Axis>
+    </LineGraph>,
+    <LineGraph
+      title="Circuit Breaker Tripped Replicas"
+      tooltip={CircuitBreakerTrippedReplicasTooltip}
+    >
+      <Axis label="replicas">
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.kv.replica_circuit_breaker.num_tripped_replicas"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+            downsampler={TimeSeriesQueryAggregator.SUM}
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+    <LineGraph
+      title="Circuit Breaker Tripped Events"
+      sources={storeSources}
+      tooltip={CircuitBreakerTrippedEventsTooltip}
+    >
+      <Axis label="events">
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.kv.replica_circuit_breaker.num_tripped_events"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+            downsampler={TimeSeriesQueryAggregator.MAX}
+          />
+        ))}
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/75068

Current change extends Replication metrics page with two
more graphs that display `Circuit Breaker Tripped Replicas`
and and `Circuit Breaker Tripped Events`.

Release note (ui change): add `Circuit Breaker` graphs on Replication
metrics page in Db Console.

Screen:
<img width="1026" alt="Screen Shot 2022-01-29 at 20 56 45" src="https://user-images.githubusercontent.com/3106437/151691797-d66613e4-77ca-4778-add5-fd5f8d36505e.png">
