### PR TITLE
server.go: misc refactors

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/apd/v3"
+	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
@@ -566,10 +566,10 @@ func cloudStorageTestWithOptions(testFn cdcTestFn, options feedTestOptions) func
 			}
 			blobClientFactory := blobs.NewLocalOnlyBlobClientFactory(options.externalIODir)
 			if serverKnobs, ok := knobs.Server.(*server.TestingKnobs); ok {
-				serverKnobs.TenantBlobClientFactory = blobClientFactory
+				serverKnobs.BlobClientFactory = blobClientFactory
 			} else {
 				knobs.Server = &server.TestingKnobs{
-					TenantBlobClientFactory: blobClientFactory,
+					BlobClientFactory: blobClientFactory,
 				}
 			}
 		}

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "index_usage_stats.go",
         "init.go",
         "init_handshake.go",
+        "listen_and_update_addrs.go",
         "loopback.go",
         "migration.go",
         "node.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "rlimit_darwin.go",
         "rlimit_unix.go",
         "server.go",
+        "server_http.go",
         "server_sql.go",
         "server_systemlog_gc.go",
         "settings_cache.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "settings_cache.go",
         "settingsworker.go",
         "sql_stats.go",
+        "start_listen.go",
         "statement_diagnostics_requests.go",
         "statements.go",
         "status.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "doc.go",
         "drain.go",
         "grpc_server.go",
+        "gzip_response_writer.go",
         "index_usage_stats.go",
         "init.go",
         "init_handshake.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "env_sampler.go",
         "grpc_server.go",
         "gzip_response_writer.go",
+        "import_ts.go",
         "index_usage_stats.go",
         "init.go",
         "init_handshake.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "statements.go",
         "status.go",
         "sticky_engine.go",
+        "tcp_keepalive_manager.go",
         "tenant.go",
         "tenant_status.go",
         "testing_knobs.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "config.go",
         "config_unix.go",
         "config_windows.go",
+        "decommission.go",
         "doc.go",
         "drain.go",
         "env_sampler.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "authentication.go",
         "auto_tls_init.go",
         "auto_upgrade.go",
+        "clock_monotonicity.go",
         "cluster_settings.go",
         "combined_statement_stats.go",
         "config.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "doc.go",
         "drain.go",
         "env_sampler.go",
+        "external_storage_builder.go",
         "grpc_server.go",
         "gzip_response_writer.go",
         "import_ts.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "config_windows.go",
         "doc.go",
         "drain.go",
+        "env_sampler.go",
         "grpc_server.go",
         "gzip_response_writer.go",
         "index_usage_stats.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "drain.go",
         "env_sampler.go",
         "external_storage_builder.go",
+        "grpc_gateway.go",
         "grpc_server.go",
         "gzip_response_writer.go",
         "import_ts.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "init_handshake.go",
         "listen_and_update_addrs.go",
         "loopback.go",
+        "loss_of_quorum.go",
         "migration.go",
         "node.go",
         "node_tenant.go",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/apd/v3"
+	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -72,6 +72,8 @@ const (
 	// administrative interface to the cockroach cluster.
 	adminPrefix = "/_admin/v1/"
 
+	adminHealth = adminPrefix + "health"
+
 	// defaultAPIEventLimit is the default maximum number of events returned by any
 	// endpoints returning events.
 	defaultAPIEventLimit = 1000
@@ -112,9 +114,11 @@ var noteworthyAdminMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEW
 
 // newAdminServer allocates and returns a new REST server for
 // administrative APIs.
-func newAdminServer(s *Server, ie *sql.InternalExecutor) *adminServer {
+func newAdminServer(
+	s *Server, adminAuthzCheck *adminPrivilegeChecker, ie *sql.InternalExecutor,
+) *adminServer {
 	server := &adminServer{
-		adminPrivilegeChecker: &adminPrivilegeChecker{ie: ie},
+		adminPrivilegeChecker: adminAuthzCheck,
 		internalExecutor:      ie,
 		server:                s,
 	}

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -77,7 +77,7 @@ var ConfigureOIDC = func(
 	ctx context.Context,
 	st *cluster.Settings,
 	locality roachpb.Locality,
-	mux *http.ServeMux,
+	handleHTTP func(pattern string, handler http.Handler),
 	userLoginFromSSO func(ctx context.Context, username string) (*http.Cookie, error),
 	ambientCtx log.AmbientContext,
 	cluster uuid.UUID,

--- a/pkg/server/clock_monotonicity.go
+++ b/pkg/server/clock_monotonicity.go
@@ -1,0 +1,279 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+)
+
+var (
+	forwardClockJumpCheckEnabled = settings.RegisterBoolSetting(
+		settings.TenantWritable,
+		"server.clock.forward_jump_check_enabled",
+		"if enabled, forward clock jumps > max_offset/2 will cause a panic",
+		false,
+	).WithPublic()
+
+	persistHLCUpperBoundInterval = settings.RegisterDurationSetting(
+		settings.TenantWritable,
+		"server.clock.persist_upper_bound_interval",
+		"the interval between persisting the wall time upper bound of the clock. The clock "+
+			"does not generate a wall time greater than the persisted timestamp and will panic if "+
+			"it sees a wall time greater than this value. When cockroach starts, it waits for the "+
+			"wall time to catch-up till this persisted timestamp. This guarantees monotonic wall "+
+			"time across server restarts. Not setting this or setting a value of 0 disables this "+
+			"feature.",
+		0,
+	).WithPublic()
+)
+
+// startMonitoringForwardClockJumps starts a background task to monitor forward
+// clock jumps based on a cluster setting.
+func (s *Server) startMonitoringForwardClockJumps(ctx context.Context) error {
+	forwardJumpCheckEnabled := make(chan bool, 1)
+	s.stopper.AddCloser(stop.CloserFn(func() { close(forwardJumpCheckEnabled) }))
+
+	forwardClockJumpCheckEnabled.SetOnChange(&s.st.SV, func(context.Context) {
+		forwardJumpCheckEnabled <- forwardClockJumpCheckEnabled.Get(&s.st.SV)
+	})
+
+	if err := s.clock.StartMonitoringForwardClockJumps(
+		ctx,
+		forwardJumpCheckEnabled,
+		time.NewTicker,
+		nil, /* tick callback */
+	); err != nil {
+		return errors.Wrap(err, "monitoring forward clock jumps")
+	}
+
+	log.Ops.Info(ctx, "monitoring forward clock jumps based on server.clock.forward_jump_check_enabled")
+	return nil
+}
+
+// checkHLCUpperBoundExists determines whether there's an HLC
+// upper bound that will need to refreshed/persisted after
+// the server has initialized.
+func (s *Server) checkHLCUpperBoundExistsAndEnsureMonotonicity(
+	ctx context.Context, initialStart bool,
+) (hlcUpperBoundExists bool, err error) {
+	if initialStart {
+		// Clock monotonicity checks can be skipped on server bootstrap
+		// because the server has never
+		// been used before.
+		return false, nil
+	}
+
+	hlcUpperBound, err := kvserver.ReadMaxHLCUpperBound(ctx, s.engines)
+	if err != nil {
+		return false, errors.Wrap(err, "reading max HLC upper bound")
+	}
+	hlcUpperBoundExists = hlcUpperBound > 0
+
+	// If the server is being restarted, sleep to ensure monotonicity of the HLC
+	// clock.
+	ensureClockMonotonicity(
+		ctx,
+		s.clock,
+		s.startTime,
+		hlcUpperBound,
+		s.clock.SleepUntil,
+	)
+
+	return hlcUpperBoundExists, nil
+}
+
+// ensureClockMonotonicity sleeps till the wall time reaches
+// prevHLCUpperBound. prevHLCUpperBound > 0 implies we need to guarantee HLC
+// monotonicity across server restarts. prevHLCUpperBound is the last
+// successfully persisted timestamp greater then any wall time used by the
+// server.
+//
+// If prevHLCUpperBound is 0, the function sleeps up to max offset.
+func ensureClockMonotonicity(
+	ctx context.Context,
+	clock *hlc.Clock,
+	startTime time.Time,
+	prevHLCUpperBound int64,
+	sleepUntilFn func(context.Context, hlc.Timestamp) error,
+) {
+	var sleepUntil int64
+	if prevHLCUpperBound != 0 {
+		// Sleep until previous HLC upper bound to ensure wall time monotonicity
+		sleepUntil = prevHLCUpperBound + 1
+	} else {
+		// Previous HLC Upper bound is not known
+		// We might have to sleep a bit to protect against this node producing non-
+		// monotonic timestamps. Before restarting, its clock might have been driven
+		// by other nodes' fast clocks, but when we restarted, we lost all this
+		// information. For example, a client might have written a value at a
+		// timestamp that's in the future of the restarted node's clock, and if we
+		// don't do something, the same client's read would not return the written
+		// value. So, we wait up to MaxOffset; we couldn't have served timestamps more
+		// than MaxOffset in the future (assuming that MaxOffset was not changed, see
+		// #9733).
+		//
+		// As an optimization for tests, we don't sleep if all the stores are brand
+		// new. In this case, the node will not serve anything anyway until it
+		// synchronizes with other nodes.
+		sleepUntil = startTime.UnixNano() + int64(clock.MaxOffset()) + 1
+	}
+
+	currentWallTime := clock.Now().WallTime
+	delta := time.Duration(sleepUntil - currentWallTime)
+	if delta > 0 {
+		log.Ops.Infof(
+			ctx,
+			"Sleeping till wall time %v to catches up to %v to ensure monotonicity. Delta: %v",
+			currentWallTime,
+			sleepUntil,
+			delta,
+		)
+		_ = sleepUntilFn(ctx, hlc.Timestamp{WallTime: sleepUntil})
+	}
+}
+
+// periodicallyPersistHLCUpperBound periodically persists an upper bound of
+// the HLC's wall time. The interval for persisting is read from
+// persistHLCUpperBoundIntervalCh. An interval of 0 disables persisting.
+//
+// persistHLCUpperBoundFn is used to persist the hlc upper bound, and should
+// return an error if the persist fails.
+//
+// tickerFn is used to create the ticker used for persisting
+//
+// tickCallback is called whenever a tick is processed
+func periodicallyPersistHLCUpperBound(
+	clock *hlc.Clock,
+	persistHLCUpperBoundIntervalCh chan time.Duration,
+	persistHLCUpperBoundFn func(int64) error,
+	tickerFn func(d time.Duration) *time.Ticker,
+	stopCh <-chan struct{},
+	tickCallback func(),
+) {
+	// Create a ticker which can be used in selects.
+	// This ticker is turned on / off based on persistHLCUpperBoundIntervalCh
+	ticker := tickerFn(time.Hour)
+	ticker.Stop()
+
+	// persistInterval is the interval used for persisting the
+	// an upper bound of the HLC
+	var persistInterval time.Duration
+	var ok bool
+
+	persistHLCUpperBound := func() {
+		if err := clock.RefreshHLCUpperBound(
+			persistHLCUpperBoundFn,
+			int64(persistInterval*3), /* delta to compute upper bound */
+		); err != nil {
+			log.Ops.Fatalf(
+				context.Background(),
+				"error persisting HLC upper bound: %v",
+				err,
+			)
+		}
+	}
+
+	for {
+		select {
+		case persistInterval, ok = <-persistHLCUpperBoundIntervalCh:
+			ticker.Stop()
+			if !ok {
+				return
+			}
+
+			if persistInterval > 0 {
+				ticker = tickerFn(persistInterval)
+				persistHLCUpperBound()
+				log.Ops.Info(context.Background(), "persisting HLC upper bound is enabled")
+			} else {
+				if err := clock.ResetHLCUpperBound(persistHLCUpperBoundFn); err != nil {
+					log.Ops.Fatalf(
+						context.Background(),
+						"error resetting hlc upper bound: %v",
+						err,
+					)
+				}
+				log.Ops.Info(context.Background(), "persisting HLC upper bound is disabled")
+			}
+
+		case <-ticker.C:
+			if persistInterval > 0 {
+				persistHLCUpperBound()
+			}
+
+		case <-stopCh:
+			ticker.Stop()
+			return
+		}
+
+		if tickCallback != nil {
+			tickCallback()
+		}
+	}
+}
+
+// startPersistingHLCUpperBound starts a goroutine to persist an upper bound
+// to the HLC.
+//
+// persistHLCUpperBoundFn is used to persist upper bound of the HLC, and should
+// return an error if the persist fails
+//
+// tickerFn is used to create a new ticker
+//
+// tickCallback is called whenever persistHLCUpperBoundCh or a ticker tick is
+// processed
+func (s *Server) startPersistingHLCUpperBound(ctx context.Context, hlcUpperBoundExists bool) error {
+	tickerFn := time.NewTicker
+	persistHLCUpperBoundFn := func(t int64) error { /* function to persist upper bound of HLC to all stores */
+		return s.node.SetHLCUpperBound(context.Background(), t)
+	}
+	persistHLCUpperBoundIntervalCh := make(chan time.Duration, 1)
+	persistHLCUpperBoundInterval.SetOnChange(&s.st.SV, func(context.Context) {
+		persistHLCUpperBoundIntervalCh <- persistHLCUpperBoundInterval.Get(&s.st.SV)
+	})
+
+	if hlcUpperBoundExists {
+		// The feature to persist upper bounds to wall times is enabled.
+		// Persist a new upper bound to continue guaranteeing monotonicity
+		// Going forward the goroutine launched below will take over persisting
+		// the upper bound
+		if err := s.clock.RefreshHLCUpperBound(
+			persistHLCUpperBoundFn,
+			int64(5*time.Second),
+		); err != nil {
+			return errors.Wrap(err, "refreshing HLC upper bound")
+		}
+	}
+
+	_ = s.stopper.RunAsyncTask(
+		ctx,
+		"persist-hlc-upper-bound",
+		func(context.Context) {
+			periodicallyPersistHLCUpperBound(
+				s.clock,
+				persistHLCUpperBoundIntervalCh,
+				persistHLCUpperBoundFn,
+				tickerFn,
+				s.stopper.ShouldQuiesce(),
+				nil, /* tick callback */
+			)
+		},
+	)
+	return nil
+}

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -1,0 +1,137 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+func getPingCheckDecommissionFn(
+	engines Engines,
+) (*nodeTombstoneStorage, func(context.Context, roachpb.NodeID, codes.Code) error) {
+	nodeTombStorage := &nodeTombstoneStorage{engs: engines}
+	return nodeTombStorage, func(ctx context.Context, nodeID roachpb.NodeID, errorCode codes.Code) error {
+		ts, err := nodeTombStorage.IsDecommissioned(ctx, nodeID)
+		if err != nil {
+			// An error here means something very basic is not working. Better to terminate
+			// than to limp along.
+			log.Fatalf(ctx, "unable to read decommissioned status for n%d: %v", nodeID, err)
+		}
+		if !ts.IsZero() {
+			// The node was decommissioned.
+			return grpcstatus.Errorf(errorCode,
+				"n%d was permanently removed from the cluster at %s; it is not allowed to rejoin the cluster",
+				nodeID, ts,
+			)
+		}
+		// The common case - target node is not decommissioned.
+		return nil
+	}
+}
+
+// Decommission idempotently sets the decommissioning flag for specified nodes.
+func (s *Server) Decommission(
+	ctx context.Context, targetStatus livenesspb.MembershipStatus, nodeIDs []roachpb.NodeID,
+) error {
+	// If we're asked to decommission ourself we may lose access to cluster RPC,
+	// so we decommission ourself last. We copy the slice to avoid mutating the
+	// input slice.
+	if targetStatus == livenesspb.MembershipStatus_DECOMMISSIONED {
+		orderedNodeIDs := make([]roachpb.NodeID, len(nodeIDs))
+		copy(orderedNodeIDs, nodeIDs)
+		sort.SliceStable(orderedNodeIDs, func(i, j int) bool {
+			return orderedNodeIDs[j] == s.NodeID()
+		})
+		nodeIDs = orderedNodeIDs
+	}
+
+	var event eventpb.EventPayload
+	var nodeDetails *eventpb.CommonNodeDecommissionDetails
+	if targetStatus.Decommissioning() {
+		ev := &eventpb.NodeDecommissioning{}
+		nodeDetails = &ev.CommonNodeDecommissionDetails
+		event = ev
+	} else if targetStatus.Decommissioned() {
+		ev := &eventpb.NodeDecommissioned{}
+		nodeDetails = &ev.CommonNodeDecommissionDetails
+		event = ev
+	} else if targetStatus.Active() {
+		ev := &eventpb.NodeRecommissioned{}
+		nodeDetails = &ev.CommonNodeDecommissionDetails
+		event = ev
+	} else {
+		panic("unexpected target membership status")
+	}
+	event.CommonDetails().Timestamp = timeutil.Now().UnixNano()
+	nodeDetails.RequestingNodeID = int32(s.NodeID())
+
+	for _, nodeID := range nodeIDs {
+		statusChanged, err := s.nodeLiveness.SetMembershipStatus(ctx, nodeID, targetStatus)
+		if err != nil {
+			if errors.Is(err, liveness.ErrMissingRecord) {
+				return grpcstatus.Error(codes.NotFound, liveness.ErrMissingRecord.Error())
+			}
+			return err
+		}
+		if statusChanged {
+			nodeDetails.TargetNodeID = int32(nodeID)
+			// Ensure an entry is produced in the external log in all cases.
+			log.StructuredEvent(ctx, event)
+
+			// If we die right now or if this transaction fails to commit, the
+			// membership event will not be recorded to the event log. While we
+			// could insert the event record in the same transaction as the liveness
+			// update, this would force a 2PC and potentially leave write intents in
+			// the node liveness range. Better to make the event logging best effort
+			// than to slow down future node liveness transactions.
+			if err := s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				return sql.InsertEventRecord(
+					ctx,
+					s.sqlServer.execCfg.InternalExecutor,
+					txn,
+					int32(s.NodeID()), /* reporting ID: the node where the event is logged */
+					sql.LogToSystemTable|sql.LogToDevChannelIfVerbose, /* we already call log.StructuredEvent above */
+					int32(nodeID), /* target ID: the node that we wee a membership change for */
+					event,
+				)
+			}); err != nil {
+				log.Ops.Errorf(ctx, "unable to record event: %+v: %+v", event, err)
+			}
+		}
+
+		// Similarly to the log event above, we may not be able to clean up the
+		// status entry if we crash or fail -- the status entry is inline, and
+		// thus cannot be transactional. However, since decommissioning is
+		// idempotent, we can attempt to remove the key regardless of whether
+		// the status changed, such that a stale key can be removed by
+		// decommissioning the node again.
+		if targetStatus.Decommissioned() {
+			if err := s.db.PutInline(ctx, keys.NodeStatusKey(nodeID), nil); err != nil {
+				log.Errorf(ctx, "unable to clean up node status data for node %d: %s", nodeID, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -1,0 +1,194 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server/goroutinedumper"
+	"github.com/cockroachdb/cockroach/pkg/server/heapprofiler"
+	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+type sampleEnvironmentCfg struct {
+	st                   *cluster.Settings
+	stopper              *stop.Stopper
+	minSampleInterval    time.Duration
+	goroutineDumpDirName string
+	heapProfileDirName   string
+	runtime              *status.RuntimeStatSampler
+	sessionRegistry      *sql.SessionRegistry
+}
+
+// startSampleEnvironment starts a periodic loop that samples the environment and,
+// when appropriate, creates goroutine and/or heap dumps.
+func startSampleEnvironment(
+	ctx context.Context,
+	settings *cluster.Settings,
+	stopper *stop.Stopper,
+	goroutineDumpDirName string,
+	heapProfileDirName string,
+	runtimeSampler *status.RuntimeStatSampler,
+	sessionRegistry *sql.SessionRegistry,
+) error {
+	cfg := sampleEnvironmentCfg{
+		st:                   settings,
+		stopper:              stopper,
+		minSampleInterval:    base.DefaultMetricsSampleInterval,
+		goroutineDumpDirName: goroutineDumpDirName,
+		heapProfileDirName:   heapProfileDirName,
+		runtime:              runtimeSampler,
+		sessionRegistry:      sessionRegistry,
+	}
+	// Immediately record summaries once on server startup.
+
+	// Initialize a goroutine dumper if we have an output directory
+	// specified.
+	var goroutineDumper *goroutinedumper.GoroutineDumper
+	if cfg.goroutineDumpDirName != "" {
+		hasValidDumpDir := true
+		if err := os.MkdirAll(cfg.goroutineDumpDirName, 0755); err != nil {
+			// This is possible when running with only in-memory stores;
+			// in that case the start-up code sets the output directory
+			// to the current directory (.). If running the process
+			// from a directory which is not writable, we won't
+			// be able to create a sub-directory here.
+			log.Warningf(ctx, "cannot create goroutine dump dir -- goroutine dumps will be disabled: %v", err)
+			hasValidDumpDir = false
+		}
+		if hasValidDumpDir {
+			var err error
+			goroutineDumper, err = goroutinedumper.NewGoroutineDumper(ctx, cfg.goroutineDumpDirName, cfg.st)
+			if err != nil {
+				return errors.Wrap(err, "starting goroutine dumper worker")
+			}
+		}
+	}
+
+	// Initialize a heap profiler if we have an output directory
+	// specified.
+	var heapProfiler *heapprofiler.HeapProfiler
+	var nonGoAllocProfiler *heapprofiler.NonGoAllocProfiler
+	var statsProfiler *heapprofiler.StatsProfiler
+	var queryProfiler *heapprofiler.ActiveQueryProfiler
+	if cfg.heapProfileDirName != "" {
+		hasValidDumpDir := true
+		if err := os.MkdirAll(cfg.heapProfileDirName, 0755); err != nil {
+			// This is possible when running with only in-memory stores;
+			// in that case the start-up code sets the output directory
+			// to the current directory (.). If wrunning the process
+			// from a directory which is not writable, we won't
+			// be able to create a sub-directory here.
+			log.Warningf(ctx, "cannot create memory dump dir -- memory profile dumps will be disabled: %v", err)
+			hasValidDumpDir = false
+		}
+
+		if hasValidDumpDir {
+			var err error
+			heapProfiler, err = heapprofiler.NewHeapProfiler(ctx, cfg.heapProfileDirName, cfg.st)
+			if err != nil {
+				return errors.Wrap(err, "starting heap profiler worker")
+			}
+			nonGoAllocProfiler, err = heapprofiler.NewNonGoAllocProfiler(ctx, cfg.heapProfileDirName, cfg.st)
+			if err != nil {
+				return errors.Wrap(err, "starting non-go alloc profiler worker")
+			}
+			statsProfiler, err = heapprofiler.NewStatsProfiler(ctx, cfg.heapProfileDirName, cfg.st)
+			if err != nil {
+				return errors.Wrap(err, "starting memory stats collector worker")
+			}
+			queryProfiler, err = heapprofiler.NewActiveQueryProfiler(ctx, cfg.heapProfileDirName, cfg.st)
+			if err != nil {
+				log.Warningf(ctx, "failed to start query profiler worker: %v", err)
+			}
+		}
+	}
+
+	return cfg.stopper.RunAsyncTaskEx(ctx,
+		stop.TaskOpts{TaskName: "mem-logger", SpanOpt: stop.SterileRootSpan},
+		func(ctx context.Context) {
+			var goMemStats atomic.Value // *status.GoMemStats
+			goMemStats.Store(&status.GoMemStats{})
+			var collectingMemStats int32 // atomic, 1 when stats call is ongoing
+
+			timer := timeutil.NewTimer()
+			defer timer.Stop()
+			timer.Reset(cfg.minSampleInterval)
+
+			for {
+				select {
+				case <-cfg.stopper.ShouldQuiesce():
+					return
+				case <-timer.C:
+					timer.Read = true
+					timer.Reset(cfg.minSampleInterval)
+
+					// We read the heap stats on another goroutine and give up after 1s.
+					// This is necessary because as of Go 1.12, runtime.ReadMemStats()
+					// "stops the world" and that requires first waiting for any current GC
+					// run to finish. With a large heap and under extreme conditions, a
+					// single GC run may take longer than the default sampling period of
+					// 10s. Under normal operations and with more recent versions of Go,
+					// this hasn't been observed to be a problem.
+					statsCollected := make(chan struct{})
+					if atomic.CompareAndSwapInt32(&collectingMemStats, 0, 1) {
+						if err := cfg.stopper.RunAsyncTaskEx(ctx,
+							stop.TaskOpts{TaskName: "get-mem-stats"},
+							func(ctx context.Context) {
+								var ms status.GoMemStats
+								runtime.ReadMemStats(&ms.MemStats)
+								ms.Collected = timeutil.Now()
+								log.VEventf(ctx, 2, "memstats: %+v", ms)
+
+								goMemStats.Store(&ms)
+								atomic.StoreInt32(&collectingMemStats, 0)
+								close(statsCollected)
+							}); err != nil {
+							close(statsCollected)
+						}
+					}
+
+					select {
+					case <-statsCollected:
+						// Good; we managed to read the Go memory stats quickly enough.
+					case <-time.After(time.Second):
+					}
+
+					curStats := goMemStats.Load().(*status.GoMemStats)
+					cgoStats := status.GetCGoMemStats(ctx)
+					cfg.runtime.SampleEnvironment(ctx, curStats, cgoStats)
+
+					if goroutineDumper != nil {
+						goroutineDumper.MaybeDump(ctx, cfg.st, cfg.runtime.Goroutines.Value())
+					}
+					if heapProfiler != nil {
+						heapProfiler.MaybeTakeProfile(ctx, cfg.runtime.GoAllocBytes.Value())
+						nonGoAllocProfiler.MaybeTakeProfile(ctx, cfg.runtime.CgoTotalBytes.Value())
+						statsProfiler.MaybeTakeProfile(ctx, cfg.runtime.RSSBytes.Value(), curStats, cgoStats)
+					}
+					if queryProfiler != nil {
+						queryProfiler.MaybeDumpQueries(ctx, cfg.sessionRegistry, cfg.st)
+					}
+				}
+			}
+		})
+}

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/blobs"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/errors"
+)
+
+// externalStorageBuilder is a wrapper around the ExternalStorage factory
+// methods. It allows us to separate the creation and initialization of the
+// builder between NewServer() and Start() respectively.
+// TODO(adityamaru): Consider moving this to pkg/cloud/impl at a future
+// stage of the ongoing refactor.
+type externalStorageBuilder struct {
+	conf              base.ExternalIODirConfig
+	settings          *cluster.Settings
+	blobClientFactory blobs.BlobClientFactory
+	initCalled        bool
+	ie                *sql.InternalExecutor
+	db                *kv.DB
+}
+
+func (e *externalStorageBuilder) init(
+	conf base.ExternalIODirConfig,
+	settings *cluster.Settings,
+	nodeIDContainer *base.NodeIDContainer,
+	nodeDialer *nodedialer.Dialer,
+	testingKnobs base.TestingKnobs,
+	ie *sql.InternalExecutor,
+	db *kv.DB,
+) {
+	var blobClientFactory blobs.BlobClientFactory
+	if p, ok := testingKnobs.Server.(*TestingKnobs); ok && p.BlobClientFactory != nil {
+		blobClientFactory = p.BlobClientFactory
+	}
+	if blobClientFactory == nil {
+		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer.Get(), nodeDialer, settings.ExternalIODir)
+	}
+	e.conf = conf
+	e.settings = settings
+	e.blobClientFactory = blobClientFactory
+	e.initCalled = true
+	e.ie = ie
+	e.db = db
+}
+
+func (e *externalStorageBuilder) makeExternalStorage(
+	ctx context.Context, dest roachpb.ExternalStorage,
+) (cloud.ExternalStorage, error) {
+	if !e.initCalled {
+		return nil, errors.New("cannot create external storage before init")
+	}
+	return cloud.MakeExternalStorage(ctx, dest, e.conf, e.settings, e.blobClientFactory, e.ie,
+		e.db)
+}
+
+func (e *externalStorageBuilder) makeExternalStorageFromURI(
+	ctx context.Context, uri string, user security.SQLUsername,
+) (cloud.ExternalStorage, error) {
+	if !e.initCalled {
+		return nil, errors.New("cannot create external storage before init")
+	}
+	return cloud.ExternalStorageFromURI(ctx, uri, e.conf, e.settings, e.blobClientFactory, user, e.ie, e.db)
+}

--- a/pkg/server/grpc_gateway.go
+++ b/pkg/server/grpc_gateway.go
@@ -1,0 +1,149 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc"
+)
+
+// grpcGatewayServer represents a grpc service with HTTP endpoints through GRPC
+// gateway.
+type grpcGatewayServer interface {
+	RegisterService(g *grpc.Server)
+	RegisterGateway(
+		ctx context.Context,
+		mux *gwruntime.ServeMux,
+		conn *grpc.ClientConn,
+	) error
+}
+
+var _ grpcGatewayServer = (*adminServer)(nil)
+var _ grpcGatewayServer = (*statusServer)(nil)
+var _ grpcGatewayServer = (*authenticationServer)(nil)
+var _ grpcGatewayServer = (*ts.Server)(nil)
+
+// configureGRPCGateway initializes services necessary for running the
+// GRPC Gateway services proxied against the server at `grpcSrv`.
+//
+// The connection between the reverse proxy provided by grpc-gateway
+// and our grpc server uses a loopback-based listener to create
+// connections between the two.
+//
+// The function returns 3 arguments that are necessary to call
+// `RegisterGateway` which generated for each of your gRPC services
+// by grpc-gateway.
+func configureGRPCGateway(
+	ctx, workersCtx context.Context,
+	ambientCtx log.AmbientContext,
+	rpcContext *rpc.Context,
+	stopper *stop.Stopper,
+	grpcSrv *grpcServer,
+	GRPCAddr string,
+) (*gwruntime.ServeMux, context.Context, *grpc.ClientConn, error) {
+	jsonpb := &protoutil.JSONPb{
+		EnumsAsInts:  true,
+		EmitDefaults: true,
+		Indent:       "  ",
+	}
+	protopb := new(protoutil.ProtoPb)
+	gwMux := gwruntime.NewServeMux(
+		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.JSONContentType, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.AltJSONContentType, jsonpb),
+		gwruntime.WithMarshalerOption(httputil.ProtoContentType, protopb),
+		gwruntime.WithMarshalerOption(httputil.AltProtoContentType, protopb),
+		gwruntime.WithOutgoingHeaderMatcher(authenticationHeaderMatcher),
+		gwruntime.WithMetadata(forwardAuthenticationMetadata),
+	)
+	gwCtx, gwCancel := context.WithCancel(ambientCtx.AnnotateCtx(context.Background()))
+	stopper.AddCloser(stop.CloserFn(gwCancel))
+
+	// loopback handles the HTTP <-> RPC loopback connection.
+	loopback := newLoopbackListener(workersCtx, stopper)
+
+	waitQuiesce := func(context.Context) {
+		<-stopper.ShouldQuiesce()
+		_ = loopback.Close()
+	}
+	if err := stopper.RunAsyncTask(workersCtx, "gw-quiesce", waitQuiesce); err != nil {
+		waitQuiesce(workersCtx)
+	}
+
+	_ = stopper.RunAsyncTask(workersCtx, "serve-loopback", func(context.Context) {
+		netutil.FatalIfUnexpected(grpcSrv.Serve(loopback))
+	})
+
+	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
+	// uniquely in-process connection.
+	dialOpts, err := rpcContext.GRPCDialOptions()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	callCountInterceptor := func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		telemetry.Inc(getServerEndpointCounter(method))
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+	conn, err := grpc.DialContext(ctx, GRPCAddr, append(append(
+		dialOpts,
+		grpc.WithUnaryInterceptor(callCountInterceptor)),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return loopback.Connect(ctx)
+		}),
+	)...)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	{
+		waitQuiesce := func(workersCtx context.Context) {
+			<-stopper.ShouldQuiesce()
+			// NB: we can't do this as a Closer because (*Server).ServeWith is
+			// running in a worker and usually sits on accept() which unblocks
+			// only when the listener closes. In other words, the listener needs
+			// to close when quiescing starts to allow that worker to shut down.
+			err := conn.Close() // nolint:grpcconnclose
+			if err != nil {
+				log.Ops.Fatalf(workersCtx, "%v", err)
+			}
+		}
+		if err := stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
+			waitQuiesce(workersCtx)
+		}
+	}
+	return gwMux, gwCtx, conn, nil
+}
+
+// getServerEndpointCounter returns a telemetry Counter corresponding to the
+// given grpc method.
+func getServerEndpointCounter(method string) telemetry.Counter {
+	const counterPrefix = "http.grpc-gateway"
+	return telemetry.GetCounter(fmt.Sprintf("%s.%s", counterPrefix, method))
+}

--- a/pkg/server/gzip_response_writer.go
+++ b/pkg/server/gzip_response_writer.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"compress/gzip"
+	"net/http"
+	"sync"
+)
+
+// TODO(benesch): Use https://github.com/NYTimes/gziphandler instead.
+// gzipResponseWriter reinvents the wheel and is not as robust.
+type gzipResponseWriter struct {
+	gz gzip.Writer
+	http.ResponseWriter
+}
+
+// Allocation pool for gzipResponseWriters.
+var gzipResponseWriterPool sync.Pool
+
+func newGzipResponseWriter(rw http.ResponseWriter) *gzipResponseWriter {
+	var w *gzipResponseWriter
+	if wI := gzipResponseWriterPool.Get(); wI == nil {
+		w = new(gzipResponseWriter)
+	} else {
+		w = wI.(*gzipResponseWriter)
+	}
+	w.Reset(rw)
+	return w
+}
+
+func (w *gzipResponseWriter) Reset(rw http.ResponseWriter) {
+	w.gz.Reset(rw)
+	w.ResponseWriter = rw
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	// The underlying http.ResponseWriter can't sniff gzipped data properly, so we
+	// do our own sniffing on the uncompressed data.
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", http.DetectContentType(b))
+	}
+	return w.gz.Write(b)
+}
+
+// Flush implements http.Flusher as required by grpc-gateway for clients
+// which access streaming endpoints (as exercised by the acceptance tests
+// at time of writing).
+func (w *gzipResponseWriter) Flush() {
+	// If Flush returns an error, we'll see it on the next call to Write or
+	// Close as well, so we can ignore it here.
+	if err := w.gz.Flush(); err == nil {
+		// Flush the wrapped ResponseWriter as well, if possible.
+		if f, ok := w.ResponseWriter.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+
+// Close implements the io.Closer interface. It is not safe to use the
+// writer after calling Close.
+func (w *gzipResponseWriter) Close() error {
+	err := w.gz.Close()
+	w.Reset(nil) // release ResponseWriter reference.
+	gzipResponseWriterPool.Put(w)
+	return err
+}

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -1,0 +1,213 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func maybeImportTS(ctx context.Context, s *Server) error {
+	knobs, _ := s.cfg.TestingKnobs.Server.(*TestingKnobs)
+	if knobs == nil {
+		return nil
+	}
+	tsImport := knobs.ImportTimeseriesFile
+	if tsImport == "" {
+		return nil
+	}
+
+	// In practice we only allow populating time series in `start-single-node` due
+	// to complexities detailed below. Additionally, we allow it only on a fresh
+	// single-node single-store cluster and we also guard against join flags even
+	// though there shouldn't be any.
+	if !s.InitialStart() || len(s.cfg.JoinList) > 0 || len(s.cfg.Stores.Specs) != 1 {
+		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
+	}
+
+	// Also do a best effort at disabling the timeseries of the local node to cause
+	// confusion.
+	ts.TimeseriesStorageEnabled.Override(ctx, &s.ClusterSettings().SV, false)
+
+	// Suppress writing of node statuses for the local node (n1). If it wrote one,
+	// and the imported data also contains n1 but with a different set of stores,
+	// we'd effectively clobber the timeseries display for n1 (which relies on the
+	// store statuses to map the store timeseries to the node under which they
+	// fall). An alternative to this is setting a FirstStoreID and FirstNodeID that
+	// is not in use in the data set to import.
+	s.node.suppressNodeStatus.Set(true)
+
+	f, err := os.Open(tsImport)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	b := &kv.Batch{}
+	var n int
+	maybeFlush := func(force bool) error {
+		if n == 0 {
+			return nil
+		}
+		if n < 100 && !force {
+			return nil
+		}
+		err := s.db.Run(ctx, b)
+		if err != nil {
+			return err
+		}
+		log.Infof(ctx, "imported %d ts pairs\n", n)
+		*b, n = kv.Batch{}, 0
+		return nil
+	}
+
+	nodeIDs := map[string]struct{}{}
+	storeIDs := map[string]struct{}{}
+	dec := gob.NewDecoder(f)
+	for {
+		var v roachpb.KeyValue
+		err := dec.Decode(&v)
+		if err != nil {
+			if err == io.EOF {
+				if err := maybeFlush(true /* force */); err != nil {
+					return err
+				}
+				break
+			}
+			return err
+		}
+
+		name, source, _, _, err := ts.DecodeDataKey(v.Key)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(name, "cr.node.") {
+			nodeIDs[source] = struct{}{}
+		} else if strings.HasPrefix(name, "cr.store.") {
+			storeIDs[source] = struct{}{}
+		} else {
+			return errors.Errorf("unknown metric %s", name)
+		}
+
+		p := roachpb.NewPut(v.Key, v.Value)
+		p.(*roachpb.PutRequest).Inline = true
+		b.AddRawRequest(p)
+		n++
+		if err := maybeFlush(false /* force */); err != nil {
+			return err
+		}
+	}
+
+	if knobs.ImportTimeseriesMappingFile == "" {
+		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
+			"a YAML file that maps StoreID to NodeID. For example, if s1 is on n1 and s2 is on n5:\n\n1: 1\n2:5")
+	}
+	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
+	if err != nil {
+		return err
+	}
+	storeToNode := map[roachpb.StoreID]roachpb.NodeID{}
+	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
+		return err
+	}
+
+	fakeStatuses, err := makeFakeNodeStatuses(storeToNode)
+	if err != nil {
+		return err
+	}
+	if err := checkFakeStatuses(fakeStatuses, storeIDs); err != nil {
+		return errors.Wrapf(err, "please provide an updated mapping file %s", knobs.ImportTimeseriesMappingFile)
+	}
+
+	// All checks passed, write the statuses.
+	for _, status := range fakeStatuses {
+		key := keys.NodeStatusKey(status.Desc.NodeID)
+		if err := s.db.PutInline(ctx, key, &status); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func makeFakeNodeStatuses(
+	storeToNode map[roachpb.StoreID]roachpb.NodeID,
+) ([]statuspb.NodeStatus, error) {
+	var sl []statuspb.NodeStatus
+	nodeToStore := map[roachpb.NodeID][]roachpb.StoreID{}
+	for sid, nid := range storeToNode {
+		nodeToStore[nid] = append(nodeToStore[nid], sid)
+	}
+
+	for nodeID, storeIDs := range nodeToStore {
+		sort.Slice(storeIDs, func(i, j int) bool {
+			return storeIDs[i] < storeIDs[j]
+		})
+		nodeStatus := statuspb.NodeStatus{
+			Desc: roachpb.NodeDescriptor{
+				NodeID: nodeID,
+			},
+		}
+		for _, storeID := range storeIDs {
+			nodeStatus.StoreStatuses = append(nodeStatus.StoreStatuses, statuspb.StoreStatus{Desc: roachpb.StoreDescriptor{
+				Node:    nodeStatus.Desc, // don't want cycles here
+				StoreID: storeID,
+			}})
+		}
+
+		sl = append(sl, nodeStatus)
+	}
+	sort.Slice(sl, func(i, j int) bool {
+		return sl[i].Desc.NodeID < sl[j].Desc.NodeID
+	})
+	return sl, nil
+}
+
+func checkFakeStatuses(fakeStatuses []statuspb.NodeStatus, storeIDs map[string]struct{}) error {
+	for _, status := range fakeStatuses {
+		for _, ss := range status.StoreStatuses {
+			storeID := ss.Desc.StoreID
+			strID := fmt.Sprint(storeID)
+			if _, ok := storeIDs[strID]; !ok {
+				// This is likely an mistake and where it isn't (for example since store
+				// is long gone and hasn't supplied metrics in a long time) the user can
+				// react by removing the assignment from the yaml file and trying again.
+				return errors.Errorf(
+					"s%d supplied in input mapping, but no timeseries found for it",
+					ss.Desc.StoreID,
+				)
+			}
+
+			delete(storeIDs, strID)
+		}
+	}
+	if len(storeIDs) > 0 {
+		return errors.Errorf(
+			"need to map the remaining stores %v to nodes", storeIDs)
+	}
+	return nil
+}

--- a/pkg/server/listen_and_update_addrs.go
+++ b/pkg/server/listen_and_update_addrs.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"net"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/errors"
+)
+
+// ListenError is returned from Start when we fail to start listening on either
+// the main Cockroach port or the HTTP port, so that the CLI can instruct the
+// user on what might have gone wrong.
+type ListenError struct {
+	cause error
+	Addr  string
+}
+
+// Error implements error.
+func (l *ListenError) Error() string { return l.cause.Error() }
+
+// Unwrap is because ListenError is a wrapper.
+func (l *ListenError) Unwrap() error { return l.cause }
+
+// ListenAndUpdateAddrs starts a TCP listener on the specified address
+// then updates the address and advertised address fields based on the
+// actual interface address resolved by the OS during the Listen()
+// call.
+func ListenAndUpdateAddrs(
+	ctx context.Context, addr, advertiseAddr *string, connName string,
+) (net.Listener, error) {
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		return nil, &ListenError{
+			cause: err,
+			Addr:  *addr,
+		}
+	}
+	if err := base.UpdateAddrs(ctx, addr, advertiseAddr, ln.Addr()); err != nil {
+		return nil, errors.Wrapf(err, "internal error: cannot parse %s listen address", connName)
+	}
+	return ln, nil
+}

--- a/pkg/server/loss_of_quorum.go
+++ b/pkg/server/loss_of_quorum.go
@@ -1,0 +1,90 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+)
+
+func logPendingLossOfQuorumRecoveryEvents(ctx context.Context, stores *kvserver.Stores) {
+	if err := stores.VisitStores(func(s *kvserver.Store) error {
+		// We are not requesting entry deletion here because we need those entries
+		// at the end of startup to populate rangelog and possibly other durable
+		// cluster-replicated destinations.
+		eventCount, err := loqrecovery.RegisterOfflineRecoveryEvents(
+			ctx,
+			s.Engine(),
+			func(ctx context.Context, record loqrecoverypb.ReplicaRecoveryRecord) (bool, error) {
+				event := record.AsStructuredLog()
+				log.StructuredEvent(ctx, &event)
+				return false, nil
+			})
+		if eventCount > 0 {
+			log.Infof(
+				ctx, "registered %d loss of quorum replica recovery events for s%d",
+				eventCount, s.Ident.StoreID)
+		}
+		return err
+	}); err != nil {
+		// We don't want to abort server if we can't record recovery events
+		// as it is the last thing we need if cluster is already unhealthy.
+		log.Errorf(ctx, "failed to record loss of quorum recovery events: %v", err)
+	}
+}
+
+func publishPendingLossOfQuorumRecoveryEvents(
+	ctx context.Context, stores *kvserver.Stores, stopper *stop.Stopper,
+) {
+	_ = stopper.RunAsyncTask(ctx, "publish-loss-of-quorum-events", func(ctx context.Context) {
+		if err := stores.VisitStores(func(s *kvserver.Store) error {
+			recoveryEventsSupported := s.ClusterSettings().Version.IsActive(ctx,
+				clusterversion.UnsafeLossOfQuorumRecoveryRangeLog)
+			_, err := loqrecovery.RegisterOfflineRecoveryEvents(
+				ctx,
+				s.Engine(),
+				func(ctx context.Context, record loqrecoverypb.ReplicaRecoveryRecord) (bool, error) {
+					sqlExec := func(ctx context.Context, stmt string, args ...interface{}) (int, error) {
+						return s.GetStoreConfig().SQLExecutor.ExecEx(ctx, "", nil,
+							sessiondata.InternalExecutorOverride{User: security.RootUserName()}, stmt, args...)
+					}
+					if recoveryEventsSupported {
+						if err := loqrecovery.UpdateRangeLogWithRecovery(ctx, sqlExec, record); err != nil {
+							return false, errors.Wrap(err,
+								"loss of quorum recovery failed to write RangeLog entry")
+						}
+					}
+					// We only bump metrics as the last step when all processing of events
+					// is finished. This is done to ensure that we don't increase metrics
+					// more than once.
+					// Note that if actual deletion of event fails, it is possible to
+					// duplicate rangelog and metrics, but that is very unlikely event
+					// and user should be able to identify those events.
+					s.Metrics().RangeLossOfQuorumRecoveries.Inc(1)
+					return true, nil
+				})
+			return err
+		}); err != nil {
+			// We don't want to abort server if we can't record recovery events
+			// as it is the last thing we need if cluster is already unhealthy.
+			log.Errorf(ctx, "failed to update range log with loss of quorum recovery events: %v", err)
+		}
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,12 +23,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cmux"
@@ -61,8 +59,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
-	"github.com/cockroachdb/cockroach/pkg/server/goroutinedumper"
-	"github.com/cockroachdb/cockroach/pkg/server/heapprofiler"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
@@ -1715,15 +1711,14 @@ func (s *Server) PreStart(ctx context.Context) error {
 	)
 
 	// Begin recording runtime statistics.
-	if err := startSampleEnvironment(s.AnnotateCtx(ctx), sampleEnvironmentCfg{
-		st:                   s.ClusterSettings(),
-		stopper:              s.stopper,
-		minSampleInterval:    base.DefaultMetricsSampleInterval,
-		goroutineDumpDirName: s.cfg.GoroutineDumpDirName,
-		heapProfileDirName:   s.cfg.HeapProfileDirName,
-		runtime:              s.runtime,
-		sessionRegistry:      s.status.sessionRegistry,
-	}); err != nil {
+	if err := startSampleEnvironment(s.AnnotateCtx(ctx),
+		s.ClusterSettings(),
+		s.stopper,
+		s.cfg.GoroutineDumpDirName,
+		s.cfg.HeapProfileDirName,
+		s.runtime,
+		s.status.sessionRegistry,
+	); err != nil {
 		return err
 	}
 
@@ -2674,153 +2669,6 @@ func (s *Server) Decommission(
 		}
 	}
 	return nil
-}
-
-type sampleEnvironmentCfg struct {
-	st                   *cluster.Settings
-	stopper              *stop.Stopper
-	minSampleInterval    time.Duration
-	goroutineDumpDirName string
-	heapProfileDirName   string
-	runtime              *status.RuntimeStatSampler
-	sessionRegistry      *sql.SessionRegistry
-}
-
-// startSampleEnvironment starts a periodic loop that samples the environment and,
-// when appropriate, creates goroutine and/or heap dumps.
-func startSampleEnvironment(ctx context.Context, cfg sampleEnvironmentCfg) error {
-	// Immediately record summaries once on server startup.
-
-	// Initialize a goroutine dumper if we have an output directory
-	// specified.
-	var goroutineDumper *goroutinedumper.GoroutineDumper
-	if cfg.goroutineDumpDirName != "" {
-		hasValidDumpDir := true
-		if err := os.MkdirAll(cfg.goroutineDumpDirName, 0755); err != nil {
-			// This is possible when running with only in-memory stores;
-			// in that case the start-up code sets the output directory
-			// to the current directory (.). If running the process
-			// from a directory which is not writable, we won't
-			// be able to create a sub-directory here.
-			log.Warningf(ctx, "cannot create goroutine dump dir -- goroutine dumps will be disabled: %v", err)
-			hasValidDumpDir = false
-		}
-		if hasValidDumpDir {
-			var err error
-			goroutineDumper, err = goroutinedumper.NewGoroutineDumper(ctx, cfg.goroutineDumpDirName, cfg.st)
-			if err != nil {
-				return errors.Wrap(err, "starting goroutine dumper worker")
-			}
-		}
-	}
-
-	// Initialize a heap profiler if we have an output directory
-	// specified.
-	var heapProfiler *heapprofiler.HeapProfiler
-	var nonGoAllocProfiler *heapprofiler.NonGoAllocProfiler
-	var statsProfiler *heapprofiler.StatsProfiler
-	var queryProfiler *heapprofiler.ActiveQueryProfiler
-	if cfg.heapProfileDirName != "" {
-		hasValidDumpDir := true
-		if err := os.MkdirAll(cfg.heapProfileDirName, 0755); err != nil {
-			// This is possible when running with only in-memory stores;
-			// in that case the start-up code sets the output directory
-			// to the current directory (.). If wrunning the process
-			// from a directory which is not writable, we won't
-			// be able to create a sub-directory here.
-			log.Warningf(ctx, "cannot create memory dump dir -- memory profile dumps will be disabled: %v", err)
-			hasValidDumpDir = false
-		}
-
-		if hasValidDumpDir {
-			var err error
-			heapProfiler, err = heapprofiler.NewHeapProfiler(ctx, cfg.heapProfileDirName, cfg.st)
-			if err != nil {
-				return errors.Wrap(err, "starting heap profiler worker")
-			}
-			nonGoAllocProfiler, err = heapprofiler.NewNonGoAllocProfiler(ctx, cfg.heapProfileDirName, cfg.st)
-			if err != nil {
-				return errors.Wrap(err, "starting non-go alloc profiler worker")
-			}
-			statsProfiler, err = heapprofiler.NewStatsProfiler(ctx, cfg.heapProfileDirName, cfg.st)
-			if err != nil {
-				return errors.Wrap(err, "starting memory stats collector worker")
-			}
-			queryProfiler, err = heapprofiler.NewActiveQueryProfiler(ctx, cfg.heapProfileDirName, cfg.st)
-			if err != nil {
-				log.Warningf(ctx, "failed to start query profiler worker: %v", err)
-			}
-		}
-	}
-
-	return cfg.stopper.RunAsyncTaskEx(ctx,
-		stop.TaskOpts{TaskName: "mem-logger", SpanOpt: stop.SterileRootSpan},
-		func(ctx context.Context) {
-			var goMemStats atomic.Value // *status.GoMemStats
-			goMemStats.Store(&status.GoMemStats{})
-			var collectingMemStats int32 // atomic, 1 when stats call is ongoing
-
-			timer := timeutil.NewTimer()
-			defer timer.Stop()
-			timer.Reset(cfg.minSampleInterval)
-
-			for {
-				select {
-				case <-cfg.stopper.ShouldQuiesce():
-					return
-				case <-timer.C:
-					timer.Read = true
-					timer.Reset(cfg.minSampleInterval)
-
-					// We read the heap stats on another goroutine and give up after 1s.
-					// This is necessary because as of Go 1.12, runtime.ReadMemStats()
-					// "stops the world" and that requires first waiting for any current GC
-					// run to finish. With a large heap and under extreme conditions, a
-					// single GC run may take longer than the default sampling period of
-					// 10s. Under normal operations and with more recent versions of Go,
-					// this hasn't been observed to be a problem.
-					statsCollected := make(chan struct{})
-					if atomic.CompareAndSwapInt32(&collectingMemStats, 0, 1) {
-						if err := cfg.stopper.RunAsyncTaskEx(ctx,
-							stop.TaskOpts{TaskName: "get-mem-stats"},
-							func(ctx context.Context) {
-								var ms status.GoMemStats
-								runtime.ReadMemStats(&ms.MemStats)
-								ms.Collected = timeutil.Now()
-								log.VEventf(ctx, 2, "memstats: %+v", ms)
-
-								goMemStats.Store(&ms)
-								atomic.StoreInt32(&collectingMemStats, 0)
-								close(statsCollected)
-							}); err != nil {
-							close(statsCollected)
-						}
-					}
-
-					select {
-					case <-statsCollected:
-						// Good; we managed to read the Go memory stats quickly enough.
-					case <-time.After(time.Second):
-					}
-
-					curStats := goMemStats.Load().(*status.GoMemStats)
-					cgoStats := status.GetCGoMemStats(ctx)
-					cfg.runtime.SampleEnvironment(ctx, curStats, cgoStats)
-
-					if goroutineDumper != nil {
-						goroutineDumper.MaybeDump(ctx, cfg.st, cfg.runtime.Goroutines.Value())
-					}
-					if heapProfiler != nil {
-						heapProfiler.MaybeTakeProfile(ctx, cfg.runtime.GoAllocBytes.Value())
-						nonGoAllocProfiler.MaybeTakeProfile(ctx, cfg.runtime.CgoTotalBytes.Value())
-						statsProfiler.MaybeTakeProfile(ctx, cfg.runtime.RSSBytes.Value(), curStats, cgoStats)
-					}
-					if queryProfiler != nil {
-						queryProfiler.MaybeDumpQueries(ctx, cfg.sessionRegistry, cfg.st)
-					}
-				}
-			}
-		})
 }
 
 // Stop stops the server.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,7 +57,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	_ "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigjob" // register jobs declared outside of pkg/sql
@@ -98,27 +97,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
-)
-
-var (
-	forwardClockJumpCheckEnabled = settings.RegisterBoolSetting(
-		settings.TenantWritable,
-		"server.clock.forward_jump_check_enabled",
-		"if enabled, forward clock jumps > max_offset/2 will cause a panic",
-		false,
-	).WithPublic()
-
-	persistHLCUpperBoundInterval = settings.RegisterDurationSetting(
-		settings.TenantWritable,
-		"server.clock.persist_upper_bound_interval",
-		"the interval between persisting the wall time upper bound of the clock. The clock "+
-			"does not generate a wall time greater than the persisted timestamp and will panic if "+
-			"it sees a wall time greater than this value. When cockroach starts, it waits for the "+
-			"wall time to catch-up till this persisted timestamp. This guarantees monotonic wall "+
-			"time across server restarts. Not setting this or setting a value of 0 disables this "+
-			"feature.",
-		0,
-	).WithPublic()
 )
 
 // Server is the cockroach server node.
@@ -939,210 +917,6 @@ func (li listenerInfo) Iter() map[string]string {
 	}
 }
 
-// startMonitoringForwardClockJumps starts a background task to monitor forward
-// clock jumps based on a cluster setting
-func (s *Server) startMonitoringForwardClockJumps(ctx context.Context) error {
-	forwardJumpCheckEnabled := make(chan bool, 1)
-	s.stopper.AddCloser(stop.CloserFn(func() { close(forwardJumpCheckEnabled) }))
-
-	forwardClockJumpCheckEnabled.SetOnChange(&s.st.SV, func(context.Context) {
-		forwardJumpCheckEnabled <- forwardClockJumpCheckEnabled.Get(&s.st.SV)
-	})
-
-	if err := s.clock.StartMonitoringForwardClockJumps(
-		ctx,
-		forwardJumpCheckEnabled,
-		time.NewTicker,
-		nil, /* tick callback */
-	); err != nil {
-		return errors.Wrap(err, "monitoring forward clock jumps")
-	}
-
-	log.Ops.Info(ctx, "monitoring forward clock jumps based on server.clock.forward_jump_check_enabled")
-	return nil
-}
-
-// ensureClockMonotonicity sleeps till the wall time reaches
-// prevHLCUpperBound. prevHLCUpperBound > 0 implies we need to guarantee HLC
-// monotonicity across server restarts. prevHLCUpperBound is the last
-// successfully persisted timestamp greater then any wall time used by the
-// server.
-//
-// If prevHLCUpperBound is 0, the function sleeps up to max offset.
-func ensureClockMonotonicity(
-	ctx context.Context,
-	clock *hlc.Clock,
-	startTime time.Time,
-	prevHLCUpperBound int64,
-	sleepUntilFn func(context.Context, hlc.Timestamp) error,
-) {
-	var sleepUntil int64
-	if prevHLCUpperBound != 0 {
-		// Sleep until previous HLC upper bound to ensure wall time monotonicity
-		sleepUntil = prevHLCUpperBound + 1
-	} else {
-		// Previous HLC Upper bound is not known
-		// We might have to sleep a bit to protect against this node producing non-
-		// monotonic timestamps. Before restarting, its clock might have been driven
-		// by other nodes' fast clocks, but when we restarted, we lost all this
-		// information. For example, a client might have written a value at a
-		// timestamp that's in the future of the restarted node's clock, and if we
-		// don't do something, the same client's read would not return the written
-		// value. So, we wait up to MaxOffset; we couldn't have served timestamps more
-		// than MaxOffset in the future (assuming that MaxOffset was not changed, see
-		// #9733).
-		//
-		// As an optimization for tests, we don't sleep if all the stores are brand
-		// new. In this case, the node will not serve anything anyway until it
-		// synchronizes with other nodes.
-		sleepUntil = startTime.UnixNano() + int64(clock.MaxOffset()) + 1
-	}
-
-	currentWallTime := clock.Now().WallTime
-	delta := time.Duration(sleepUntil - currentWallTime)
-	if delta > 0 {
-		log.Ops.Infof(
-			ctx,
-			"Sleeping till wall time %v to catches up to %v to ensure monotonicity. Delta: %v",
-			currentWallTime,
-			sleepUntil,
-			delta,
-		)
-		_ = sleepUntilFn(ctx, hlc.Timestamp{WallTime: sleepUntil})
-	}
-}
-
-// periodicallyPersistHLCUpperBound periodically persists an upper bound of
-// the HLC's wall time. The interval for persisting is read from
-// persistHLCUpperBoundIntervalCh. An interval of 0 disables persisting.
-//
-// persistHLCUpperBoundFn is used to persist the hlc upper bound, and should
-// return an error if the persist fails.
-//
-// tickerFn is used to create the ticker used for persisting
-//
-// tickCallback is called whenever a tick is processed
-func periodicallyPersistHLCUpperBound(
-	clock *hlc.Clock,
-	persistHLCUpperBoundIntervalCh chan time.Duration,
-	persistHLCUpperBoundFn func(int64) error,
-	tickerFn func(d time.Duration) *time.Ticker,
-	stopCh <-chan struct{},
-	tickCallback func(),
-) {
-	// Create a ticker which can be used in selects.
-	// This ticker is turned on / off based on persistHLCUpperBoundIntervalCh
-	ticker := tickerFn(time.Hour)
-	ticker.Stop()
-
-	// persistInterval is the interval used for persisting the
-	// an upper bound of the HLC
-	var persistInterval time.Duration
-	var ok bool
-
-	persistHLCUpperBound := func() {
-		if err := clock.RefreshHLCUpperBound(
-			persistHLCUpperBoundFn,
-			int64(persistInterval*3), /* delta to compute upper bound */
-		); err != nil {
-			log.Ops.Fatalf(
-				context.Background(),
-				"error persisting HLC upper bound: %v",
-				err,
-			)
-		}
-	}
-
-	for {
-		select {
-		case persistInterval, ok = <-persistHLCUpperBoundIntervalCh:
-			ticker.Stop()
-			if !ok {
-				return
-			}
-
-			if persistInterval > 0 {
-				ticker = tickerFn(persistInterval)
-				persistHLCUpperBound()
-				log.Ops.Info(context.Background(), "persisting HLC upper bound is enabled")
-			} else {
-				if err := clock.ResetHLCUpperBound(persistHLCUpperBoundFn); err != nil {
-					log.Ops.Fatalf(
-						context.Background(),
-						"error resetting hlc upper bound: %v",
-						err,
-					)
-				}
-				log.Ops.Info(context.Background(), "persisting HLC upper bound is disabled")
-			}
-
-		case <-ticker.C:
-			if persistInterval > 0 {
-				persistHLCUpperBound()
-			}
-
-		case <-stopCh:
-			ticker.Stop()
-			return
-		}
-
-		if tickCallback != nil {
-			tickCallback()
-		}
-	}
-}
-
-// startPersistingHLCUpperBound starts a goroutine to persist an upper bound
-// to the HLC.
-//
-// persistHLCUpperBoundFn is used to persist upper bound of the HLC, and should
-// return an error if the persist fails
-//
-// tickerFn is used to create a new ticker
-//
-// tickCallback is called whenever persistHLCUpperBoundCh or a ticker tick is
-// processed
-func (s *Server) startPersistingHLCUpperBound(
-	ctx context.Context,
-	hlcUpperBoundExists bool,
-	persistHLCUpperBoundFn func(int64) error,
-	tickerFn func(d time.Duration) *time.Ticker,
-) error {
-	persistHLCUpperBoundIntervalCh := make(chan time.Duration, 1)
-	persistHLCUpperBoundInterval.SetOnChange(&s.st.SV, func(context.Context) {
-		persistHLCUpperBoundIntervalCh <- persistHLCUpperBoundInterval.Get(&s.st.SV)
-	})
-
-	if hlcUpperBoundExists {
-		// The feature to persist upper bounds to wall times is enabled.
-		// Persist a new upper bound to continue guaranteeing monotonicity
-		// Going forward the goroutine launched below will take over persisting
-		// the upper bound
-		if err := s.clock.RefreshHLCUpperBound(
-			persistHLCUpperBoundFn,
-			int64(5*time.Second),
-		); err != nil {
-			return errors.Wrap(err, "refreshing HLC upper bound")
-		}
-	}
-
-	_ = s.stopper.RunAsyncTask(
-		ctx,
-		"persist-hlc-upper-bound",
-		func(context.Context) {
-			periodicallyPersistHLCUpperBound(
-				s.clock,
-				persistHLCUpperBoundIntervalCh,
-				persistHLCUpperBoundFn,
-				tickerFn,
-				s.stopper.ShouldQuiesce(),
-				nil, /* tick callback */
-			)
-		},
-	)
-	return nil
-}
-
 // Start calls PreStart() and AcceptClient() in sequence.
 // This is suitable for use e.g. in tests.
 func (s *Server) Start(ctx context.Context) error {
@@ -1534,24 +1308,9 @@ func (s *Server) PreStart(ctx context.Context) error {
 		}
 	})
 
-	// If the server is being restarted, sleep to ensure monotonicity of the HLC
-	// clock. This can be skipped on server bootstrap because the server has never
-	// been used before.
-	var hlcUpperBoundExists bool
-	if !initialStart {
-		hlcUpperBound, err := kvserver.ReadMaxHLCUpperBound(ctx, s.engines)
-		if err != nil {
-			return errors.Wrap(err, "reading max HLC upper bound")
-		}
-		hlcUpperBoundExists = hlcUpperBound > 0
-
-		ensureClockMonotonicity(
-			ctx,
-			s.clock,
-			s.startTime,
-			hlcUpperBound,
-			s.clock.SleepUntil,
-		)
+	hlcUpperBoundExists, err := s.checkHLCUpperBoundExistsAndEnsureMonotonicity(ctx, initialStart)
+	if err != nil {
+		return err
 	}
 
 	// Record a walltime that is lower than the lowest hlc timestamp this current
@@ -1589,14 +1348,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	s.storeGrantCoords.SetPebbleMetricsProvider(ctx, s.node)
 
 	log.Event(ctx, "started node")
-	if err := s.startPersistingHLCUpperBound(
-		ctx,
-		hlcUpperBoundExists,
-		func(t int64) error { /* function to persist upper bound of HLC to all stores */
-			return s.node.SetHLCUpperBound(context.Background(), t)
-		},
-		time.NewTicker,
-	); err != nil {
+	if err := s.startPersistingHLCUpperBound(ctx, hlcUpperBoundExists); err != nil {
 		return err
 	}
 	s.replicationReporter.Start(ctx, s.stopper)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -87,7 +87,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -96,8 +95,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/cockroachdb/sentry-go"
-	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
@@ -853,17 +850,6 @@ func (s *Server) InitialStart() bool {
 	return s.node.initialStart
 }
 
-// grpcGatewayServer represents a grpc service with HTTP endpoints through GRPC
-// gateway.
-type grpcGatewayServer interface {
-	RegisterService(g *grpc.Server)
-	RegisterGateway(
-		ctx context.Context,
-		mux *gwruntime.ServeMux,
-		conn *grpc.ClientConn,
-	) error
-}
-
 // inspectEngines goes through engines and constructs an initState. The
 // initState returned by this method will reflect a zero NodeID if none has
 // been assigned yet (i.e. if none of the engines is initialized). See
@@ -1157,13 +1143,6 @@ func (s *Server) startPersistingHLCUpperBound(
 	return nil
 }
 
-// getServerEndpointCounter returns a telemetry Counter corresponding to the
-// given grpc method.
-func getServerEndpointCounter(method string) telemetry.Counter {
-	const counterPrefix = "http.grpc-gateway"
-	return telemetry.GetCounter(fmt.Sprintf("%s.%s", counterPrefix, method))
-}
-
 // Start calls PreStart() and AcceptClient() in sequence.
 // This is suitable for use e.g. in tests.
 func (s *Server) Start(ctx context.Context) error {
@@ -1368,7 +1347,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 
 	// Initialize grpc-gateway mux and context in order to get the /health
 	// endpoint working even before the node has fully initialized.
-	gwMux, gwCtx, conn, err := ConfigureGRPCGateway(
+	gwMux, gwCtx, conn, err := configureGRPCGateway(
 		ctx,
 		workersCtx,
 		s.cfg.AmbientCtx,
@@ -1955,104 +1934,6 @@ func publishPendingLossOfQuorumRecoveryEvents(
 			log.Errorf(ctx, "failed to update range log with loss of quorum recovery events: %v", err)
 		}
 	})
-}
-
-// ConfigureGRPCGateway initializes services necessary for running the
-// GRPC Gateway services proxied against the server at `grpcSrv`.
-//
-// The connection between the reverse proxy provided by grpc-gateway
-// and our grpc server uses a loopback-based listener to create
-// connections between the two.
-//
-// The function returns 3 arguments that are necessary to call
-// `RegisterGateway` which generated for each of your gRPC services
-// by grpc-gateway.
-func ConfigureGRPCGateway(
-	ctx, workersCtx context.Context,
-	ambientCtx log.AmbientContext,
-	rpcContext *rpc.Context,
-	stopper *stop.Stopper,
-	grpcSrv *grpcServer,
-	GRPCAddr string,
-) (*gwruntime.ServeMux, context.Context, *grpc.ClientConn, error) {
-	jsonpb := &protoutil.JSONPb{
-		EnumsAsInts:  true,
-		EmitDefaults: true,
-		Indent:       "  ",
-	}
-	protopb := new(protoutil.ProtoPb)
-	gwMux := gwruntime.NewServeMux(
-		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.JSONContentType, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.AltJSONContentType, jsonpb),
-		gwruntime.WithMarshalerOption(httputil.ProtoContentType, protopb),
-		gwruntime.WithMarshalerOption(httputil.AltProtoContentType, protopb),
-		gwruntime.WithOutgoingHeaderMatcher(authenticationHeaderMatcher),
-		gwruntime.WithMetadata(forwardAuthenticationMetadata),
-	)
-	gwCtx, gwCancel := context.WithCancel(ambientCtx.AnnotateCtx(context.Background()))
-	stopper.AddCloser(stop.CloserFn(gwCancel))
-
-	// loopback handles the HTTP <-> RPC loopback connection.
-	loopback := newLoopbackListener(workersCtx, stopper)
-
-	waitQuiesce := func(context.Context) {
-		<-stopper.ShouldQuiesce()
-		_ = loopback.Close()
-	}
-	if err := stopper.RunAsyncTask(workersCtx, "gw-quiesce", waitQuiesce); err != nil {
-		waitQuiesce(workersCtx)
-	}
-
-	_ = stopper.RunAsyncTask(workersCtx, "serve-loopback", func(context.Context) {
-		netutil.FatalIfUnexpected(grpcSrv.Serve(loopback))
-	})
-
-	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
-	// uniquely in-process connection.
-	dialOpts, err := rpcContext.GRPCDialOptions()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	callCountInterceptor := func(
-		ctx context.Context,
-		method string,
-		req, reply interface{},
-		cc *grpc.ClientConn,
-		invoker grpc.UnaryInvoker,
-		opts ...grpc.CallOption,
-	) error {
-		telemetry.Inc(getServerEndpointCounter(method))
-		return invoker(ctx, method, req, reply, cc, opts...)
-	}
-	conn, err := grpc.DialContext(ctx, GRPCAddr, append(append(
-		dialOpts,
-		grpc.WithUnaryInterceptor(callCountInterceptor)),
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			return loopback.Connect(ctx)
-		}),
-	)...)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	{
-		waitQuiesce := func(workersCtx context.Context) {
-			<-stopper.ShouldQuiesce()
-			// NB: we can't do this as a Closer because (*Server).ServeWith is
-			// running in a worker and usually sits on accept() which unblocks
-			// only when the listener closes. In other words, the listener needs
-			// to close when quiescing starts to allow that worker to shut down.
-			err := conn.Close() // nolint:grpcconnclose
-			if err != nil {
-				log.Ops.Fatalf(workersCtx, "%v", err)
-			}
-		}
-		if err := stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
-			waitQuiesce(workersCtx)
-		}
-	}
-	return gwMux, gwCtx, conn, nil
 }
 
 // AcceptClients starts listening for incoming SQL clients over the network.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,16 +11,13 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/gob"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -61,7 +58,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
-	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -107,7 +103,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -2121,187 +2116,6 @@ func ConfigureGRPCGateway(
 		}
 	}
 	return gwMux, gwCtx, conn, nil
-}
-
-func maybeImportTS(ctx context.Context, s *Server) error {
-	knobs, _ := s.cfg.TestingKnobs.Server.(*TestingKnobs)
-	if knobs == nil {
-		return nil
-	}
-	tsImport := knobs.ImportTimeseriesFile
-	if tsImport == "" {
-		return nil
-	}
-
-	// In practice we only allow populating time series in `start-single-node` due
-	// to complexities detailed below. Additionally, we allow it only on a fresh
-	// single-node single-store cluster and we also guard against join flags even
-	// though there shouldn't be any.
-	if !s.InitialStart() || len(s.cfg.JoinList) > 0 || len(s.cfg.Stores.Specs) != 1 {
-		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
-	}
-
-	// Also do a best effort at disabling the timeseries of the local node to cause
-	// confusion.
-	ts.TimeseriesStorageEnabled.Override(ctx, &s.ClusterSettings().SV, false)
-
-	// Suppress writing of node statuses for the local node (n1). If it wrote one,
-	// and the imported data also contains n1 but with a different set of stores,
-	// we'd effectively clobber the timeseries display for n1 (which relies on the
-	// store statuses to map the store timeseries to the node under which they
-	// fall). An alternative to this is setting a FirstStoreID and FirstNodeID that
-	// is not in use in the data set to import.
-	s.node.suppressNodeStatus.Set(true)
-
-	f, err := os.Open(tsImport)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	b := &kv.Batch{}
-	var n int
-	maybeFlush := func(force bool) error {
-		if n == 0 {
-			return nil
-		}
-		if n < 100 && !force {
-			return nil
-		}
-		err := s.db.Run(ctx, b)
-		if err != nil {
-			return err
-		}
-		log.Infof(ctx, "imported %d ts pairs\n", n)
-		*b, n = kv.Batch{}, 0
-		return nil
-	}
-
-	nodeIDs := map[string]struct{}{}
-	storeIDs := map[string]struct{}{}
-	dec := gob.NewDecoder(f)
-	for {
-		var v roachpb.KeyValue
-		err := dec.Decode(&v)
-		if err != nil {
-			if err == io.EOF {
-				if err := maybeFlush(true /* force */); err != nil {
-					return err
-				}
-				break
-			}
-			return err
-		}
-
-		name, source, _, _, err := ts.DecodeDataKey(v.Key)
-		if err != nil {
-			return err
-		}
-		if strings.HasPrefix(name, "cr.node.") {
-			nodeIDs[source] = struct{}{}
-		} else if strings.HasPrefix(name, "cr.store.") {
-			storeIDs[source] = struct{}{}
-		} else {
-			return errors.Errorf("unknown metric %s", name)
-		}
-
-		p := roachpb.NewPut(v.Key, v.Value)
-		p.(*roachpb.PutRequest).Inline = true
-		b.AddRawRequest(p)
-		n++
-		if err := maybeFlush(false /* force */); err != nil {
-			return err
-		}
-	}
-
-	if knobs.ImportTimeseriesMappingFile == "" {
-		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
-			"a YAML file that maps StoreID to NodeID. For example, if s1 is on n1 and s2 is on n5:\n\n1: 1\n2:5")
-	}
-	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
-	if err != nil {
-		return err
-	}
-	storeToNode := map[roachpb.StoreID]roachpb.NodeID{}
-	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
-		return err
-	}
-
-	fakeStatuses, err := makeFakeNodeStatuses(storeToNode)
-	if err != nil {
-		return err
-	}
-	if err := checkFakeStatuses(fakeStatuses, storeIDs); err != nil {
-		return errors.Wrapf(err, "please provide an updated mapping file %s", knobs.ImportTimeseriesMappingFile)
-	}
-
-	// All checks passed, write the statuses.
-	for _, status := range fakeStatuses {
-		key := keys.NodeStatusKey(status.Desc.NodeID)
-		if err := s.db.PutInline(ctx, key, &status); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func makeFakeNodeStatuses(
-	storeToNode map[roachpb.StoreID]roachpb.NodeID,
-) ([]statuspb.NodeStatus, error) {
-	var sl []statuspb.NodeStatus
-	nodeToStore := map[roachpb.NodeID][]roachpb.StoreID{}
-	for sid, nid := range storeToNode {
-		nodeToStore[nid] = append(nodeToStore[nid], sid)
-	}
-
-	for nodeID, storeIDs := range nodeToStore {
-		sort.Slice(storeIDs, func(i, j int) bool {
-			return storeIDs[i] < storeIDs[j]
-		})
-		nodeStatus := statuspb.NodeStatus{
-			Desc: roachpb.NodeDescriptor{
-				NodeID: nodeID,
-			},
-		}
-		for _, storeID := range storeIDs {
-			nodeStatus.StoreStatuses = append(nodeStatus.StoreStatuses, statuspb.StoreStatus{Desc: roachpb.StoreDescriptor{
-				Node:    nodeStatus.Desc, // don't want cycles here
-				StoreID: storeID,
-			}})
-		}
-
-		sl = append(sl, nodeStatus)
-	}
-	sort.Slice(sl, func(i, j int) bool {
-		return sl[i].Desc.NodeID < sl[j].Desc.NodeID
-	})
-	return sl, nil
-}
-
-func checkFakeStatuses(fakeStatuses []statuspb.NodeStatus, storeIDs map[string]struct{}) error {
-	for _, status := range fakeStatuses {
-		for _, ss := range status.StoreStatuses {
-			storeID := ss.Desc.StoreID
-			strID := fmt.Sprint(storeID)
-			if _, ok := storeIDs[strID]; !ok {
-				// This is likely an mistake and where it isn't (for example since store
-				// is long gone and hasn't supplied metrics in a long time) the user can
-				// react by removing the assignment from the yaml file and trying again.
-				return errors.Errorf(
-					"s%d supplied in input mapping, but no timeseries found for it",
-					ss.Desc.StoreID,
-				)
-			}
-
-			delete(storeIDs, strID)
-		}
-	}
-	if len(storeIDs) > 0 {
-		return errors.Errorf(
-			"need to map the remaining stores %v to nodes", storeIDs)
-	}
-	return nil
 }
 
 // AcceptClients starts listening for incoming SQL clients over the network.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -920,20 +920,6 @@ type grpcGatewayServer interface {
 	) error
 }
 
-// ListenError is returned from Start when we fail to start listening on either
-// the main Cockroach port or the HTTP port, so that the CLI can instruct the
-// user on what might have gone wrong.
-type ListenError struct {
-	cause error
-	Addr  string
-}
-
-// Error implements error.
-func (l *ListenError) Error() string { return l.cause.Error() }
-
-// Unwrap is because ListenError is a wrapper.
-func (l *ListenError) Unwrap() error { return l.cause }
-
 // inspectEngines goes through engines and constructs an initState. The
 // initState returned by this method will reflect a zero NodeID if none has
 // been assigned yet (i.e. if none of the engines is initialized). See
@@ -2553,26 +2539,6 @@ func (s *Server) StartDiagnostics(ctx context.Context) {
 
 func init() {
 	tracing.RegisterTagRemapping("n", "node")
-}
-
-// ListenAndUpdateAddrs starts a TCP listener on the specified address
-// then updates the address and advertised address fields based on the
-// actual interface address resolved by the OS during the Listen()
-// call.
-func ListenAndUpdateAddrs(
-	ctx context.Context, addr, advertiseAddr *string, connName string,
-) (net.Listener, error) {
-	ln, err := net.Listen("tcp", *addr)
-	if err != nil {
-		return nil, &ListenError{
-			cause: err,
-			Addr:  *addr,
-		}
-	}
-	if err := base.UpdateAddrs(ctx, addr, advertiseAddr, ln.Addr()); err != nil {
-		return nil, errors.Wrapf(err, "internal error: cannot parse %s listen address", connName)
-	}
-	return ln, nil
 }
 
 // RunLocalSQL calls fn on a SQL internal executor on this server.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -122,7 +122,6 @@ type Server struct {
 	status          *statusServer
 	authentication  *authenticationServer
 	migrationServer *migrationServer
-	oidc            OIDC
 	tsDB            *ts.DB
 	tsServer        *ts.Server
 	raftTransport   *kvserver.RaftTransport
@@ -1386,7 +1385,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.oidc = oidc
 
 	// Serve UI assets.
 	//

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,7 +71,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scjob" // register jobs declared outside of pkg/sql
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ui"
@@ -826,72 +825,6 @@ func (s *Server) NodeID() roachpb.NodeID {
 // during server startup.
 func (s *Server) InitialStart() bool {
 	return s.node.initialStart
-}
-
-// inspectEngines goes through engines and constructs an initState. The
-// initState returned by this method will reflect a zero NodeID if none has
-// been assigned yet (i.e. if none of the engines is initialized). See
-// commentary on initState for the intended usage of inspectEngines.
-func inspectEngines(
-	ctx context.Context,
-	engines []storage.Engine,
-	binaryVersion, binaryMinSupportedVersion roachpb.Version,
-) (*initState, error) {
-	var clusterID uuid.UUID
-	var nodeID roachpb.NodeID
-	var initializedEngines, uninitializedEngines []storage.Engine
-	var initialSettingsKVs []roachpb.KeyValue
-
-	for _, eng := range engines {
-		// Once cached settings are loaded from any engine we can stop.
-		if len(initialSettingsKVs) == 0 {
-			var err error
-			initialSettingsKVs, err = loadCachedSettingsKVs(ctx, eng)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		storeIdent, err := kvserver.ReadStoreIdent(ctx, eng)
-		if errors.HasType(err, (*kvserver.NotBootstrappedError)(nil)) {
-			uninitializedEngines = append(uninitializedEngines, eng)
-			continue
-		} else if err != nil {
-			return nil, err
-		}
-
-		if clusterID != uuid.Nil && clusterID != storeIdent.ClusterID {
-			return nil, errors.Errorf("conflicting store ClusterIDs: %s, %s", storeIdent.ClusterID, clusterID)
-		}
-		clusterID = storeIdent.ClusterID
-
-		if storeIdent.StoreID == 0 || storeIdent.NodeID == 0 || storeIdent.ClusterID == uuid.Nil {
-			return nil, errors.Errorf("partially initialized store: %+v", storeIdent)
-		}
-
-		if nodeID != 0 && nodeID != storeIdent.NodeID {
-			return nil, errors.Errorf("conflicting store NodeIDs: %s, %s", storeIdent.NodeID, nodeID)
-		}
-		nodeID = storeIdent.NodeID
-
-		initializedEngines = append(initializedEngines, eng)
-	}
-	clusterVersion, err := kvserver.SynthesizeClusterVersionFromEngines(
-		ctx, initializedEngines, binaryVersion, binaryMinSupportedVersion,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	state := &initState{
-		clusterID:            clusterID,
-		nodeID:               nodeID,
-		initializedEngines:   initializedEngines,
-		uninitializedEngines: uninitializedEngines,
-		clusterVersion:       clusterVersion,
-		initialSettingsKVs:   initialSettingsKVs,
-	}
-	return state, nil
 }
 
 // listenerInfo is a helper used to write files containing various listener

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,7 +88,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -2527,9 +2526,7 @@ func (s *SQLServer) startServeSQL(
 	// Start servicing SQL connections.
 
 	pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
-	tcpKeepAlive := tcpKeepAliveManager{
-		tcpKeepAlive: envutil.EnvOrDefaultDuration("COCKROACH_SQL_TCP_KEEP_ALIVE", time.Minute),
-	}
+	tcpKeepAlive := makeTCPKeepAliveManager()
 
 	_ = stopper.RunAsyncTaskEx(pgCtx,
 		stop.TaskOpts{TaskName: "pgwire-listener", SpanOpt: stop.SterileRootSpan},
@@ -2894,51 +2891,6 @@ func (s *Server) StartDiagnostics(ctx context.Context) {
 
 func init() {
 	tracing.RegisterTagRemapping("n", "node")
-}
-
-// configure attempts to set TCP keep-alive on
-// connection. Does not fail on errors.
-func (k *tcpKeepAliveManager) configure(ctx context.Context, conn net.Conn) {
-	if k.tcpKeepAlive == 0 {
-		return
-	}
-
-	muxConn, ok := conn.(*cmux.MuxConn)
-	if !ok {
-		return
-	}
-	tcpConn, ok := muxConn.Conn.(*net.TCPConn)
-	if !ok {
-		return
-	}
-
-	// Only log success/failure once.
-	doLog := atomic.CompareAndSwapInt32(&k.loggedKeepAliveStatus, 0, 1)
-	if err := tcpConn.SetKeepAlive(true); err != nil {
-		if doLog {
-			log.Ops.Warningf(ctx, "failed to enable TCP keep-alive for pgwire: %v", err)
-		}
-		return
-
-	}
-	if err := tcpConn.SetKeepAlivePeriod(k.tcpKeepAlive); err != nil {
-		if doLog {
-			log.Ops.Warningf(ctx, "failed to set TCP keep-alive duration for pgwire: %v", err)
-		}
-		return
-	}
-
-	if doLog {
-		log.VEventf(ctx, 2, "setting TCP keep-alive to %s for pgwire", k.tcpKeepAlive)
-	}
-}
-
-type tcpKeepAliveManager struct {
-	// The keepalive duration.
-	tcpKeepAlive time.Duration
-	// loggedKeepAliveStatus ensures that errors about setting the TCP
-	// keepalive status are only reported once.
-	loggedKeepAliveStatus int32
 }
 
 // ListenAndUpdateAddrs starts a TCP listener on the specified address

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -1017,7 +1016,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// and dispatches the server worker for the RPC.
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
-	pgL, startRPCServer, err := StartListenRPCAndSQL(ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc)
+	pgL, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc)
 	if err != nil {
 		return err
 	}
@@ -1568,125 +1567,6 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 
 	log.Event(ctx, "server ready")
 	return nil
-}
-
-// StartListenRPCAndSQL starts the RPC and SQL listeners.
-// It returns the SQL listener, which can be used
-// to start the SQL server when initialization has completed.
-// It also returns a function that starts the RPC server,
-// when the cluster is known to have bootstrapped or
-// when waiting for init().
-func StartListenRPCAndSQL(
-	ctx, workersCtx context.Context, cfg BaseConfig, stopper *stop.Stopper, grpc *grpcServer,
-) (sqlListener net.Listener, startRPCServer func(ctx context.Context), err error) {
-	rpcChanName := "rpc/sql"
-	if cfg.SplitListenSQL {
-		rpcChanName = "rpc"
-	}
-	var ln net.Listener
-	if k := cfg.TestingKnobs.Server; k != nil {
-		knobs := k.(*TestingKnobs)
-		ln = knobs.RPCListener
-	}
-	if ln == nil {
-		var err error
-		ln, err = ListenAndUpdateAddrs(ctx, &cfg.Addr, &cfg.AdvertiseAddr, rpcChanName)
-		if err != nil {
-			return nil, nil, err
-		}
-		log.Eventf(ctx, "listening on port %s", cfg.Addr)
-	}
-
-	var pgL net.Listener
-	if cfg.SplitListenSQL {
-		pgL, err = ListenAndUpdateAddrs(ctx, &cfg.SQLAddr, &cfg.SQLAdvertiseAddr, "sql")
-		if err != nil {
-			return nil, nil, err
-		}
-		// The SQL listener shutdown worker, which closes everything under
-		// the SQL port when the stopper indicates we are shutting down.
-		waitQuiesce := func(ctx context.Context) {
-			<-stopper.ShouldQuiesce()
-			// NB: we can't do this as a Closer because (*Server).ServeWith is
-			// running in a worker and usually sits on accept() which unblocks
-			// only when the listener closes. In other words, the listener needs
-			// to close when quiescing starts to allow that worker to shut down.
-			if err := pgL.Close(); err != nil {
-				log.Ops.Fatalf(ctx, "%v", err)
-			}
-		}
-		if err := stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
-			waitQuiesce(workersCtx)
-			return nil, nil, err
-		}
-		log.Eventf(ctx, "listening on sql port %s", cfg.SQLAddr)
-	}
-
-	// serveOnMux is used to ensure that the mux gets listened on eventually,
-	// either via the returned startRPCServer() or upon stopping.
-	var serveOnMux sync.Once
-
-	m := cmux.New(ln)
-
-	if !cfg.SplitListenSQL {
-		// If the pg port is split, it will be opened above. Otherwise,
-		// we make it hang off the RPC listener via cmux here.
-		pgL = m.Match(func(r io.Reader) bool {
-			return pgwire.Match(r)
-		})
-		// Also if the pg port is not split, the actual listen
-		// and advertise addresses for SQL become equal to that
-		// of RPC, regardless of what was configured.
-		cfg.SQLAddr = cfg.Addr
-		cfg.SQLAdvertiseAddr = cfg.AdvertiseAddr
-	}
-
-	anyL := m.Match(cmux.Any())
-	if serverTestKnobs, ok := cfg.TestingKnobs.Server.(*TestingKnobs); ok {
-		if serverTestKnobs.ContextTestingKnobs.ArtificialLatencyMap != nil {
-			anyL = rpc.NewDelayingListener(anyL)
-		}
-	}
-
-	// The remainder shutdown worker.
-	waitForQuiesce := func(context.Context) {
-		<-stopper.ShouldQuiesce()
-		// TODO(bdarnell): Do we need to also close the other listeners?
-		netutil.FatalIfUnexpected(anyL.Close())
-	}
-	stopper.AddCloser(stop.CloserFn(func() {
-		grpc.Stop()
-		serveOnMux.Do(func() {
-			// The cmux matches don't shut down properly unless serve is called on the
-			// cmux at some point. Use serveOnMux to ensure it's called during shutdown
-			// if we wouldn't otherwise reach the point where we start serving on it.
-			netutil.FatalIfUnexpected(m.Serve())
-		})
-	}))
-	if err := stopper.RunAsyncTask(
-		workersCtx, "grpc-quiesce", waitForQuiesce,
-	); err != nil {
-		return nil, nil, err
-	}
-
-	// startRPCServer starts the RPC server. We do not do this
-	// immediately because we want the cluster to be ready (or ready to
-	// initialize) before we accept RPC requests. The caller
-	// (Server.Start) will call this at the right moment.
-	startRPCServer = func(ctx context.Context) {
-		// Serve the gRPC endpoint.
-		_ = stopper.RunAsyncTask(workersCtx, "serve-grpc", func(context.Context) {
-			netutil.FatalIfUnexpected(grpc.Serve(anyL))
-		})
-
-		_ = stopper.RunAsyncTask(ctx, "serve-mux", func(context.Context) {
-			serveOnMux.Do(func() {
-				netutil.FatalIfUnexpected(m.Serve())
-			})
-		})
-	}
-
-	return pgL, startRPCServer, nil
 }
 
 func (s *Server) startServeUI(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"encoding/gob"
@@ -117,9 +116,6 @@ import (
 )
 
 var (
-	// Allocation pool for gzipResponseWriters.
-	gzipResponseWriterPool sync.Pool
-
 	forwardClockJumpCheckEnabled = settings.RegisterBoolSetting(
 		settings.TenantWritable,
 		"server.clock.forward_jump_check_enabled",
@@ -2894,61 +2890,6 @@ func (s *Server) PGServer() *pgwire.Server {
 func (s *Server) StartDiagnostics(ctx context.Context) {
 	s.updates.PeriodicallyCheckForUpdates(ctx, s.stopper)
 	s.sqlServer.StartDiagnostics(ctx)
-}
-
-// TODO(benesch): Use https://github.com/NYTimes/gziphandler instead.
-// gzipResponseWriter reinvents the wheel and is not as robust.
-type gzipResponseWriter struct {
-	gz gzip.Writer
-	http.ResponseWriter
-}
-
-func newGzipResponseWriter(rw http.ResponseWriter) *gzipResponseWriter {
-	var w *gzipResponseWriter
-	if wI := gzipResponseWriterPool.Get(); wI == nil {
-		w = new(gzipResponseWriter)
-	} else {
-		w = wI.(*gzipResponseWriter)
-	}
-	w.Reset(rw)
-	return w
-}
-
-func (w *gzipResponseWriter) Reset(rw http.ResponseWriter) {
-	w.gz.Reset(rw)
-	w.ResponseWriter = rw
-}
-
-func (w *gzipResponseWriter) Write(b []byte) (int, error) {
-	// The underlying http.ResponseWriter can't sniff gzipped data properly, so we
-	// do our own sniffing on the uncompressed data.
-	if w.Header().Get("Content-Type") == "" {
-		w.Header().Set("Content-Type", http.DetectContentType(b))
-	}
-	return w.gz.Write(b)
-}
-
-// Flush implements http.Flusher as required by grpc-gateway for clients
-// which access streaming endpoints (as exercised by the acceptance tests
-// at time of writing).
-func (w *gzipResponseWriter) Flush() {
-	// If Flush returns an error, we'll see it on the next call to Write or
-	// Close as well, so we can ignore it here.
-	if err := w.gz.Flush(); err == nil {
-		// Flush the wrapped ResponseWriter as well, if possible.
-		if f, ok := w.ResponseWriter.(http.Flusher); ok {
-			f.Flush()
-		}
-	}
-}
-
-// Close implements the io.Closer interface. It is not safe to use the
-// writer after calling Close.
-func (w *gzipResponseWriter) Close() error {
-	err := w.gz.Close()
-	w.Reset(nil) // release ResponseWriter reference.
-	gzipResponseWriterPool.Put(w)
-	return err
 }
 
 func init() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1616,7 +1616,11 @@ func (s *Server) startServeUI(
 	})
 }
 
-// Stop stops the server.
+// Stop shuts down this server instance. Note that this method exists
+// solely for the benefit of the `\demo shutdown` command in
+// `cockroach demo`. It is not called as part of the regular server
+// shutdown sequence; for this, see cli/start.go and the Drain()
+// RPC.
 func (s *Server) Stop() {
 	s.stopper.Stop(context.Background())
 }

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -10,8 +10,134 @@
 
 package server
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+
+	"github.com/cockroachdb/cockroach/pkg/server/debug"
+	"github.com/cockroachdb/cockroach/pkg/ts"
+	"github.com/cockroachdb/cockroach/pkg/ui"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/metadata"
+)
 
 type httpServer struct {
 	mux http.ServeMux
+}
+
+func (s *httpServer) handleHealth(healthHandler http.Handler) {
+	s.mux.Handle("/health", healthHandler)
+}
+
+func (s *httpServer) setupRoutes(
+	ctx context.Context,
+	cfg Config,
+	authnServer *authenticationServer,
+	adminAuthzCheck *adminPrivilegeChecker,
+	handleRequestsUnauthenticated http.Handler,
+	handleStatusVarsUnauthenticated http.Handler,
+	handleDebugUnauthenticated http.Handler,
+	apiServer *apiV2Server,
+) error {
+	// OIDC Configuration must happen prior to the UI Handler being defined below so that we have
+	// the system settings initialized for it to pick up from the oidcAuthenticationServer.
+	oidc, err := ConfigureOIDC(
+		ctx, cfg.Settings, cfg.Locality,
+		s.mux.Handle, authnServer.UserLoginFromSSO, cfg.AmbientCtx, cfg.ClusterIDContainer.Get(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Define the http.Handler for UI assets.
+	assetHandler := ui.Handler(ui.Config{
+		ExperimentalUseLogin: cfg.EnableWebSessionAuthentication,
+		LoginEnabled:         cfg.RequireWebSession(),
+		NodeID:               cfg.IDContainer,
+		OIDC:                 oidc,
+		GetUser: func(ctx context.Context) *string {
+			if u, ok := ctx.Value(webSessionUserKey{}).(string); ok {
+				return &u
+			}
+			return nil
+		},
+	})
+
+	// The authentication mux used here is created in "allow anonymous" mode so that the UI
+	// assets are served up whether or not there is a session. If there is a session, the mux
+	// adds it to the context, and it is templated into index.html so that the UI can show
+	// the username of the currently-logged-in user.
+	authenticatedUIHandler := newAuthenticationMuxAllowAnonymous(
+		authnServer, assetHandler)
+	s.mux.Handle("/", authenticatedUIHandler)
+
+	// Add HTTP authentication to the gRPC-gateway endpoints used by the UI,
+	// if not disabled by configuration.
+	var authenticatedHandler http.Handler = handleRequestsUnauthenticated
+	if cfg.RequireWebSession() {
+		authenticatedHandler = newAuthenticationMux(authnServer, authenticatedHandler)
+	}
+
+	// Login and logout paths.
+	// The /login endpoint is, by definition, available pre-authentication.
+	s.mux.Handle(loginPath, handleRequestsUnauthenticated)
+	s.mux.Handle(logoutPath, authenticatedHandler)
+	// The login path for 'cockroach demo', if we're currently running
+	// that.
+	if cfg.EnableDemoLoginEndpoint {
+		s.mux.Handle(DemoLoginPath, http.HandlerFunc(authnServer.demoLogin))
+	}
+
+	// Admin/Status servers. These are used by the UI via RPC-over-HTTP.
+	s.mux.Handle(statusPrefix, authenticatedHandler)
+	s.mux.Handle(adminPrefix, authenticatedHandler)
+
+	// The timeseries endpoint, used to produce graphs.
+	s.mux.Handle(ts.URLPrefix, authenticatedHandler)
+
+	// Exempt the 2nd health check endpoint from authentication.
+	// (This simply mirrors /health and exists for backward compatibility.)
+	s.mux.Handle(adminHealth, handleRequestsUnauthenticated)
+	// The /_status/vars endpoint is not authenticated either. Useful for monitoring.
+	s.mux.Handle(statusVars, handleStatusVarsUnauthenticated)
+
+	// The new "v2" HTTP API tree.
+	s.mux.Handle(apiV2Path, apiServer)
+
+	// Register debugging endpoints.
+	handleDebugAuthenticated := handleDebugUnauthenticated
+	if cfg.RequireWebSession() {
+		// Mandate both authentication and admin authorization.
+		handleDebugAuthenticated = makeAdminAuthzCheckHandler(adminAuthzCheck, handleDebugAuthenticated)
+		handleDebugAuthenticated = newAuthenticationMux(authnServer, handleDebugAuthenticated)
+	}
+	s.mux.Handle(debug.Endpoint, handleDebugAuthenticated)
+
+	log.Event(ctx, "added http endpoints")
+
+	return nil
+}
+
+func makeAdminAuthzCheckHandler(
+	adminAuthzCheck *adminPrivilegeChecker, handler http.Handler,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Retrieve the username embedded in the grpc metadata, if any.
+		// This will be provided by the authenticationMux.
+		md := forwardAuthenticationMetadata(req.Context(), req)
+		authCtx := metadata.NewIncomingContext(req.Context(), md)
+		// Check the privileges of the requester.
+		_, err := adminAuthzCheck.requireAdminUser(authCtx)
+		if errors.Is(err, errRequiresAdmin) {
+			http.Error(w, "admin privilege required", http.StatusUnauthorized)
+			return
+		} else if err != nil {
+			log.Ops.Infof(authCtx, "web session error: %s", err)
+			http.Error(w, "error checking authentication", http.StatusInternalServerError)
+			return
+		}
+		// Forward the request to the inner handler.
+		handler.ServeHTTP(w, req)
+	})
 }

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import "net/http"
+
+type httpServer struct {
+	mux http.ServeMux
+}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1220,3 +1220,81 @@ func (s *SQLServer) StartDiagnostics(ctx context.Context) {
 func (s *SQLServer) AnnotateCtx(ctx context.Context) context.Context {
 	return s.ambientCtx.AnnotateCtx(ctx)
 }
+
+// startServeSQL starts accepting incoming SQL connections over TCP.
+// It also starts listening on the Unix socket, if that was configured.
+func (s *SQLServer) startServeSQL(
+	ctx context.Context,
+	stopper *stop.Stopper,
+	connManager netutil.Server,
+	pgL net.Listener,
+	socketFile string,
+) error {
+	log.Ops.Info(ctx, "serving sql connections")
+	// Start servicing SQL connections.
+
+	pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
+	tcpKeepAlive := makeTCPKeepAliveManager()
+
+	_ = stopper.RunAsyncTaskEx(pgCtx,
+		stop.TaskOpts{TaskName: "pgwire-listener", SpanOpt: stop.SterileRootSpan},
+		func(ctx context.Context) {
+			err := connManager.ServeWith(ctx, stopper, pgL, func(ctx context.Context, conn net.Conn) {
+				connCtx := s.pgServer.AnnotateCtxForIncomingConn(ctx, conn)
+				tcpKeepAlive.configure(connCtx, conn)
+
+				if err := s.pgServer.ServeConn(connCtx, conn, pgwire.SocketTCP); err != nil {
+					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+				}
+			})
+			netutil.FatalIfUnexpected(err)
+		})
+
+	// If a unix socket was requested, start serving there too.
+	if len(socketFile) != 0 {
+		log.Ops.Infof(ctx, "starting postgres server at unix:%s", socketFile)
+
+		// Unix socket enabled: postgres protocol only.
+		unixLn, err := net.Listen("unix", socketFile)
+		if err != nil {
+			return err
+		}
+
+		waitQuiesce := func(ctx context.Context) {
+			<-stopper.ShouldQuiesce()
+			// NB: we can't do this as a Closer because (*Server).ServeWith is
+			// running in a worker and usually sits on accept() which unblocks
+			// only when the listener closes. In other words, the listener needs
+			// to close when quiescing starts to allow that worker to shut down.
+			if err := unixLn.Close(); err != nil {
+				log.Ops.Fatalf(ctx, "%v", err)
+			}
+		}
+		if err := stopper.RunAsyncTaskEx(ctx,
+			stop.TaskOpts{TaskName: "unix-ln-close", SpanOpt: stop.SterileRootSpan},
+			func(ctx context.Context) {
+				waitQuiesce(ctx)
+			}); err != nil {
+			waitQuiesce(ctx)
+			return err
+		}
+
+		if err := stopper.RunAsyncTaskEx(pgCtx,
+			stop.TaskOpts{TaskName: "unix-listener", SpanOpt: stop.SterileRootSpan},
+			func(ctx context.Context) {
+				err := connManager.ServeWith(ctx, stopper, unixLn, func(ctx context.Context, conn net.Conn) {
+					connCtx := s.pgServer.AnnotateCtxForIncomingConn(ctx, conn)
+					if err := s.pgServer.ServeConn(connCtx, conn, pgwire.SocketUnix); err != nil {
+						log.Ops.Errorf(connCtx, "%v", err)
+					}
+				})
+				netutil.FatalIfUnexpected(err)
+			}); err != nil {
+			return err
+		}
+	}
+
+	s.acceptingClients.Set(true)
+
+	return nil
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -93,7 +93,7 @@ func TestPanicRecovery(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// Enable a test-only endpoint that induces a panic.
-	ts.mux.Handle("/panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	ts.http.mux.Handle("/panic", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("induced panic for testing")
 	}))
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -104,7 +104,7 @@ func TestPanicRecovery(t *testing.T) {
 	// Create a ResponseRecorder to record the response.
 	rr := httptest.NewRecorder()
 	require.NotPanics(t, func() {
-		ts.ServeHTTP(rr, req)
+		ts.http.baseHandler(rr, req)
 	})
 
 	// Check that the status code is correct.

--- a/pkg/server/start_listen.go
+++ b/pkg/server/start_listen.go
@@ -1,0 +1,145 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/cockroachdb/cmux"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+// startListenRPCAndSQL starts the RPC and SQL listeners.
+// It returns the SQL listener, which can be used
+// to start the SQL server when initialization has completed.
+// It also returns a function that starts the RPC server,
+// when the cluster is known to have bootstrapped or
+// when waiting for init().
+// This does not start *accepting* connections just yet.
+func startListenRPCAndSQL(
+	ctx, workersCtx context.Context, cfg BaseConfig, stopper *stop.Stopper, grpc *grpcServer,
+) (sqlListener net.Listener, startRPCServer func(ctx context.Context), err error) {
+	rpcChanName := "rpc/sql"
+	if cfg.SplitListenSQL {
+		rpcChanName = "rpc"
+	}
+	var ln net.Listener
+	if k := cfg.TestingKnobs.Server; k != nil {
+		knobs := k.(*TestingKnobs)
+		ln = knobs.RPCListener
+	}
+	if ln == nil {
+		var err error
+		ln, err = ListenAndUpdateAddrs(ctx, &cfg.Addr, &cfg.AdvertiseAddr, rpcChanName)
+		if err != nil {
+			return nil, nil, err
+		}
+		log.Eventf(ctx, "listening on port %s", cfg.Addr)
+	}
+
+	var pgL net.Listener
+	if cfg.SplitListenSQL {
+		pgL, err = ListenAndUpdateAddrs(ctx, &cfg.SQLAddr, &cfg.SQLAdvertiseAddr, "sql")
+		if err != nil {
+			return nil, nil, err
+		}
+		// The SQL listener shutdown worker, which closes everything under
+		// the SQL port when the stopper indicates we are shutting down.
+		waitQuiesce := func(ctx context.Context) {
+			<-stopper.ShouldQuiesce()
+			// NB: we can't do this as a Closer because (*Server).ServeWith is
+			// running in a worker and usually sits on accept() which unblocks
+			// only when the listener closes. In other words, the listener needs
+			// to close when quiescing starts to allow that worker to shut down.
+			if err := pgL.Close(); err != nil {
+				log.Ops.Fatalf(ctx, "%v", err)
+			}
+		}
+		if err := stopper.RunAsyncTask(workersCtx, "wait-quiesce", waitQuiesce); err != nil {
+			waitQuiesce(workersCtx)
+			return nil, nil, err
+		}
+		log.Eventf(ctx, "listening on sql port %s", cfg.SQLAddr)
+	}
+
+	// serveOnMux is used to ensure that the mux gets listened on eventually,
+	// either via the returned startRPCServer() or upon stopping.
+	var serveOnMux sync.Once
+
+	m := cmux.New(ln)
+
+	if !cfg.SplitListenSQL {
+		// If the pg port is split, it will be opened above. Otherwise,
+		// we make it hang off the RPC listener via cmux here.
+		pgL = m.Match(func(r io.Reader) bool {
+			return pgwire.Match(r)
+		})
+		// Also if the pg port is not split, the actual listen
+		// and advertise addresses for SQL become equal to that
+		// of RPC, regardless of what was configured.
+		cfg.SQLAddr = cfg.Addr
+		cfg.SQLAdvertiseAddr = cfg.AdvertiseAddr
+	}
+
+	anyL := m.Match(cmux.Any())
+	if serverTestKnobs, ok := cfg.TestingKnobs.Server.(*TestingKnobs); ok {
+		if serverTestKnobs.ContextTestingKnobs.ArtificialLatencyMap != nil {
+			anyL = rpc.NewDelayingListener(anyL)
+		}
+	}
+
+	// The remainder shutdown worker.
+	waitForQuiesce := func(context.Context) {
+		<-stopper.ShouldQuiesce()
+		// TODO(bdarnell): Do we need to also close the other listeners?
+		netutil.FatalIfUnexpected(anyL.Close())
+	}
+	stopper.AddCloser(stop.CloserFn(func() {
+		grpc.Stop()
+		serveOnMux.Do(func() {
+			// The cmux matches don't shut down properly unless serve is called on the
+			// cmux at some point. Use serveOnMux to ensure it's called during shutdown
+			// if we wouldn't otherwise reach the point where we start serving on it.
+			netutil.FatalIfUnexpected(m.Serve())
+		})
+	}))
+	if err := stopper.RunAsyncTask(
+		workersCtx, "grpc-quiesce", waitForQuiesce,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	// startRPCServer starts the RPC server. We do not do this
+	// immediately because we want the cluster to be ready (or ready to
+	// initialize) before we accept RPC requests. The caller
+	// (Server.Start) will call this at the right moment.
+	startRPCServer = func(ctx context.Context) {
+		// Serve the gRPC endpoint.
+		_ = stopper.RunAsyncTask(workersCtx, "serve-grpc", func(context.Context) {
+			netutil.FatalIfUnexpected(grpc.Serve(anyL))
+		})
+
+		_ = stopper.RunAsyncTask(ctx, "serve-mux", func(context.Context) {
+			serveOnMux.Do(func() {
+				netutil.FatalIfUnexpected(m.Serve())
+			})
+		})
+	}
+
+	return pgL, startRPCServer, nil
+}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -404,6 +404,7 @@ func newStatusServer(
 	ambient log.AmbientContext,
 	st *cluster.Settings,
 	cfg *base.Config,
+	adminAuthzCheck *adminPrivilegeChecker,
 	adminServer *adminServer,
 	db *kv.DB,
 	gossip *gossip.Gossip,
@@ -422,7 +423,7 @@ func newStatusServer(
 	server := &statusServer{
 		baseStatusServer: &baseStatusServer{
 			AmbientContext:     ambient,
-			privilegeChecker:   adminServer.adminPrivilegeChecker,
+			privilegeChecker:   adminAuthzCheck,
 			sessionRegistry:    sessionRegistry,
 			contentionRegistry: contentionRegistry,
 			flowScheduler:      flowScheduler,

--- a/pkg/server/tcp_keepalive_manager.go
+++ b/pkg/server/tcp_keepalive_manager.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cmux"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+type tcpKeepAliveManager struct {
+	// The keepalive duration.
+	tcpKeepAlive time.Duration
+	// loggedKeepAliveStatus ensures that errors about setting the TCP
+	// keepalive status are only reported once.
+	loggedKeepAliveStatus int32
+}
+
+func makeTCPKeepAliveManager() tcpKeepAliveManager {
+	return tcpKeepAliveManager{
+		tcpKeepAlive: envutil.EnvOrDefaultDuration("COCKROACH_SQL_TCP_KEEP_ALIVE", time.Minute),
+	}
+}
+
+// configure attempts to set TCP keep-alive on
+// connection. Does not fail on errors.
+func (k *tcpKeepAliveManager) configure(ctx context.Context, conn net.Conn) {
+	if k.tcpKeepAlive == 0 {
+		return
+	}
+
+	muxConn, ok := conn.(*cmux.MuxConn)
+	if !ok {
+		return
+	}
+	tcpConn, ok := muxConn.Conn.(*net.TCPConn)
+	if !ok {
+		return
+	}
+
+	// Only log success/failure once.
+	doLog := atomic.CompareAndSwapInt32(&k.loggedKeepAliveStatus, 0, 1)
+	if err := tcpConn.SetKeepAlive(true); err != nil {
+		if doLog {
+			log.Ops.Warningf(ctx, "failed to enable TCP keep-alive for pgwire: %v", err)
+		}
+		return
+
+	}
+	if err := tcpConn.SetKeepAlivePeriod(k.tcpKeepAlive); err != nil {
+		if doLog {
+			log.Ops.Warningf(ctx, "failed to set TCP keep-alive duration for pgwire: %v", err)
+		}
+		return
+	}
+
+	if doLog {
+		log.VEventf(ctx, 2, "setting TCP keep-alive to %s for pgwire", k.tcpKeepAlive)
+	}
+}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -108,7 +108,7 @@ func StartTenant(
 	// correctly.
 	baseCfg.Addr = baseCfg.SQLAddr
 	baseCfg.AdvertiseAddr = baseCfg.SQLAdvertiseAddr
-	pgL, startRPCServer, err := StartListenRPCAndSQL(ctx, background, baseCfg, stopper, grpcMain)
+	pgL, startRPCServer, err := startListenRPCAndSQL(ctx, background, baseCfg, stopper, grpcMain)
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -244,15 +244,14 @@ func StartTenant(
 
 	// TODO(tbg): the log dir is not configurable at this point
 	// since it is integrated too tightly with the `./cockroach start` command.
-	if err := startSampleEnvironment(ctx, sampleEnvironmentCfg{
-		st:                   args.Settings,
-		stopper:              args.stopper,
-		minSampleInterval:    base.DefaultMetricsSampleInterval,
-		goroutineDumpDirName: args.GoroutineDumpDirName,
-		heapProfileDirName:   args.HeapProfileDirName,
-		runtime:              args.runtime,
-		sessionRegistry:      args.sessionRegistry,
-	}); err != nil {
+	if err := startSampleEnvironment(ctx,
+		args.Settings,
+		args.stopper,
+		args.GoroutineDumpDirName,
+		args.HeapProfileDirName,
+		args.runtime,
+		args.sessionRegistry,
+	); err != nil {
 		return nil, "", "", err
 	}
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -182,7 +182,7 @@ func StartTenant(
 	startRPCServer(background)
 
 	// Begin configuration of GRPC Gateway
-	gwMux, gwCtx, conn, err := ConfigureGRPCGateway(
+	gwMux, gwCtx, conn, err := configureGRPCGateway(
 		ctx,
 		background,
 		args.AmbientCtx,

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -102,10 +102,9 @@ type TestingKnobs struct {
 	// a custom function that counts the number of times the sleep function is called.
 	DrainSleepFn func(time.Duration)
 
-	// TenantBlobClientFactory supplies a BlobClientFactory for
-	// use by tenants. By default, tenants have no blob client
-	// factory.
-	TenantBlobClientFactory blobs.BlobClientFactory
+	// BlobClientFactory supplies a BlobClientFactory for
+	// use by servers.
+	BlobClientFactory blobs.BlobClientFactory
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This moves code out of server.go into distinct files, to make the code easier to navigate/explore.

