### PR TITLE
sql,roachpb: add plan hash correct value to persisted stats

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -164,6 +164,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.RowsRead.Add(other.RowsRead, s.Count, other.Count)
 	s.RowsWritten.Add(other.RowsWritten, s.Count, other.Count)
 	s.Nodes = util.CombineUniqueInt64(s.Nodes, other.Nodes)
+	s.PlanGists = util.CombineUniqueString(s.PlanGists, other.PlanGists)
 
 	s.ExecStats.Add(other.ExecStats)
 

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -104,6 +104,12 @@ message StatementStatistics {
   // Nodes is the ordered list of nodes ids on which the statement was executed.
   repeated int64 nodes = 24;
 
+  // plan_gists is list of a compressed version of plan that can be converted (lossily)
+  // back into a logical plan.
+  // Each statement contain only one plan gist, but the same statement fingerprint id
+  // can contain more than one value.
+  repeated string plan_gists = 26;
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5118,10 +5118,8 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 				transactionFingerprintID := tree.NewDBytes(
 					tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(uint64(statistics.Key.TransactionFingerprintID))))
 
-				// TODO(azhng): properly update plan_hash value once we can expose it
-				//  from the optimizer.
 				planHash := tree.NewDBytes(
-					tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(0)))
+					tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(statistics.Key.PlanHash)))
 
 				metadataJSON, err := sqlstatsutil.BuildStmtMetadataJSON(statistics)
 				if err != nil {

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -163,6 +163,7 @@ func (ex *connExecutor) recordStatementSummary(
 		FullScan:     flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan),
 		Failed:       stmtErr != nil,
 		Database:     planner.SessionData().Database,
+		PlanHash:     planner.instrumentation.planGist.Hash(),
 	}
 
 	// We only populate the transaction fingerprint ID field if we are in an
@@ -204,6 +205,7 @@ func (ex *connExecutor) recordStatementSummary(
 		Nodes:           getNodesFromPlanner(planner),
 		StatementType:   stmt.AST.StatementType(),
 		Plan:            planner.instrumentation.PlanForStats(ctx),
+		PlanGist:        planner.instrumentation.planGist.String(),
 		StatementError:  stmtErr,
 	}
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -296,6 +296,7 @@ func (ih *instrumentationHelper) Finish(
 			ImplicitTxn: ih.implicitTxn,
 			Database:    p.SessionData().Database,
 			Failed:      retErr != nil,
+			PlanHash:    ih.planGist.Hash(),
 		}
 		// We populate transaction fingerprint ID if this is an implicit transaction.
 		// See executor_statement_metrics.go:recordStatementSummary() for further

--- a/pkg/sql/instrumentation_test.go
+++ b/pkg/sql/instrumentation_test.go
@@ -73,6 +73,7 @@ func TestSampledStatsCollection(t *testing.T) {
 					},
 				))
 			require.NotNil(t, stats)
+			require.NotZero(t, stats.Key.PlanHash)
 			return stats
 		}
 

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -147,7 +147,7 @@ func (s *PersistedSQLStats) doFlushSingleStmtStats(
 
 		serializedFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(scopedStats.ID))
 		serializedTransactionFingerprintID := sqlstatsutil.EncodeUint64ToBytes(uint64(scopedStats.Key.TransactionFingerprintID))
-		serializedPlanHash := sqlstatsutil.EncodeUint64ToBytes(uint64(dummyPlanHash))
+		serializedPlanHash := sqlstatsutil.EncodeUint64ToBytes(scopedStats.Key.PlanHash)
 
 		insertFn := func(ctx context.Context, txn *kv.Txn) (alreadyExists bool, err error) {
 			rowsAffected, err := s.insertStatementStats(
@@ -417,7 +417,7 @@ WHERE fingerprint_id = $2
 			"plan_hash: %d, "+
 			"node_id: %d",
 			serializedFingerprintID, serializedTransactionFingerprintID, stats.Key.App,
-			aggregatedTs, dummyPlanHash, s.cfg.SQLIDContainer.SQLInstanceID())
+			aggregatedTs, serializedPlanHash, s.cfg.SQLIDContainer.SQLInstanceID())
 	}
 
 	return nil
@@ -581,12 +581,12 @@ FOR UPDATE
 	if row == nil {
 		return errors.AssertionFailedf(
 			"statement statistics not found fingerprint_id: %s, app: %s, aggregated_ts: %s, plan_hash: %d, node_id: %d",
-			serializedFingerprintID, key.App, aggregatedTs, dummyPlanHash, s.cfg.SQLIDContainer.SQLInstanceID())
+			serializedFingerprintID, key.App, aggregatedTs, serializedPlanHash, s.cfg.SQLIDContainer.SQLInstanceID())
 	}
 
 	if len(row) != 1 {
 		return errors.AssertionFailedf("unexpectedly found %d returning columns for fingerprint_id: %s, app: %s, aggregated_ts: %s, plan_hash %d, node_id: %d",
-			len(row), serializedFingerprintID, key.App, aggregatedTs, dummyPlanHash,
+			len(row), serializedFingerprintID, key.App, aggregatedTs, serializedPlanHash,
 			s.cfg.SQLIDContainer.SQLInstanceID())
 	}
 

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -34,14 +34,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const (
-	// TODO(azhng): currently we do not have the ability to compute a hash for
-	//  query plan. This is currently being worked on by the SQL Queries team.
-	//  Once we are able get consistent hash value from a query plan, we should
-	//  update this.
-	dummyPlanHash = int64(0)
-)
-
 // ErrConcurrentSQLStatsCompaction is reported when two sql stats compaction
 // jobs are issued concurrently. This is a sentinel error.
 var ErrConcurrentSQLStatsCompaction = errors.New("another sql stats compaction job is already running")

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -96,7 +96,8 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "mean": {{.Float}},
            "sqDiff": {{.Float}}
          },
-         "nodes": [{{joinInts .IntArray}}]
+         "nodes": [{{joinInts .IntArray}}],
+         "planGists": [{{joinStrings .StringArray}}]
        },
        "execution_statistics": {
          "cnt": {{.Int64}},
@@ -211,6 +212,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "sqDiff": {{.Float}}
          },
          "nodes": [{{joinInts .IntArray}}]
+         "planGists": [{{joinStrings .StringArray}}]
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -135,6 +135,39 @@ func (a *int64Array) encodeJSON() (json.JSON, error) {
 	return builder.Build(), nil
 }
 
+type stringArray []string
+
+func (a *stringArray) decodeJSON(js json.JSON) error {
+	arrLen := js.Len()
+	for i := 0; i < arrLen; i++ {
+		var value jsonString
+		valJSON, err := js.FetchValIdx(i)
+		if err != nil {
+			return err
+		}
+		if err := value.decodeJSON(valJSON); err != nil {
+			return err
+		}
+		*a = append(*a, string(value))
+	}
+
+	return nil
+}
+
+func (a *stringArray) encodeJSON() (json.JSON, error) {
+	builder := json.NewArrayBuilder(len(*a))
+
+	for _, value := range *a {
+		jsVal, err := (*jsonString)(&value).encodeJSON()
+		if err != nil {
+			return nil, err
+		}
+		builder.Add(jsVal)
+	}
+
+	return builder.Build(), nil
+}
+
 type stmtFingerprintIDArray []roachpb.StmtFingerprintID
 
 func (s *stmtFingerprintIDArray) decodeJSON(js json.JSON) error {
@@ -237,6 +270,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"rowsRead", (*numericStats)(&s.RowsRead)},
 		{"rowsWritten", (*numericStats)(&s.RowsWritten)},
 		{"nodes", (*int64Array)(&s.Nodes)},
+		{"planGists", (*stringArray)(&s.PlanGists)},
 	}
 }
 

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/testutils.go
@@ -11,12 +11,13 @@
 package sqlstatsutil
 
 import (
-	"html/template"
+	"fmt"
 	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -36,12 +37,13 @@ func GetRandomizedCollectedStatementStatisticsForTest(
 }
 
 type randomData struct {
-	Bool     bool
-	String   string
-	Int64    int64
-	Float    float64
-	IntArray []int64
-	Time     time.Time
+	Bool        bool
+	String      string
+	Int64       int64
+	Float       float64
+	IntArray    []int64
+	StringArray []string
+	Time        time.Time
 }
 
 var alphabet = []rune("abcdefghijklmkopqrstuvwxyz")
@@ -57,11 +59,22 @@ func genRandomData() randomData {
 	}
 	r.String = b.String()
 
+	// Generate a randomized array of length 5.
+	arrLen := 5
+	r.StringArray = make([]string, arrLen)
+	for i := 0; i < arrLen; i++ {
+		// Randomly generating 10-character string.
+		b := strings.Builder{}
+		for j := 0; j < 10; j++ {
+			b.WriteRune(alphabet[rand.Intn(26)])
+		}
+		r.StringArray[i] = b.String()
+	}
+
 	r.Int64 = rand.Int63()
 	r.Float = rand.Float64()
 
 	// Generate a randomized array of length 5.
-	arrLen := 5
 	r.IntArray = make([]int64, arrLen)
 	for i := 0; i < arrLen; i++ {
 		r.IntArray[i] = rand.Int63()
@@ -79,6 +92,13 @@ func fillTemplate(t *testing.T, tmplStr string, data randomData) string {
 		}
 		return strings.Join(strArr, ",")
 	}
+	joinStrings := func(arr []string) string {
+		strArr := make([]string, len(arr))
+		for i, val := range arr {
+			strArr[i] = fmt.Sprintf("%q", val)
+		}
+		return strings.Join(strArr, ",")
+	}
 	stringifyTime := func(tm time.Time) string {
 		s, err := tm.MarshalText()
 		require.NoError(t, err)
@@ -88,6 +108,7 @@ func fillTemplate(t *testing.T, tmplStr string, data randomData) string {
 		New("").
 		Funcs(template.FuncMap{
 			"joinInts":      joinInts,
+			"joinStrings":   joinStrings,
 			"stringifyTime": stringifyTime,
 		}).
 		Parse(tmplStr)
@@ -133,8 +154,15 @@ func fillObject(t *testing.T, val reflect.Value, data *randomData) {
 	case reflect.Bool:
 		val.SetBool(data.Bool)
 	case reflect.Slice:
-		for _, randInt := range data.IntArray {
-			val.Set(reflect.Append(val, reflect.ValueOf(randInt)))
+		switch val.Type().String() {
+		case "[]string":
+			for _, randString := range data.StringArray {
+				val.Set(reflect.Append(val, reflect.ValueOf(randString)))
+			}
+		case "[]int64":
+			for _, randInt := range data.IntArray {
+				val.Set(reflect.Append(val, reflect.ValueOf(randInt)))
+			}
 		}
 	case reflect.Struct:
 		switch val.Type().Name() {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -94,6 +94,7 @@ func (s *StmtStatsIterator) Next() bool {
 			Failed:                   stmtKey.failed,
 			App:                      s.container.appName,
 			Database:                 database,
+			PlanHash:                 stmtKey.planHash,
 			TransactionFingerprintID: stmtKey.transactionFingerprintID,
 		},
 		ID:    stmtFingerprintID,

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -196,6 +196,7 @@ type RecordedStmtStats struct {
 	Nodes           []int64
 	StatementType   tree.StatementType
 	Plan            *roachpb.ExplainTreePlanNode
+	PlanGist        string
 	StatementError  error
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -92,6 +92,7 @@ const statementStats: Required<IStatementStatistics> = {
     mean: 2,
     squared_diffs: 0.005,
   },
+  plan_gists: ["Ais="],
   exec_stats: execStats,
   last_exec_timestamp: {
     seconds: Long.fromInt(1599670292),

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
@@ -274,6 +274,7 @@ function randomStats(
       nanos: 111613000,
     },
     nodes: [Long.fromInt(1), Long.fromInt(3), Long.fromInt(4)],
+    plan_gists: ["Ais="],
   };
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -15,6 +15,7 @@ import {
   TimestampToNumber,
   DurationToNumber,
   uniqueLong,
+  unique,
 } from "src/util";
 
 export type StatementStatistics = protos.cockroach.sql.IStatementStatistics;
@@ -127,6 +128,15 @@ export function addStatementStats(
 ): Required<StatementStatistics> {
   const countA = FixLong(a.count).toInt();
   const countB = FixLong(b.count).toInt();
+  let planGists: string[] = [];
+  if (a.plan_gists && b.plan_gists) {
+    planGists = unique(a.plan_gists.concat(b.plan_gists));
+  } else if (a.plan_gists) {
+    planGists = a.plan_gists;
+  } else if (b.plan_gists) {
+    planGists = b.plan_gists;
+  }
+
   return {
     count: a.count.add(b.count),
     first_attempt_count: a.first_attempt_count.add(b.first_attempt_count),
@@ -174,6 +184,7 @@ export function addStatementStats(
         ? a.last_exec_timestamp
         : b.last_exec_timestamp,
     nodes: uniqueLong([...a.nodes, ...b.nodes]),
+    plan_gists: planGists,
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -497,6 +497,7 @@ function makeStats(): Required<StatementStatistics> {
       nanos: 111613000,
     },
     nodes: [Long.fromInt(1), Long.fromInt(2), Long.fromInt(3)],
+    plan_gists: ["Ais="],
   };
 }
 


### PR DESCRIPTION
Previously, we didn't have the plan hash/gist values, so
a dummy value was being used instead. Now that we have the value,
this commit uses those values to be corrected stored.
The Plan Hash is saved on its own column and is part of a
statement key. A plan gist is a string saved in the metadata
and can later on converted back into a logical plan.

Partially addresses #72129

Release note (sql change): Saving plan hash/gist to the Statements
persisted stats.