### PR TITLE
sql: skip TestDistSQLFlowsVirtualTables

### DIFF
--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -516,6 +517,7 @@ UPDATE system.namespace SET id = 12345 WHERE id = %d;
 
 func TestDistSQLFlowsVirtualTables(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRaceWithIssue(t, 75208, "flaky test under race")
 	defer log.Scope(t).Close(t)
 
 	const numNodes = 3


### PR DESCRIPTION
Refs: #75208

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None