### PR TITLE
sql: introduce contention event resolver

### DIFF
--- a/pkg/sql/contention/BUILD.bazel
+++ b/pkg/sql/contention/BUILD.bazel
@@ -2,18 +2,24 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "contention",
-    srcs = ["registry.go"],
+    srcs = [
+        "registry.go",
+        "resolver.go",
+        "test_utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/contention",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/server/serverpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/contentionpb",
         "//pkg/util/cache",
         "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_biogo_store//llrb",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -22,6 +28,7 @@ go_test(
     size = "small",
     srcs = [
         "registry_test.go",
+        "resolver_test.go",
         "utils_test.go",
     ],
     data = glob(["testdata/**"]),
@@ -38,6 +45,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/contention/resolver.go
+++ b/pkg/sql/contention/resolver.go
@@ -1,0 +1,286 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contention
+
+import (
+	"context"
+	"sort"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+)
+
+// resolverQueue's main responsibility is to map the transaction IDs
+// present in the contention events into transaction fingerprint IDs.
+// When a transaction waits because of contention, we will not yet know the
+// blocking transaction's fingerprint ID. The mapping from the txnID of the
+// blocking transaction to its transaction fingerprint ID is likely stored in
+// txnID cache of a different node. So in order to translate blocking
+// transaction's txnID into transaction fingerprint ID, RPC calls need to be
+// issued to other nodes to query their transaction ID caches.
+// These operations can be very expensive. To amortize the network cost, the
+// resolver batches up the contention events in the queue with same coordinator
+// ID, and send only one RPC request per remote node when the resolution is
+// explicitly requested.
+type resolverQueue interface {
+	// enqueue queues a block of unresolved contention events into resolverQueue
+	// to be resolved later.
+	enqueue([]contentionpb.ExtendedContentionEvent)
+
+	// dequeue attempts to resolveLocked the pending unresolved contention events
+	// and returns all the resolved contention events. The contention events
+	// that cannot be resolved will either be re-queued or dropped (only after
+	// retry has been attempted).
+	dequeue(context.Context) ([]contentionpb.ExtendedContentionEvent, error)
+}
+
+const (
+	// retryBudgetForMissingResult is set to a relatively low value. This is
+	// because when a txnID entry is missing on remote node, there are two
+	// scenarios:
+	// 1. the txnID is in the writer buffer of a remote node, and it's not yet
+	//    inserted into the txnID cache.
+	//    The RPC handler for TxnIDResolution forces the txnID cache to drain its
+	//    write buffer if the handler encounters txnIDs it doesn't know about.
+	//    This means next retry should succeed or always fails.
+	//
+	//    More detail note: In CRDB, when a transaction starts executing, it
+	//    immediately writes a provisional entry into txnID cache before even
+	//    executing its first statement. (This means, before the transaction even
+	//    has a chance of causing contention, it has made itself aware to other
+	//    node that it exists). Due to the asynchronous nature of txnID cache,
+	//    there's always non-zero probability that it takes a while before the
+	//    transaction's write operation to complete. (E.g. this can happen when
+	//    the cluster QPS is very low and it didn't generate enough transaction to
+	//    fill the write buffer of the txnID cache). Since when the
+	//    TxnIDResolution handler encounters a missing txnID entry, it will force
+	//    a txnID cache flush. This means that next time when the resolver attempt
+	//    to issue RPC request, the txnID entry should be present in the txnID
+	//    cache in the remote node. If the txnID cache entry is still missing upon
+	//    subsequent RPC call, then this leads us to the next scenario.
+	// 2. the txnID entry is permanently lost. This can happen due to TxnID cache
+	//    eviction (very not ideal situation, indicating that the cluster is
+	//    very overloaded or a transaction has been running way too long) or
+	//    in-memory data corruption (shouldn't happen in normal circumstances,
+	//    since access to txnID cache is all synchronized). In this case, no
+	//    amount of retries will be able to resolveLocked the txnID.
+	retryBudgetForMissingResult = uint32(1)
+
+	// retryBudgetForRPCFailure is the number of times the resolverQueue will
+	// retry resolving until giving up. This needs to be a finite number to handle
+	// the case where the node is permanently removed from the cluster.
+	retryBudgetForRPCFailure = uint32(3)
+)
+
+// ResolverEndpoint is an alias for the TxnIDResolution RPC endpoint in the
+// status server.
+type ResolverEndpoint func(context.Context, *serverpb.TxnIDResolutionRequest) (*serverpb.TxnIDResolutionResponse, error)
+
+type resolverQueueImpl struct {
+	mu struct {
+		syncutil.RWMutex
+
+		unresolvedEvents []contentionpb.ExtendedContentionEvent
+		resolvedEvents   []contentionpb.ExtendedContentionEvent
+
+		remainingRetries map[uuid.UUID]uint32
+	}
+
+	resolverEndpoint ResolverEndpoint
+}
+
+var _ resolverQueue = &resolverQueueImpl{}
+
+func newResolver(endpoint ResolverEndpoint, sizeHint int) *resolverQueueImpl {
+	s := &resolverQueueImpl{
+		resolverEndpoint: endpoint,
+	}
+
+	s.mu.unresolvedEvents = make([]contentionpb.ExtendedContentionEvent, 0, sizeHint)
+	s.mu.resolvedEvents = make([]contentionpb.ExtendedContentionEvent, 0, sizeHint)
+	s.mu.remainingRetries = make(map[uuid.UUID]uint32, sizeHint)
+
+	return s
+}
+
+// enqueue implements the resolverQueue interface.
+func (q *resolverQueueImpl) enqueue(block []contentionpb.ExtendedContentionEvent) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.mu.unresolvedEvents = append(q.mu.unresolvedEvents, block...)
+}
+
+// dequeue implements the resolverQueue interface.
+func (q *resolverQueueImpl) dequeue(
+	ctx context.Context,
+) ([]contentionpb.ExtendedContentionEvent, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	err := q.resolveLocked(ctx)
+	result := q.mu.resolvedEvents
+	q.mu.resolvedEvents = q.mu.resolvedEvents[:0]
+
+	return result, err
+}
+
+func (q *resolverQueueImpl) resolveLocked(ctx context.Context) error {
+	queueCpy := make([]contentionpb.ExtendedContentionEvent, len(q.mu.unresolvedEvents))
+	copy(queueCpy, q.mu.unresolvedEvents)
+
+	// Clear the queue.
+	q.mu.unresolvedEvents = q.mu.unresolvedEvents[:0]
+
+	// We sort the queue by the CoordinatorNodeID.
+	sort.Slice(queueCpy, func(i, j int) bool {
+		return queueCpy[i].Event.TxnMeta.CoordinatorNodeID < queueCpy[j].Event.TxnMeta.CoordinatorNodeID
+	})
+
+	currentBatch, remaining := readUntilNextCoordinatorID(queueCpy)
+	var allErrors error
+	for len(currentBatch) > 0 {
+		// TODO(azhng): we can inject random sleep/wait here to slow down our
+		//  outbound RPC request rate. This can be down proactively by self-throttle
+		//  the outbound RPC rate at a given cluster setting, or reactively
+		//  by observing some node'q load metrics (e.g. QPS value) and start
+		//  self-throttling once that QPS value exceed certain value.
+
+		req := makeRPCRequestFromBatch(currentBatch)
+		resp, err := q.resolverEndpoint(ctx, req)
+		if err != nil {
+			q.maybeRequeueBatchLocked(currentBatch, retryBudgetForRPCFailure)
+			// Read next batch of unresolved contention events.
+			currentBatch, remaining = readUntilNextCoordinatorID(remaining)
+			allErrors = errors.CombineErrors(allErrors, err)
+			continue
+		}
+		resolvedTxnIDs, inProgressTxnIDs := extractResolvedAndInProgressTxnIDs(resp)
+
+		for _, event := range currentBatch {
+			// If the coordinator node indicates that it is aware of the requested
+			// txnID but does not yet have the corresponding txnFingerprintID,
+			// (e.g. when the transaction is still executing), we re-queue
+			// the contention event, so we will check in with the coordinator node
+			// again later. In this case, we don't want to update the retry
+			// record since we are confident that the txnID entry on the coordinator
+			// node has not yet being evicted.
+			if _, ok := inProgressTxnIDs[event.Event.TxnMeta.ID]; ok {
+				q.mu.unresolvedEvents = append(q.mu.unresolvedEvents, event)
+				// Clear any retry count if there is any.
+				delete(q.mu.remainingRetries, event.Event.TxnMeta.ID)
+				continue
+			}
+
+			// If we successfully resolveLocked the transaction ID, we append it to the
+			// resolvedEvent slice and clear remaining retry count if there is any.
+			if txnFingerprintID, ok := resolvedTxnIDs[event.Event.TxnMeta.ID]; ok {
+				event.TxnFingerprintID = txnFingerprintID
+				q.mu.resolvedEvents = append(q.mu.resolvedEvents, event)
+
+				delete(q.mu.remainingRetries, event.Event.TxnMeta.ID)
+				continue
+			}
+
+			q.maybeRequeueEventForRetryLocked(event, retryBudgetForMissingResult)
+		}
+
+		currentBatch, remaining = readUntilNextCoordinatorID(remaining)
+	}
+
+	return allErrors
+}
+
+func (q *resolverQueueImpl) maybeRequeueBatchLocked(
+	batch []contentionpb.ExtendedContentionEvent, initialBudget uint32,
+) {
+	for _, event := range batch {
+		q.maybeRequeueEventForRetryLocked(event, initialBudget)
+	}
+}
+
+func (q *resolverQueueImpl) maybeRequeueEventForRetryLocked(
+	event contentionpb.ExtendedContentionEvent, initialBudget uint32,
+) (requeued bool) {
+	// If we fail to resolve the result, we look up this event's remaining retry
+	// count. If its retry budget is exhausted, we discard it. Else, we
+	// re-queue the event for retry and decrement its retry budget for the
+	// event.
+	remainingRetryBudget, ok := q.mu.remainingRetries[event.Event.TxnMeta.ID]
+	if !ok {
+		remainingRetryBudget = initialBudget
+	} else {
+		remainingRetryBudget--
+	}
+	q.mu.remainingRetries[event.Event.TxnMeta.ID] = remainingRetryBudget
+
+	if remainingRetryBudget == 0 {
+		delete(q.mu.remainingRetries, event.Event.TxnMeta.ID)
+		return false /* requeued */
+	}
+
+	q.mu.unresolvedEvents = append(q.mu.unresolvedEvents, event)
+	return true /* requeued */
+}
+
+func readUntilNextCoordinatorID(
+	sortedEvents []contentionpb.ExtendedContentionEvent,
+) (eventsForFirstCoordinator, remaining []contentionpb.ExtendedContentionEvent) {
+	if len(sortedEvents) == 0 {
+		return nil /* eventsForFirstCoordinator */, nil /* remaining */
+	}
+
+	currentCoordinatorID := sortedEvents[0].Event.TxnMeta.CoordinatorNodeID
+	for idx, event := range sortedEvents {
+		if event.Event.TxnMeta.CoordinatorNodeID != currentCoordinatorID {
+			return sortedEvents[:idx], sortedEvents[idx:]
+		}
+	}
+
+	return sortedEvents, nil /* remaining */
+}
+
+func extractResolvedAndInProgressTxnIDs(
+	resp *serverpb.TxnIDResolutionResponse,
+) (resolvedTxnIDs, inProgressTxnIDs map[uuid.UUID]roachpb.TransactionFingerprintID) {
+	resolvedTxnIDs = make(map[uuid.UUID]roachpb.TransactionFingerprintID, len(resp.ResolvedTxnIDs))
+	inProgressTxnIDs = make(map[uuid.UUID]roachpb.TransactionFingerprintID, len(resp.ResolvedTxnIDs))
+
+	for _, event := range resp.ResolvedTxnIDs {
+		if event.TxnFingerprintID == roachpb.InvalidTransactionFingerprintID {
+			inProgressTxnIDs[event.TxnID] = roachpb.InvalidTransactionFingerprintID
+		} else {
+			resolvedTxnIDs[event.TxnID] = event.TxnFingerprintID
+		}
+	}
+
+	return resolvedTxnIDs, inProgressTxnIDs
+}
+
+func makeRPCRequestFromBatch(
+	batch []contentionpb.ExtendedContentionEvent,
+) *serverpb.TxnIDResolutionRequest {
+	req := &serverpb.TxnIDResolutionRequest{
+		CoordinatorID: strconv.Itoa(int(batch[0].Event.TxnMeta.CoordinatorNodeID)),
+		TxnIDs:        make([]uuid.UUID, 0, len(batch)),
+	}
+
+	for _, event := range batch {
+		req.TxnIDs = append(req.TxnIDs, event.Event.TxnMeta.ID)
+	}
+
+	return req
+}

--- a/pkg/sql/contention/resolver_test.go
+++ b/pkg/sql/contention/resolver_test.go
@@ -1,0 +1,408 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contention
+
+import (
+	"context"
+	"math/rand"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type testData struct {
+	contentionpb.ResolvedTxnID
+	coordinatorNodeID string
+}
+
+func TestResolver(t *testing.T) {
+	statusServer := newFakeStatusServerCluster()
+	resolver := newResolver(statusServer.txnIDResolution, 0 /* sizeHint */)
+	ctx := context.Background()
+
+	t.Run("normal_resolution", func(t *testing.T) {
+		tcs := []testData{
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 100,
+				},
+				coordinatorNodeID: "1",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 101,
+				},
+				coordinatorNodeID: "1",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 102,
+				},
+				coordinatorNodeID: "1",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 200,
+				},
+				coordinatorNodeID: "2",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 201,
+				},
+				coordinatorNodeID: "2",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 300,
+				},
+				coordinatorNodeID: "3",
+			},
+		}
+		rand.Shuffle(len(tcs), func(i, j int) {
+			tcs[i], tcs[j] = tcs[j], tcs[i]
+		})
+		populateFakeStatusServerCluster(statusServer, tcs)
+		input, expected := generateUnresolvedContentionEventsFromTestData(t, tcs)
+		resolver.enqueue(input)
+		actual, err := resolver.dequeue(ctx)
+		require.NoError(t, err)
+
+		expected = sortResolvedContentionEvents(expected)
+		actual = sortResolvedContentionEvents(actual)
+
+		require.Equal(t, expected, actual)
+		require.Empty(t, resolver.mu.unresolvedEvents)
+	})
+
+	t.Run("retry_after_encountering_provisional_value", func(t *testing.T) {
+		// Reset the status server from previous test.
+		statusServer.clear()
+		activeTxnID := uuid.FastMakeV4()
+		tcs := []testData{
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 101,
+				},
+				coordinatorNodeID: "3",
+			},
+			{
+				// This is a provisional entry in TxnID Cache, representing that
+				// the transaction is open and its fingerprint ID is not yet
+				// available.
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            activeTxnID,
+					TxnFingerprintID: roachpb.InvalidTransactionFingerprintID,
+				},
+				coordinatorNodeID: "1",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 102,
+				},
+				coordinatorNodeID: "1",
+			},
+		}
+
+		populateFakeStatusServerCluster(statusServer, tcs)
+		input, expected := generateUnresolvedContentionEventsFromTestData(t, tcs)
+		resolver.enqueue(input)
+		actual, err := resolver.dequeue(ctx)
+		require.NoError(t, err)
+
+		expected = sortResolvedContentionEvents(expected)
+		actual = sortResolvedContentionEvents(actual)
+		require.Equal(t, expected, actual)
+
+		require.Equal(t, 1 /* expected */, len(resolver.mu.unresolvedEvents),
+			"expected resolver to retry resolution for active txns, "+
+				"but it did not")
+		require.True(t, activeTxnID.Equal(resolver.mu.unresolvedEvents[0].Event.TxnMeta.ID))
+		require.Empty(t, resolver.mu.remainingRetries,
+			"expected resolver not to create retry record for active txns, "+
+				"but it did")
+
+		// Create 1 new entry to simulate another new txn that finished execution,
+		// and update the existing entry to have a valid transaction fingerprint id.
+		newTxns := []testData{
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 2000,
+				},
+				coordinatorNodeID: "2",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            activeTxnID,
+					TxnFingerprintID: 1000,
+				},
+				coordinatorNodeID: "1",
+			},
+		}
+		populateFakeStatusServerCluster(statusServer, newTxns)
+		newInput, newExpected := generateUnresolvedContentionEventsFromTestData(t, newTxns)
+		// The txn with 'activeTxnID' is already present in the resolver. Omit it
+		// from the input.
+		newInput = newInput[:1]
+		newExpected = sortResolvedContentionEvents(newExpected)
+
+		// Enqueue the new contention event into the resolver.
+		resolver.enqueue(newInput)
+
+		actual, err = resolver.dequeue(ctx)
+		require.NoError(t, err)
+		actual = sortResolvedContentionEvents(actual)
+		require.Equal(t, newExpected, actual)
+
+		// Nothing should be left inside the resolver after we are done.
+		require.Empty(t, resolver.mu.unresolvedEvents)
+		require.Empty(t, resolver.mu.remainingRetries)
+		require.Empty(t, resolver.mu.resolvedEvents)
+	})
+
+	t.Run("retry_after_missing_value", func(t *testing.T) {
+		statusServer.clear()
+		missingTxnID := uuid.FastMakeV4()
+		tcs := []testData{
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 101,
+				},
+				coordinatorNodeID: "3",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 102,
+				},
+				coordinatorNodeID: "1",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            missingTxnID,
+					TxnFingerprintID: 1000,
+				},
+				coordinatorNodeID: "1",
+			},
+		}
+		// Explicitly omit the last missing txnID from status server to simulate an
+		// evicted txnID from txnIDCache.
+		populateFakeStatusServerCluster(statusServer, tcs[:2])
+		input, expected := generateUnresolvedContentionEventsFromTestData(t, tcs)
+
+		resolver.enqueue(input)
+		actual, err := resolver.dequeue(ctx)
+		require.NoError(t, err)
+
+		// Assert that we have only resolved the first two txnIDs, the third txnID
+		// should not be resolved.
+		require.Equal(t,
+			sortResolvedContentionEvents(expected[:2]), sortResolvedContentionEvents(actual))
+		require.Equal(t, 1, len(resolver.mu.remainingRetries))
+		remainingRetryBudget, foundRetryRecord := resolver.mu.remainingRetries[missingTxnID]
+		require.True(t, foundRetryRecord)
+		require.Equal(t, retryBudgetForMissingResult, remainingRetryBudget)
+
+		actual, err = resolver.dequeue(ctx)
+		require.NoError(t, err)
+		require.Empty(t, actual)
+
+		// Attempt to resolve again, simulating the firing of the resolution
+		// interval timer. This attempt will fail again, which cause the
+		// event to be discarded.
+		actual, err = resolver.dequeue(ctx)
+		require.NoError(t, err)
+		require.Empty(t, actual)
+
+		// The retry record should be cleared.
+		require.Empty(t, resolver.mu.remainingRetries)
+
+		// The unresolved event should not be re-queued.
+		require.Empty(t, resolver.mu.unresolvedEvents)
+	})
+
+	t.Run("handle_transient_rpc_failure", func(t *testing.T) {
+		missingTxnID1 := uuid.FastMakeV4()
+		statusServer.clear()
+		tcs := []testData{
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 201,
+				},
+				coordinatorNodeID: "2",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            missingTxnID1,
+					TxnFingerprintID: 301,
+				},
+				coordinatorNodeID: "3",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 100,
+				},
+				coordinatorNodeID: "1",
+			},
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            uuid.FastMakeV4(),
+					TxnFingerprintID: 101,
+				},
+				coordinatorNodeID: "1",
+			},
+		}
+		populateFakeStatusServerCluster(statusServer, tcs)
+
+		injectedErr := errors.New("injected error")
+		// Take down node 3.
+		statusServer.setStatusServerError(
+			"3" /* coordinatorNode */, injectedErr)
+
+		input, expected := generateUnresolvedContentionEventsFromTestData(t, tcs)
+		expected = sortResolvedContentionEvents(expected)
+		expectedWithOnlyResultsFromAvailableNodes := make([]contentionpb.ExtendedContentionEvent, 0, len(expected))
+		for _, event := range expected {
+			if event.Event.TxnMeta.CoordinatorNodeID != 3 {
+				expectedWithOnlyResultsFromAvailableNodes = append(expectedWithOnlyResultsFromAvailableNodes, event)
+			}
+		}
+
+		resolver.enqueue(input)
+		actual, err := resolver.dequeue(ctx)
+		require.ErrorIs(t, err, injectedErr)
+
+		require.Equal(t, 1, len(resolver.mu.unresolvedEvents),
+			"expected unresolved contention events be re-queued "+
+				"when experience RPC errors, but the events were dropped")
+
+		actual = sortResolvedContentionEvents(actual)
+		require.Equal(t, expectedWithOnlyResultsFromAvailableNodes, actual)
+		require.Equal(t, 1, len(resolver.mu.unresolvedEvents),
+			"expected unresolved contention events be re-queued after "+
+				"encountering RPC failure, but it was dropped")
+		require.Equal(t, 1, len(resolver.mu.remainingRetries),
+			"expected to have a retry record after RPC failure, but the "+
+				"retry record is missing")
+		remainingRetryBudget, found := resolver.mu.remainingRetries[missingTxnID1]
+		require.True(t, found)
+		require.Equal(t, retryBudgetForRPCFailure, remainingRetryBudget)
+
+		// Throw in a second unresolved contention event where the RPC failure
+		// is happening.
+		missingTxnID2 := uuid.FastMakeV4()
+		tcs = []testData{
+			{
+				ResolvedTxnID: contentionpb.ResolvedTxnID{
+					TxnID:            missingTxnID2,
+					TxnFingerprintID: 202,
+				},
+				coordinatorNodeID: "2",
+			},
+		}
+		populateFakeStatusServerCluster(statusServer, tcs)
+		// Take down node 2.
+		statusServer.setStatusServerError(
+			"2" /* coordinatorNodeID */, injectedErr)
+		input2, expected2 := generateUnresolvedContentionEventsFromTestData(t, tcs)
+
+		resolver.enqueue(input2)
+		require.Equal(t, 2, len(resolver.mu.unresolvedEvents))
+		// Attempt resolving again, this should still fail.
+		require.ErrorIs(t, resolver.resolveLocked(ctx), injectedErr)
+		require.Equal(t, 2, len(resolver.mu.remainingRetries))
+
+		remainingRetryBudget, found = resolver.mu.remainingRetries[missingTxnID1]
+		require.True(t, found)
+		require.Equal(t, retryBudgetForRPCFailure-1, remainingRetryBudget,
+			"expect retry budget be decremented after consecutive failures, "+
+				"but it was not")
+
+		remainingRetryBudget, found = resolver.mu.remainingRetries[missingTxnID2]
+		require.True(t, found)
+		require.Equal(t, retryBudgetForRPCFailure, remainingRetryBudget)
+
+		// Perform 2 consecutive resolution to cause the `missingTxnID1` to be
+		// dropped.
+		require.ErrorIs(t, resolver.resolveLocked(ctx), injectedErr)
+		require.ErrorIs(t, resolver.resolveLocked(ctx), injectedErr)
+
+		require.Equal(t, 1, len(resolver.mu.unresolvedEvents))
+		require.Equal(t, 1, len(resolver.mu.remainingRetries))
+		require.Empty(t, resolver.mu.resolvedEvents)
+		require.True(t, resolver.mu.unresolvedEvents[0].Event.TxnMeta.ID.Equal(missingTxnID2))
+
+		// Lift all injected RPC errors to simulate nodes coming back online.
+		statusServer.clearErrors()
+		actual, err = resolver.dequeue(ctx)
+		require.NoError(t, err)
+		require.Equal(t, expected2, actual)
+		require.Empty(t, resolver.mu.remainingRetries)
+		require.Empty(t, resolver.mu.unresolvedEvents)
+	})
+}
+
+func sortResolvedContentionEvents(
+	events []contentionpb.ExtendedContentionEvent,
+) []contentionpb.ExtendedContentionEvent {
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].TxnFingerprintID < events[j].TxnFingerprintID
+	})
+	return events
+}
+
+func generateUnresolvedContentionEventsFromTestData(
+	t *testing.T, tcs []testData,
+) (
+	input []contentionpb.ExtendedContentionEvent,
+	expected []contentionpb.ExtendedContentionEvent,
+) {
+	for _, tc := range tcs {
+		event := contentionpb.ExtendedContentionEvent{}
+		event.Event.TxnMeta.ID = tc.TxnID
+		coordinatorID, err := strconv.Atoi(tc.coordinatorNodeID)
+		require.NoError(t, err)
+		event.Event.TxnMeta.CoordinatorNodeID = int32(coordinatorID)
+		input = append(input, event)
+
+		if tc.TxnFingerprintID != roachpb.InvalidTransactionFingerprintID {
+			resolvedEvent := contentionpb.ExtendedContentionEvent{}
+			resolvedEvent.Event = event.Event
+			resolvedEvent.TxnFingerprintID = tc.TxnFingerprintID
+			expected = append(expected, resolvedEvent)
+		}
+	}
+	return input, expected
+}
+
+func populateFakeStatusServerCluster(f fakeStatusServerCluster, tcs []testData) {
+	for _, tc := range tcs {
+		f.setTxnIDEntry(tc.coordinatorNodeID, tc.TxnID, tc.TxnFingerprintID)
+	}
+}

--- a/pkg/sql/contention/test_utils.go
+++ b/pkg/sql/contention/test_utils.go
@@ -1,0 +1,104 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contention
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+type fakeStatusServer struct {
+	data          map[uuid.UUID]roachpb.TransactionFingerprintID
+	injectedError error
+}
+
+func newFakeStatusServer() *fakeStatusServer {
+	return &fakeStatusServer{
+		data:          make(map[uuid.UUID]roachpb.TransactionFingerprintID),
+		injectedError: nil,
+	}
+}
+
+func (f *fakeStatusServer) txnIDResolution(
+	_ context.Context, req *serverpb.TxnIDResolutionRequest,
+) (*serverpb.TxnIDResolutionResponse, error) {
+	if f.injectedError != nil {
+		return nil, f.injectedError
+	}
+
+	resp := &serverpb.TxnIDResolutionResponse{
+		ResolvedTxnIDs: make([]contentionpb.ResolvedTxnID, 0),
+	}
+
+	for _, txnID := range req.TxnIDs {
+		if txnFingerprintID, ok := f.data[txnID]; ok {
+			resp.ResolvedTxnIDs = append(resp.ResolvedTxnIDs, contentionpb.ResolvedTxnID{
+				TxnID:            txnID,
+				TxnFingerprintID: txnFingerprintID,
+			})
+		}
+	}
+
+	return resp, nil
+}
+
+func (f *fakeStatusServer) setTxnIDEntry(
+	txnID uuid.UUID, txnFingerprintID roachpb.TransactionFingerprintID,
+) {
+	f.data[txnID] = txnFingerprintID
+}
+
+type fakeStatusServerCluster map[string]*fakeStatusServer
+
+func newFakeStatusServerCluster() fakeStatusServerCluster {
+	return make(fakeStatusServerCluster)
+}
+
+func (f fakeStatusServerCluster) getStatusServer(coordinatorID string) *fakeStatusServer {
+	statusServer, ok := f[coordinatorID]
+	if !ok {
+		statusServer = newFakeStatusServer()
+		f[coordinatorID] = statusServer
+	}
+	return statusServer
+}
+
+func (f fakeStatusServerCluster) txnIDResolution(
+	ctx context.Context, req *serverpb.TxnIDResolutionRequest,
+) (*serverpb.TxnIDResolutionResponse, error) {
+	return f.getStatusServer(req.CoordinatorID).txnIDResolution(ctx, req)
+}
+
+func (f fakeStatusServerCluster) setTxnIDEntry(
+	coordinatorNodeID string, txnID uuid.UUID, txnFingerprintID roachpb.TransactionFingerprintID,
+) {
+	f.getStatusServer(coordinatorNodeID).setTxnIDEntry(txnID, txnFingerprintID)
+}
+
+func (f fakeStatusServerCluster) setStatusServerError(coordinatorNodeID string, err error) {
+	f.getStatusServer(coordinatorNodeID).injectedError = err
+}
+
+func (f fakeStatusServerCluster) clear() {
+	for k := range f {
+		delete(f, k)
+	}
+}
+
+func (f fakeStatusServerCluster) clearErrors() {
+	for _, statusServer := range f {
+		statusServer.injectedError = nil
+	}
+}

--- a/pkg/sql/contentionpb/BUILD.bazel
+++ b/pkg/sql/contentionpb/BUILD.bazel
@@ -17,8 +17,10 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachpb:roachpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/pkg/sql/contentionpb/contention.proto
+++ b/pkg/sql/contentionpb/contention.proto
@@ -12,8 +12,11 @@ syntax = "proto3";
 package cockroach.sql.contentionpb;
 option go_package = "contentionpb";
 
+import "roachpb/api.proto";
+
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 // IndexContentionEvents describes all of the available contention information
 // about a single index.
@@ -142,4 +145,16 @@ message ResolvedTxnID {
   uint64 txnFingerprintID = 2 [(gogoproto.customname) = "TxnFingerprintID",
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/roachpb.TransactionFingerprintID",
     (gogoproto.nullable) = false];
+}
+
+
+message ExtendedContentionEvent {
+  cockroach.roachpb.ContentionEvent event = 1 [
+    (gogoproto.nullable) = false
+  ];
+
+  uint64 txn_fingerprint_id = 2 [
+    (gogoproto.customname) = "TxnFingerprintID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.TransactionFingerprintID"
+  ];
 }


### PR DESCRIPTION
This commit introduces contention event resolver. The new resolver
implements a queue-like interface, where unresolved contention events
will be queued into the resolver. The resolution is performed by
invoking the `resolve()` method on the resolver queue, and the result of
the resolution can be retrieved by calling `dequeue()` method.

Release note: None