### PR TITLE
sql,security: gate session revival behind a cluster setting

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -303,10 +303,6 @@ type sqlServerArgs struct {
 	// monitorAndMetrics contains the return value of newRootSQLMemoryMonitor.
 	monitorAndMetrics monitorAndMetrics
 
-	// allowSessionRevival is true if the cluster is allowed to create session
-	// revival tokens and use them to authenticate a session.
-	allowSessionRevival bool
-
 	// settingsStorage is an optional interface to drive storing of settings
 	// data on disk to provide a fresh source of settings upon next startup.
 	settingsStorage settingswatcher.Storage
@@ -692,7 +688,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		CompactEngineSpanFunc:   compactEngineSpanFunc,
 		TraceCollector:          traceCollector,
 		TenantUsageServer:       cfg.tenantUsageServer,
-		AllowSessionRevival:     cfg.allowSessionRevival,
 
 		DistSQLPlanner: sql.NewDistSQLPlanner(
 			ctx,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -567,7 +567,6 @@ func makeTenantSQLServerArgs(
 		rangeFeedFactory:         rangeFeedFactory,
 		regionsServer:            tenantConnect,
 		costController:           costController,
-		allowSessionRevival:      true,
 		grpc:                     grpcServer,
 	}, nil
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1267,10 +1267,6 @@ type ExecutorConfig struct {
 	// SessionData and other ExtraTxnState.
 	// This is currently only for builtin functions where we need to execute sql.
 	InternalExecutorFactory sqlutil.SessionBoundInternalExecutorFactory
-
-	// AllowSessionRevival is true if the cluster is allowed to create session
-	// revival tokens and use them to authenticate a session.
-	AllowSessionRevival bool
 }
 
 // UpdateVersionSystemSettingHook provides a callback that allows us

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3136,6 +3136,11 @@ SELECT hmac('dog', 'key', 'made up alg')
 
 subtest session_revival_token
 
+statement ok
+SET CLUSTER SETTING server.user_login.session_revival_token.enabled = true;
+CREATE USER parentuser;
+GRANT parentuser TO testuser
+
 skipif config 3node-tenant
 statement error session revival tokens are not supported on this cluster
 select crdb_internal.create_session_revival_token()
@@ -3143,10 +3148,6 @@ select crdb_internal.create_session_revival_token()
 onlyif config 3node-tenant
 statement error cannot create token for root user
 select crdb_internal.create_session_revival_token()
-
-statement ok
-CREATE USER parentuser;
-GRANT parentuser TO testuser
 
 user testuser
 
@@ -3194,3 +3195,8 @@ FROM
   c, a
 ----
 Ed25519  testuser  true  true  true  true
+
+user root
+
+statement ok
+SET CLUSTER SETTING server.user_login.session_revival_token.enabled = false

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -609,7 +609,7 @@ func authSessionRevivalToken(token []byte) AuthMethod {
 		b.SetRoleMapper(UseProvidedIdentity)
 		b.SetAuthenticator(func(ctx context.Context, user security.SQLUsername, _ bool, _ PasswordRetrievalFn) error {
 			c.LogAuthInfof(ctx, "session revival token detected; attempting to use it")
-			if !execCfg.AllowSessionRevival {
+			if !sql.AllowSessionRevival.Get(&execCfg.Settings.SV) || execCfg.Codec.ForSystemTenant() {
 				return errors.New("session revival tokens are not supported on this cluster")
 			}
 			cm, err := execCfg.RPCContext.SecurityContext.GetCertificateManager()


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/74643

Stop allowing any multitenant cluster from using this functionality.

Release note (security update): The cluster setting
server.user_login.session_revival_token.enabled has been added. It is
false by default. If it is set to true, then a new
token-based authentication mechanism is enabled. A token can be
generated using the crdb_internal.create_session_revival_token builtin
function. The token has a lifetime of 10 minutes and is
cryptographically signed to prevent spoofing and brute-forcing attempts.
When initializing a session later, the token can be presented in a
pgwire StartupMessage with a parameter name of
`crdb:session_revival_token_base64`, with the value encoded in base64.
If this parameter is present, all other authentication checks are
disabled, and if the token is valid and has a valid signature, the user
who originally generated the token authenticates into a new SQL
session. If the token is not valid, then authentication fails.

The token does not have "use-once" semantics, so the same token can be
used any number of times to create multiple new SQL sessions within the
10 minute lifetime of the token. As such, the token should be treated as
highly sensitive cryptographic information.

This feature is meant to be used by multitenant deployments to move a
SQL session from one node to another. It requires the presence of a
valid Ed25519 keypair in tenant-signing.<tenant_id>.crt and
tenant-signing.<tenant_id>.key.