### PR TITLE
[WIP] opt: add passthrough orderings to ProjectSet

### DIFF
--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1122,6 +1122,14 @@ define OrdinalityPrivate {
 define ProjectSet {
     Input RelExpr
     Zip ZipExpr
+
+    # notNullCols is the set of columns (input or synthesized) that are known to
+    # be not-null.
+    notNullCols ColSet
+
+    # internalFuncDeps are the functional dependencies between all columns
+    # (input or synthesized).
+    internalFuncDeps FuncDepSet
 }
 
 # Window represents a window function. Window functions are operators which

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "mutation.go",
         "ordering.go",
         "project.go",
+        "project_set.go",
         "row_number.go",
         "scan.go",
         "select.go",

--- a/pkg/sql/opt/ordering/interesting_orderings.go
+++ b/pkg/sql/opt/ordering/interesting_orderings.go
@@ -41,6 +41,9 @@ func DeriveInterestingOrderings(e memo.RelExpr) props.OrderingSet {
 	case opt.ProjectOp:
 		res = interestingOrderingsForProject(e.(*memo.ProjectExpr))
 
+	case opt.ProjectSetOp:
+		res = interestingOrderingsForProjectSet(e.(*memo.ProjectSetExpr))
+
 	case opt.GroupByOp, opt.ScalarGroupByOp:
 		res = interestingOrderingsForGroupBy(e)
 
@@ -132,6 +135,15 @@ func interestingOrderingsForProject(prj *memo.ProjectExpr) props.OrderingSet {
 	res := inOrd.Copy()
 	outCols := prj.Relational().OutputCols
 	fds := prj.InternalFDs()
+	res.RestrictToCols(outCols, fds)
+	return res
+}
+
+func interestingOrderingsForProjectSet(prjs *memo.ProjectSetExpr) props.OrderingSet {
+	inOrd := DeriveInterestingOrderings(prjs.Input)
+	res := inOrd.Copy()
+	outCols := prjs.Relational().OutputCols
+	fds := prjs.InternalFDs()
 	res.RestrictToCols(outCols, fds)
 	return res
 }

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -109,6 +109,11 @@ func init() {
 		buildChildReqOrdering: projectBuildChildReqOrdering,
 		buildProvidedOrdering: projectBuildProvided,
 	}
+	funcMap[opt.ProjectSetOp] = funcs{
+		canProvideOrdering:    projectSetCanProvideOrdering,
+		buildChildReqOrdering: projectSetBuildChildReqOrdering,
+		buildProvidedOrdering: projectSetBuildProvided,
+	}
 	funcMap[opt.UnionOp] = funcs{
 		canProvideOrdering:    setOpCanProvideOrdering,
 		buildChildReqOrdering: setOpBuildChildReqOrdering,

--- a/pkg/sql/opt/ordering/project_set.go
+++ b/pkg/sql/opt/ordering/project_set.go
@@ -1,0 +1,70 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ordering
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+)
+
+func projectSetCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
+	// ProjectSet can pass through its ordering if the ordering depends only on
+	// columns present in the input.
+	prjs := expr.(*memo.ProjectSetExpr)
+	inputCols := prjs.Input.Relational().OutputCols
+
+	// Use a simplified ordering if it exists. This must be kept consistent with
+	// projectSetBuildChildReqOrdering, which always simplifies the ordering if
+	// possible.
+	simplified := *required
+	if fdSet := prjs.InternalFDs(); simplified.CanSimplify(fdSet) {
+		simplified = required.Copy()
+		simplified.Simplify(fdSet)
+	}
+	return simplified.CanProjectCols(inputCols)
+}
+
+func projectSetBuildChildReqOrdering(
+	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
+) props.OrderingChoice {
+	if childIdx != 0 {
+		return props.OrderingChoice{}
+	}
+
+	// ProjectSet can prune input columns, which can cause its FD set to be pruned
+	// as well. Check the ordering to see if it can be simplified with respect to
+	// the internal FD set.
+	prjs := parent.(*memo.ProjectSetExpr)
+	simplified := *required
+	if fdSet := prjs.InternalFDs(); simplified.CanSimplify(fdSet) {
+		simplified = simplified.Copy()
+		simplified.Simplify(fdSet)
+	}
+
+	// We may need to remove ordering columns that are not output by the input
+	// expression.
+	result := projectOrderingToInput(prjs.Input, &simplified)
+
+	return result
+}
+
+func projectSetBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {
+	prjs := expr.(*memo.ProjectSetExpr)
+	// ProjectSet can only satisfy required orderings that refer to projected
+	// columns; it should always be possible to remap the columns in the input's
+	// provided ordering.
+	return remapProvided(
+		prjs.Input.ProvidedPhysical().Ordering,
+		prjs.InternalFDs(),
+		prjs.Relational().OutputCols,
+	)
+}


### PR DESCRIPTION
Addresses: #26704

ProjectSet, like Project, should always preserve input orderings (for columns
that are included in the output). Previously we were not tracking this in the
optimizer. This patch adds ordering code for ProjectSet (which mostly matches
the ordering code for Project).

This patch does not add orderings that come from the zipped functions, such as
set-returning functions like `generate_series`, so this does not yet fix

Release note: None