### PR TITLE
logictest: randomize distsql_workmem in all configs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -459,17 +459,16 @@ query IIT
 SELECT "targetID", "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
-AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
-AND info NOT LIKE '%sql.stats.automatic_collection.enabled%'
-AND info NOT LIKE '%sql.defaults.vectorize%'
+AND info NOT LIKE '%version%'
+AND info NOT LIKE '%cluster.secret%'
+AND info NOT LIKE '%sql.defaults%'
+AND info NOT LIKE '%sql.distsql%'
 AND info NOT LIKE '%sql.testing%'
-AND info NOT LIKE '%sql.defaults.experimental_distsql_planning%'
-AND info NOT LIKE '%sql.defaults.use_declarative_schema_changer%'
+AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
 0  1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
 0  1  {"EventType": "set_cluster_setting", "SettingName": "kv.range_merge.queue_enabled", "Statement": "SET CLUSTER SETTING \"kv.range_merge.queue_enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
-0  1  {"EventType": "set_cluster_setting", "PlaceholderValues": ["5"], "SettingName": "sql.stats.automatic_collection.min_stale_rows", "Statement": "SET CLUSTER SETTING \"sql.stats.automatic_collection.min_stale_rows\" = $1::INT8", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "5"}
 0  1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
 0  1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
 0  1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}
@@ -480,16 +479,15 @@ query IIT
 SELECT "targetID", "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
-AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%' AND info NOT LIKE '%cluster.secret%'
-AND info NOT LIKE '%sql.stats.automatic_collection.enabled%'
-AND info NOT LIKE '%sql.defaults.vectorize%'
+AND info NOT LIKE '%version%'
+AND info NOT LIKE '%cluster.secret%'
+AND info NOT LIKE '%sql.defaults%'
+AND info NOT LIKE '%sql.distsql%'
 AND info NOT LIKE '%sql.testing%'
-AND info NOT LIKE '%sql.defaults.experimental_distsql_planning%'
-AND info NOT LIKE '%sql.defaults.use_declarative_schema_changer%'
+AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
 0  1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-0  1  {"EventType": "set_cluster_setting", "PlaceholderValues": ["5"], "SettingName": "sql.stats.automatic_collection.min_stale_rows", "Statement": "SET CLUSTER SETTING \"sql.stats.automatic_collection.min_stale_rows\" = $1::INT8", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "5"}
 0  1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
 0  1  {"EventType": "set_cluster_setting", "PlaceholderValues": ["'some string'"], "SettingName": "cluster.organization", "Statement": "SET CLUSTER SETTING \"cluster.organization\" = $1", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "'some string'"}
 

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,3 +1,10 @@
+# For some reason, some of the queries produce non-deterministic results if
+# distsql_workmem value is randomized, so we'll override it to the production
+# value.
+# TODO(yuzefovich): figure it out.
+statement ok
+SET distsql_workmem = '64MiB'
+
 ##################
 # TABLE DDL
 ##################

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4674,12 +4674,27 @@ test               pg_catalog        zh-Hant              NULL                  
 ## information_schema.session_variables
 subtest variables
 
-## excluding crdb_version and session_id variables as they are generated on each
-## commit/session; distsql, experimental_distsql_planning and vectorize as they
-## depend on distsql and vectorization turned on/off. Also excluding
-## use_declarative_schema_changer, which can be adjusted based on the mode.
+## Excluding crdb_version and session_id variables as they are generated on each
+## commit/session.; , experimental_distsql_planning and vectorize as they
+## depend on distsql and vectorization turned on/off. Also excluding distsql,
+## vectorize, experimental_distsql_planning, use_declarative_schema_changer,
+## and distsql_workmem which can be adjusted based on the logic test mode.
 query TT colnames
-SELECT * FROM information_schema.session_variables where variable not in ('crdb_version', 'session_id', 'distsql', 'vectorize', 'experimental_distsql_planning', 'use_declarative_schema_changer')
+SELECT
+  *
+FROM
+  information_schema.session_variables
+WHERE
+  variable
+  NOT IN (
+      'crdb_version',
+      'session_id',
+      'distsql',
+      'vectorize',
+      'experimental_distsql_planning',
+      'use_declarative_schema_changer',
+      'distsql_workmem'
+    );
 ----
 variable                                              value
 allow_prepare_as_opt_plan                             off
@@ -4707,7 +4722,6 @@ default_with_oids                                     off
 disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off
-distsql_workmem                                       64 MiB
 enable_drop_enum_value                                on
 enable_experimental_alter_column_type_general         off
 enable_experimental_stream_replication                off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1,5 +1,10 @@
 # LogicTest: local
 
+# Set the distsql_workmem to the default production value because of a problem
+# with losing 'name' attribute when spilling to disk (#78547).
+statement ok
+SET distsql_workmem = '64MiB'
+
 # Verify pg_catalog database handles mutation statements correctly.
 
 query error database "pg_catalog" does not exist
@@ -4058,7 +4063,7 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name != 'optimizer' AND name != 'crdb_version' AND name != 'session_id'
+  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem')
 ----
 name                                                  setting             category  short_desc  extra_desc  vartype
 alter_primary_region_super_region_override            off                 NULL      NULL        NULL        string
@@ -4086,7 +4091,6 @@ disable_partially_distributed_plans                   off                 NULL  
 disable_plan_gists                                    off                 NULL      NULL        NULL        string
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
 distsql                                               off                 NULL      NULL        NULL        string
-distsql_workmem                                       64 MiB              NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general         off                 NULL      NULL        NULL        string
 enable_experimental_stream_replication                off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update                     on                  NULL      NULL        NULL        string
@@ -4178,7 +4182,7 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name != 'optimizer' AND name != 'crdb_version' AND name != 'session_id'
+  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem')
 ----
 name                                                  setting             unit  context  enumvals  boot_val            reset_val
 alter_primary_region_super_region_override            off                 NULL  user     NULL      off                 off
@@ -4206,7 +4210,6 @@ disable_partially_distributed_plans                   off                 NULL  
 disable_plan_gists                                    off                 NULL  user     NULL      off                 off
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
 distsql                                               off                 NULL  user     NULL      off                 off
-distsql_workmem                                       64 MiB              NULL  user     NULL      64 MiB              64 MiB
 enable_experimental_alter_column_type_general         off                 NULL  user     NULL      off                 off
 enable_experimental_stream_replication                off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update                     on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -23,7 +23,7 @@ UTF8                1
 query TT colnames
 SELECT *
 FROM [SHOW ALL]
-WHERE variable != 'optimizer' AND variable != 'crdb_version' AND variable != 'session_id'
+WHERE variable NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem')
 ----
 variable                                              value
 alter_primary_region_super_region_override            off
@@ -51,7 +51,6 @@ disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off
 distsql                                               off
-distsql_workmem                                       64 MiB
 enable_experimental_alter_column_type_general         off
 enable_experimental_stream_replication                off
 enable_implicit_select_for_update                     on

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -1061,37 +1061,31 @@ skipif config 3node-tenant
 query T
 SELECT name
 FROM system.settings
-WHERE name != 'sql.defaults.distsql'
-AND name != 'sql.stats.automatic_collection.enabled'
-AND name NOT LIKE '%sql.defaults.vectorize%'
-AND name NOT LIKE '%sql.testing%'
-AND name NOT LIKE '%sql.defaults.experimental_distsql_planning%'
-AND name != 'sql.defaults.use_declarative_schema_changer'
+WHERE name NOT LIKE 'sql.defaults%'
+AND name NOT LIKE 'sql.distsql%'
+AND name NOT LIKE 'sql.testing%'
+AND name NOT LIKE 'sql.stats%'
 ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
 kv.range_merge.queue_enabled
 sql.crdb_internal.table_row_statistics.as_of_time
-sql.stats.automatic_collection.min_stale_rows
 version
 
 onlyif config 3node-tenant
 query T
 SELECT name
 FROM system.settings
-WHERE name != 'sql.defaults.distsql'
-AND name != 'sql.stats.automatic_collection.enabled'
-AND name NOT LIKE '%sql.defaults.vectorize%'
-AND name NOT LIKE '%sql.testing%'
-AND name NOT LIKE '%sql.defaults.experimental_distsql_planning%'
-AND name NOT LIKE '%sql.defaults.use_declarative_schema_changer%'
+WHERE name NOT LIKE 'sql.defaults%'
+AND name NOT LIKE 'sql.distsql%'
+AND name NOT LIKE 'sql.testing%'
+AND name NOT LIKE 'sql.stats%'
 ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
 sql.crdb_internal.table_row_statistics.as_of_time
-sql.stats.automatic_collection.min_stale_rows
 version
 
 statement ok
@@ -1103,31 +1097,32 @@ skipif config 3node-tenant
 query TT
 SELECT name, value
 FROM system.settings
-WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret',
-  'sql.stats.automatic_collection.enabled', 'sql.defaults.vectorize',
-  'sql.defaults.experimental_distsql_planning',
-  'sql.defaults.use_declarative_schema_changer')
+WHERE name NOT LIKE 'sql.defaults%'
+AND name NOT LIKE 'sql.distsql%'
+AND name NOT LIKE 'sql.testing%'
+AND name NOT LIKE 'sql.stats%'
+AND name NOT IN ('version', 'cluster.secret')
 ORDER BY name
 ----
 diagnostics.reporting.enabled                      true
 kv.range_merge.queue_enabled                       false
 somesetting                                        somevalue
 sql.crdb_internal.table_row_statistics.as_of_time  -1µs
-sql.stats.automatic_collection.min_stale_rows      5
 
 onlyif config 3node-tenant
 query TT
 SELECT name, value
 FROM system.settings
-WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret',
-  'sql.stats.automatic_collection.enabled', 'sql.defaults.vectorize',
-  'sql.defaults.experimental_distsql_planning', 'sql.defaults.use_declarative_schema_changer')
+WHERE name NOT LIKE 'sql.defaults%'
+AND name NOT LIKE 'sql.distsql%'
+AND name NOT LIKE 'sql.testing%'
+AND name NOT LIKE 'sql.stats%'
+AND name NOT IN ('version', 'cluster.secret')
 ORDER BY name
 ----
 diagnostics.reporting.enabled                      true
 somesetting                                        somevalue
 sql.crdb_internal.table_row_statistics.as_of_time  -1µs
-sql.stats.automatic_collection.min_stale_rows      5
 
 user testuser
 

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -30,5 +30,5 @@ func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
 	skip.UnderDeadlock(t, "times out and/or hangs")
-	logictest.RunLogicTest(t, logictest.TestServerArgs{}, testutils.TestDataPath(t, "[^.]*"))
+	logictest.RunLogicTest(t, logictest.TestServerArgs{DisableWorkmemRandomization: true}, testutils.TestDataPath(t, "[^.]*"))
 }

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -145,14 +145,11 @@ func newWindower(
 	// windower will overflow to disk if this limit is not enough.
 	limit := execinfra.GetWorkMemLimit(flowCtx)
 	if limit < memRequiredByWindower {
-		if !flowCtx.Cfg.TestingKnobs.ForceDiskSpill && flowCtx.Cfg.TestingKnobs.MemoryLimitBytes == 0 {
-			return nil, errors.Errorf(
-				"window functions require %d bytes of RAM but only %d are in the budget. "+
-					"Consider increasing sql.distsql.temp_storage.workmem cluster setting or distsql_workmem session variable",
-				memRequiredByWindower, limit)
-		}
-		// The limit is set very low by the tests, but the windower requires
-		// some amount of RAM, so we override the limit.
+		// The limit is set very low (likely by the tests in order to improve
+		// the test coverage), but the windower requires some amount of RAM, so
+		// we override the limit. This behavior is acceptable given that we
+		// don't expect anyone to lower the setting to less than 100KiB in
+		// production.
 		limit = memRequiredByWindower
 	}
 	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon)


### PR DESCRIPTION
**logictest: clean up filters in queries of events**

This commit cleans up queries that check the contents of `settings` and
`eventlog` system tables (there, we want to ignore some of the
non-default cluster setting values). Additionally, this commit removes
an empty file introduced in 28ed7d0b8a128f1de4d4d5d33059a4556f8cdd65.

Release note: None

**logictest: randomize distsql_workmem in all configs**

This commit makes it so that `sql.distsql.temp_storage.workmem` cluster
setting is randomized in `[10KiB, 100KiB)` range in every config with
50% probability. This increases test coverage. Note that `*-disk`
configs use a different knob, so they are still useful to keep. The
randomization is only disabled for opt logic tests.

This required changing the way we handle small limits in the windower
(there, we used to return an error if there isn't enough workmem budget,
and we silently bump it up to the minimum - this is what we already do
for the join reader) as well as minor cleanups to the logic tests.

Fixes: #77645.

Release note: None

Jira issue: CRDB-14802