### PR TITLE
sql/catalog/descs: move direct KV access methods under an interface

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -774,7 +774,7 @@ func fullyQualifyScheduledBackupTargetTables(
 					if err != nil {
 						return err
 					}
-					schemaID, err = col.ResolveSchemaID(ctx, txn, dbDesc.GetID(), tp.SchemaName.String())
+					schemaID, err = col.Direct().ResolveSchemaID(ctx, txn, dbDesc.GetID(), tp.SchemaName.String())
 					return err
 				}); err != nil {
 					return nil, err

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2484,7 +2484,7 @@ func getRestorePrivilegesForTableOrSchema(
 			}
 		}
 	} else if descCoverage == tree.RequestedDescriptors {
-		parentDB, err := descsCol.MustGetDatabaseDescByID(ctx, txn, desc.GetParentID())
+		parentDB, err := descsCol.Direct().MustGetDatabaseDescByID(ctx, txn, desc.GetParentID())
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to lookup parent DB %d", errors.Safe(desc.GetParentID()))
 		}

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -760,7 +760,7 @@ func TestRestoreWithDroppedSchemaCorruption(t *testing.T) {
 	hasSameNameSchema := func(dbName string) (exists bool) {
 		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
 			// Using this method to avoid validation.
-			id, err := col.LookupDatabaseID(ctx, txn, dbName)
+			id, err := col.Direct().LookupDatabaseID(ctx, txn, dbName)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -547,7 +547,7 @@ func checkMultiRegionCompatible(
 		// For REGION BY TABLE IN <region> tables, allow the restore if the
 		// database has the region.
 		regionEnumID := database.GetRegionConfig().RegionEnumID
-		regionEnum, err := col.MustGetTypeDescByID(ctx, txn, regionEnumID)
+		regionEnum, err := col.Direct().MustGetTypeDescByID(ctx, txn, regionEnumID)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -895,7 +895,7 @@ func getQualifiedTableName(
 	ctx context.Context, execCfg *sql.ExecutorConfig, txn *kv.Txn, desc catalog.TableDescriptor,
 ) (string, error) {
 	col := execCfg.CollectionFactory.MakeCollection(nil /* temporarySchemaProvider */)
-	dbDesc, err := col.MustGetDatabaseDescByID(ctx, txn, desc.GetParentID())
+	dbDesc, err := col.Direct().MustGetDatabaseDescByID(ctx, txn, desc.GetParentID())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -519,7 +519,7 @@ func prepareNewTablesForIngestion(
 	// collisions with any importing tables.
 	for i := range newMutableTableDescriptors {
 		tbl := newMutableTableDescriptors[i]
-		err := descsCol.CheckObjectCollision(
+		err := descsCol.Direct().CheckObjectCollision(
 			ctx,
 			txn,
 			tbl.GetParentID(),
@@ -672,7 +672,7 @@ func createSchemaDescriptorWithID(
 		log.VEventf(ctx, 2, "CPut %s -> %d", idKey, descID)
 	}
 	b.CPut(idKey, descID, nil)
-	if err := descsCol.WriteNewDescToBatch(
+	if err := descsCol.Direct().WriteNewDescToBatch(
 		ctx,
 		p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 		b,
@@ -1125,7 +1125,7 @@ func (r *importResumer) checkForUDTModification(
 		ctx context.Context, txn *kv.Txn, col *descs.Collection,
 		savedTypeDesc *descpb.TypeDescriptor,
 	) error {
-		typeDesc, err := col.MustGetTypeDescByID(ctx, txn, savedTypeDesc.GetID())
+		typeDesc, err := col.Direct().MustGetTypeDescByID(ctx, txn, savedTypeDesc.GetID())
 		if err != nil {
 			return errors.Wrap(err, "resolving type descriptor when checking version mismatch")
 		}

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -1939,7 +1939,7 @@ func TestFailedImportGC(t *testing.T) {
 	tableID := descpb.ID(dbID + 2)
 	var td catalog.TableDescriptor
 	if err := sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-		td, err = col.MustGetTableDescByID(ctx, txn, tableID)
+		td, err = col.Direct().MustGetTableDescByID(ctx, txn, tableID)
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -6131,7 +6131,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 		for _, schemaID := range schemaIDs {
 			// Expect that the schema descriptor is deleted.
 			if err := sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-				_, err = col.MustGetSchemaDescByID(ctx, txn, schemaID)
+				_, err = col.Direct().MustGetSchemaDescByID(ctx, txn, schemaID)
 				if !testutils.IsError(err, "descriptor not found") {
 					return err
 				}
@@ -6144,7 +6144,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 		for _, tableID := range tableIDs {
 			// Expect that the table descriptor is deleted.
 			if err := sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-				_, err = col.MustGetTableDescByID(ctx, txn, tableID)
+				_, err = col.Direct().MustGetTableDescByID(ctx, txn, tableID)
 				if !testutils.IsError(err, "descriptor not found") {
 					return err
 				}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -874,11 +874,11 @@ func readPostgresStmt(
 		for _, name := range names {
 			tableName := name.ToUnresolvedObjectName().String()
 			if err := sql.DescsTxn(ctx, p.ExecCfg(), func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
-				dbDesc, err := col.MustGetDatabaseDescByID(ctx, txn, parentID)
+				dbDesc, err := col.Direct().MustGetDatabaseDescByID(ctx, txn, parentID)
 				if err != nil {
 					return err
 				}
-				err = col.CheckObjectCollision(
+				err = col.Direct().CheckObjectCollision(
 					ctx,
 					txn,
 					parentID,

--- a/pkg/migration/migrations/grant_option_migration_external_test.go
+++ b/pkg/migration/migrations/grant_option_migration_external_test.go
@@ -187,7 +187,7 @@ func TestGrantOptionMigration(t *testing.T) {
 
 			err = sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
 				// Avoid running validation on the descriptors.
-				cat, err := col.GetCatalogUnvalidated(ctx, txn)
+				cat, err := col.Direct().GetCatalogUnvalidated(ctx, txn)
 				if err != nil {
 					return err
 				}

--- a/pkg/migration/migrations/public_schema_migration.go
+++ b/pkg/migration/migrations/public_schema_migration.go
@@ -124,7 +124,7 @@ func createPublicSchemaDescriptor(
 	// Remove namespace entry for old public schema.
 	b.Del(oldKey)
 	b.CPut(newKey, publicSchemaID, nil)
-	if err := descriptors.WriteNewDescToBatch(
+	if err := descriptors.Direct().WriteNewDescToBatch(
 		ctx,
 		false,
 		b,

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -120,7 +120,7 @@ func (n *alterTableSetSchemaNode) startExec(params runParams) error {
 		return nil
 	}
 
-	objectID, err := p.Descriptors().LookupObjectID(
+	objectID, err := p.Descriptors().Direct().LookupObjectID(
 		ctx, p.txn, tableDesc.GetParentID(), desiredSchemaID, tableDesc.GetName(),
 	)
 	if err == nil && objectID != descpb.InvalidID {

--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -214,7 +214,7 @@ func (p *planner) dropEnumValue(
 }
 
 func (p *planner) renameType(ctx context.Context, n *alterTypeNode, newName string) error {
-	err := p.Descriptors().CheckObjectCollision(
+	err := p.Descriptors().Direct().CheckObjectCollision(
 		ctx,
 		p.txn,
 		n.desc.ParentID,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1300,7 +1300,7 @@ func (sc *SchemaChanger) updateJobRunningStatus(
 ) (tableDesc catalog.TableDescriptor, err error) {
 	err = DescsTxn(ctx, sc.execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
 		// Read table descriptor without holding a lease.
-		tableDesc, err = col.MustGetTableDescByID(ctx, txn, sc.descID)
+		tableDesc, err = col.Direct().MustGetTableDescByID(ctx, txn, sc.descID)
 		if err != nil {
 			return err
 		}
@@ -2209,7 +2209,7 @@ func validateFkInTxn(
 	if fk == nil {
 		return errors.AssertionFailedf("foreign key %s does not exist", fkName)
 	}
-	targetTable, err := descsCol.MustGetTableDescByID(ctx, txn, fk.ReferencedTableID)
+	targetTable, err := descsCol.Direct().MustGetTableDescByID(ctx, txn, fk.ReferencedTableID)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -53,6 +53,7 @@ func makeCollection(
 		leased:         makeLeasedDescriptors(leaseMgr),
 		kv:             makeKVDescriptors(codec),
 		temporary:      makeTemporaryDescriptors(settings, codec, temporarySchemaProvider),
+		direct:         makeDirect(codec, settings),
 	}
 }
 
@@ -119,6 +120,10 @@ type Collection struct {
 	// It must be set in the multi-tenant environment for ephemeral
 	// SQL pods. It should not be set otherwise.
 	sqlLivenessSession sqlliveness.Session
+
+	// direct provides low-level access to descriptors via the Direct interface.
+	// For the most part, it is in deprecated or testing settings.
+	direct direct
 }
 
 var _ catalog.Accessor = (*Collection)(nil)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4453,7 +4453,7 @@ CREATE TABLE crdb_internal.invalid_objects (
 	) error {
 		// The internalLookupContext will only have descriptors in the current
 		// database. To deal with this, we fall through.
-		c, err := p.Descriptors().GetCatalogUnvalidated(ctx, p.txn)
+		c, err := p.Descriptors().Direct().GetCatalogUnvalidated(ctx, p.txn)
 		if err != nil {
 			return err
 		}
@@ -4734,7 +4734,7 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 		}
 		// Get all descriptors which will be used to determine
 		// which ones are missing.
-		c, err := p.Descriptors().GetCatalogUnvalidated(ctx, p.txn)
+		c, err := p.Descriptors().Direct().GetCatalogUnvalidated(ctx, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -158,7 +158,7 @@ func getSchemaForCreateTable(
 		return nil, err
 	}
 
-	desc, err := params.p.Descriptors().GetDescriptorCollidingWithObject(
+	desc, err := params.p.Descriptors().Direct().GetDescriptorCollidingWithObject(
 		params.ctx,
 		params.p.txn,
 		db.GetID(),

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -165,7 +165,7 @@ func getCreateTypeParams(
 		sqltelemetry.IncrementUserDefinedSchemaCounter(sqltelemetry.UserDefinedSchemaUsedByObject)
 	}
 
-	err = params.p.Descriptors().CheckObjectCollision(
+	err = params.p.Descriptors().Direct().CheckObjectCollision(
 		params.ctx,
 		params.p.txn,
 		db.GetID(),
@@ -193,7 +193,7 @@ func findFreeArrayTypeName(
 	arrayName := "_" + name
 	for {
 		// See if there is a collision with the current name.
-		objectID, err := col.LookupObjectID(ctx, txn, parentID, schemaID, arrayName)
+		objectID, err := col.Direct().LookupObjectID(ctx, txn, parentID, schemaID, arrayName)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -138,7 +138,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		case n.replace:
 			// If we are replacing an existing view see if what we are
 			// replacing is actually a view.
-			id, err := params.p.Descriptors().LookupObjectID(
+			id, err := params.p.Descriptors().Direct().LookupObjectID(
 				params.ctx,
 				params.p.txn,
 				n.dbDesc.GetID(),

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -42,7 +42,7 @@ func (p *planner) renameDatabase(
 	}
 
 	// Check that the new name is available.
-	if dbID, err := p.Descriptors().LookupDatabaseID(ctx, p.txn, newName); err == nil && dbID != descpb.InvalidID {
+	if dbID, err := p.Descriptors().Direct().LookupDatabaseID(ctx, p.txn, newName); err == nil && dbID != descpb.InvalidID {
 		return pgerror.Newf(pgcode.DuplicateDatabase,
 			"the new database name %q already exists", newName)
 	} else if err != nil {

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -33,7 +33,7 @@ func TestDatabaseAccessors(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	if err := TestingDescsTxn(context.Background(), s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
-		if _, err := col.MustGetDatabaseDescByID(ctx, txn, keys.SystemDatabaseID); err != nil {
+		if _, err := col.Direct().MustGetDatabaseDescByID(ctx, txn, keys.SystemDatabaseID); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -71,10 +71,10 @@ func (p *planner) createDatabase(
 	dbName := string(database.Name)
 	dKey := catalogkeys.MakeDatabaseNameKey(p.ExecCfg().Codec, dbName)
 
-	if dbID, err := p.Descriptors().LookupDatabaseID(ctx, p.txn, dbName); err == nil && dbID != descpb.InvalidID {
+	if dbID, err := p.Descriptors().Direct().LookupDatabaseID(ctx, p.txn, dbName); err == nil && dbID != descpb.InvalidID {
 		if database.IfNotExists {
 			// Check if the database is in a dropping state
-			desc, err := p.Descriptors().MustGetDatabaseDescByID(ctx, p.txn, dbID)
+			desc, err := p.Descriptors().Direct().MustGetDatabaseDescByID(ctx, p.txn, dbID)
 			if err != nil {
 				return nil, false, err
 			}
@@ -254,7 +254,7 @@ func (p *planner) createDescriptorWithID(
 		log.VEventf(ctx, 2, "CPut %s -> %d", idKey, descID)
 	}
 	b.CPut(idKey, descID, nil)
-	if err := p.Descriptors().WriteNewDescToBatch(
+	if err := p.Descriptors().Direct().WriteNewDescToBatch(
 		ctx,
 		p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 		b,

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -124,7 +124,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tbDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
 	var dbDesc catalog.DatabaseDescriptor
 	require.NoError(t, sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-		dbDesc, err = col.MustGetDatabaseDescByID(ctx, txn, tbDesc.GetParentID())
+		dbDesc, err = col.Direct().MustGetDatabaseDescByID(ctx, txn, tbDesc.GetParentID())
 		return err
 	}))
 
@@ -288,7 +288,7 @@ INSERT INTO t.kv2 VALUES ('c', 'd'), ('a', 'b'), ('e', 'a');
 	tb2Desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv2")
 	var dbDesc catalog.DatabaseDescriptor
 	require.NoError(t, sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-		dbDesc, err = col.MustGetDatabaseDescByID(ctx, txn, tbDesc.GetParentID())
+		dbDesc, err = col.Direct().MustGetDatabaseDescByID(ctx, txn, tbDesc.GetParentID())
 		return err
 	}))
 
@@ -859,7 +859,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	// Simulate a migration upgrading the table descriptor's format version after
 	// the table has been dropped but before the truncation has occurred.
 	if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-		tbl, err := col.MustGetTableDescByID(ctx, txn, tableDesc.ID)
+		tbl, err := col.Direct().MustGetTableDescByID(ctx, txn, tableDesc.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -92,7 +92,7 @@ func updateStatusForGCElements(
 	earliestDeadline := timeutil.Unix(0, int64(math.MaxInt64))
 
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
-		table, err := col.MustGetTableDescByID(ctx, txn, tableID)
+		table, err := col.Direct().MustGetTableDescByID(ctx, txn, tableID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -45,7 +45,7 @@ func gcTables(
 
 		var table catalog.TableDescriptor
 		if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-			table, err = col.MustGetTableDescByID(ctx, txn, droppedTable.ID)
+			table, err = col.Direct().MustGetTableDescByID(ctx, txn, droppedTable.ID)
 			return err
 		}); err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -98,12 +98,12 @@ func TestSchemaChangeGCJob(t *testing.T) {
 			var myTableDesc *tabledesc.Mutable
 			var myOtherTableDesc *tabledesc.Mutable
 			if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
-				myImm, err := col.MustGetTableDescByID(ctx, txn, myTableID)
+				myImm, err := col.Direct().MustGetTableDescByID(ctx, txn, myTableID)
 				if err != nil {
 					return err
 				}
 				myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
-				myOtherImm, err := col.MustGetTableDescByID(ctx, txn, myOtherTableID)
+				myOtherImm, err := col.Direct().MustGetTableDescByID(ctx, txn, myOtherTableID)
 				if err != nil {
 					return err
 				}
@@ -230,7 +230,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 			}
 
 			if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
-				myImm, err := col.MustGetTableDescByID(ctx, txn, myTableID)
+				myImm, err := col.Direct().MustGetTableDescByID(ctx, txn, myTableID)
 				if ttlTime != FUTURE && (dropItem == TABLE || dropItem == DATABASE) {
 					// We dropped the table, so expect it to not be found.
 					require.EqualError(t, err, "descriptor not found")
@@ -240,7 +240,7 @@ func TestSchemaChangeGCJob(t *testing.T) {
 					return err
 				}
 				myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
-				myOtherImm, err := col.MustGetTableDescByID(ctx, txn, myOtherTableID)
+				myOtherImm, err := col.Direct().MustGetTableDescByID(ctx, txn, myOtherTableID)
 				if ttlTime != FUTURE && dropItem == DATABASE {
 					// We dropped the entire database, so expect none of the tables to be found.
 					require.EqualError(t, err, "descriptor not found")

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -2135,7 +2135,7 @@ func forEachSchema(
 		}
 	}
 
-	userDefinedSchemas, err := p.Descriptors().GetSchemaDescriptorsFromIDs(ctx, p.txn, userDefinedSchemaIDs)
+	userDefinedSchemas, err := p.Descriptors().Direct().GetSchemaDescriptorsFromIDs(ctx, p.txn, userDefinedSchemaIDs)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -349,7 +349,7 @@ func (oc *optCatalog) fullyQualifiedNameWithTxn(
 	}
 
 	dbID := desc.GetParentID()
-	dbDesc, err := oc.planner.Descriptors().MustGetDatabaseDescByID(ctx, txn, dbID)
+	dbDesc, err := oc.planner.Descriptors().Direct().MustGetDatabaseDescByID(ctx, txn, dbID)
 	if err != nil {
 		return cat.DataSourceName{}, err
 	}
@@ -359,7 +359,7 @@ func (oc *optCatalog) fullyQualifiedNameWithTxn(
 	if scID == keys.PublicSchemaID {
 		scName = tree.PublicSchemaName
 	} else {
-		scDesc, err := oc.planner.Descriptors().MustGetSchemaDescByID(ctx, txn, scID)
+		scDesc, err := oc.planner.Descriptors().Direct().MustGetSchemaDescByID(ctx, txn, scID)
 		if err != nil {
 			return cat.DataSourceName{}, err
 		}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1018,7 +1018,7 @@ func (r oneAtATimeSchemaResolver) getTableByID(id descpb.ID) (catalog.TableDescr
 }
 
 func (r oneAtATimeSchemaResolver) getSchemaByID(id descpb.ID) (catalog.SchemaDescriptor, error) {
-	return r.p.Descriptors().MustGetSchemaDescByID(r.ctx, r.p.txn, id)
+	return r.p.Descriptors().Direct().MustGetSchemaDescByID(r.ctx, r.p.txn, id)
 }
 
 // makeAllRelationsVirtualTableWithDescriptorIDIndex creates a virtual table that searches through

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -158,7 +158,7 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 			}
 
 			if err := tbDesc.ForeachDependedOnBy(func(dependedOn *descpb.TableDescriptor_Reference) error {
-				dependentDesc, err := p.Descriptors().MustGetTableDescByID(ctx, p.txn, dependedOn.ID)
+				dependentDesc, err := p.Descriptors().Direct().MustGetTableDescByID(ctx, p.txn, dependedOn.ID)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -221,7 +221,7 @@ func (n *renameTableNode) startExec(params runParams) error {
 		return nil
 	}
 
-	err := p.Descriptors().CheckObjectCollision(
+	err := p.Descriptors().Direct().CheckObjectCollision(
 		params.ctx,
 		params.p.txn,
 		targetDbDesc.GetID(),
@@ -278,7 +278,7 @@ func (n *renameTableNode) Close(context.Context)        {}
 func (p *planner) dependentViewError(
 	ctx context.Context, typeName, objName string, parentID, viewID descpb.ID, op string,
 ) error {
-	viewDesc, err := p.Descriptors().MustGetTableDescByID(ctx, p.txn, viewID)
+	viewDesc, err := p.Descriptors().Direct().MustGetTableDescByID(ctx, p.txn, viewID)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -275,7 +275,7 @@ func (c *DatumRowConverter) getSequenceAnnotation(
 			return err
 		}
 		for seqID := range sequenceIDs {
-			seqDesc, err := descsCol.MustGetTableDescByID(ctx, txn, seqID)
+			seqDesc, err := descsCol.Direct().MustGetTableDescByID(ctx, txn, seqID)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -198,7 +198,7 @@ func GetResumeSpans(
 	mutationID descpb.MutationID,
 	filter backfill.MutationFilter,
 ) ([]roachpb.Span, *jobs.Job, int, error) {
-	tableDesc, err := col.MustGetTableDescByID(ctx, txn, tableID)
+	tableDesc, err := col.Direct().MustGetTableDescByID(ctx, txn, tableID)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -36,7 +36,7 @@ func schemaExists(
 		}
 	}
 	// Now lookup in the namespace for other schemas.
-	schemaID, err := col.LookupSchemaID(ctx, txn, parentID, schema)
+	schemaID, err := col.Direct().LookupSchemaID(ctx, txn, parentID, schema)
 	if err != nil || schemaID == descpb.InvalidID {
 		return false, descpb.InvalidID, err
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1393,7 +1393,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		timeoutCtx, cancel := context.WithTimeout(ctx, base.DefaultDescriptorLeaseDuration/2)
 		defer cancel()
 		if err := sql.TestingDescsTxn(timeoutCtx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
-			tbl, err := col.MustGetTableDescByID(ctx, txn, tableDesc.GetID())
+			tbl, err := col.Direct().MustGetTableDescByID(ctx, txn, tableDesc.GetID())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5357,7 +5357,7 @@ value if you rely on the HLC for accuracy.`,
 				// instead of cobbling a descs.Collection in this way.
 				cf := descs.NewBareBonesCollectionFactory(ctx.Settings, ctx.Codec)
 				descsCol := cf.MakeCollection(descs.NewTemporarySchemaProvider(ctx.SessionDataStack))
-				tableDesc, err := descsCol.MustGetTableDescByID(ctx.Ctx(), ctx.Txn, descpb.ID(tableID))
+				tableDesc, err := descsCol.Direct().MustGetTableDescByID(ctx.Ctx(), ctx.Txn, descpb.ID(tableID))
 				if err != nil {
 					return nil, err
 				}
@@ -5395,7 +5395,7 @@ value if you rely on the HLC for accuracy.`,
 				// instead of cobbling a descs.Collection in this way.
 				cf := descs.NewBareBonesCollectionFactory(ctx.Settings, ctx.Codec)
 				descsCol := cf.MakeCollection(descs.NewTemporarySchemaProvider(ctx.SessionDataStack))
-				tableDesc, err := descsCol.MustGetTableDescByID(ctx.Ctx(), ctx.Txn, descpb.ID(tableID))
+				tableDesc, err := descsCol.Direct().MustGetTableDescByID(ctx.Ctx(), ctx.Txn, descpb.ID(tableID))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/set_schema.go
+++ b/pkg/sql/set_schema.go
@@ -78,7 +78,7 @@ func (p *planner) prepareSetSchema(
 		return desiredSchemaID, nil
 	}
 
-	err = p.Descriptors().CheckObjectCollision(ctx, p.txn, db.GetID(), desiredSchemaID, objectName)
+	err = p.Descriptors().Direct().CheckObjectCollision(ctx, p.txn, db.GetID(), desiredSchemaID, objectName)
 	if err != nil {
 		return descpb.InvalidID, err
 	}

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -427,7 +427,7 @@ CREATE TABLE test.tt (x test.t);
 	typLookup := func(ctx context.Context, id descpb.ID) (tree.TypeName, catalog.TypeDescriptor, error) {
 		var typeDesc catalog.TypeDescriptor
 		if err := TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-			typeDesc, err = col.MustGetTypeDescByID(ctx, txn, id)
+			typeDesc, err = col.Direct().MustGetTypeDescByID(ctx, txn, id)
 			return err
 		}); err != nil {
 			return tree.TypeName{}, nil, err

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -255,7 +255,7 @@ func cleanupSchemaObjects(
 	tblDescsByID := make(map[descpb.ID]catalog.TableDescriptor, len(tbNames))
 	tblNamesByID := make(map[descpb.ID]tree.TableName, len(tbNames))
 	for i, tbName := range tbNames {
-		desc, err := descsCol.MustGetTableDescByID(ctx, txn, tbIDs[i])
+		desc, err := descsCol.Direct().MustGetTableDescByID(ctx, txn, tbIDs[i])
 		if err != nil {
 			return err
 		}
@@ -308,11 +308,11 @@ func cleanupSchemaObjects(
 					if _, ok := tblDescsByID[d.ID]; ok {
 						return nil
 					}
-					dTableDesc, err := descsCol.MustGetTableDescByID(ctx, txn, d.ID)
+					dTableDesc, err := descsCol.Direct().MustGetTableDescByID(ctx, txn, d.ID)
 					if err != nil {
 						return err
 					}
-					db, err := descsCol.MustGetDatabaseDescByID(ctx, txn, dTableDesc.GetParentID())
+					db, err := descsCol.Direct().MustGetDatabaseDescByID(ctx, txn, dTableDesc.GetParentID())
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -97,7 +97,7 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 			kvDB,
 			func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
 				execCfg := s.ExecutorConfig().(ExecutorConfig)
-				defaultDB, err := descsCol.MustGetDatabaseDescByID(ctx, txn, namesToID["defaultdb"])
+				defaultDB, err := descsCol.Direct().MustGetDatabaseDescByID(ctx, txn, namesToID["defaultdb"])
 				require.NoError(t, err)
 				err = cleanupSchemaObjects(
 					ctx,

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -198,7 +198,7 @@ func (t *typeSchemaChanger) getTypeDescFromStore(
 ) (catalog.TypeDescriptor, error) {
 	var typeDesc catalog.TypeDescriptor
 	if err := DescsTxn(ctx, t.execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-		typeDesc, err = col.MustGetTypeDescByID(ctx, txn, t.typeID)
+		typeDesc, err = col.Direct().MustGetTypeDescByID(ctx, txn, t.typeID)
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -95,7 +95,7 @@ func (n *unsplitAllNode) startExec(params runParams) error {
 		WHERE
 			database_name=$1 AND table_name=$2 AND index_name=$3 AND split_enforced_until IS NOT NULL
 	`
-	dbDesc, err := params.p.Descriptors().MustGetDatabaseDescByID(
+	dbDesc, err := params.p.Descriptors().Direct().MustGetDatabaseDescByID(
 		params.ctx, params.p.txn, n.tableDesc.GetParentID(),
 	)
 	if err != nil {

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -431,7 +431,7 @@ func resolveZone(
 	errMissingKey := errors.New("missing key")
 	id, err := zonepb.ResolveZoneSpecifier(ctx, zs,
 		func(parentID uint32, schemaID uint32, name string) (uint32, error) {
-			id, err := col.LookupObjectID(ctx, txn, descpb.ID(parentID), descpb.ID(schemaID), name)
+			id, err := col.Direct().LookupObjectID(ctx, txn, descpb.ID(parentID), descpb.ID(schemaID), name)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
These things are both generally frowned upon and have different contracts
than the collection itself. Separate them with an interface layer of
indirection to make it clearer that there's a trap lurking around these
methods.

Release note: None