### PR TITLE
cdc: support ALTER CHANGEFEED statement for adding/dropping targets

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -4,6 +4,7 @@ FILES = [
     "abort_stmt",
     "add_column",
     "add_constraint",
+    "alter_changefeed_stmt",
     "alter_column",
     "alter_database_add_region_stmt",
     "alter_database_drop_region",

--- a/docs/generated/sql/bnf/alter_changefeed_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_changefeed_stmt.bnf
@@ -1,0 +1,2 @@
+alter_changefeed_stmt ::=
+	'ALTER' 'CHANGEFEED' a_expr alter_changefeed_cmds

--- a/docs/generated/sql/bnf/alter_ddl_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_ddl_stmt.bnf
@@ -9,3 +9,4 @@ alter_ddl_stmt ::=
 	| alter_schema_stmt
 	| alter_type_stmt
 	| alter_default_privileges_stmt
+	| alter_changefeed_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -399,6 +399,7 @@ alter_ddl_stmt ::=
 	| alter_schema_stmt
 	| alter_type_stmt
 	| alter_default_privileges_stmt
+	| alter_changefeed_stmt
 
 alter_role_stmt ::=
 	'ALTER' role_or_group_or_user role_spec opt_role_options
@@ -1385,6 +1386,9 @@ alter_default_privileges_stmt ::=
 	| 'ALTER' 'DEFAULT' 'PRIVILEGES' 'FOR' 'ALL' 'ROLES' opt_in_schemas abbreviated_grant_stmt
 	| 'ALTER' 'DEFAULT' 'PRIVILEGES' 'FOR' 'ALL' 'ROLES' opt_in_schemas abbreviated_revoke_stmt
 
+alter_changefeed_stmt ::=
+	'ALTER' 'CHANGEFEED' a_expr alter_changefeed_cmds
+
 role_or_group_or_user ::=
 	'ROLE'
 	| 'USER'
@@ -1879,6 +1883,9 @@ abbreviated_revoke_stmt ::=
 	'REVOKE' privileges 'ON' alter_default_privileges_target_object 'FROM' role_spec_list opt_drop_behavior
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privileges 'ON' alter_default_privileges_target_object 'FROM' role_spec_list opt_drop_behavior
 
+alter_changefeed_cmds ::=
+	( alter_changefeed_cmd ) ( ( alter_changefeed_cmd ) )*
+
 role_options ::=
 	( role_option ) ( ( role_option ) )*
 
@@ -2357,6 +2364,10 @@ alter_default_privileges_target_object ::=
 	| 'SEQUENCES'
 	| 'TYPES'
 	| 'SCHEMAS'
+
+alter_changefeed_cmd ::=
+	'ADD' changefeed_targets
+	| 'DROP' changefeed_targets
 
 role_option ::=
 	'CREATEROLE'

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "changefeedccl",
     srcs = [
+        "alter_changefeed_stmt.go",
         "avro.go",
         "changefeed.go",
         "changefeed_dist.go",
@@ -65,6 +66,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/flowinfra",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",
@@ -122,6 +124,7 @@ go_test(
     name = "changefeedccl_test",
     size = "enormous",
     srcs = [
+        "alter_changefeed_test.go",
         "avro_test.go",
         "bench_test.go",
         "changefeed_test.go",

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -1,0 +1,202 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+func init() {
+	sql.AddPlanHook("alter changefeed", alterChangefeedPlanHook)
+}
+
+type alterChangefeedOpts struct {
+	AddTargets  []tree.TargetList
+	DropTargets []tree.TargetList
+}
+
+// alterChangefeedPlanHook implements sql.PlanHookFn.
+func alterChangefeedPlanHook(
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+	alterChangefeedStmt, ok := stmt.(*tree.AlterChangefeed)
+	if !ok {
+		return nil, nil, nil, false, nil
+	}
+
+	header := colinfo.ResultColumns{
+		{Name: "job_id", Typ: types.Int},
+		{Name: "job_description", Typ: types.String},
+	}
+	lockForUpdate := false
+
+	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+		if err := validateSettings(ctx, p); err != nil {
+			return err
+		}
+
+		typedExpr, err := alterChangefeedStmt.Jobs.TypeCheck(ctx, p.SemaCtx(), types.Int)
+		if err != nil {
+			return err
+		}
+		jobID := jobspb.JobID(tree.MustBeDInt(typedExpr))
+
+		job, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.ExtendedEvalContext().Txn)
+		if err != nil {
+			err = errors.Wrapf(err, `could not load job with job id %d`, jobID)
+			return err
+		}
+
+		details, ok := job.Details().(jobspb.ChangefeedDetails)
+		if !ok {
+			return errors.Errorf(`job %d is not changefeed job`, jobID)
+		}
+
+		if job.Status() != jobs.StatusPaused {
+			return errors.Errorf(`job %d is not paused`, jobID)
+		}
+
+		var opts alterChangefeedOpts
+		for _, cmd := range alterChangefeedStmt.Cmds {
+			switch v := cmd.(type) {
+			case *tree.AlterChangefeedAddTarget:
+				opts.AddTargets = append(opts.AddTargets, v.Targets)
+			case *tree.AlterChangefeedDropTarget:
+				opts.DropTargets = append(opts.DropTargets, v.Targets)
+			}
+		}
+
+		var initialHighWater hlc.Timestamp
+		statementTime := hlc.Timestamp{
+			WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
+		}
+
+		if opts.AddTargets != nil {
+			var targetDescs []catalog.Descriptor
+
+			for _, targetList := range opts.AddTargets {
+				descs, err := getTableDescriptors(ctx, p, &targetList, statementTime, initialHighWater)
+				if err != nil {
+					return err
+				}
+				targetDescs = append(targetDescs, descs...)
+			}
+
+			newTargets, err := getTargets(ctx, p, targetDescs, details.Opts)
+			if err != nil {
+				return err
+			}
+			// add old targets
+			for id, target := range details.Targets {
+				newTargets[id] = target
+			}
+			details.Targets = newTargets
+		}
+
+		if opts.DropTargets != nil {
+			var targetDescs []catalog.Descriptor
+
+			for _, targetList := range opts.DropTargets {
+				descs, err := getTableDescriptors(ctx, p, &targetList, statementTime, initialHighWater)
+				if err != nil {
+					return err
+				}
+				targetDescs = append(targetDescs, descs...)
+			}
+
+			for _, desc := range targetDescs {
+				if table, isTable := desc.(catalog.TableDescriptor); isTable {
+					if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
+						return err
+					}
+					delete(details.Targets, table.GetID())
+				}
+			}
+		}
+
+		if len(details.Targets) == 0 {
+			return errors.Errorf("cannot drop all targets for changefeed job %d", jobID)
+		}
+
+		if err := validateSink(ctx, p, jobID, details, details.Opts); err != nil {
+			return err
+		}
+
+		oldStmt, err := parser.ParseOne(job.Payload().Description)
+		if err != nil {
+			return err
+		}
+		oldChangefeedStmt, ok := oldStmt.AST.(*tree.CreateChangefeed)
+		if !ok {
+			return errors.Errorf(`could not parse create changefeed statement for job %d`, jobID)
+		}
+
+		var targets tree.TargetList
+		for _, target := range details.Targets {
+			targetName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{}, tree.Name(target.StatementTimeName))
+			targets.Tables = append(targets.Tables, &targetName)
+		}
+
+		oldChangefeedStmt.Targets = targets
+		jobDescription := tree.AsString(oldChangefeedStmt)
+
+		newPayload := job.Payload()
+		newPayload.Description = jobDescription
+		newPayload.Details = jobspb.WrapPayloadDetails(details)
+
+		finalDescs, err := getTableDescriptors(ctx, p, &targets, statementTime, initialHighWater)
+		if err != nil {
+			return err
+		}
+
+		newPayload.DescriptorIDs = func() (sqlDescIDs []descpb.ID) {
+			for _, desc := range finalDescs {
+				sqlDescIDs = append(sqlDescIDs, desc.GetID())
+			}
+			return sqlDescIDs
+		}()
+
+		err = p.ExecCfg().JobRegistry.UpdateJobWithTxn(ctx, jobID, p.ExtendedEvalContext().Txn, lockForUpdate, func(
+			txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
+		) error {
+			ju.UpdatePayload(&newPayload)
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case resultsCh <- tree.Datums{
+			tree.NewDInt(tree.DInt(jobID)),
+			tree.NewDString(jobDescription),
+		}:
+			return nil
+		}
+	}
+
+	return fn, header, nil, false, nil
+}

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1,0 +1,157 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	gosql "database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlterChangefeedAddTarget(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		defer closeFeed(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar`, feed.JobID()))
+
+		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
+		waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES(1)`)
+		assertPayloads(t, testFeed, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+		})
+
+		sqlDB.Exec(t, `INSERT INTO bar VALUES(2)`)
+		assertPayloads(t, testFeed, []string{
+			`bar: [2]->{"after": {"a": 2}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedDropTarget(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo, bar`)
+		defer closeFeed(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d DROP bar`, feed.JobID()))
+
+		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
+		waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES(1)`)
+		assertPayloads(t, testFeed, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+		})
+
+		sqlDB.Exec(t, `INSERT INTO bar VALUES(2)`)
+		assertPayloads(t, testFeed, nil)
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		defer closeFeed(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.ExpectErr(t,
+			`could not load job with job id -1`,
+			`ALTER CHANGEFEED -1 ADD bar`,
+		)
+
+		sqlDB.Exec(t, `ALTER TABLE bar ADD COLUMN b INT`)
+		var alterTableJobID jobspb.JobID
+		sqlDB.QueryRow(t, `SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE'`).Scan(&alterTableJobID)
+		sqlDB.ExpectErr(t,
+			fmt.Sprintf(`job %d is not changefeed job`, alterTableJobID),
+			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar`, alterTableJobID),
+		)
+
+		sqlDB.ExpectErr(t,
+			fmt.Sprintf(`job %d is not paused`, feed.JobID()),
+			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar`, feed.JobID()),
+		)
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedDropAllTargetsError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo, bar`)
+		defer closeFeed(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.ExpectErr(t,
+			fmt.Sprintf(`cannot drop all targets for changefeed job %d`, feed.JobID()),
+			fmt.Sprintf(`ALTER CHANGEFEED %d DROP foo, bar`, feed.JobID()),
+		)
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -122,28 +122,8 @@ func changefeedPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		if err := featureflag.CheckEnabled(
-			ctx,
-			p.ExecCfg(),
-			featureChangefeedEnabled,
-			"CHANGEFEED",
-		); err != nil {
+		if err := validateSettings(ctx, p); err != nil {
 			return err
-		}
-
-		// Changefeeds are based on the Rangefeed abstraction, which
-		// requires the `kv.rangefeed.enabled` setting to be true.
-		if !kvserver.RangefeedEnabled.Get(&p.ExecCfg().Settings.SV) {
-			return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
-				docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
-		}
-
-		ok, err := p.HasRoleOption(ctx, roleoption.CONTROLCHANGEFEED)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return pgerror.New(pgcode.InsufficientPrivilege, "permission denied to create changefeed")
 		}
 
 		sinkURI, err := sinkURIFn()
@@ -196,63 +176,15 @@ func changefeedPlanHook(
 			statementTime = initialHighWater
 		}
 
-		// For now, disallow targeting a database or wildcard table selection.
-		// Getting it right as tables enter and leave the set over time is
-		// tricky.
-		if len(changefeedStmt.Targets.Databases) > 0 {
-			return errors.Errorf(`CHANGEFEED cannot target %s`,
-				tree.AsString(&changefeedStmt.Targets))
-		}
-		for _, t := range changefeedStmt.Targets.Tables {
-			p, err := t.NormalizeTablePattern()
-			if err != nil {
-				return err
-			}
-			if _, ok := p.(*tree.TableName); !ok {
-				return errors.Errorf(`CHANGEFEED cannot target %s`, tree.AsString(t))
-			}
-		}
-
 		// This grabs table descriptors once to get their ids.
-		targetDescs, _, err := backupresolver.ResolveTargetsToDescriptors(
-			ctx, p, statementTime, &changefeedStmt.Targets)
+		targetDescs, err := getTableDescriptors(ctx, p, &changefeedStmt.Targets, statementTime, initialHighWater)
 		if err != nil {
-			var m *backupresolver.MissingTableErr
-			if errors.As(err, &m) {
-				tableName := m.GetTableName()
-				err = errors.Errorf("table %q does not exist", tableName)
-			}
-			err = errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")
-			if !initialHighWater.IsEmpty() {
-				// We specified cursor -- it is possible the targets do not exist at that time.
-				// Give a bit more context in the error message.
-				err = errors.WithHintf(err,
-					"do the targets exist at the specified cursor time %s?", initialHighWater)
-			}
 			return err
 		}
 
-		targets := make(jobspb.ChangefeedTargets, len(targetDescs))
-		for _, desc := range targetDescs {
-			if table, isTable := desc.(catalog.TableDescriptor); isTable {
-				if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
-					return err
-				}
-				_, qualified := opts[changefeedbase.OptFullTableName]
-				name, err := getChangefeedTargetName(ctx, table, p.ExecCfg(), p.ExtendedEvalContext().Txn, qualified)
-				if err != nil {
-					return err
-				}
-				targets[table.GetID()] = jobspb.ChangefeedTarget{
-					StatementTimeName: name,
-				}
-				if err := changefeedbase.ValidateTable(targets, table); err != nil {
-					return err
-				}
-				for _, warning := range changefeedbase.WarningsForTable(targets, table, opts) {
-					p.BufferClientNotice(ctx, pgnotice.Newf("%s", warning))
-				}
-			}
+		targets, err := getTargets(ctx, p, targetDescs, opts)
+		if err != nil {
+			return err
 		}
 
 		details := jobspb.ChangefeedDetails{
@@ -376,34 +308,13 @@ func changefeedPlanHook(
 
 		telemetry.Count(`changefeed.create.enterprise`)
 
-		metrics := p.ExecCfg().JobRegistry.MetricsStruct().Changefeed.(*Metrics)
-		sli, err := metrics.getSLIMetrics(opts[changefeedbase.OptMetricsScope])
-		if err != nil {
-			return err
-		}
-
 		// In the case where a user is executing a CREATE CHANGEFEED and is still
 		// waiting for the statement to return, we take the opportunity to ensure
 		// that the user has not made any obvious errors when specifying the sink in
 		// the CREATE CHANGEFEED statement. To do this, we create a "canary" sink,
 		// which will be immediately closed, only to check for errors.
-		{
-			var nilOracle timestampLowerBoundOracle
-			canarySink, err := getSink(ctx, &p.ExecCfg().DistSQLSrv.ServerConfig, details,
-				nilOracle, p.User(), jobspb.InvalidJobID, sli)
-			if err != nil {
-				return changefeedbase.MaybeStripRetryableErrorMarker(err)
-			}
-			if err := canarySink.Close(); err != nil {
-				return err
-			}
-			if sink, ok := canarySink.(SinkWithTopics); ok {
-				topics := sink.Topics()
-				for _, topic := range topics {
-					p.BufferClientNotice(ctx, pgnotice.Newf(`changefeed will emit to topic %s`, topic))
-				}
-				details.Opts[changefeedbase.Topics] = strings.Join(topics, ",")
-			}
+		if err := validateSink(ctx, p, jobspb.InvalidJobID, details, opts); err != nil {
+			return err
 		}
 
 		// The below block creates the job and if there's an initial scan, protects
@@ -491,6 +402,140 @@ func changefeedPlanHook(
 
 	}
 	return fn, header, nil, avoidBuffering, nil
+}
+
+func validateSettings(ctx context.Context, p sql.PlanHookState) error {
+	if err := featureflag.CheckEnabled(
+		ctx,
+		p.ExecCfg(),
+		featureChangefeedEnabled,
+		"CHANGEFEED",
+	); err != nil {
+		return err
+	}
+
+	// Changefeeds are based on the Rangefeed abstraction, which
+	// requires the `kv.rangefeed.enabled` setting to be true.
+	if !kvserver.RangefeedEnabled.Get(&p.ExecCfg().Settings.SV) {
+		return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
+			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
+	}
+
+	ok, err := p.HasRoleOption(ctx, roleoption.CONTROLCHANGEFEED)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return pgerror.New(pgcode.InsufficientPrivilege, "current user must have a role WITH CONTROLCHANGEFEED")
+	}
+
+	return nil
+}
+
+func getTableDescriptors(
+	ctx context.Context,
+	p sql.PlanHookState,
+	targets *tree.TargetList,
+	statementTime hlc.Timestamp,
+	initialHighWater hlc.Timestamp,
+) ([]catalog.Descriptor, error) {
+	// For now, disallow targeting a database or wildcard table selection.
+	// Getting it right as tables enter and leave the set over time is
+	// tricky.
+	if len(targets.Databases) > 0 {
+		return nil, errors.Errorf(`CHANGEFEED cannot target %s`,
+			tree.AsString(targets))
+	}
+	for _, t := range targets.Tables {
+		p, err := t.NormalizeTablePattern()
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := p.(*tree.TableName); !ok {
+			return nil, errors.Errorf(`CHANGEFEED cannot target %s`, tree.AsString(t))
+		}
+	}
+
+	// This grabs table descriptors once to get their ids.
+	targetDescs, _, err := backupresolver.ResolveTargetsToDescriptors(
+		ctx, p, statementTime, targets)
+	if err != nil {
+		var m *backupresolver.MissingTableErr
+		if errors.As(err, &m) {
+			tableName := m.GetTableName()
+			err = errors.Errorf("table %q does not exist", tableName)
+		}
+		err = errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")
+		if !initialHighWater.IsEmpty() {
+			// We specified cursor -- it is possible the targets do not exist at that time.
+			// Give a bit more context in the error message.
+			err = errors.WithHintf(err,
+				"do the targets exist at the specified cursor time %s?", initialHighWater)
+		}
+	}
+	return targetDescs, err
+}
+
+func getTargets(
+	ctx context.Context,
+	p sql.PlanHookState,
+	targetDescs []catalog.Descriptor,
+	opts map[string]string,
+) (jobspb.ChangefeedTargets, error) {
+	targets := make(jobspb.ChangefeedTargets, len(targetDescs))
+	for _, desc := range targetDescs {
+		if table, isTable := desc.(catalog.TableDescriptor); isTable {
+			if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
+				return nil, err
+			}
+			_, qualified := opts[changefeedbase.OptFullTableName]
+			name, err := getChangefeedTargetName(ctx, table, p.ExecCfg(), p.ExtendedEvalContext().Txn, qualified)
+			if err != nil {
+				return nil, err
+			}
+			targets[table.GetID()] = jobspb.ChangefeedTarget{
+				StatementTimeName: name,
+			}
+			if err := changefeedbase.ValidateTable(targets, table); err != nil {
+				return nil, err
+			}
+			for _, warning := range changefeedbase.WarningsForTable(targets, table, opts) {
+				p.BufferClientNotice(ctx, pgnotice.Newf("%s", warning))
+			}
+		}
+	}
+	return targets, nil
+}
+
+func validateSink(
+	ctx context.Context,
+	p sql.PlanHookState,
+	jobID jobspb.JobID,
+	details jobspb.ChangefeedDetails,
+	opts map[string]string,
+) error {
+	metrics := p.ExecCfg().JobRegistry.MetricsStruct().Changefeed.(*Metrics)
+	sli, err := metrics.getSLIMetrics(opts[changefeedbase.OptMetricsScope])
+	if err != nil {
+		return err
+	}
+	var nilOracle timestampLowerBoundOracle
+	canarySink, err := getSink(ctx, &p.ExecCfg().DistSQLSrv.ServerConfig, details,
+		nilOracle, p.User(), jobID, sli)
+	if err != nil {
+		return changefeedbase.MaybeStripRetryableErrorMarker(err)
+	}
+	if err := canarySink.Close(); err != nil {
+		return err
+	}
+	if sink, ok := canarySink.(SinkWithTopics); ok {
+		topics := sink.Topics()
+		for _, topic := range topics {
+			p.BufferClientNotice(ctx, pgnotice.Newf(`changefeed will emit to topic %s`, topic))
+		}
+		details.Opts[changefeedbase.Topics] = strings.Join(topics, ",")
+	}
+	return nil
 }
 
 func changefeedJobDescription(

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1724,7 +1724,7 @@ func TestChangefeedAuthorization(t *testing.T) {
 			rootDB.Exec(t, `create type type_a as enum ('a');`)
 			rootDB.Exec(t, `create table table_a (id int, type type_a);`)
 
-			guestDB.ExpectErr(t, `permission denied to create changefeed`, tc.statement)
+			guestDB.ExpectErr(t, `current user must have a role WITH CONTROLCHANGEFEED`, tc.statement)
 			feedCreatorDB.ExpectErr(t, `user feedcreator does not have SELECT privilege on relation table_a`, tc.statement)
 
 			// Actual success would hang in sinkless and require cleanup in enterprise, so checking for successful authorization

--- a/pkg/ccl/logictestccl/testdata/logic_test/changefeed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/changefeed
@@ -8,7 +8,7 @@ SET CLUSTER SETTING kv.rangefeed.enabled = true
 
 user testuser
 
-statement error permission denied to create changefeed
+statement error current user must have a role WITH CONTROLCHANGEFEED
 CREATE CHANGEFEED FOR t
 
 user root
@@ -33,5 +33,5 @@ ALTER USER testuser NOCONTROLCHANGEFEED
 
 user testuser
 
-statement error permission denied to create changefeed
+statement error current user must have a role WITH CONTROLCHANGEFEED
 CREATE CHANGEFEED FOR t

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -228,6 +228,7 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 
 func init() {
 	for _, stmt := range []tree.Statement{
+		&tree.AlterChangefeed{},
 		&tree.AlterDatabaseAddRegion{},
 		&tree.AlterDatabaseDropRegion{},
 		&tree.AlterDatabaseOwner{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -36,6 +36,10 @@ func TestContextualHelp(t *testing.T) {
 	}{
 		{`ALTER ??`, `ALTER`},
 
+		{`ALTER CHANGEFEED ??`, `ALTER CHANGEFEED`},
+		{`ALTER CHANGEFEED 123 ADD ??`, `ALTER CHANGEFEED`},
+		{`ALTER CHANGEFEED 123 DROP ??`, `ALTER CHANGEFEED`},
+
 		{`ALTER TABLE IF ??`, `ALTER TABLE`},
 		{`ALTER TABLE blah ??`, `ALTER TABLE`},
 		{`ALTER TABLE blah ADD ??`, `ALTER TABLE`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -543,6 +543,12 @@ func (u *sqlSymUnion) dir() tree.Direction {
 func (u *sqlSymUnion) nullsOrder() tree.NullsOrder {
     return u.val.(tree.NullsOrder)
 }
+func (u *sqlSymUnion) alterChangefeedCmd() tree.AlterChangefeedCmd {
+    return u.val.(tree.AlterChangefeedCmd)
+}
+func (u *sqlSymUnion) alterChangefeedCmds() tree.AlterChangefeedCmds {
+    return u.val.(tree.AlterChangefeedCmds)
+}
 func (u *sqlSymUnion) alterTableCmd() tree.AlterTableCmd {
     return u.val.(tree.AlterTableCmd)
 }
@@ -897,6 +903,7 @@ func (u *sqlSymUnion) setVar() *tree.SetVar {
 
 
 %type <tree.Statement> alter_stmt
+%type <tree.Statement> alter_changefeed_stmt
 %type <tree.Statement> alter_ddl_stmt
 %type <tree.Statement> alter_table_stmt
 %type <tree.Statement> alter_index_stmt
@@ -1142,6 +1149,9 @@ func (u *sqlSymUnion) setVar() *tree.SetVar {
 %type <tree.Expr> alter_column_visible
 %type <tree.Direction> opt_asc_desc
 %type <tree.NullsOrder> opt_nulls_order
+
+%type <tree.AlterChangefeedCmd> alter_changefeed_cmd
+%type <tree.AlterChangefeedCmds> alter_changefeed_cmds
 
 %type <tree.AlterTableCmd> alter_table_cmd
 %type <tree.AlterTableCmds> alter_table_cmds
@@ -1541,6 +1551,7 @@ alter_ddl_stmt:
 | alter_schema_stmt             // EXTEND WITH HELP: ALTER SCHEMA
 | alter_type_stmt               // EXTEND WITH HELP: ALTER TYPE
 | alter_default_privileges_stmt // EXTEND WITH HELP: ALTER DEFAULT PRIVILEGES
+| alter_changefeed_stmt         // EXTEND WITH HELP: ALTER CHANGEFEED
 
 // %Help: ALTER TABLE - change the definition of a table
 // %Category: DDL
@@ -4293,6 +4304,46 @@ explain_option_list:
 | explain_option_list ',' explain_option_name
   {
     $$.val = append($1.strs(), $3)
+  }
+
+// %Help: ALTER CHANGEFEED - alter an existing changefeed
+// %Category: CCL
+// %Text:
+// ALTER CHANGEFEED <job_id> {{ADD|DROP} <targets...>}...
+alter_changefeed_stmt:
+  ALTER CHANGEFEED a_expr alter_changefeed_cmds
+  {
+    $$.val = &tree.AlterChangefeed{
+      Jobs: $3.expr(),
+      Cmds: $4.alterChangefeedCmds(),
+    }
+  }
+| ALTER CHANGEFEED error // SHOW HELP: ALTER CHANGEFEED
+
+alter_changefeed_cmds:
+  alter_changefeed_cmd
+  {
+    $$.val = tree.AlterChangefeedCmds{$1.alterChangefeedCmd()}
+  }
+| alter_changefeed_cmds alter_changefeed_cmd
+  {
+    $$.val = append($1.alterChangefeedCmds(), $2.alterChangefeedCmd())
+  }
+
+alter_changefeed_cmd:
+  // ALTER CHANGEFEED <job_id> ADD [TABLE] ...
+  ADD changefeed_targets
+  {
+    $$.val = &tree.AlterChangefeedAddTarget{
+      Targets: $2.targetList(),
+    }
+  }
+  // ALTER CHANGEFEED <job_id> DROP [TABLE] ...
+| DROP changefeed_targets
+  {
+    $$.val = &tree.AlterChangefeedDropTarget{
+      Targets: $2.targetList(),
+    }
   }
 
 // %Help: PREPARE - prepare a statement for later execution

--- a/pkg/sql/parser/testdata/alter_changefeed
+++ b/pkg/sql/parser/testdata/alter_changefeed
@@ -1,0 +1,58 @@
+parse
+ALTER CHANGEFEED 123 ADD foo
+----
+ALTER CHANGEFEED 123 ADD foo
+ALTER CHANGEFEED (123) ADD (foo) -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo -- literals removed
+ALTER CHANGEFEED 123 ADD _ -- identifiers removed
+
+
+parse
+ALTER CHANGEFEED 123 DROP foo
+----
+ALTER CHANGEFEED 123 DROP foo
+ALTER CHANGEFEED (123) DROP (foo) -- fully parenthesized
+ALTER CHANGEFEED _ DROP foo -- literals removed
+ALTER CHANGEFEED 123 DROP _ -- identifiers removed
+
+
+parse
+ALTER CHANGEFEED 123 ADD foo DROP bar
+----
+ALTER CHANGEFEED 123 ADD foo  DROP bar -- normalized!
+ALTER CHANGEFEED (123) ADD (foo)  DROP (bar) -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo  DROP bar -- literals removed
+ALTER CHANGEFEED 123 ADD _  DROP _ -- identifiers removed
+
+
+parse
+ALTER CHANGEFEED 123 DROP foo ADD bar
+----
+ALTER CHANGEFEED 123 DROP foo  ADD bar -- normalized!
+ALTER CHANGEFEED (123) DROP (foo)  ADD (bar) -- fully parenthesized
+ALTER CHANGEFEED _ DROP foo  ADD bar -- literals removed
+ALTER CHANGEFEED 123 DROP _  ADD _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo, bar
+----
+ALTER CHANGEFEED 123 ADD foo, bar
+ALTER CHANGEFEED (123) ADD (foo), (bar) -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo, bar -- literals removed
+ALTER CHANGEFEED 123 ADD _, _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 DROP foo, bar ADD baz, qux
+----
+ALTER CHANGEFEED 123 DROP foo, bar  ADD baz, qux -- normalized!
+ALTER CHANGEFEED (123) DROP (foo), (bar)  ADD (baz), (qux) -- fully parenthesized
+ALTER CHANGEFEED _ DROP foo, bar  ADD baz, qux -- literals removed
+ALTER CHANGEFEED 123 DROP _, _  ADD _, _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo DROP bar ADD baz, qux DROP quux
+----
+ALTER CHANGEFEED 123 ADD foo  DROP bar  ADD baz, qux  DROP quux -- normalized!
+ALTER CHANGEFEED (123) ADD (foo)  DROP (bar)  ADD (baz), (qux)  DROP (quux) -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo  DROP bar  ADD baz, qux  DROP quux -- literals removed
+ALTER CHANGEFEED 123 ADD _  DROP _  ADD _, _  DROP _ -- identifiers removed

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     name = "tree",
     srcs = [
         "aggregate_funcs.go",
+        "alter_changefeed.go",
         "alter_database.go",
         "alter_default_privileges.go",
         "alter_index.go",

--- a/pkg/sql/sem/tree/alter_changefeed.go
+++ b/pkg/sql/sem/tree/alter_changefeed.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// AlterChangefeed represents an ALTER CHANGEFEED statement.
+type AlterChangefeed struct {
+	Jobs Expr
+	Cmds AlterChangefeedCmds
+}
+
+var _ Statement = &AlterChangefeed{}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterChangefeed) Format(ctx *FmtCtx) {
+	ctx.WriteString(`ALTER CHANGEFEED `)
+	ctx.FormatNode(node.Jobs)
+	ctx.FormatNode(&node.Cmds)
+}
+
+// AlterChangefeedCmds represents a list of changefeed alterations
+type AlterChangefeedCmds []AlterChangefeedCmd
+
+// Format implements the NodeFormatter interface.
+func (node *AlterChangefeedCmds) Format(ctx *FmtCtx) {
+	for i, n := range *node {
+		if i > 0 {
+			ctx.WriteString(" ")
+		}
+		ctx.FormatNode(n)
+	}
+}
+
+// AlterChangefeedCmd represents a changefeed modification operation.
+type AlterChangefeedCmd interface {
+	NodeFormatter
+	// Placeholder function to ensure that only desired types
+	// (AlterChangefeed*) conform to the AlterChangefeedCmd interface.
+	alterChangefeedCmd()
+}
+
+func (*AlterChangefeedAddTarget) alterChangefeedCmd()  {}
+func (*AlterChangefeedDropTarget) alterChangefeedCmd() {}
+
+var _ AlterChangefeedCmd = &AlterChangefeedAddTarget{}
+var _ AlterChangefeedCmd = &AlterChangefeedDropTarget{}
+
+// AlterChangefeedAddTarget represents an ADD <targets> command
+type AlterChangefeedAddTarget struct {
+	Targets TargetList
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterChangefeedAddTarget) Format(ctx *FmtCtx) {
+	ctx.WriteString(" ADD ")
+	ctx.FormatNode(&node.Targets.Tables)
+}
+
+// AlterChangefeedDropTarget represents an DROP <targets> command
+type AlterChangefeedDropTarget struct {
+	Targets TargetList
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterChangefeedDropTarget) Format(ctx *FmtCtx) {
+	ctx.WriteString(" DROP ")
+	ctx.FormatNode(&node.Targets.Tables)
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -171,11 +171,23 @@ var _ CCLOnlyStatement = &Backup{}
 var _ CCLOnlyStatement = &ShowBackup{}
 var _ CCLOnlyStatement = &Restore{}
 var _ CCLOnlyStatement = &CreateChangefeed{}
+var _ CCLOnlyStatement = &AlterChangefeed{}
 var _ CCLOnlyStatement = &Import{}
 var _ CCLOnlyStatement = &Export{}
 var _ CCLOnlyStatement = &ScheduledBackup{}
 var _ CCLOnlyStatement = &StreamIngestion{}
 var _ CCLOnlyStatement = &ReplicationStream{}
+
+// StatementReturnType implements the Statement interface.
+func (*AlterChangefeed) StatementReturnType() StatementReturnType { return Rows }
+
+// StatementType implements the Statement interface.
+func (*AlterChangefeed) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterChangefeed) StatementTag() string { return `ALTER CHANGEFEED` }
+
+func (*AlterChangefeed) cclOnlyStatement() {}
 
 // StatementReturnType implements the Statement interface.
 func (*AlterDatabaseOwner) StatementReturnType() StatementReturnType { return DDL }
@@ -1648,6 +1660,8 @@ func (*ValuesClause) StatementType() StatementType { return TypeDML }
 // StatementTag returns a short string identifying the type of statement.
 func (*ValuesClause) StatementTag() string { return "VALUES" }
 
+func (n *AlterChangefeed) String() string                { return AsString(n) }
+func (n *AlterChangefeedCmds) String() string            { return AsString(n) }
 func (n *AlterIndex) String() string                     { return AsString(n) }
 func (n *AlterDatabaseOwner) String() string             { return AsString(n) }
 func (n *AlterDatabaseAddRegion) String() string         { return AsString(n) }


### PR DESCRIPTION
This PR introduces a new SQL statement called ALTER
CHANGEFEED, which allows users to add/drop targets
for an existing changefeed. Note that the changefeed
job must be paused in order for the alterations to
be applied to the changefeed. The syntax of the
statement is as follows:

ALTER CHANGEFEED <job_id> {{ADD|DROP} \<targets\>}...

Where there can be an arbitrary number of ADD/
DROP commands in any order. Once a user
executes this statement, the targets will be
added/dropped, and the statement will return the
job id and the new job description of the changefeed
job. It is also important to note that a user cannot
drop all targets in a changefeed.

Example:
ALTER CHANGEFEED 123 ADD foo,bar DROP baz;

Release note (enterprise change): Added support
for a new SQL statement called ALTER CHANGEFEED,
which allows users to add/drop targets for an
existing changefeed. The syntax of the statement
is as follows:

ALTER CHANGEFEED <job_id> {{ADD|DROP} \<targets\>}...

Where there can be an abritrary number of ADD/DROP
commands in any order. The following is an example
of this statement:

ALTER CHANGEFEED 123 ADD foo,bar DROP baz;

With this statement, users can avoid going through
the process of altering a changefeed on their own,
and rely on CRDB to carry out this task.