### PR TITLE
ui/sessions: db console remove retries for internal errors

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/liveness/liveness.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/liveness/liveness.sagas.ts
@@ -40,7 +40,7 @@ export function* livenessSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed, rootActions.resetState],
+      [actions.invalidated, rootActions.resetState],
       refreshLivenessSaga,
     ),
     takeLatest(actions.request, requestLivenessSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.sagas.ts
@@ -43,7 +43,7 @@ export function* nodesSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed, rootActions.resetState],
+      [actions.invalidated, rootActions.resetState],
       refreshNodesSaga,
     ),
     takeLatest(actions.request, requestNodesSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
@@ -40,7 +40,7 @@ export function* sessionsSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed, rootActions.resetState],
+      [actions.invalidated, rootActions.resetState],
       refreshSessionsSaga,
     ),
     takeLatest(actions.request, requestSessionsSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -95,11 +95,7 @@ export function* sqlStatsSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       sqlStatsActions.refresh,
-      [
-        sqlStatsActions.invalidated,
-        sqlStatsActions.failed,
-        rootActions.resetState,
-      ],
+      [sqlStatsActions.invalidated, rootActions.resetState],
       refreshSQLStatsSaga,
     ),
     takeLatest(sqlStatsActions.request, requestSQLStatsSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
@@ -63,7 +63,7 @@ export function* statementsDiagnosticsSagas(
     throttleWithReset(
       delayMs,
       actions.refresh,
-      [actions.invalidated, actions.failed, rootActions.resetState],
+      [actions.invalidated, rootActions.resetState],
       refreshStatementsDiagnosticsSaga,
     ),
     takeLatest(actions.request, requestStatementsDiagnosticsSaga),


### PR DESCRIPTION
[CC-4500](https://cockroachlabs.atlassian.net/browse/CC-4500)

DB Console would retry requests indefinitely when receiving 
an Internal Server Error, flooding the backend with 
hundreds of requests per second. This change stops the 
throttler from retrying on such failures.

Additionally, request retries are no longer done on all 
db-console sagas that use the `throttleWithReset()` 
retry throttler and fail with an error code greater than 299. 

This change is implemented because we do not want a single 
error to overwhelm or kill a saga.

Release note: None