### PR TITLE
systemspanconfig: introduce Target and encoding/decoding methods

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -198,6 +198,7 @@ ALL_TESTS = [
     "//pkg/spanconfig/spanconfigsqlwatcher:spanconfigsqlwatcher_test",
     "//pkg/spanconfig/spanconfigstore:spanconfigstore_test",
     "//pkg/spanconfig/spanconfigtestutils:spanconfigtestutils_test",
+    "//pkg/spanconfig/systemspanconfig:systemspanconfig_test",
     "//pkg/sql/catalog/catalogkeys:catalogkeys_test",
     "//pkg/sql/catalog/catformat:catformat_test",
     "//pkg/sql/catalog/catprivilege:catprivilege_test",

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
@@ -11,7 +11,7 @@ upsert /{Min-System/NodeLiveness}          ttl_seconds=3600 num_replicas=5
 upsert /System/NodeLiveness{-Max}          ttl_seconds=600 num_replicas=5
 upsert /System/{NodeLivenessMax-tsd}       range system
 upsert /System{/tsd-tse}                   range default
-upsert /System{tse-/Max}                   range system
+upsert /System{tse-/SystemSpanConfigKeys}  range system
 upsert /Table/{SystemConfigSpan/Start-4}   database system (host)
 upsert /Table/{4-5}                        database system (host)
 upsert /Table/{5-6}                        database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
@@ -13,7 +13,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system
 ...
 
 # Adding an explicit zone configuration for the timeseries range should work
@@ -48,8 +48,8 @@ mutations
 ----
 delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       range default
-delete /System{tse-/Max}
-upsert /System{tse-/Max}                   range default
+delete /System{tse-/SystemSpanConfigKeys}
+upsert /System{tse-/SystemSpanConfigKeys}  range default
 
 state limit=5
 ----
@@ -57,7 +57,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          ttl_seconds=42
-/System{tse-/Max}                          range default
+/System{tse-/SystemSpanConfigKeys}         range default
 ...
 
 # Ensure that discarding other named zones behave as expected (reparenting them
@@ -80,7 +80,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range default
+/System{tse-/SystemSpanConfigKeys}         range default
 ...
 
 
@@ -106,8 +106,8 @@ delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       ttl_seconds=50
 delete /System{/tsd-tse}
 upsert /System{/tsd-tse}                   ttl_seconds=50
-delete /System{tse-/Max}
-upsert /System{tse-/Max}                   ttl_seconds=50
+delete /System{tse-/SystemSpanConfigKeys}
+upsert /System{tse-/SystemSpanConfigKeys}  ttl_seconds=50
 delete /Table/5{6-7}
 upsert /Table/5{6-7}                       ttl_seconds=50
 
@@ -117,7 +117,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              ttl_seconds=50
 /System{/tsd-tse}                          ttl_seconds=50
-/System{tse-/Max}                          ttl_seconds=50
+/System{tse-/SystemSpanConfigKeys}         ttl_seconds=50
 ...
 
 state offset=46
@@ -150,8 +150,8 @@ mutations
 ----
 delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       ttl_seconds=100
-delete /System{tse-/Max}
-upsert /System{tse-/Max}                   ttl_seconds=100
+delete /System{tse-/SystemSpanConfigKeys}
+upsert /System{tse-/SystemSpanConfigKeys}  ttl_seconds=100
 
 state limit=5
 ----
@@ -159,5 +159,5 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              ttl_seconds=100
 /System{/tsd-tse}                          ttl_seconds=50
-/System{tse-/Max}                          ttl_seconds=100
+/System{tse-/SystemSpanConfigKeys}         ttl_seconds=100
 ...

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
@@ -24,7 +24,7 @@ full-translate
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system
 /Table/{SystemConfigSpan/Start-4}          database system (host)
 /Table/{4-5}                               database system (host)
 /Table/{5-6}                               database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
@@ -40,7 +40,7 @@ full-translate
 /System/NodeLiveness{-Max}                 range default
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range default
+/System{tse-/SystemSpanConfigKeys}         range default
 /Table/{SystemConfigSpan/Start-4}          database system (host)
 /Table/{4-5}                               database system (host)
 /Table/{5-6}                               database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/named_zones
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/named_zones
@@ -47,4 +47,4 @@ translate named-zone=liveness
 translate named-zone=system
 ----
 /System/{NodeLivenessMax-tsd}              range system
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -75,4 +75,3 @@ translate database=db
 /Table/56/{2-3}                            ttl_seconds=1 num_replicas=7 num_voters=5 pts=[3]
 /Table/5{6/3-7}                            num_replicas=7 num_voters=5 pts=[3]
 /Table/5{7-8}                              num_replicas=7
-

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
@@ -109,7 +109,7 @@ full-translate
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system
 /Table/{SystemConfigSpan/Start-4}          ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/{4-5}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/{5-6}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -293,7 +293,31 @@ var (
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 	// TimeseriesKeyMax is the maximum value for any timeseries data.
 	TimeseriesKeyMax = TimeseriesPrefix.PrefixEnd()
-
+	//
+	// SystemSpanConfigPrefix is the key prefix for all system span config data.
+	//
+	// We sort this at the end of the system keyspace to easily be able to exclude
+	// it from the span configuration that applies over the system keyspace. This
+	// is important because spans carved out from this range are used to store
+	// system span configurations in the `system.span_configurations` table, and
+	// as such, have special meaning associated with them; nothing is stored in
+	// the range itself.
+	SystemSpanConfigPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("\xffsys-scfg")))
+	// SystemSpanConfigEntireKeyspace is the key prefix used to denote that the
+	// associated system span configuration applies over the entire keyspace
+	// (including all secondary tenants).
+	SystemSpanConfigEntireKeyspace = roachpb.Key(makeKey(SystemSpanConfigPrefix, roachpb.RKey("host/all")))
+	// SystemSpanConfigHostOnTenantKeyspace is the key prefix used to denote that
+	// the associated system span configuration was applied by the host tenant
+	// over the keyspace of a secondary tenant.
+	SystemSpanConfigHostOnTenantKeyspace = roachpb.Key(makeKey(SystemSpanConfigPrefix, roachpb.RKey("host/ten/")))
+	// SystemSpanConfigSecondaryTenantOnEntireKeyspace is the key prefix used to
+	// denote that the associated system span configuration was applied by a
+	// secondary tenant over its entire keyspace.
+	SystemSpanConfigSecondaryTenantOnEntireKeyspace = roachpb.Key(makeKey(SystemSpanConfigPrefix, roachpb.RKey("ten/")))
+	// SystemSpanConfigKeyMax is the maximum value for any system span config key.
+	SystemSpanConfigKeyMax = SystemSpanConfigPrefix.PrefixEnd()
+	//
 	// 3. System tenant SQL keys
 	//
 	// TODO(nvanbenschoten): Figure out what to do with all of these. At a

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -245,17 +245,18 @@ var _ = [...]interface{}{
 	// 	2. System keys: This is where we store global, system data which is
 	// 	replicated across the cluster.
 	SystemPrefix,
-	NodeLivenessPrefix,  // "\x00liveness-"
-	BootstrapVersionKey, // "bootstrap-version"
-	descIDGenerator,     // "desc-idgen"
-	NodeIDGenerator,     // "node-idgen"
-	RangeIDGenerator,    // "range-idgen"
-	StatusPrefix,        // "status-"
-	StatusNodePrefix,    // "status-node-"
-	StoreIDGenerator,    // "store-idgen"
-	MigrationPrefix,     // "system-version/"
-	MigrationLease,      // "system-version/lease"
-	TimeseriesPrefix,    // "tsd"
+	NodeLivenessPrefix,     // "\x00liveness-"
+	BootstrapVersionKey,    // "bootstrap-version"
+	descIDGenerator,        // "desc-idgen"
+	NodeIDGenerator,        // "node-idgen"
+	RangeIDGenerator,       // "range-idgen"
+	StatusPrefix,           // "status-"
+	StatusNodePrefix,       // "status-node-"
+	StoreIDGenerator,       // "store-idgen"
+	MigrationPrefix,        // "system-version/"
+	MigrationLease,         // "system-version/lease"
+	TimeseriesPrefix,       // "tsd"
+	SystemSpanConfigPrefix, // "xffsys-scfg"
 	SystemMax,
 
 	// 	3. System tenant SQL keys: This is where we store all system-tenant

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -128,6 +128,10 @@ var (
 				ppFunc: timeseriesKeyPrint,
 				PSFunc: parseUnsupported,
 			},
+			{Name: "/SystemSpanConfigKeys", prefix: SystemSpanConfigPrefix,
+				ppFunc: decodeKeyPrint,
+				PSFunc: parseUnsupported,
+			},
 		}},
 		{Name: "/NamespaceTable", start: NamespaceTableMin, end: NamespaceTableMax, Entries: []DictEntry{
 			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: parseUnsupported},

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -37,6 +37,12 @@ var (
 	// TimeseriesSpan holds all the timeseries data in the cluster.
 	TimeseriesSpan = roachpb.Span{Key: TimeseriesPrefix, EndKey: TimeseriesKeyMax}
 
+	// SystemSpanConfigSpan is part of the system keyspace that is used to carve
+	// out spans for system span configurations. No data is stored in these spans,
+	// instead, special meaning is assigned to them when stored in
+	// `system.span_configurations`.
+	SystemSpanConfigSpan = roachpb.Span{Key: SystemSpanConfigPrefix, EndKey: SystemSpanConfigKeyMax}
+
 	// SystemConfigSpan is the range of system objects which will be gossiped.
 	SystemConfigSpan = roachpb.Span{Key: SystemConfigSplitKey, EndKey: SystemConfigTableDataMax}
 

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -270,7 +270,7 @@ func (f *fullReconciler) reconcile(
 func (f *fullReconciler) fetchExistingSpanConfigs(
 	ctx context.Context,
 ) (*spanconfigstore.Store, error) {
-	var tenantSpan roachpb.Span
+	var spans []roachpb.Span
 	if f.codec.ForSystemTenant() {
 		// The system tenant governs all system keys (meta, liveness, timeseries
 		// ranges, etc.) and system tenant tables.
@@ -278,28 +278,36 @@ func (f *fullReconciler) fetchExistingSpanConfigs(
 		// TODO(irfansharif): Should we include the scratch range here? Some
 		// tests make use of it; we may want to declare configs over it and have
 		// it considered all the same.
-		tenantSpan = roachpb.Span{
+		//
+		// We don't want to request configs that are part of the
+		// SystemSpanConfigSpan, as the host tenant reserves that part of the
+		// keyspace to translate and persist SystemSpanConfigs. At the level of the
+		// reconciler we shouldn't be requesting these configs directly, instead,
+		// they should be targeted through SystemSpanConfigTargets instead.
+		spans = append(spans, roachpb.Span{
 			Key:    keys.EverythingSpan.Key,
+			EndKey: keys.SystemSpanConfigSpan.Key,
+		})
+		spans = append(spans, roachpb.Span{
+			Key:    keys.TableDataMin,
 			EndKey: keys.TableDataMax,
-		}
+		})
 		if f.knobs.ConfigureScratchRange {
-			tenantSpan.EndKey = keys.ScratchRangeMax
+			spans[1].EndKey = keys.ScratchRangeMax
 		}
 	} else {
 		// Secondary tenants govern everything prefixed by their tenant ID.
 		tenPrefix := keys.MakeTenantPrefix(f.tenID)
-		tenantSpan = roachpb.Span{
+		spans = append(spans, roachpb.Span{
 			Key:    tenPrefix,
 			EndKey: tenPrefix.PrefixEnd(),
-		}
+		})
 	}
 
 	store := spanconfigstore.New(roachpb.SpanConfig{})
 	{
 		// Fully populate the store with KVAccessor contents.
-		entries, err := f.kvAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			tenantSpan,
-		})
+		entries, err := f.kvAccessor.GetSpanConfigEntriesFor(ctx, spans)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -209,6 +209,10 @@ func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 		// Add spans for the system range without the timeseries and
 		// liveness ranges, which are individually captured above.
 		//
+		// We also don't apply configurations over the SystemSpanConfigSpan; spans
+		// carved from this range have no data, instead, associated configurations
+		// for these spans have special meaning in `system.span_configurations`.
+		//
 		// Note that the NodeLivenessSpan sorts before the rest of the system
 		// keyspace, so the first span here starts at the end of the
 		// NodeLivenessSpan.
@@ -218,7 +222,7 @@ func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 		})
 		spans = append(spans, roachpb.Span{
 			Key:    keys.TimeseriesSpan.EndKey,
-			EndKey: keys.SystemMax,
+			EndKey: keys.SystemSpanConfigSpan.Key,
 		})
 	case zonepb.TenantsZoneName: // nothing to do.
 	default:

--- a/pkg/spanconfig/systemspanconfig/BUILD.bazel
+++ b/pkg/spanconfig/systemspanconfig/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "systemspanconfig",
+    srcs = [
+        "encoderdecoder.go",
+        "target.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/systemspanconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/util/encoding",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "systemspanconfig_test",
+    srcs = ["target_test.go"],
+    embed = [":systemspanconfig"],
+    deps = [
+        "//pkg/roachpb:with-mocks",
+        "//pkg/testutils",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/spanconfig/systemspanconfig/encoderdecoder.go
+++ b/pkg/spanconfig/systemspanconfig/encoderdecoder.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package systemspanconfig
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/errwrap/testdata/src/github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+// EncodeTarget is used to convert a systemspanconfig.Target into a roachpb.Span
+// suitable for persistence in the `system.span_configurations` table.
+func EncodeTarget(target Target) roachpb.Span {
+	var k roachpb.Key
+
+	if target.SourceTenantID == roachpb.SystemTenantID && target.TargetTenantID == roachpb.SystemTenantID {
+		k = keys.SystemSpanConfigEntireKeyspace
+	} else if target.SourceTenantID == roachpb.SystemTenantID {
+		k = encoding.EncodeUvarintAscending(
+			keys.SystemSpanConfigHostOnTenantKeyspace, target.TargetTenantID.InternalValue,
+		)
+	} else {
+		k = encoding.EncodeUvarintAscending(
+			keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace, target.SourceTenantID.InternalValue,
+		)
+	}
+	return roachpb.Span{Key: k, EndKey: k.PrefixEnd()}
+}
+
+// DecodeTarget converts the given span into a systemspanconfig.Target. An error
+// is returned if the span does not conform to the encoding used to store system
+// span configs in `system.span_configurations`.
+func DecodeTarget(span roachpb.Span) (Target, error) {
+	if bytes.HasPrefix(span.Key, keys.SystemSpanConfigEntireKeyspace) {
+		return MakeTarget(roachpb.SystemTenantID, roachpb.SystemTenantID)
+	}
+
+	// System span config was applied by the host tenant over a secondary
+	// tenant's entire keyspace.
+	if bytes.HasPrefix(span.Key, keys.SystemSpanConfigHostOnTenantKeyspace) {
+		tenIDBytes := span.Key[len(keys.SystemSpanConfigHostOnTenantKeyspace):]
+		_, tenIDRaw, err := encoding.DecodeUvarintAscending(tenIDBytes)
+		if err != nil {
+			return Target{}, err
+		}
+		tenID := roachpb.MakeTenantID(tenIDRaw)
+		return MakeTarget(roachpb.SystemTenantID, tenID)
+	}
+
+	// System span config was applied by a secondary tenant over its entire
+	// keyspace.
+	if bytes.HasPrefix(span.Key, keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace) {
+		tenIDBytes := span.Key[len(keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace):]
+		_, tenIDRaw, err := encoding.DecodeUvarintAscending(tenIDBytes)
+		if err != nil {
+			return Target{}, err
+		}
+		tenID := roachpb.MakeTenantID(tenIDRaw)
+		return MakeTarget(tenID, tenID)
+	}
+
+	return Target{}, errors.AssertionFailedf("did not find prefix")
+}

--- a/pkg/spanconfig/systemspanconfig/target.go
+++ b/pkg/spanconfig/systemspanconfig/target.go
@@ -1,0 +1,77 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package systemspanconfig
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// Target specifies the target of a system span configuration.
+type Target struct {
+	// SourceTenantID is the ID of the tenant that specified the system span
+	// configuration.
+	SourceTenantID roachpb.TenantID
+
+	// TargetTenantID is the ID of the tenant that the associated system span
+	// configuration applies to. If the host tenant is the source then the
+	// system span configuration applies over all ranges in the system (including
+	// those belonging to secondary tenants).
+	//
+	// Secondary tenants are only allowed to target themselves. The host tenant
+	// may use this field to target a specific secondary tenant.
+	TargetTenantID roachpb.TenantID
+}
+
+// MakeTargetUsingSourceContext constructs a new systemspanconfig.Target given a
+// roachp.SystemSpanConfigTarget. The SourceTenantID is derived from the
+// context passed in.
+func MakeTargetUsingSourceContext(
+	ctx context.Context, target roachpb.SystemSpanConfigTarget,
+) (Target, error) {
+	var sourceTenantID roachpb.TenantID
+	var targetTenantID roachpb.TenantID
+	if tenID, ok := roachpb.TenantFromContext(ctx); ok {
+		sourceTenantID = tenID
+	} else {
+		sourceTenantID = roachpb.SystemTenantID
+	}
+
+	if target.TenantID != nil {
+		targetTenantID = *target.TenantID
+	} else {
+		targetTenantID = sourceTenantID
+	}
+	return MakeTarget(sourceTenantID, targetTenantID)
+}
+
+// MakeTarget constructs a systemspanconfig.Target given a sourceTenantID and
+// targetTenantID.
+func MakeTarget(sourceTenantID roachpb.TenantID, targetTenantID roachpb.TenantID) (Target, error) {
+	t := Target{
+		SourceTenantID: sourceTenantID,
+		TargetTenantID: targetTenantID,
+	}
+	return t, t.validate()
+}
+
+func (t *Target) validate() error {
+	if t.SourceTenantID != roachpb.SystemTenantID && t.SourceTenantID != t.TargetTenantID {
+		return errors.AssertionFailedf(
+			"secondary tenant %s cannot target another tenant with ID %s",
+			t.SourceTenantID,
+			t.TargetTenantID,
+		)
+	}
+	return nil
+}

--- a/pkg/spanconfig/systemspanconfig/target_test.go
+++ b/pkg/spanconfig/systemspanconfig/target_test.go
@@ -1,0 +1,140 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package systemspanconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncodeDecodeTarget ensures that encoding/decoding a
+// systemspanconfig.Target is roundtripable.
+func TestEncodeDecodeTarget(t *testing.T) {
+	makeTargetOrFatal := func(sourceID roachpb.TenantID, targetID roachpb.TenantID) Target {
+		target, err := MakeTarget(sourceID, targetID)
+		require.NoError(t, err)
+		return target
+	}
+	for _, testTarget := range []Target{
+		// Tenant targeting its logical cluster.
+		makeTargetOrFatal(roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+		// System tenant targeting its logical cluster.
+		makeTargetOrFatal(roachpb.SystemTenantID, roachpb.SystemTenantID),
+		// System tenant targeting a secondary tenant.
+		makeTargetOrFatal(roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+	} {
+		target, err := DecodeTarget(EncodeTarget(testTarget))
+		require.NoError(t, err)
+		require.Equal(t, testTarget, target)
+	}
+}
+
+// TestTargetValidation ensures target.validate() works as expected.
+func TestTargetValidation(t *testing.T) {
+	for _, tc := range []struct {
+		sourceID roachpb.TenantID
+		targetID roachpb.TenantID
+		expErr   string
+	}{
+		{
+			// Secondary tenants cannot target the system tenant.
+			sourceID: roachpb.MakeTenantID(10),
+			targetID: roachpb.SystemTenantID,
+			expErr:   "secondary tenant 10 cannot target another tenant with ID",
+		},
+		{
+			// Secondary tenants cannot target other secondary tenants.
+			sourceID: roachpb.MakeTenantID(10),
+			targetID: roachpb.MakeTenantID(20),
+			expErr:   "secondary tenant 10 cannot target another tenant with ID",
+		},
+		// Test some valid targets.
+		{
+			// System tenant targeting secondary tenant is allowed.
+			sourceID: roachpb.SystemTenantID,
+			targetID: roachpb.MakeTenantID(20),
+		},
+		{
+			// System tenant targeting itself is allowed.
+			sourceID: roachpb.SystemTenantID,
+			targetID: roachpb.SystemTenantID,
+		},
+		{
+			// Secondary tenant targeting itself is allowed.
+			sourceID: roachpb.MakeTenantID(10),
+			targetID: roachpb.MakeTenantID(10),
+		},
+	} {
+		target := Target{
+			SourceTenantID: tc.sourceID,
+			TargetTenantID: tc.targetID,
+		}
+		require.True(t, testutils.IsError(target.validate(), tc.expErr))
+	}
+}
+
+// TestMakeTargetUsingSourceContext ensures that the targeting tenant ID is
+// correctly inferred from a context when constructing a systemspanconfig.Target
+// from a roachpb.SystemSpanConfigTarget.
+func TestMakeTargetUsingSourceContext(t *testing.T) {
+	makeSystemSpanConfigTarget := func(tenantID roachpb.TenantID) roachpb.SystemSpanConfigTarget {
+		return roachpb.SystemSpanConfigTarget{
+			TenantID: &tenantID,
+		}
+	}
+	clusterTarget := roachpb.SystemSpanConfigTarget{}
+	for _, tc := range []struct {
+		tenantID               roachpb.TenantID
+		systemSpanConfigTarget roachpb.SystemSpanConfigTarget
+		expErr                 string
+	}{
+		{
+			tenantID:               roachpb.SystemTenantID,
+			systemSpanConfigTarget: makeSystemSpanConfigTarget(roachpb.MakeTenantID(10)),
+		},
+		{
+			tenantID:               roachpb.SystemTenantID,
+			systemSpanConfigTarget: clusterTarget,
+		},
+		{
+			tenantID:               roachpb.MakeTenantID(10),
+			systemSpanConfigTarget: clusterTarget,
+		},
+		// Invalid scenarios.
+		{
+			tenantID:               roachpb.MakeTenantID(10),
+			systemSpanConfigTarget: makeSystemSpanConfigTarget(roachpb.SystemTenantID),
+			expErr:                 "secondary tenant 10 cannot target another tenant with ID",
+		},
+		{
+			tenantID:               roachpb.MakeTenantID(10),
+			systemSpanConfigTarget: makeSystemSpanConfigTarget(roachpb.MakeTenantID(20)),
+			expErr:                 "secondary tenant 10 cannot target another tenant with ID",
+		},
+	} {
+		ctx := roachpb.NewContextForTenant(context.Background(), tc.tenantID)
+		target, err := MakeTargetUsingSourceContext(ctx, tc.systemSpanConfigTarget)
+		require.True(t, testutils.IsError(err, tc.expErr))
+		if tc.expErr != "" {
+			require.Equal(t, tc.tenantID, target.SourceTenantID)
+			expectedTargetTenantID := tc.tenantID
+			if tc.systemSpanConfigTarget.TenantID != nil {
+				expectedTargetTenantID = *tc.systemSpanConfigTarget.TenantID
+			}
+			require.Equal(t, expectedTargetTenantID, target.TargetTenantID)
+		}
+		require.True(t, testutils.IsError(target.validate(), tc.expErr))
+	}
+}


### PR DESCRIPTION
This patch introduces a new `systemspanconfig.Target` type which is
intended as in interemediate representation for system span config
targets throughout the `spanconfig` package. It ties together a
targeter tenant ID with a targetee tenant ID (along with validation
to ensure secondary tenants don't target other tenants).

We also reserve a `SystemSpanConfigSpan` at the end of the System
range. This allows us to assign special meaning to key-prefixes carved
out of this range (when stored in `system.span_configurations`).
By ensuring this span is carved at the end of the system range, we can
ensure that the host tenant does not install span configurations to this
span directly.

We define special key prefixes for system span configurations in this
range and establish a mapping between a Target <-> span using `Encode`
and `Decode` methods. This is useful when we store sysytem span
configurations in `system.span_configurations`  given its schema. Ditto
for reading from the table.

We'll make use of the `Target` in upcoming PRs, specifically in the
`KVAccessor`, `KVSubscriber`, and (the upcoming)
`SystemSpanConfigStore`.

The `KVAccessor` will construct `Targets` using tenant information from
the context as the targeter tenant. It'll use the
`roachpb.SystemSpanConfigTargets` supplied to it by RPCs (See cockroachdb#75615).
The encoding/decoding methods will be used when writing to/reading from
`system.span_configurations`.

While the existing `roachpb.SystemSpanConfigTarget` is sufficient
for our use in the `KVAccessor` (which runs on SQL pods), the richer
structure is motivated by the desire to also use this type in the
`KVSubscriber` (when receiving system span config events) and
`SystemSpanConfigStore` (which is an in-memory representation of the
system span config state). Down in KV we want to distinguish between a
tenant installed system span config on its entire keyspace vs. a host
tenant installed system span config over a tenants keyspace.

Release note: None