### PR TITLE
roachprod: add cockroach-roachstress GCE project to GC cronjob

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -34,7 +34,7 @@ spec:
               image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:master
               args:
                 - gc
-                - --gce-project=cockroach-ephemeral,andrei-jepsen
+                - --gce-project=cockroach-ephemeral,andrei-jepsen,cockroach-roachstress
                 - --slack-token
                 - $(SLACK_TOKEN)
               env:


### PR DESCRIPTION
Roachtest Stress runs nightly in TC; to reduce the chance of
resource exhaustion, these tests are executed in cockroach-roachstress
project whereas roachtests are normally executed in cockroach-ephemeral.
Thus, to ensure all resources are eventually GCed, we add
cockroach-roachstress to the list of currently GCed projects.

Release note: None