### PR TITLE
backup: added support for Google Cloud KMS to encrypt backups

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,6 +55,7 @@ exports_files([
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/caller_test @cockroach//pkg/util/caller:caller_test
 # gazelle:resolve go github.com/cockroachdb/cockroach/pkg/util/json_test @cockroach//pkg/util/json:json_test
 # gazelle:resolve go google.golang.org/genproto/googleapis/pubsub/v1 @org_golang_google_genproto//googleapis/pubsub/v1:pubsub
+# gazelle:resolve go google.golang.org/genproto/googleapis/cloud/kms/v1 @org_golang_google_genproto//googleapis/cloud/kms/v1:kms
 
 # These packages use github.com/golang/mock to generate mocks. The target
 # generating mocks for a given package necessarily depends on the package's

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 
 require (
 	cloud.google.com/go v0.99.0 // indirect
-	cloud.google.com/go/kms v1.1.0 // indirect
+	cloud.google.com/go/kms v1.1.0
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "external_storage.go",
         "impl_registry.go",
         "kms.go",
+        "kms_test_utils.go",
         "uris.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud",
@@ -26,5 +27,6 @@ go_library(
         "//pkg/util/sysutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     name = "amazon_test",
     srcs = [
         "aws_kms_test.go",
-        "kms_test.go",
         "s3_storage_test.go",
     ],
     embed = [":amazon"],

--- a/pkg/cloud/amazon/aws_kms_test.go
+++ b/pkg/cloud/amazon/aws_kms_test.go
@@ -80,7 +80,7 @@ func TestEncryptDecryptAWS(t *testing.T) {
 			params.Add(KMSRegionParam, kmsRegion)
 
 			uri := fmt.Sprintf("aws:///%s?%s", keyID, params.Encode())
-			_, err := cloud.KMSFromURI(uri, &testKMSEnv{externalIOConfig: &base.ExternalIODirConfig{}})
+			_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
 			require.EqualError(t, err, fmt.Sprintf(
 				`%s is set to '%s', but %s is not set`,
 				cloud.AuthParam,
@@ -106,8 +106,9 @@ func TestEncryptDecryptAWS(t *testing.T) {
 			params.Add(KMSRegionParam, kmsRegion)
 
 			uri := fmt.Sprintf("aws:///%s?%s", keyID, params.Encode())
-			testEncryptDecrypt(t, uri, testKMSEnv{
-				cluster.NoSettings, &base.ExternalIODirConfig{},
+			cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+				Settings:         cluster.NoSettings,
+				ExternalIOConfig: &base.ExternalIODirConfig{},
 			})
 		})
 
@@ -116,8 +117,9 @@ func TestEncryptDecryptAWS(t *testing.T) {
 			q.Set(cloud.AuthParam, cloud.AuthParamSpecified)
 			uri := fmt.Sprintf("aws:///%s?%s", keyID, q.Encode())
 
-			testEncryptDecrypt(t, uri, testKMSEnv{
-				cluster.NoSettings, &base.ExternalIODirConfig{},
+			cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+				Settings:         cluster.NoSettings,
+				ExternalIOConfig: &base.ExternalIODirConfig{},
 			})
 		})
 	}
@@ -148,15 +150,17 @@ func TestPutAWSKMSEndpoint(t *testing.T) {
 
 	t.Run("allow-endpoints", func(t *testing.T) {
 		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
-		testEncryptDecrypt(t, uri, testKMSEnv{
-			awsKMSTestSettings, &base.ExternalIODirConfig{},
+		cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+			Settings:         awsKMSTestSettings,
+			ExternalIOConfig: &base.ExternalIODirConfig{},
 		})
 	})
 
 	t.Run("disallow-endpoints", func(t *testing.T) {
 		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
-		_, err := cloud.KMSFromURI(uri, &testKMSEnv{awsKMSTestSettings,
-			&base.ExternalIODirConfig{DisableHTTP: true}})
+		_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+			Settings:         awsKMSTestSettings,
+			ExternalIOConfig: &base.ExternalIODirConfig{DisableHTTP: true}})
 		require.True(t, testutils.IsError(err, "custom endpoints disallowed"))
 	})
 }
@@ -174,7 +178,8 @@ func TestAWSKMSDisallowImplicitCredentials(t *testing.T) {
 		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN_A env var must be set")
 	}
 	uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
-	_, err := cloud.KMSFromURI(uri, &testKMSEnv{cluster.NoSettings,
-		&base.ExternalIODirConfig{DisableImplicitCredentials: true}})
+	_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+		Settings:         cluster.NoSettings,
+		ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
 	require.True(t, testutils.IsError(err, "implicit credentials disallowed"))
 }

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "gcp",
-    srcs = ["gcs_storage.go"],
+    srcs = [
+        "gcs_kms.go",
+        "gcs_storage.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/gcp",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,16 +19,22 @@ go_library(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//types",
+        "@com_google_cloud_go_kms//apiv1",
         "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//iterator",
         "@org_golang_google_api//option",
+        "@org_golang_google_genproto//googleapis/cloud/kms/v1:kms",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
         "@org_golang_x_oauth2//google",
     ],
 )
 
 go_test(
     name = "gcp_test",
-    srcs = ["gcs_storage_test.go"],
+    srcs = [
+        "gcs_kms_test.go",
+        "gcs_storage_test.go",
+    ],
     embed = [":gcp"],
     deps = [
         "//pkg/base",

--- a/pkg/cloud/gcp/gcs_kms.go
+++ b/pkg/cloud/gcp/gcs_kms.go
@@ -1,0 +1,195 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gcp
+
+import (
+	"context"
+	"encoding/base64"
+	"hash/crc32"
+	"net/url"
+	"strings"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/api/option"
+	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+const gcsScheme = "gs"
+
+type gcsKMS struct {
+	kms                 *kms.KeyManagementClient
+	customerMasterKeyID string
+}
+
+var _ cloud.KMS = &gcsKMS{}
+
+func init() {
+	cloud.RegisterKMSFromURIFactory(MakeGCSKMS, gcsScheme)
+}
+
+type kmsURIParams struct {
+	credentials string
+	auth        string
+}
+
+func resolveKMSURIParams(kmsURI url.URL) kmsURIParams {
+	params := kmsURIParams{
+		credentials: kmsURI.Query().Get(CredentialsParam),
+		auth:        kmsURI.Query().Get(cloud.AuthParam),
+	}
+
+	return params
+}
+
+// MakeGCSKMS is the factory method which returns a configured, ready-to-use
+// GCS KMS object.
+func MakeGCSKMS(uri string, env cloud.KMSEnv) (cloud.KMS, error) {
+	if env.KMSConfig().DisableOutbound {
+		return nil, errors.New("external IO must be enabled to use GCS KMS")
+	}
+	kmsURI, err := url.ParseRequestURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the URI parameters required to setup the GCS KMS session.
+	kmsURIParams := resolveKMSURIParams(*kmsURI)
+
+	// Client options to authenticate and start a GCS KMS session.
+	// Currently only accepting json of service account.
+	var credentialsOpt []option.ClientOption
+
+	switch kmsURIParams.auth {
+	case "", cloud.AuthParamSpecified:
+		if kmsURIParams.credentials == "" {
+			return nil, errors.Errorf(
+				"%s is set to '%s', but %s is not set",
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				CredentialsParam,
+			)
+		}
+
+		// Credentials are passed in base64 encoded, so decode the credentials first.
+		credentialsJSON, err := base64.StdEncoding.DecodeString(kmsURIParams.credentials)
+		if err != nil {
+			return nil, err
+		}
+
+		credentialsOpt = append(credentialsOpt, option.WithCredentialsJSON(credentialsJSON))
+	case cloud.AuthParamImplicit:
+		if env.KMSConfig().DisableImplicitCredentials {
+			return nil, errors.New(
+				"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag")
+		}
+		// If implicit credentials used, no client options needed.
+	default:
+		return nil, errors.Errorf("unsupported value %s for %s", kmsURIParams.auth, cloud.AuthParam)
+	}
+
+	ctx := context.Background()
+
+	kmc, err := kms.NewKeyManagementClient(ctx, credentialsOpt...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the key version from the cmk if it's present.
+	// https://cloud.google.com/sdk/gcloud/reference/kms/decrypt
+	// - For symmetric keys, Cloud KMS detects the decryption key version from the ciphertext.
+	//   If you specify a key version as part of a symmetric decryption request,
+	//   an error is logged and decryption fails.
+	cmkID := strings.Split(kmsURI.Path, "/cryptoKeyVersions/")[0]
+
+	return &gcsKMS{
+		kms:                 kmc,
+		customerMasterKeyID: strings.TrimPrefix(cmkID, "/"),
+	}, nil
+}
+
+// MasterKeyID implements the KMS interface.
+func (k *gcsKMS) MasterKeyID() (string, error) {
+	return k.customerMasterKeyID, nil
+}
+
+// Encrypt implements the KMS interface.
+func (k *gcsKMS) Encrypt(ctx context.Context, data []byte) ([]byte, error) {
+	// Optional but recommended by GCS.
+	crc32c := func(data []byte) uint32 {
+		t := crc32.MakeTable(crc32.Castagnoli)
+		return crc32.Checksum(data, t)
+	}
+	plaintextCRC32C := crc32c(data)
+
+	encryptInput := &kmspb.EncryptRequest{
+		Name:            k.customerMasterKeyID,
+		Plaintext:       data,
+		PlaintextCrc32C: wrapperspb.Int64(int64(plaintextCRC32C)),
+	}
+
+	encryptOutput, err := k.kms.Encrypt(ctx, encryptInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional, but recommended by GCS.
+	// For more details on ensuring E2E in-transit integrity to and from Cloud KMS visit:
+	// https://cloud.google.com/kms/docs/data-integrity-guidelines
+	// TODO(darrylwong): Look into adding some exponential backoff retry behaviour if error is frequent
+	if !encryptOutput.VerifiedPlaintextCrc32C {
+		return nil, errors.Errorf("Encrypt: request corrupted in-transit")
+	}
+	if int64(crc32c(encryptOutput.Ciphertext)) != encryptOutput.CiphertextCrc32C.Value {
+		return nil, errors.Errorf("Encrypt: response corrupted in-transit")
+	}
+
+	return encryptOutput.Ciphertext, nil
+}
+
+// Decrypt implements the KMS interface.
+func (k *gcsKMS) Decrypt(ctx context.Context, data []byte) ([]byte, error) {
+	// Optional but recommended by the documentation
+	crc32c := func(data []byte) uint32 {
+		t := crc32.MakeTable(crc32.Castagnoli)
+		return crc32.Checksum(data, t)
+	}
+	ciphertextCRC32C := crc32c(data)
+
+	decryptInput := &kmspb.DecryptRequest{
+		Name:             k.customerMasterKeyID,
+		Ciphertext:       data,
+		CiphertextCrc32C: wrapperspb.Int64(int64(ciphertextCRC32C)),
+	}
+
+	decryptOutput, err := k.kms.Decrypt(ctx, decryptInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optional, but recommended: perform integrity verification on result.
+	// For more details on ensuring E2E in-transit integrity to and from Cloud KMS visit:
+	// https://cloud.google.com/kms/docs/data-integrity-guidelines
+	// TODO(darrylwong): Look into adding some exponential backoff retry behaviour if error is frequent
+	if int64(crc32c(decryptOutput.Plaintext)) != decryptOutput.PlaintextCrc32C.Value {
+		return nil, errors.Errorf("Decrypt: response corrupted in-transit")
+	}
+
+	return decryptOutput.Plaintext, nil
+}
+
+// Close implements the KMS interface.
+func (k *gcsKMS) Close() error {
+	return k.kms.Close()
+}

--- a/pkg/cloud/gcp/gcs_kms_test.go
+++ b/pkg/cloud/gcp/gcs_kms_test.go
@@ -1,0 +1,115 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package gcp
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecryptGCS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	q := make(url.Values)
+	expect := map[string]string{
+		"CREDENTIALS":                    CredentialsParam,
+		"GOOGLE_APPLICATION_CREDENTIALS": "GOOGLE_APPLICATION_CREDENTIALS",
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			skip.IgnoreLintf(t, "%s env var must be set", env)
+		}
+		q.Add(param, v)
+	}
+
+	// The KeyID for GCS is the following format:
+	// projects/{project name}/locations/{key region}/keyRings/{keyring name}/cryptoKeys/{key name}
+	// It can be specified as the following:
+	// - GCS_KEY_ID
+	// - GCS_KEY_NAME
+	for _, id := range []string{"GCS_KEY_ID", "GCS_KEY_NAME"} {
+		// Get GCS Key identifier from env variable.
+		keyID := os.Getenv(id)
+		if keyID == "" {
+			skip.IgnoreLint(t, fmt.Sprintf("%s env var must be set", id))
+		}
+
+		t.Run(fmt.Sprintf("auth-empty-no-cred-%s", id), func(t *testing.T) {
+			// Set AUTH to specified but don't provide CREDENTIALS params.
+			params := make(url.Values)
+			params.Add(cloud.AuthParam, cloud.AuthParamSpecified)
+
+			uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
+
+			_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
+			require.EqualError(t, err, fmt.Sprintf(
+				`%s is set to '%s', but %s is not set`,
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				CredentialsParam,
+			))
+		})
+
+		t.Run(fmt.Sprintf("auth-implicit-%s", id), func(t *testing.T) {
+			// Set the AUTH params.
+			params := make(url.Values)
+			params.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+
+			uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
+			cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+				Settings:         cluster.NoSettings,
+				ExternalIOConfig: &base.ExternalIODirConfig{},
+			})
+		})
+
+		t.Run(fmt.Sprintf("auth-specified-%s", id), func(t *testing.T) {
+			// Set AUTH to specified.
+			q.Set(cloud.AuthParam, cloud.AuthParamSpecified)
+			uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
+
+			cloud.KMSEncryptDecrypt(t, uri, cloud.TestKMSEnv{
+				Settings:         cluster.NoSettings,
+				ExternalIOConfig: &base.ExternalIODirConfig{},
+			})
+		})
+	}
+}
+
+func TestGCSKMSDisallowImplicitCredentials(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	q := make(url.Values)
+
+	// Set AUTH to implicit.
+	q.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+	for _, id := range []string{"GCS_KEY_ID", "GCS_KEY_NAME"} {
+		keyID := os.Getenv(id)
+		if keyID == "" {
+			skip.IgnoreLint(t, "%s env var must be set", id)
+		}
+		uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
+		_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+			Settings:         cluster.NoSettings,
+			ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
+		require.True(t, testutils.IsError(err,
+			"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag"),
+		)
+	}
+}

--- a/pkg/cloud/kms_test_utils.go
+++ b/pkg/cloud/kms_test_utils.go
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-package amazon
+
+package cloud
 
 import (
 	"bytes"
@@ -15,29 +16,33 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/stretchr/testify/require"
 )
 
-type testKMSEnv struct {
-	settings         *cluster.Settings
-	externalIOConfig *base.ExternalIODirConfig
+// TestKMSEnv holds the KMS configuration and the cluster settings
+type TestKMSEnv struct {
+	Settings         *cluster.Settings
+	ExternalIOConfig *base.ExternalIODirConfig
 }
 
-var _ cloud.KMSEnv = &testKMSEnv{}
+var _ KMSEnv = &TestKMSEnv{}
 
-func (e *testKMSEnv) ClusterSettings() *cluster.Settings {
-	return e.settings
+// ClusterSettings returns the cluster settings
+func (e *TestKMSEnv) ClusterSettings() *cluster.Settings {
+	return e.Settings
 }
 
-func (e *testKMSEnv) KMSConfig() *base.ExternalIODirConfig {
-	return e.externalIOConfig
+// KMSConfig returns the configurable settings of the KMS
+func (e *TestKMSEnv) KMSConfig() *base.ExternalIODirConfig {
+	return e.ExternalIOConfig
 }
 
-func testEncryptDecrypt(t *testing.T, kmsURI string, env testKMSEnv) {
+// KMSEncryptDecrypt is the method used to test if the given KMS can
+// correctly encrypt and decrypt a string
+func KMSEncryptDecrypt(t *testing.T, kmsURI string, env TestKMSEnv) {
 	ctx := context.Background()
-	kms, err := cloud.KMSFromURI(kmsURI, &env)
+	kms, err := KMSFromURI(kmsURI, &env)
 	require.NoError(t, err)
 
 	t.Run("simple encrypt decrypt", func(t *testing.T) {
@@ -50,5 +55,7 @@ func testEncryptDecrypt(t *testing.T, kmsURI string, env testKMSEnv) {
 		require.NoError(t, err)
 
 		require.True(t, bytes.Equal(decryptedBytes, []byte(sampleBytes)))
+
+		require.NoError(t, kms.Close())
 	})
 }

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -158,6 +158,7 @@ go_library(
         "//pkg/cli",
         "//pkg/cloud",
         "//pkg/cloud/amazon",
+        "//pkg/cloud/gcp",
         "//pkg/clusterversion",
         "//pkg/cmd/cmpconn",
         "//pkg/cmd/roachtest/cluster",

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -13,6 +13,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -23,6 +24,7 @@ import (
 
 	cloudstorage "github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/amazon"
+	"github.com/cockroachdb/cockroach/pkg/cloud/gcp"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
@@ -41,10 +43,13 @@ import (
 // configuration for the nightly roachtests. Any changes must be made to both
 // references of the name.
 const (
-	KMSRegionAEnvVar = "AWS_KMS_REGION_A"
-	KMSRegionBEnvVar = "AWS_KMS_REGION_B"
-	KMSKeyARNAEnvVar = "AWS_KMS_KEY_ARN_A"
-	KMSKeyARNBEnvVar = "AWS_KMS_KEY_ARN_B"
+	KMSRegionAEnvVar  = "AWS_KMS_REGION_A"
+	KMSRegionBEnvVar  = "AWS_KMS_REGION_B"
+	KMSKeyARNAEnvVar  = "AWS_KMS_KEY_ARN_A"
+	KMSKeyARNBEnvVar  = "AWS_KMS_KEY_ARN_B"
+	KMSKeyNameAEnvVar = "GOOGLE_KMS_KEY_A"
+	KMSKeyNameBEnvVar = "GOOGLE_KMS_KEY_B"
+	KMSGCSCredentials = "GOOGLE_EPHEMERAL_CREDENTIALS"
 
 	// rows2TiB is the number of rows to import to load 2TB of data (when
 	// replicated).
@@ -281,120 +286,142 @@ func registerBackup(r registry.Registry) {
 	})
 
 	KMSSpec := r.MakeClusterSpec(3)
-	r.Add(registry.TestSpec{
-		Name:    fmt.Sprintf("backup/KMS/%s", KMSSpec.String()),
-		Owner:   registry.OwnerBulkIO,
-		Cluster: KMSSpec,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().Cloud == spec.GCE {
-				t.Skip("backupKMS roachtest is only configured to run on AWS", "")
-			}
+	for _, item := range []struct {
+		kmsProvider string
+		machine     string
+	}{
+		{kmsProvider: "GCS", machine: spec.GCE},
+		{kmsProvider: "AWS", machine: spec.AWS},
+	} {
+		item := item
+		r.Add(registry.TestSpec{
+			Name:    fmt.Sprintf("backup/KMS/%s/%s", item.kmsProvider, KMSSpec.String()),
+			Owner:   registry.OwnerBulkIO,
+			Cluster: KMSSpec,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				if c.Spec().Cloud != item.machine {
+					t.Skip("backupKMS roachtest is only configured to run on "+item.machine, "")
+				}
 
-			// ~10GiB - which is 30Gib replicated.
-			rows := rows30GiB
-			if c.IsLocal() {
-				rows = 100
-			}
-			dest := importBankData(ctx, rows, t, c)
+				// ~10GiB - which is 30Gib replicated.
+				rows := rows30GiB
+				if c.IsLocal() {
+					rows = 100
+				}
+				dest := importBankData(ctx, rows, t, c)
 
-			conn := c.Conn(ctx, t.L(), 1)
-			m := c.NewMonitor(ctx)
-			m.Go(func(ctx context.Context) error {
-				_, err := conn.ExecContext(ctx, `
+				conn := c.Conn(ctx, t.L(), 1)
+				m := c.NewMonitor(ctx)
+				m.Go(func(ctx context.Context) error {
+					_, err := conn.ExecContext(ctx, `
 					CREATE DATABASE restoreA;
 					CREATE DATABASE restoreB;
 				`)
-				return err
-			})
-			m.Wait()
-
-			var kmsURIA, kmsURIB string
-			var err error
-			m = c.NewMonitor(ctx)
-			m.Go(func(ctx context.Context) error {
-				t.Status(`running encrypted backup`)
-				kmsURIA, err = getAWSKMSURI(KMSRegionAEnvVar, KMSKeyARNAEnvVar)
-				if err != nil {
 					return err
-				}
+				})
+				m.Wait()
+				var kmsURIA, kmsURIB string
+				var err error
+				backupPath := fmt.Sprintf("nodelocal://1/kmsbackup/%s/%s", item.kmsProvider, dest)
 
-				kmsURIB, err = getAWSKMSURI(KMSRegionBEnvVar, KMSKeyARNBEnvVar)
-				if err != nil {
-					return err
-				}
+				m = c.NewMonitor(ctx)
+				m.Go(func(ctx context.Context) error {
+					switch item.kmsProvider {
+					case "AWS":
+						t.Status(`running encrypted backup with AWS KMS`)
+						kmsURIA, err = getAWSKMSURI(KMSRegionAEnvVar, KMSKeyARNAEnvVar)
+						if err != nil {
+							return err
+						}
 
-				kmsOptions := fmt.Sprintf("KMS=('%s', '%s')", kmsURIA, kmsURIB)
-				_, err := conn.ExecContext(ctx,
-					`BACKUP bank.bank TO 'nodelocal://1/kmsbackup/`+dest+`' WITH `+kmsOptions)
-				return err
-			})
-			m.Wait()
+						kmsURIB, err = getAWSKMSURI(KMSRegionBEnvVar, KMSKeyARNBEnvVar)
+						if err != nil {
+							return err
+						}
+					case "GCS":
+						t.Status(`running encrypted backup with GCS KMS`)
+						kmsURIA, err = getGCSKMSURI(KMSKeyNameAEnvVar)
+						if err != nil {
+							return err
+						}
 
-			// Restore the encrypted BACKUP using each of KMS URI A and B separately.
-			m = c.NewMonitor(ctx)
-			m.Go(func(ctx context.Context) error {
-				t.Status(`restore using KMSURIA`)
-				if _, err := conn.ExecContext(ctx,
-					`RESTORE bank.bank FROM $1 WITH into_db=restoreA, kms=$2`,
-					`nodelocal://1/kmsbackup/`+dest, kmsURIA,
-				); err != nil {
-					return err
-				}
-
-				t.Status(`restore using KMSURIB`)
-				if _, err := conn.ExecContext(ctx,
-					`RESTORE bank.bank FROM $1 WITH into_db=restoreB, kms=$2`,
-					`nodelocal://1/kmsbackup/`+dest, kmsURIB,
-				); err != nil {
-					return err
-				}
-
-				t.Status(`fingerprint`)
-				fingerprint := func(db string) (string, error) {
-					var b strings.Builder
-
-					query := fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.%s", db, "bank")
-					rows, err := conn.QueryContext(ctx, query)
-					if err != nil {
-						return "", err
+						kmsURIB, err = getGCSKMSURI(KMSKeyNameBEnvVar)
+						if err != nil {
+							return err
+						}
 					}
-					defer rows.Close()
-					for rows.Next() {
-						var name, fp string
-						if err := rows.Scan(&name, &fp); err != nil {
+
+					kmsOptions := fmt.Sprintf("KMS=('%s', '%s')", kmsURIA, kmsURIB)
+					_, err := conn.ExecContext(ctx, `BACKUP bank.bank TO '`+backupPath+`' WITH `+kmsOptions)
+					return err
+				})
+				m.Wait()
+
+				// Restore the encrypted BACKUP using each of KMS URI A and B separately.
+				m = c.NewMonitor(ctx)
+				m.Go(func(ctx context.Context) error {
+					t.Status(`restore using KMSURIA`)
+					if _, err := conn.ExecContext(ctx,
+						`RESTORE bank.bank FROM $1 WITH into_db=restoreA, kms=$2`,
+						backupPath, kmsURIA,
+					); err != nil {
+						return err
+					}
+
+					t.Status(`restore using KMSURIB`)
+					if _, err := conn.ExecContext(ctx,
+						`RESTORE bank.bank FROM $1 WITH into_db=restoreB, kms=$2`,
+						backupPath, kmsURIB,
+					); err != nil {
+						return err
+					}
+
+					t.Status(`fingerprint`)
+					fingerprint := func(db string) (string, error) {
+						var b strings.Builder
+
+						query := fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.%s", db, "bank")
+						rows, err := conn.QueryContext(ctx, query)
+						if err != nil {
 							return "", err
 						}
-						fmt.Fprintf(&b, "%s: %s\n", name, fp)
+						defer rows.Close()
+						for rows.Next() {
+							var name, fp string
+							if err := rows.Scan(&name, &fp); err != nil {
+								return "", err
+							}
+							fmt.Fprintf(&b, "%s: %s\n", name, fp)
+						}
+
+						return b.String(), rows.Err()
 					}
 
-					return b.String(), rows.Err()
-				}
+					originalBank, err := fingerprint("bank")
+					if err != nil {
+						return err
+					}
+					restoreA, err := fingerprint("restoreA")
+					if err != nil {
+						return err
+					}
+					restoreB, err := fingerprint("restoreB")
+					if err != nil {
+						return err
+					}
 
-				originalBank, err := fingerprint("bank")
-				if err != nil {
-					return err
-				}
-				restoreA, err := fingerprint("restoreA")
-				if err != nil {
-					return err
-				}
-				restoreB, err := fingerprint("restoreB")
-				if err != nil {
-					return err
-				}
-
-				if originalBank != restoreA {
-					return errors.Errorf("got %s, expected %s while comparing restoreA with originalBank", restoreA, originalBank)
-				}
-				if originalBank != restoreB {
-					return errors.Errorf("got %s, expected %s while comparing restoreB with originalBank", restoreB, originalBank)
-				}
-
-				return nil
-			})
-			m.Wait()
-		},
-	})
+					if originalBank != restoreA {
+						return errors.Errorf("got %s, expected %s while comparing restoreA with originalBank", restoreA, originalBank)
+					}
+					if originalBank != restoreB {
+						return errors.Errorf("got %s, expected %s while comparing restoreB with originalBank", restoreB, originalBank)
+					}
+					return nil
+				})
+				m.Wait()
+			},
+		})
+	}
 
 	// backupTPCC continuously runs TPCC, takes a full backup after some time,
 	// and incremental after more time. It then restores the two backups and
@@ -628,9 +655,35 @@ func getAWSKMSURI(regionEnvVariable, keyIDEnvVariable string) (string, error) {
 		return "", errors.Newf("env variable %s must be present to run the KMS test", keyIDEnvVariable)
 	}
 
-	// Set AUTH to implicit
+	// Set AUTH to specified
 	q.Add(cloudstorage.AuthParam, cloudstorage.AuthParamSpecified)
 	correctURI := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
+
+	return correctURI, nil
+}
+
+func getGCSKMSURI(keyIDEnvVariable string) (string, error) {
+	q := make(url.Values)
+	expect := map[string]string{
+		KMSGCSCredentials: gcp.CredentialsParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			return "", errors.Newf("env variable %s must be present to run the KMS test", env)
+		}
+		// Nightlies load in json file of credentials but we want base64 encoded
+		q.Add(param, base64.StdEncoding.EncodeToString([]byte(v)))
+	}
+
+	keyID := os.Getenv(keyIDEnvVariable)
+	if keyID == "" {
+		return "", errors.Newf("", "%s env var must be set", keyIDEnvVariable)
+	}
+
+	// Set AUTH to specified
+	q.Set(cloudstorage.AuthParam, cloudstorage.AuthParamSpecified)
+	correctURI := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
 
 	return correctURI, nil
 }


### PR DESCRIPTION
Now allows for encrypting backups and decrypting restores with Google Cloud KMS
Added Roachtests for GCS KMS encrypting and decrypting.

Release note (enterprise): Backup and Restore now allows for encryption/decryption with GCS KMS