### PR TITLE
jobs: make short intervals longer under race

### DIFF
--- a/pkg/jobs/testing_knobs.go
+++ b/pkg/jobs/testing_knobs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -96,7 +97,10 @@ type TestingIntervalOverrides struct {
 // NewTestingKnobsWithShortIntervals return a TestingKnobs structure with
 // overrides for short adopt and cancel intervals.
 func NewTestingKnobsWithShortIntervals() *TestingKnobs {
-	const defaultShortInterval = 10 * time.Millisecond
+	defaultShortInterval := 10 * time.Millisecond
+	if util.RaceEnabled {
+		defaultShortInterval *= 5
+	}
 	return NewTestingKnobsWithIntervals(
 		defaultShortInterval, defaultShortInterval, defaultShortInterval, defaultShortInterval,
 	)


### PR DESCRIPTION
We've seen that fast loops on race builds have a hard time keeping up. In the
case of #75616 we see an apparent live-lock situation due to contending low
priority transactions such that the jitter does not help. 10ms under stress
race is actually very short. I know we had problems with the closed timestamp
notifications at that frequency under stress race in the past. Hopefully
this helps deflake #75616.

Release note: None