### PR TITLE
release-21.2: sql: assign sequence ownership created when create/alter table

### DIFF
--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -429,6 +429,7 @@ func mysqlTableToCockroach(
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
 			seqDesc, err = sql.NewSequenceTableDesc(
 				ctx,
+				nil, /* planner */
 				seqName,
 				opts,
 				parentDB.GetID(),
@@ -437,7 +438,6 @@ func mysqlTableToCockroach(
 				time,
 				priv,
 				tree.PersistencePermanent,
-				nil, /* params */
 				// If this is multi-region, this will get added by WriteDescriptors.
 				false, /* isMultiRegion */
 			)
@@ -445,6 +445,7 @@ func mysqlTableToCockroach(
 			priv := descpb.NewDefaultPrivilegeDescriptor(owner)
 			seqDesc, err = sql.NewSequenceTableDesc(
 				ctx,
+				nil, /* planner */
 				seqName,
 				opts,
 				parentDB.GetID(),
@@ -453,7 +454,6 @@ func mysqlTableToCockroach(
 				time,
 				priv,
 				tree.PersistencePermanent,
-				nil, /* params */
 				// If this is multi-region, this will get added by WriteDescriptors.
 				false, /* isMultiRegion */
 			)

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -312,6 +312,7 @@ func createPostgresSequences(
 		}
 		desc, err := sql.NewSequenceTableDesc(
 			ctx,
+			nil, /* planner */
 			schemaAndTableName.table,
 			seq.Options,
 			parentID,
@@ -320,7 +321,6 @@ func createPostgresSequences(
 			hlc.Timestamp{WallTime: walltime},
 			descpb.NewDefaultPrivilegeDescriptor(owner),
 			tree.PersistencePermanent,
-			nil, /* params */
 			// If this is multi-region, this will get added by WriteDescriptors.
 			false, /* isMultiRegion */
 		)

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -56,6 +56,7 @@ func descForTable(
 		priv := descpb.NewDefaultPrivilegeDescriptor(security.AdminRoleName())
 		desc, err := sql.NewSequenceTableDesc(
 			ctx,
+			nil, /* planner */
 			name,
 			tree.SequenceOptions{},
 			parent,
@@ -64,7 +65,6 @@ func descForTable(
 			ts,
 			priv,
 			tree.PersistencePermanent,
-			nil,   /* params */
 			false, /* isMultiRegion */
 		)
 		if err != nil {

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -53,20 +53,24 @@ func (p *planner) addColumnImpl(
 		return err
 	}
 
+	var colOwnedSeqDesc *tabledesc.Mutable
 	newDef, seqPrefix, seqName, seqOpts, err := params.p.processSerialLikeInColumnDef(params.ctx, d, tn)
 	if err != nil {
 		return err
 	}
 	if seqName != nil {
-		if err := doCreateSequence(
-			params,
+		colOwnedSeqDesc, err = doCreateSequence(
+			params.ctx,
+			params.p,
+			params.SessionData(),
 			seqPrefix.Database,
 			seqPrefix.Schema,
 			seqName,
 			n.tableDesc.Persistence(),
 			seqOpts,
 			tree.AsStringWithFQNames(n.n, params.Ann()),
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 	}
@@ -101,27 +105,6 @@ func (p *planner) addColumnImpl(
 		if err != nil {
 			return err
 		}
-	}
-
-	// If the new column has a DEFAULT or an ON UPDATE expression that uses a
-	// sequence, add references between its descriptor and this column descriptor.
-	if err := cdd.ForEachTypedExpr(func(expr tree.TypedExpr) error {
-		changedSeqDescs, err := maybeAddSequenceDependencies(
-			params.ctx, params.ExecCfg().Settings, params.p, n.tableDesc, col, expr, nil,
-		)
-		if err != nil {
-			return err
-		}
-		for _, changedSeqDesc := range changedSeqDescs {
-			if err := params.p.writeSchemaChange(
-				params.ctx, changedSeqDesc, descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
-			); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	// We're checking to see if a user is trying add a non-nullable column without a default to a
@@ -176,16 +159,45 @@ func (p *planner) addColumnImpl(
 		n.tableDesc.SetPrimaryIndex(primaryIndex)
 	}
 
+	// We need to allocate new ID for the created column in order to correctly
+	// assign sequence ownership.
+	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+		return err
+	}
+
+	// If the new column has a DEFAULT or an ON UPDATE expression that uses a
+	// sequence, add references between its descriptor and this column descriptor.
+	if err := cdd.ForEachTypedExpr(func(expr tree.TypedExpr) error {
+		changedSeqDescs, err := maybeAddSequenceDependencies(
+			params.ctx, params.ExecCfg().Settings, params.p, n.tableDesc, col, expr, nil,
+		)
+		if err != nil {
+			return err
+		}
+		for _, changedSeqDesc := range changedSeqDescs {
+			// `colOwnedSeqDesc` and `changedSeqDesc` should refer to a same instance.
+			// But we still want to use the right copy to write a schema change by
+			// using `changedSeqDesc` just in case the assumption became false in the
+			// future.
+			if colOwnedSeqDesc != nil && colOwnedSeqDesc.ID == changedSeqDesc.ID {
+				if err := setSequenceOwner(changedSeqDesc, d.Name, desc); err != nil {
+					return err
+				}
+			}
+			if err := params.p.writeSchemaChange(
+				params.ctx, changedSeqDesc, descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
 	// Zone configuration logic is only required for REGIONAL BY ROW tables
 	// with newly created indexes.
 	if n.tableDesc.IsLocalityRegionalByRow() && idx != nil {
-		// We need to allocate new IDs for the created columns and indexes
-		// in case we need to configure their zone partitioning.
-		// This must be done after every object is created.
-		if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
-			return err
-		}
-
 		// Configure zone configuration if required. This must happen after
 		// all the IDs have been allocated.
 		if err := p.configureZoneConfigForNewIndexPartitioning(

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -66,10 +66,15 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 	oldMinValue := desc.SequenceOpts.MinValue
 	oldMaxValue := desc.SequenceOpts.MaxValue
 
-	err := assignSequenceOptions(
-		desc.SequenceOpts, n.n.Options, false /* setDefaults */, &params, desc.GetID(), desc.ParentID,
-	)
-	if err != nil {
+	if err := assignSequenceOptions(
+		params.ctx,
+		params.p,
+		desc.SequenceOpts,
+		n.n.Options,
+		false, /* setDefaults */
+		desc.GetID(),
+		desc.ParentID,
+	); err != nil {
 		return err
 	}
 	opts := desc.SequenceOpts

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -78,31 +80,37 @@ func (n *createSequenceNode) startExec(params runParams) error {
 		return err
 	}
 
-	return doCreateSequence(
-		params, n.dbDesc, schemaDesc, &n.n.Name, n.n.Persistence, n.n.Options,
+	_, err = doCreateSequence(
+		params.ctx, params.p, params.SessionData(), n.dbDesc, schemaDesc, &n.n.Name, n.n.Persistence, n.n.Options,
 		tree.AsStringWithFQNames(n.n, params.Ann()),
 	)
+
+	return err
 }
 
 // doCreateSequence performs the creation of a sequence in KV. The
 // context argument is a string to use in the event log.
 func doCreateSequence(
-	params runParams,
+	ctx context.Context,
+	p *planner,
+	sessionData *sessiondata.SessionData,
 	dbDesc catalog.DatabaseDescriptor,
 	scDesc catalog.SchemaDescriptor,
 	name *tree.TableName,
 	persistence tree.Persistence,
 	opts tree.SequenceOptions,
 	jobDesc string,
-) error {
-	id, err := catalogkv.GenerateUniqueDescID(params.ctx, params.p.ExecCfg().DB, params.p.ExecCfg().Codec)
+) (*tabledesc.Mutable, error) {
+	id, err := catalogkv.GenerateUniqueDescID(ctx, p.ExecCfg().DB, p.ExecCfg().Codec)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	privs := dbDesc.GetDefaultPrivilegeDescriptor().CreatePrivilegesFromDefaultPrivileges(
 		dbDesc.GetID(),
-		params.SessionData().User(), tree.Sequences, dbDesc.GetPrivileges(),
+		sessionData.User(),
+		tree.Sequences,
+		dbDesc.GetPrivileges(),
 	)
 
 	if persistence.IsTemporary() {
@@ -116,7 +124,8 @@ func doCreateSequence(
 	// currently relied on in import and restore code and tests.
 	var creationTime hlc.Timestamp
 	desc, err := NewSequenceTableDesc(
-		params.ctx,
+		ctx,
+		p,
 		name.Object(),
 		opts,
 		dbDesc.GetID(),
@@ -125,42 +134,99 @@ func doCreateSequence(
 		creationTime,
 		privs,
 		persistence,
-		&params,
 		dbDesc.IsMultiRegion(),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// makeSequenceTableDesc already validates the table. No call to
 	// desc.ValidateSelf() needed here.
 
-	key := catalogkeys.MakeObjectNameKey(params.ExecCfg().Codec, dbDesc.GetID(), scDesc.GetID(), name.Object())
-	if err = params.p.createDescriptorWithID(
-		params.ctx, key, id, desc, params.EvalContext().Settings, jobDesc,
+	key := catalogkeys.MakeObjectNameKey(p.ExecCfg().Codec, dbDesc.GetID(), scDesc.GetID(), name.Object())
+	if err = p.createDescriptorWithID(
+		ctx, key, id, desc, p.EvalContext().Settings, jobDesc,
 	); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Initialize the sequence value.
-	seqValueKey := params.ExecCfg().Codec.SequenceKey(uint32(id))
+	seqValueKey := p.ExecCfg().Codec.SequenceKey(uint32(id))
 	b := &kv.Batch{}
 	b.Inc(seqValueKey, desc.SequenceOpts.Start-desc.SequenceOpts.Increment)
-	if err := params.p.txn.Run(params.ctx, b); err != nil {
-		return err
+	if err := p.txn.Run(ctx, b); err != nil {
+		return nil, err
 	}
 
-	if err := validateDescriptor(params.ctx, params.p, desc); err != nil {
-		return err
+	if err := validateDescriptor(ctx, p, desc); err != nil {
+		return nil, err
 	}
 
 	// Log Create Sequence event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	return params.p.logEvent(params.ctx,
+	return desc, p.logEvent(ctx,
 		desc.ID,
 		&eventpb.CreateSequence{
 			SequenceName: name.FQString(),
 		})
+}
+
+func createSequencesForSerialColumns(
+	ctx context.Context,
+	p *planner,
+	sessionData *sessiondata.SessionData,
+	db catalog.DatabaseDescriptor,
+	sc catalog.SchemaDescriptor,
+	n *tree.CreateTable,
+) (map[tree.Name]*tabledesc.Mutable, error) {
+	colNameToSeqDesc := make(map[tree.Name]*tabledesc.Mutable)
+	createStmt := n
+	ensureCopy := func() {
+		if createStmt == n {
+			newCreateStmt := *n
+			n.Defs = append(tree.TableDefs(nil), n.Defs...)
+			createStmt = &newCreateStmt
+		}
+	}
+
+	tn := tree.MakeTableNameFromPrefix(catalog.ResolvedObjectPrefix{
+		Database: db,
+		Schema:   sc,
+	}.NamePrefix(), tree.Name(n.Table.Table()))
+	for i, def := range n.Defs {
+		d, ok := def.(*tree.ColumnTableDef)
+		if !ok {
+			continue
+		}
+		newDef, prefix, seqName, seqOpts, err := p.processSerialLikeInColumnDef(ctx, d, &tn)
+		if err != nil {
+			return nil, err
+		}
+		// TODO (lucy): Have more consistent/informative names for dependent jobs.
+		if seqName != nil {
+			seqDesc, err := doCreateSequence(
+				ctx,
+				p,
+				sessionData,
+				prefix.Database,
+				prefix.Schema,
+				seqName,
+				n.Persistence,
+				seqOpts,
+				fmt.Sprintf("creating sequence %s for new table %s", seqName, n.Table.Table()),
+			)
+			if err != nil {
+				return nil, err
+			}
+			colNameToSeqDesc[d.Name] = seqDesc
+		}
+		if d != newDef {
+			ensureCopy()
+			n.Defs[i] = newDef
+		}
+	}
+
+	return colNameToSeqDesc, nil
 }
 
 func (*createSequenceNode) Next(runParams) (bool, error) { return false, nil }
@@ -170,6 +236,7 @@ func (*createSequenceNode) Close(context.Context)        {}
 // NewSequenceTableDesc creates a sequence descriptor.
 func NewSequenceTableDesc(
 	ctx context.Context,
+	p *planner,
 	sequenceName string,
 	sequenceOptions tree.SequenceOptions,
 	parentID descpb.ID,
@@ -178,7 +245,6 @@ func NewSequenceTableDesc(
 	creationTime hlc.Timestamp,
 	privileges *descpb.PrivilegeDescriptor,
 	persistence tree.Persistence,
-	params *runParams,
 	isMultiRegion bool,
 ) (*tabledesc.Mutable, error) {
 	desc := tabledesc.InitTableDescriptor(
@@ -222,8 +288,16 @@ func NewSequenceTableDesc(
 	opts := &descpb.TableDescriptor_SequenceOpts{
 		Increment: 1,
 	}
-	err := assignSequenceOptions(opts, sequenceOptions, true /* setDefaults */, params, id, parentID)
-	if err != nil {
+
+	if err := assignSequenceOptions(
+		ctx,
+		p,
+		opts,
+		sequenceOptions,
+		true, /* setDefaults */
+		id,
+		parentID,
+	); err != nil {
 		return nil, err
 	}
 	desc.SequenceOpts = opts

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2320,16 +2320,6 @@ func newTableDesc(
 	privileges *descpb.PrivilegeDescriptor,
 	affected map[descpb.ID]*tabledesc.Mutable,
 ) (ret *tabledesc.Mutable, err error) {
-	// Process any SERIAL columns to remove the SERIAL type,
-	// as required by NewTableDesc.
-	createStmt := n
-	ensureCopy := func() {
-		if createStmt == n {
-			newCreateStmt := *n
-			n.Defs = append(tree.TableDefs(nil), n.Defs...)
-			createStmt = &newCreateStmt
-		}
-	}
 	newDefs, err := replaceLikeTableOpts(n, params)
 	if err != nil {
 		return nil, err
@@ -2342,37 +2332,13 @@ func newTableDesc(
 		n.Defs = newDefs
 	}
 
-	tn := tree.MakeTableNameFromPrefix(catalog.ResolvedObjectPrefix{
-		Database: db,
-		Schema:   sc,
-	}.NamePrefix(), tree.Name(n.Table.Table()))
-	for i, def := range n.Defs {
-		d, ok := def.(*tree.ColumnTableDef)
-		if !ok {
-			continue
-		}
-		newDef, prefix, seqName, seqOpts, err := params.p.processSerialLikeInColumnDef(params.ctx, d, &tn)
-		if err != nil {
-			return nil, err
-		}
-		// TODO (lucy): Have more consistent/informative names for dependent jobs.
-		if seqName != nil {
-			if err := doCreateSequence(
-				params,
-				prefix.Database,
-				prefix.Schema,
-				seqName,
-				n.Persistence,
-				seqOpts,
-				fmt.Sprintf("creating sequence %s for new table %s", seqName, n.Table.Table()),
-			); err != nil {
-				return nil, err
-			}
-		}
-		if d != newDef {
-			ensureCopy()
-			n.Defs[i] = newDef
-		}
+	// Process any SERIAL columns to remove the SERIAL type, as required by
+	// NewTableDesc.
+	colNameToOwnedSeq, err := createSequencesForSerialColumns(
+		params.ctx, params.p, params.SessionData(), db, sc, n,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	var regionConfig *multiregion.RegionConfig
@@ -2408,6 +2374,20 @@ func newTableDesc(
 			n.Persistence,
 		)
 	})
+	if err != nil {
+		return ret, err
+	}
+
+	// We need to ensure sequence ownerships so that column owned sequences are
+	// correctly dropped when a column/table is dropped.
+	for colName, seqDesc := range colNameToOwnedSeq {
+		// When a table is first created, `affected` includes all the newly created
+		// sequenced. So `affectedSeqDesc` should be always non-nil.
+		affectedSeqDesc := affected[seqDesc.ID]
+		if err := setSequenceOwner(affectedSeqDesc, colName, ret); err != nil {
+			return nil, err
+		}
+	}
 
 	return ret, err
 }
@@ -2877,5 +2857,34 @@ func checkTypeIsSupported(ctx context.Context, settings *cluster.Settings, typ *
 			typ.SQLString(),
 		)
 	}
+	return nil
+}
+
+// setSequenceOwner adds sequence id to the sequence id list owned by a column
+// and set ownership values of sequence options.
+func setSequenceOwner(
+	seqDesc *tabledesc.Mutable, colName tree.Name, table *tabledesc.Mutable,
+) error {
+	if !seqDesc.IsSequence() {
+		return errors.Errorf("%s is not a sequence", seqDesc.Name)
+	}
+
+	col, err := table.FindColumnWithName(colName)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, seqID := range col.ColumnDesc().OwnsSequenceIds {
+		if seqID == seqDesc.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		col.ColumnDesc().OwnsSequenceIds = append(col.ColumnDesc().OwnsSequenceIds, seqDesc.ID)
+	}
+	seqDesc.SequenceOpts.SequenceOwner.OwnerTableID = table.ID
+	seqDesc.SequenceOpts.SequenceOwner.OwnerColumnID = col.GetID()
+
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2065,3 +2065,83 @@ SELECT * FROM multipleinstmt ORDER BY id ASC;
 1  a  a  false  NULL  true  NULL
 2  b  b  false  NULL  true  NULL
 3  c  c  false  NULL  true  NULL
+
+# Test sequence is drop when a owner table/column is dropped
+subtest test_serial_ownership_add_column
+
+statement ok
+SET serial_normalization = sql_sequence;
+
+statement ok
+CREATE TABLE test_serial (
+	a INT PRIMARY KEY
+);
+
+statement ok
+ALTER TABLE test_serial ADD COLUMN b SERIAL;
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name               state   refobjid
+144       test_serial_b_seq  PUBLIC  143
+143       test_serial        PUBLIC  NULL
+
+statement ok
+DROP TABLE test_serial;
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name  state  refobjid
+
+statement ok
+CREATE TABLE test_serial (
+	a INT PRIMARY KEY
+);
+
+statement ok
+ALTER TABLE test_serial ADD COLUMN b SERIAL;
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name               state   refobjid
+146       test_serial_b_seq  PUBLIC  145
+145       test_serial        PUBLIC  NULL
+
+statement ok
+ALTER TABLE test_serial DROP COLUMN b;
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name         state   refobjid
+145       test_serial  PUBLIC  NULL
+
+statement ok
+DROP TABLE test_serial;

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -628,3 +628,87 @@ CREATE TABLE error (a INT, b INT, UNIQUE INDEX idx (a), UNIQUE INDEX idx (b))
 
 statement ok
 CREATE TABLE regression_73498 AS select * from [SHOW CLUSTER QUERIES]
+
+# Test sequence is drop when a owner table/column is dropped
+subtest test_serial_ownership_create_table
+
+statement ok
+SET serial_normalization = sql_sequence;
+
+# Make sure it does not panic when failing to create table descriptor before
+# setting sequence ownership.
+statement error pq: BUCKET_COUNT must be a 32-bit integer greater than 1, got -1
+CREATE TABLE test_ownership_invalid_bucket_count (
+  a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=-1,
+  b SERIAL
+);
+
+statement ok
+CREATE TABLE test_serial (
+	a INT PRIMARY KEY,
+	b SERIAL
+);
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name               state   refobjid
+120       test_serial_b_seq  PUBLIC  119
+119       test_serial        PUBLIC  NULL
+
+statement ok
+DROP TABLE test_serial;
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name  state  refobjid
+
+statement ok
+CREATE TABLE test_serial (
+	a INT PRIMARY KEY,
+	b SERIAL
+);
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name               state   refobjid
+122       test_serial_b_seq  PUBLIC  121
+121       test_serial        PUBLIC  NULL
+
+statement ok
+ALTER TABLE test_serial DROP COLUMN b;
+
+query ITTT colnames
+SELECT l.table_id, l.name, l.state, r.refobjid
+FROM (
+  SELECT table_id, name, state
+  FROM crdb_internal.tables WHERE name
+  LIKE 'test_serial%' AND state = 'PUBLIC'
+) l
+LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
+----
+table_id  name         state   refobjid
+121       test_serial  PUBLIC  NULL
+
+statement ok
+DROP TABLE test_serial;

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1399,14 +1399,16 @@ FROM pg_catalog.pg_depend
 ORDER BY objid
 ----
 classid     objid       objsubid  refclassid  refobjid   refobjsubid  deptype
+4294967127  56          0         4294967130  55         14           a
+4294967127  57          0         4294967130  55         15           a
 4294967127  109163875   0         4294967130  450499960  0            n
 4294967127  1329876328  0         4294967130  0          0            n
 4294967127  1652586190  0         4294967130  450499961  0            n
 4294967127  3173756726  0         4294967130  0          0            n
-4294967084  4079785833  0         4294967130  55         3            n
-4294967084  4079785833  0         4294967130  55         4            n
 4294967084  4079785833  0         4294967130  55         1            n
 4294967084  4079785833  0         4294967130  55         2            n
+4294967084  4079785833  0         4294967130  55         3            n
+4294967084  4079785833  0         4294967130  55         4            n
 
 # Some entries in pg_depend are dependency links from the pg_constraint system
 # table to the pg_class system table. Other entries are links to pg_class when it is
@@ -1433,6 +1435,8 @@ ORDER BY relname
 ----
 relname    relkind
 index_key  i
+t1         r
+t1         r
 t1         r
 t1         r
 t1         r

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -222,23 +222,23 @@ query TT
 SHOW CREATE TABLE serial
 ----
 serial  CREATE TABLE public.serial (
-        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq1'::REGCLASS),
+        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq'::REGCLASS),
         b INT8 NULL DEFAULT 7:::INT8,
-        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq3'::REGCLASS),
+        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2'::REGCLASS),
         CONSTRAINT "primary" PRIMARY KEY (a ASC),
         UNIQUE INDEX serial_c_key (c ASC),
         FAMILY "primary" (a, b, c)
 )
 
 query TT
-SHOW CREATE SEQUENCE serial_a_seq1
+SHOW CREATE SEQUENCE serial_a_seq
 ----
-serial_a_seq1  CREATE SEQUENCE public.serial_a_seq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+serial_a_seq  CREATE SEQUENCE public.serial_a_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
 
 query TT
 SELECT pg_get_serial_sequence('serial', 'a'), pg_get_serial_sequence('serial', 'b')
 ----
-public.serial_a_seq1  NULL
+public.serial_a_seq  NULL
 
 statement error relation "non_existent_tbl" does not exist
 SELECT pg_get_serial_sequence('non_existent_tbl', 'a')
@@ -305,8 +305,8 @@ query TT
 SHOW CREATE TABLE smallbig
 ----
 smallbig  CREATE TABLE public.smallbig (
-          a INT2 NOT NULL DEFAULT nextval('public.smallbig_a_seq1'::REGCLASS),
-          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq1'::REGCLASS),
+          a INT2 NOT NULL DEFAULT nextval('public.smallbig_a_seq'::REGCLASS),
+          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq'::REGCLASS),
           c INT8 NULL,
           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
           CONSTRAINT "primary" PRIMARY KEY (rowid ASC),
@@ -328,9 +328,9 @@ query TT
 SHOW CREATE TABLE serials
 ----
 serials  CREATE TABLE public.serials (
-         a INT2 NOT NULL DEFAULT nextval('public.serials_a_seq1'::REGCLASS),
-         b INT4 NOT NULL DEFAULT nextval('public.serials_b_seq1'::REGCLASS),
-         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq1'::REGCLASS),
+         a INT2 NOT NULL DEFAULT nextval('public.serials_a_seq'::REGCLASS),
+         b INT4 NOT NULL DEFAULT nextval('public.serials_b_seq'::REGCLASS),
+         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq'::REGCLASS),
          d INT8 NULL,
          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
          CONSTRAINT "primary" PRIMARY KEY (rowid ASC),

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -207,7 +207,13 @@ statement ok
 DROP TABLE perm_table; DROP TABLE ref_temp_table
 
 statement ok
-DROP SEQUENCE pg_temp.temp_seq; DROP SEQUENCE pg_temp.ref_temp_table_a_seq; DROP TABLE a
+DROP SEQUENCE pg_temp.temp_seq; DROP TABLE a
+
+query ITT
+SELECT table_id, name, state
+FROM crdb_internal.tables WHERE name
+LIKE 'ref_temp_table%' AND state = 'PUBLIC'
+----
 
 statement ok
 SET serial_normalization='rowid'

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -263,11 +263,16 @@ func cleanupSchemaObjects(
 
 		databaseIDToTempSchemaID[uint32(desc.GetParentID())] = uint32(desc.GetParentSchemaID())
 
-		if desc.GetSequenceOpts() != nil {
+		// If a sequence is owned by a table column, it is dropped when the owner
+		// table/column is dropped. So here we want to only drop sequences not
+		// owned.
+		if desc.IsSequence() &&
+			desc.GetSequenceOpts().SequenceOwner.OwnerColumnID == 0 &&
+			desc.GetSequenceOpts().SequenceOwner.OwnerTableID == 0 {
 			sequences = append(sequences, desc.GetID())
 		} else if desc.GetViewQuery() != "" {
 			views = append(views, desc.GetID())
-		} else {
+		} else if !desc.IsSequence() {
 			tables = append(tables, desc.GetID())
 		}
 	}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -74,13 +74,13 @@ func CreateTestTableDescriptor(
 	case *tree.CreateSequence:
 		desc, err := NewSequenceTableDesc(
 			ctx,
+			nil, /* planner */
 			n.Name.Table(),
 			n.Options,
 			parentID, keys.PublicSchemaID, id,
 			hlc.Timestamp{}, /* creationTime */
 			privileges,
 			tree.PersistencePermanent,
-			nil,   /* params */
 			false, /* isMultiRegion */
 		)
 		return desc, err


### PR DESCRIPTION
Backport 1/1 commits from #74840.

/cc @cockroachdb/release

---

  Fixes #69298

  Release note (bug fix): A sequence is created when a column is
  defined as `SERIAL` type and the `serial_normalization` session
  variable is set to `sql_sequence`. In this case, the sequence is
  owned by the column and the table where the column exists. The
  sequence should be dropped when the owner table/column is dropped,
  which is the postgres behavior. However, cockroach never set
  ownership information correctly but only dependecy relationship.
  So the sequence stays even the owner table/column does not exist
  anymore. This fix assigns correct ownership information to sequence
  descriptor and column descriptor so that cockroach can align with
  postgres behavior.

---

Release justification: backporting so that 21.2 can have same sequence drop behavior as postgres