### PR TITLE
allows `roachprod start` runtime parameters `--log` or `--log-config-file` to override the hardcoded default

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -489,11 +489,17 @@ func (c *SyncedCluster) generateStartArgs(
 	}
 
 	logDir := c.LogDir(node)
-	if vers.AtLeast(version.MustParse("v21.1.0-alpha.0")) {
-		// Specify exit-on-error=false to work around #62763.
-		args = append(args, "--log", `file-defaults: {dir: '`+logDir+`', exit-on-error: false}`)
-	} else {
-		args = append(args, `--log-dir`, logDir)
+	idx1 := argExists(startOpts.ExtraArgs, "--log")
+	idx2 := argExists(startOpts.ExtraArgs, "--log-config-file")
+
+	// if neither --log nor --log-config-file are present
+	if idx1 == -1 && idx2 == -1 {
+		if vers.AtLeast(version.MustParse("v21.1.0-alpha.0")) {
+			// Specify exit-on-error=false to work around #62763.
+			args = append(args, "--log", `file-defaults: {dir: '`+logDir+`', exit-on-error: false}`)
+		} else {
+			args = append(args, `--log-dir`, logDir)
+		}
 	}
 
 	listenHost := ""


### PR DESCRIPTION
When running `roachprod start`, by default a flag `--log` is added
with some hardcoded value to the `cockroach start` command.
This value cannot be overriden by passing either `--log`
or `--log-config-file` at runtime via the `--args` option
in `roachprod start`.

Therefore, there is no way to specify a custom log option.
To allow for this feature, I added a check that checks whether
a `--log` or `--log-config-file` flag was passed inside `--args`,
and if eiher is true, then the default value
should not apply and the runtime param should be used instead.

Release note: None