### PR TITLE
sql: don't attempt to rollback DROP INDEX

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1464,8 +1464,8 @@ COMMIT
 statement ok
 DROP TABLE t
 
-# Test that DROP INDEX on an index with dependent foreign keys is correctly
-# rolled back when there is an error
+# Test that DROP INDEX on an index with dependent foreign keys doesn't
+# leave table in inconsistent state.
 subtest 38733
 
 statement ok
@@ -1491,7 +1491,7 @@ BEGIN
 statement ok
 DROP INDEX y_b_idx CASCADE;
 
-# This will fail, causing the previous DROP INDEX to also be rolled back
+# This will fail, but DROP INDEX won't be rolled back
 statement ok
 CREATE UNIQUE INDEX ON y (b);
 
@@ -1517,7 +1517,7 @@ BEGIN
 statement ok
 DROP INDEX x_b_key CASCADE;
 
-# This will fail, causing the previous DROP INDEX to also be rolled back
+# This will fail, but the previous DROP INDEX won't be rolled back
 statement ok
 CREATE UNIQUE INDEX ON x (c);
 
@@ -1529,8 +1529,15 @@ COMMIT
 query TTTTB
 SHOW CONSTRAINTS FROM x
 ----
-x  x_b_key  UNIQUE       UNIQUE (b ASC)       true
 x  x_pkey   PRIMARY KEY  PRIMARY KEY (a ASC)  true
+
+# Verify that table y is in a consistent state (otherwise, SHOW
+# CONSTRAINTS would fail with an error). The foreign constraint here
+# hasn't been rolled back because the index hasn't been rolled back.
+query TTTTB
+SHOW CONSTRAINTS FROM y
+----
+y  y_pkey    PRIMARY KEY  PRIMARY KEY (a ASC)              true
 
 statement ok
 DROP TABLE x, y


### PR DESCRIPTION
Previously, we attempted to rollback a failed DROP INDEX mutation by
reversing the direction of the mutation. This would result in a full
index backfill, an expensive operation to restore data that the user
has indicated they don't want anymore. Further, while the index would
be rebuilt, other dependent objects that may have been dropped such as
comments, views, and foreign key constraints would not be rolled back.

The rollback of DROP INDEX is also a mild problem for the
MVCC-compliant index backfiller. Reverting a DROP INDEX will no longer
be a simple direction change, but also require carefully inserting the
new temporary index used during the backfilling process. More
importantly, in the case of restore, we might already be half-way
through an old-style index backfill. Accounting for that would require
that we (1) abandon and drop the in-progress index backfill and (2)
carefully insert a new index backfill that needs to start from the
top.

To avoid these complications, we stop reverting failed DROP
INDEX mutations. Any resumed jobs with previously reverted DROP INDEX
mutations will rewrite those mutations to continue with the DROP.

Release note (sql change): Failed DROP INDEX schema changes are no longer
rolled back. Rolling back a failed DROP INDEX requires the
index to be rebuilt -- a potentially long-running, expensive
operation. Further, in previous versions, such rollbacks were already
incomplete as the failed to roll back cascaded drops for dependent
views and foreign key constraints.