### PR TITLE
release-21.2: backupccl: backup processor goroutines may outlive the processor

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -114,6 +114,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/retry",
         "//pkg/util/span",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",


### PR DESCRIPTION
Backport 2/7 commits from #72624.

/cc @cockroachdb/release

---

See individual commits.
This is all happening because I want to make using Spans after they've been FInish()ed less tolerated than it has historically been.

Fixes: https://github.com/cockroachdb/cockroach/issues/75754

Release justification (bug fix): goroutines spawned by the backup processor
were mutating BoundAccounts used for memory monitoring, after the BoundAccount
was closed by the processor on shutdown. To prevent this, we teach the processor
to wait for all goroutines to terminate before running its cleanup on shutdown.
