### PR TITLE
acceptance,dev: inject `cockroach` binary into acceptance for bazel

### DIFF
--- a/build/teamcity/cockroach/ci/tests/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests/acceptance.sh
@@ -4,6 +4,11 @@ set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Build cockroach"
+run_bazel /usr/bin/bash -c 'bazel build --config crosslinux --config ci //pkg/cmd/cockroach-short && cp $(bazel info bazel-bin --config crosslinux --config ci)/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short /artifacts/cockroach && chmod a+w /artifacts/cockroach'
+tc_end_block "Build cockroach"
 
 export ARTIFACTSDIR=$PWD/artifacts/acceptance
 mkdir -p "$ARTIFACTSDIR"
@@ -17,6 +22,7 @@ BAZCI=$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci
 $BAZCI run --config=crosslinux --config=test --artifacts_dir=$PWD/artifacts \
   //pkg/acceptance:acceptance_test -- \
   --test_arg=-l="$ARTIFACTSDIR" \
+  --test_arg=-b=$PWD/artifacts/cockroach \
   --test_env=TZ=America/New_York \
   --test_env=GO_TEST_WRAP_TESTV=1 \
   --test_timeout=1800 || status=$?

--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=7
+DEV_VERSION=8
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -40,18 +40,11 @@ go_test(
         "debug_remote_test.go",
         "main_test.go",
     ],
-    args = [
-        "-e",
-        "/cockroach/cockroach",
-        "-b",
-        "../../../../../../cmd/cockroach/cockroach_/cockroach",
-    ],
     data = glob([
         "testdata/**",
         "compose/**",
     ]) + [
         "//pkg/cli:interactive_tests",
-        "//pkg/cmd/cockroach:cockroach",
     ],
     embed = [":acceptance"],
     gotags = ["acceptance"],


### PR DESCRIPTION
The way `acceptance` used to be written meant that you couldn't run `dev
acceptance` on macOS -- getting a working Cockroach binary for Linux
requires building with `--config crosslinux`, which you can't do
natively on macOS since the cross-compilers run on Linux hosts. So to
make this work, we remove the explicit dependency of `acceptance` on
`cockroach` and instead require injecting a `cockroach` binary built
elsewhere. Then we rewrite `dev acceptance` to first cross-build
`cockroach-short` for Linux and then run the appropriate test.

Closes #75635.

Release note: None