### PR TITLE
roachtest/follower_reads: unskip follower-reads/mixed-version/single-region

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -90,7 +90,6 @@ func registerFollowerReads(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Skip:  "https://github.com/cockroachdb/cockroach/issues/69817",
 		Name:  "follower-reads/mixed-version/single-region",
 		Owner: registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(


### PR DESCRIPTION
It should have been unskipped with the rest of the follower reads tests
when #69817 was closed.

Release note: None