### PR TITLE
sql: delete preserving indexes shouldn't preserve deletes in DELETE_ONLY

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -511,6 +511,16 @@ message IndexDescriptor {
   // This is necessary to preserve the delete history for the MVCC-compatible
   // index backfiller
   // docs/RFCS/20211004_incremental_index_backfiller.md#new-index-encoding-for-deletions-vs-mvcc
+  //
+  // We only use the delete preserving encoding if the index is
+  // writable. Otherwise, we may preserve a delete when in DELETE_ONLY but never
+  // see a subsequent write that replaces it. This a problem for the
+  // MVCC-compatible index backfiller which merges entries from a
+  // delete-preserving index into a newly-added index. A delete preserved in
+  // DELETE_ONLY could result in a value being erroneously deleted during the
+  // merge process. While we could filter such deletes, the filtering would
+  // require more data being stored in each deleted entry and further complicate
+  // the merge process. See #75720 for further details.
   optional bool use_delete_preserving_encoding = 24 [(gogoproto.nullable) = false];
 }
 


### PR DESCRIPTION
Delete preseving indexes are intended for use in the mvcc-compliant
index backfiller where the are used to construct a log of writes that
occur when a newly added index is backfilling.

Delete preserving indexes need to step through DELETE_ONLY before
entering DELETE_AND_WRITE_ONLY like any other index.

Consider the following order of events:

    t0: Insert of a=1 in primary index
    t1: CREATE INDEX adds a delete-preseving index mutation with DELETE_ONLY state
    t2: Delete of a=1
    t3: Insert of a=1
    t4: Temporary index mutation stepped to DELETE_AND_WRITE_ONLY

At this point, the delete-preserving index would have a preserved
delete for `a=1` that was never replaced with the following write.

If we were to merge the entries from this delete-preserving index into
the newly added index, we would end up erroneously deleting our entry
for a=1.

We considered filtering entries during the merge based on their
timestamp (that is, filtering any entries that wer written before our
backfill started). But, this will not work if an inflight schema
change is then backed up and restored as the timestamps in the KVs
will all have changed.

Here, we simply skip preserving any deletes when in DELETE_ONLY.  We
believe this to be correct for the purposes of the backfiller, because
we only care about writes and deletes that happen after the index is
in a DELETE_AND_WRITE_ONLY state since we only start the backfill
after the delete-preserving index enters the DELETE_AND_WRITE_ONLY
state and waiting for a single table descriptor version.

Release note: None