### PR TITLE
cli: preserve options query param when using \c

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1285,6 +1285,9 @@ func (c *cliState) handleConnectInternal(cmd []string) error {
 	} else {
 		newURL.WithTransport(pgurl.TransportNone())
 	}
+	if err := newURL.AddOptions(currURL.GetExtraOptions()); err != nil {
+		return err
+	}
 
 	// Parse the arguments to \connect:
 	// it accepts newdb, user, host, port in that order.

--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -145,6 +145,31 @@ end_test
 send "\\q\r"
 eexpect eof
 
+start_test "Check that extra URL params are preserved when changing database"
+
+spawn $argv sql --certs-dir=$certs_dir --url=postgres://root@localhost:26257/defaultdb?options=--search_path%3Dcustom_path&statement_timeout=1234
+eexpect root@
+eexpect "/defaultdb>"
+send "SHOW search_path;\r"
+eexpect "custom_path"
+send "SHOW statement_timeout;\r"
+eexpect "1234"
+eexpect root@
+eexpect "/defaultdb>"
+send "\\c postgres\r"
+eexpect "using new connection URL"
+eexpect root@
+eexpect "/postgres>"
+send "SHOW search_path;\r"
+eexpect "custom_path"
+send "SHOW statement_timeout;\r"
+eexpect "1234"
+
+end_test
+
+send "\\q\r"
+eexpect eof
+
 stop_secure_server $argv $certs_dir
 
 # Some more tests with the insecure mode.

--- a/pkg/server/pgurl/pgurl.go
+++ b/pkg/server/pgurl/pgurl.go
@@ -129,6 +129,11 @@ func (u *URL) GetOption(opt string) string {
 	return getVal(u.extraOptions, opt)
 }
 
+// GetExtraOptions retrieves all of the extra options.
+func (u *URL) GetExtraOptions() url.Values {
+	return u.extraOptions
+}
+
 // WithInsecure configures the URL for CockroachDB servers running with
 // all security controls disabled.
 func (u *URL) WithInsecure() *URL {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/75345

Release note (bug fix): The "options" query parameter is no longer
removed when using the `\c` command in the cockroach SQL shell to
reconnect to the cluster.