### PR TITLE
cli: add signal handler to launch pprof endpoints

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -14,7 +14,11 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net"
+	"net/http"
+	"net/http/pprof"
 	"os"
+	"os/signal"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
@@ -23,7 +27,9 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
+	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+
 	// intentionally not all the workloads in pkg/ccl/workloadccl/allccl
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bank"       // registers workloads
 	_ "github.com/cockroachdb/cockroach/pkg/workload/bulkingest" // registers workloads
@@ -83,6 +89,8 @@ func getExitCode(err error) (errCode exit.Code) {
 }
 
 func doMain(cmd *cobra.Command, cmdName string) error {
+	defer debugSignalSetup()()
+
 	if cmd != nil {
 		// Apply the configuration defaults from environment variables.
 		// This must occur before the parameters are parsed by cobra, so
@@ -296,4 +304,63 @@ func UsageAndErr(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	return fmt.Errorf("unknown sub-command: %q", strings.Join(args, " "))
+}
+
+// debugSignalSetup sets up a signal handler for SIGUSR2 to enable debugging a
+// stuck or misbehaving process by opening an http server that exposes the pprof
+// endpoints on localhost. The resturned shutdown function should be called at
+// process exit to stop its associated goroutines.
+func debugSignalSetup() func() {
+	exit := make(chan struct{})
+	ctx := context.Background()
+
+	// For SIGUSR, we spawn a goroutine that when signaled will then start an http
+	// server, bound to localhost, which serves the go pprof endpoints. While a
+	// cockroach server process already serves theese on its HTTP port, other CLI
+	// commands, particularly short-lived client commands, do not open HTTP ports
+	// by default. The pprof endpoints however can be invaluable when inspecting
+	// a process that is behaving unexpectedly, thus this mechanism to request any
+	// cockroach process begin serving them when needed.
+	if debugSignal != nil {
+		debugSignalCh := make(chan os.Signal, 1)
+		signal.Notify(debugSignalCh, debugSignal)
+		go func() {
+			for {
+				select {
+				case <-exit:
+					return
+				case <-debugSignalCh:
+					log.Shout(context.Background(), severity.INFO, "setting up localhost debugging endpoint...")
+					mux := http.NewServeMux()
+					mux.HandleFunc("/debug/pprof/", pprof.Index)
+					mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+					mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+					mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+					mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+					listenAddr := "localhost:0"
+					listener, err := net.Listen("tcp", listenAddr)
+					if err != nil {
+						log.Shoutf(ctx, severity.WARNING, "debug server could not start listening on %s: %v", listenAddr, err)
+						continue
+					}
+
+					server := http.Server{Handler: mux}
+					go func() {
+						if err := server.Serve(listener); err != nil {
+							log.Warningf(ctx, "debug server: %v", err)
+						}
+					}()
+					log.Shoutf(ctx, severity.INFO, "debug server listening on %s", listener.Addr())
+					<-exit
+					if err := server.Shutdown(ctx); err != nil {
+						log.Warningf(ctx, "error shutting down debug server: %s", err)
+					}
+				}
+			}
+		}()
+	}
+	return func() {
+		close(exit)
+	}
 }

--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -29,10 +29,15 @@ send "$argv demo --no-example-database\r"
 eexpect root@
 # Dump goroutines in server.
 system "killall -QUIT `basename \$(realpath $argv)`"
-eexpect "SIGQUIT: quit"
+eexpect "SIGQUIT received"
 eexpect "RunAsyncTask"
 
-# Check that the client terminates.
+# Check that the client has survived.
+send "\r"
+eexpect root@
+
+# Finish the test.
+interrupt
 eexpect ":/# "
 end_test
 

--- a/pkg/cli/mt_proxy.go
+++ b/pkg/cli/mt_proxy.go
@@ -112,18 +112,6 @@ func waitForSignals(
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, drainSignals...)
 
-	// Dump the stacks when QUIT is received.
-	if quitSignal != nil {
-		quitSignalCh := make(chan os.Signal, 1)
-		signal.Notify(quitSignalCh, quitSignal)
-		go func() {
-			for {
-				<-quitSignalCh
-				log.DumpStacks(context.Background())
-			}
-		}()
-	}
-
 	select {
 	case err := <-errChan:
 		log.StartAlwaysFlush()

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -378,22 +378,6 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) (returnEr
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, drainSignals...)
 
-	// SIGQUIT is handled differently: for SIGQUIT we spawn a goroutine
-	// and we always handle it, no matter at which point during
-	// execution we are. This makes it possible to use SIGQUIT to
-	// inspect a running process and determine what it is currently
-	// doing, even if it gets stuck somewhere.
-	if quitSignal != nil {
-		quitSignalCh := make(chan os.Signal, 1)
-		signal.Notify(quitSignalCh, quitSignal)
-		go func() {
-			for {
-				<-quitSignalCh
-				log.DumpStacks(context.Background())
-			}
-		}()
-	}
-
 	// Check for stores with full disks and exit with an informative exit
 	// code. This needs to happen early during start, before we perform any
 	// writes to the filesystem including log rotation. We need to guarantee

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -40,6 +40,9 @@ var termSignal os.Signal = unix.SIGTERM
 // quitSignal is the signal to recognize to dump Go stacks.
 var quitSignal os.Signal = unix.SIGQUIT
 
+// debugSignal is the signal to open a pprof debugging server.
+var debugSignal os.Signal = unix.SIGUSR2
+
 func handleSignalDuringShutdown(sig os.Signal) {
 	// On Unix, a signal that was not handled gracefully by the application
 	// should be reraised so it is visible in the exit code.

--- a/pkg/cli/start_windows.go
+++ b/pkg/cli/start_windows.go
@@ -26,6 +26,9 @@ var termSignal os.Signal = nil
 // quitSignal is the signal to recognize to dump Go stacks.
 var quitSignal os.Signal = nil
 
+// debugSignal is the signal to open a pprof debugging server.
+var debugSignal os.Signal = nil
+
 const backgroundFlagDefined = false
 
 func handleSignalDuringShutdown(os.Signal) {

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // logging is the global state of the logging setup.
@@ -376,11 +377,13 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 	}
 }
 
-// DumpStacks produces a dump of the stack traces in the logging output.
-func DumpStacks(ctx context.Context) {
+// DumpStacks produces a dump of the stack traces in the logging
+// output, and also to stderr if the remainder of the logs don't go to
+// stderr by default.
+func DumpStacks(ctx context.Context, reason redact.RedactableString) {
 	allStacks := getStacks(true)
 	// TODO(knz): This should really be a "debug" level, not "info".
-	Infof(ctx, "stack traces:\n%s", allStacks)
+	Shoutf(ctx, severity.INFO, "%s. stack traces:\n%s", reason, allStacks)
 }
 
 func setActive() {


### PR DESCRIPTION
If we come across a stuck cockroach command that isn't a server, sometimes it is
is very difficult to debug it, as these non-server commands do not default to starting
a server on which to serve the usual pprof endpoints. These endpoints are enormously
helpful in debugging stuck processes, memory usage or performance, but at the same time
we do not want to just always start an http server in every shell command execution.
We could conditionally start a server on some flag or env var, but in many cases by the
time we realize we need to investigate the state of a stuck process, it is already running.

Instead, this change introduces a signal handler so that any cockroach process can be sent a
SIGUSR2 signal that will cuase it to start an http server bound to localhost that serves the
pprof inspection endpoints (heap, cpu, goroutine, etc).

Release note (ops change): sending a cockroach process, including one running a client command, a SIGUSR2 signal now causes it to open an http port that is serving the basic go performance inspection endpoints for use with pprof.