### PR TITLE
cmd/dev: check if doctor needs to be run

### DIFF
--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -127,10 +127,18 @@ Typical usage:
 		subCmd.Flags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev")
 	}
 	for _, subCmd := range ret.cli.Commands() {
-		subCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		isDoctor := subCmd.Name() == "doctor"
+
+		subCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+			if !isTesting && !isDoctor {
+				if err := ret.checkDoctorStatus(cmd.Context()); err != nil {
+					return err
+				}
+			}
 			if debugVar {
 				ret.log.SetOutput(stdos.Stderr)
 			}
+			return nil
 		}
 	}
 

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -10,7 +10,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 dev build cockroach-short --cpus=12 --skip-generate
 ----
 bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
@@ -19,7 +18,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 dev build --debug short --skip-generate
 ----
 bazel build //pkg/cmd/cockroach-short:cockroach-short
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
@@ -28,7 +26,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 dev build cockroach-short --remote-cache 127.0.0.1:9090 --skip-generate
 ----
 bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short:cockroach-short
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
@@ -37,7 +34,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 dev build cockroach-short
 ----
 bazel build //pkg/cmd/cockroach-short:cockroach-short //:go_path
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
@@ -54,7 +50,6 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 dev build short --skip-generate -- -s
 ----
 bazel build //pkg/cmd/cockroach-short:cockroach-short -s
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach-short
@@ -63,7 +58,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 dev build --skip-generate -- --verbose_failures --sandbox_debug
 ----
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/cockroach
@@ -73,7 +67,6 @@ dev build @com_github_cockroachdb_stress//:stress --skip-generate
 ----
 bazel query @com_github_cockroachdb_stress//:stress --output=label_kind
 bazel build @com_github_cockroachdb_stress//:stress
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/bin/stress
@@ -83,7 +76,6 @@ dev build pkg/roachpb:roachpb_test --skip-generate
 ----
 bazel query pkg/roachpb:roachpb_test --output=label_kind
 bazel build //pkg/roachpb:roachpb_test --config=test
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 
@@ -91,7 +83,6 @@ dev build pkg/foo/... --skip-generate
 ----
 bazel query pkg/foo/... --output=label_kind
 bazel build //pkg/foo:bar //pkg/foo:baz --config=test
-bazel info workspace --color=no
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no
 rm go/src/github.com/cockroachdb/cockroach/bin/bar

--- a/pkg/cmd/dev/testdata/builder.txt
+++ b/pkg/cmd/dev/testdata/builder.txt
@@ -1,7 +1,6 @@
 dev builder
 ----
 id
-bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir go/src/github.com/cockroachdb/cockroach/artifacts
@@ -10,7 +9,6 @@ docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --work
 dev builder echo hi
 ----
 id
-bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir go/src/github.com/cockroachdb/cockroach/artifacts

--- a/pkg/cmd/dev/testdata/generate.txt
+++ b/pkg/cmd/dev/testdata/generate.txt
@@ -1,11 +1,9 @@
 dev gen bazel
 ----
-bazel info workspace --color=no
 go/src/github.com/cockroachdb/cockroach/build/bazelutil/bazel-generate.sh
 
 dev gen docs
 ----
-bazel info workspace --color=no
 cat go/src/github.com/cockroachdb/cockroach/docs/generated/bazel_targets.txt
 bazel build //docs/generated:gen-logging-md //docs/generated/sql
 bazel info bazel-bin --color=no
@@ -22,7 +20,6 @@ echo MOCK_REDACT_SAFE_OUTPUT > go/src/github.com/cockroachdb/cockroach/docs/gene
 dev gen go
 ----
 bazel build //:go_path --show_result=0
-bazel info workspace --color=no
 bazel info bazel-bin --color=no
 git status --ignored --short go/src/github.com/cockroachdb/cockroach/pkg
 rm pkg/file_to_delete.go

--- a/pkg/cmd/dev/testdata/logic.txt
+++ b/pkg/cmd/dev/testdata/logic.txt
@@ -10,5 +10,4 @@ bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --
 
 dev testlogic base --files=auto_span_config_reconciliation_job --config=local -v --show-logs --timeout=50s --rewrite
 ----
-bazel info workspace --color=no
 bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_timeout=50 --test_arg -show-sql --test_arg -config --test_arg local --test_output all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/sql/logictest //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation_job$/'

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -21,10 +21,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short
 ----
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
@@ -40,10 +36,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 bazel build //pkg/cmd/cockroach-short:cockroach-short
 ----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
@@ -61,10 +53,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 bazel build --remote_local_fallback --remote_cache=grpc://127.0.0.1:9090 --experimental_remote_downloader=grpc://127.0.0.1:9090 //pkg/cmd/cockroach-short:cockroach-short
 ----
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
@@ -80,10 +68,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 bazel build //pkg/cmd/cockroach-short:cockroach-short //:go_path
 ----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
@@ -147,10 +131,6 @@ cp /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/b
 bazel build //pkg/cmd/cockroach-short:cockroach-short -s
 ----
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
@@ -166,10 +146,6 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
 ----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
@@ -191,10 +167,6 @@ go_binary rule @com_github_cockroachdb_stress//:stress
 bazel build @com_github_cockroachdb_stress//:stress
 ----
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
@@ -215,10 +187,6 @@ go_test rule //pkg/roachpb:roachpb_test
 bazel build //pkg/roachpb:roachpb_test --config=test
 ----
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----
 
@@ -237,10 +205,6 @@ go_proto_library rule //pkg/foo:bar_proto_library
 
 bazel build //pkg/foo:bar //pkg/foo:baz --config=test
 ----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 ----

--- a/pkg/cmd/dev/testdata/recording/builder.txt
+++ b/pkg/cmd/dev/testdata/recording/builder.txt
@@ -2,10 +2,6 @@ id
 ----
 1001:1002
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 ----
 BAZEL_IMAGE=mock_bazel_image:1234
@@ -22,10 +18,6 @@ docker run --rm -it -v go/src/github.com/cockroachdb/cockroach:/cockroach --work
 id
 ----
 1001:1002
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 cat go/src/github.com/cockroachdb/cockroach/build/teamcity-bazel-support.sh
 ----

--- a/pkg/cmd/dev/testdata/recording/generate.txt
+++ b/pkg/cmd/dev/testdata/recording/generate.txt
@@ -1,13 +1,5 @@
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 go/src/github.com/cockroachdb/cockroach/build/bazelutil/bazel-generate.sh
 ----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 cat go/src/github.com/cockroachdb/cockroach/docs/generated/bazel_targets.txt
 ----
@@ -104,10 +96,6 @@ echo MOCK_REDACT_SAFE_OUTPUT > go/src/github.com/cockroachdb/cockroach/docs/gene
 
 bazel build //:go_path --show_result=0
 ----
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 bazel info bazel-bin --color=no
 ----

--- a/pkg/cmd/dev/testdata/recording/logic.txt
+++ b/pkg/cmd/dev/testdata/recording/logic.txt
@@ -10,9 +10,5 @@ bazel test --test_env=GOTRACEBACK=all --test_output errors //pkg/sql/opt/exec/ex
 bazel test --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -config --test_arg local --test_output errors //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^prepare|fk$/20042'
 ----
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 bazel test --test_env=GOTRACEBACK=all --test_arg -test.v --test_arg -show-logs --test_timeout=50 --test_arg -show-sql --test_arg -config --test_arg local --test_output all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/sql/logictest //pkg/sql/logictest:logictest_test --test_filter 'TestLogic/^local$/^auto_span_config_reconciliation_job$/'
 ----

--- a/pkg/cmd/dev/testdata/recording/test.txt
+++ b/pkg/cmd/dev/testdata/recording/test.txt
@@ -245,10 +245,6 @@ bazel query 'kind(go_test, //pkg/testutils:all)'
 ----
 //pkg/testutils:testutils_test
 
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
-
 bazel test //pkg/testutils:testutils_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --test_output errors
 ----
 
@@ -267,10 +263,6 @@ pkg/other/test
 bazel query 'kind(go_test, //pkg/other/test:all)'
 ----
 //pkg/other/test:test_test
-
-bazel info workspace --color=no
-----
-go/src/github.com/cockroachdb/cockroach
 
 bazel test //pkg/testutils:testutils_test //pkg/other/test:test_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/other/test --test_output errors
 ----

--- a/pkg/cmd/dev/testdata/test.txt
+++ b/pkg/cmd/dev/testdata/test.txt
@@ -80,7 +80,6 @@ dev test //pkg/testutils --rewrite
 ----
 find pkg/testutils -type d
 bazel query 'kind(go_test, //pkg/testutils:all)'
-bazel info workspace --color=no
 bazel test //pkg/testutils:testutils_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --test_output errors
 
 dev test //pkg/testutils pkg/other/test --rewrite
@@ -89,5 +88,4 @@ find pkg/testutils -type d
 bazel query 'kind(go_test, //pkg/testutils:all)'
 find pkg/other/test -type d
 bazel query 'kind(go_test, //pkg/other/test:all)'
-bazel info workspace --color=no
 bazel test //pkg/testutils:testutils_test //pkg/other/test:test_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=go/src/github.com/cockroachdb/cockroach --test_arg -rewrite --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/testutils --sandbox_writable_path=go/src/github.com/cockroachdb/cockroach/pkg/other/test --test_output errors

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -112,8 +112,25 @@ func (d *dev) getBazelInfo(ctx context.Context, key string) (string, error) {
 
 }
 
+var workspace string
+
 func (d *dev) getWorkspace(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "workspace")
+	if workspace == "" {
+		if _, err := os.Stat("WORKSPACE"); err == nil {
+			w, err := os.Getwd()
+			if err != nil {
+				return "", err
+			}
+			workspace = w
+		} else {
+			w, err := d.getBazelInfo(ctx, "workspace")
+			if err != nil {
+				return "", err
+			}
+			workspace = w
+		}
+	}
+	return workspace, nil
 }
 
 func (d *dev) getBazelBin(ctx context.Context) (string, error) {


### PR DESCRIPTION
This adds a check to all non-`doctor` dev commands that `dev doctor` has
previous succeeded, so that in those commands we can assume all of the
state checked or setup by `dev doctor` is correct.

If the definition of `doctor` is updated, this check can also be used to
force a re-run of doctor to run the new version and its new logic.

The is implemented by persisting the "version" of doctor that most recently
succeeded in a file (bin/.dev-status) and then comparing that to the
current dev version.

This also adds "setup" as an alias for "doctor" as it is now expected to
be run after initial clone to "setup" the dev environment (i.e. write
the status file, potentially setup githooks, etc).

Release note: none.