### PR TITLE
colfetcher: use IndexFetchSpec

### DIFF
--- a/pkg/sql/catalog/descpb/index_fetch.proto
+++ b/pkg/sql/catalog/descpb/index_fetch.proto
@@ -45,9 +45,15 @@ message IndexFetchSpec {
   message KeyColumn {
     optional Column column = 1 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
     optional IndexDescriptor.Direction direction = 2 [(gogoproto.nullable) = false];
+
     // IsComposite is true if this column can have a composite encoding (i.e. it
     // can appear in the value in addition to the key).
     optional bool is_composite = 3 [(gogoproto.nullable) = false];
+
+    // IsInverted is true if this column is the inverted key of an inverted index.
+    // In this case, the type of this column is the type of the data element
+    // (currently always Bytes).
+    optional bool is_inverted = 4 [(gogoproto.nullable) = false];
   }
 
   // FamilyDefaultColumn specifies the default column ID for a given family ID.
@@ -98,17 +104,21 @@ message IndexFetchSpec {
   // index ID.
   optional uint32 key_prefix_length = 10 [(gogoproto.nullable) = false];
 
+  optional uint32 max_family_id = 11 [(gogoproto.nullable) = false,
+                                      (gogoproto.customname) = "MaxFamilyID",
+                                      (gogoproto.casttype) = "FamilyID"];
+
   // FamilyDefaultColumns contains the default column IDs for families with a
   // default column. This is used to decode values that use the single column
   // optimization (where the column ID is omitted).
-  repeated FamilyDefaultColumn family_default_columns = 11 [(gogoproto.nullable) = false];
+  repeated FamilyDefaultColumn family_default_columns = 12 [(gogoproto.nullable) = false];
 
   // KeyAndSuffixColumns contains all the key and suffix columns, in order.
-  repeated KeyColumn key_and_suffix_columns = 12 [(gogoproto.nullable) = false];
+  repeated KeyColumn key_and_suffix_columns = 13 [(gogoproto.nullable) = false];
 
   // FetchedColumns contains all the columns we are producing values for. The
   // fetched columns can overlap with the key columns.
   //
   // Any other column IDs present in the fetched KVs will be ignored.
-  repeated Column fetched_columns = 13 [(gogoproto.nullable) = false];
+  repeated Column fetched_columns = 14 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/catalog/descpb/index_fetch.proto
+++ b/pkg/sql/catalog/descpb/index_fetch.proto
@@ -22,10 +22,13 @@ import "sql/catalog/descpb/structured.proto";
 // IndexDescriptor) that is necessary to decode KVs into SQL keys and values.
 message IndexFetchSpec {
   message Column {
-    optional string name = 1 [(gogoproto.nullable) = false];
-    optional uint32 column_id = 2 [(gogoproto.nullable) = false,
+    optional uint32 column_id = 1 [(gogoproto.nullable) = false,
                                    (gogoproto.customname) = "ColumnID",
                                    (gogoproto.casttype) = "ColumnID"];
+
+    // Name of the column, as it is expected to appear in debug and error
+    // messages.
+    optional string name = 2 [(gogoproto.nullable) = false];
 
     // Type of the column. If this is the key column of an inverted index, this
     // is the actual type of whan the index encodes (usually Bytes), rather than

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -49,14 +49,12 @@ func DecodeKeyValsToCols(
 	rowIdx int,
 	indexColIdx []int,
 	checkAllColsForNull bool,
-	types []*types.T,
-	directions []descpb.IndexDescriptor_Direction,
+	keyCols []descpb.IndexFetchSpec_KeyColumn,
 	unseen *util.FastIntSet,
 	key []byte,
-	invertedColIdx int,
 	scratch []byte,
 ) (remainingKey []byte, foundNull bool, retScratch []byte, _ error) {
-	for j := range types {
+	for j := range keyCols {
 		var err error
 		vecIdx := indexColIdx[j]
 		if vecIdx == -1 {
@@ -71,8 +69,11 @@ func DecodeKeyValsToCols(
 				unseen.Remove(vecIdx)
 			}
 			var isNull bool
-			isInverted := invertedColIdx == vecIdx
-			key, isNull, scratch, err = decodeTableKeyToCol(da, vecs, vecIdx, rowIdx, types[j], key, directions[j], isInverted, scratch)
+			key, isNull, scratch, err = decodeTableKeyToCol(
+				da, vecs, vecIdx, rowIdx,
+				keyCols[j].Type, key, keyCols[j].Direction, keyCols[j].IsInverted,
+				scratch,
+			)
 			foundNull = isNull || foundNull
 		}
 		if err != nil {

--- a/pkg/sql/colfetcher/cfetcher_setup.go
+++ b/pkg/sql/colfetcher/cfetcher_setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -30,15 +31,11 @@ import (
 // from. Note that only columns that need to be fetched (i.e. requested by the
 // caller) are included in the internal state.
 type cFetcherTableArgs struct {
-	desc  catalog.TableDescriptor
-	index catalog.Index
+	spec descpb.IndexFetchSpec
 	// ColIdxMap is a mapping from ColumnID to the ordinal of the corresponding
-	// column within the cols field.
-	ColIdxMap        catalog.TableColMap
-	isSecondaryIndex bool
-	// cols are the columns for which we need to produce values.
-	cols []catalog.Column
-	// typs are the types of only needed columns from the table.
+	// column within spec.FetchedColumns.
+	ColIdxMap catalog.TableColMap
+	// typs are the types from spec.FetchedColumns.
 	typs []*types.T
 }
 
@@ -49,12 +46,7 @@ var cFetcherTableArgsPool = sync.Pool{
 }
 
 func (a *cFetcherTableArgs) Release() {
-	// Deeply reset the column descriptors.
-	for i := range a.cols {
-		a.cols[i] = nil
-	}
 	*a = cFetcherTableArgs{
-		cols: a.cols[:0],
 		// The types are small objects, so we don't bother deeply resetting this
 		// slice.
 		typs: a.typs[:0],
@@ -62,14 +54,14 @@ func (a *cFetcherTableArgs) Release() {
 	cFetcherTableArgsPool.Put(a)
 }
 
-func (a *cFetcherTableArgs) populateTypes(cols []catalog.Column) {
+func (a *cFetcherTableArgs) populateTypes(cols []descpb.IndexFetchSpec_Column) {
 	if cap(a.typs) < len(cols) {
 		a.typs = make([]*types.T, len(cols))
 	} else {
 		a.typs = a.typs[:len(cols)]
 	}
 	for i := range cols {
-		a.typs[i] = cols[i].GetType()
+		a.typs[i] = cols[i].Type
 	}
 }
 
@@ -85,31 +77,17 @@ func populateTableArgs(
 ) (_ *cFetcherTableArgs, _ error) {
 	args := cFetcherTableArgsPool.Get().(*cFetcherTableArgs)
 
-	if cap(args.cols) < len(columnIDs) {
-		args.cols = make([]catalog.Column, len(columnIDs))
-	}
-	cols := args.cols[:0]
-	for _, colID := range columnIDs {
-		if invertedCol != nil && colID == invertedCol.GetID() {
-			cols = append(cols, invertedCol)
-		} else {
-			col, err := table.FindColumnWithID(colID)
-			if err != nil {
-				return nil, err
-			}
-			cols = append(cols, col)
-		}
-	}
 	*args = cFetcherTableArgs{
-		desc:             table,
-		index:            index,
-		isSecondaryIndex: !index.Primary(),
-		cols:             cols,
-		typs:             args.typs,
+		typs: args.typs,
 	}
-	args.populateTypes(cols)
-	for i := range cols {
-		args.ColIdxMap.Set(cols[i].GetID(), i)
+	if err := rowenc.InitIndexFetchSpec(
+		&args.spec, flowCtx.Codec(), table, index, columnIDs,
+	); err != nil {
+		return nil, err
+	}
+	args.populateTypes(args.spec.FetchedColumns)
+	for i := range args.spec.FetchedColumns {
+		args.ColIdxMap.Set(args.spec.FetchedColumns[i].ColumnID, i)
 	}
 
 	// Before we can safely use types from the table descriptor, we need to
@@ -137,33 +115,41 @@ func populateTableArgsLegacy(
 	helper *colexecargs.ExprHelper,
 ) (_ *cFetcherTableArgs, neededColumns util.FastIntSet, _ error) {
 	args := cFetcherTableArgsPool.Get().(*cFetcherTableArgs)
-	// First, find all columns present in the table and possibly include the
-	// system columns (when requested).
-	cols := args.cols[:0]
-	cols = append(cols, table.ReadableColumns()...)
-	if invertedCol != nil {
-		for i, col := range cols {
-			if col.GetID() == invertedCol.GetID() {
-				cols[i] = invertedCol
-				break
-			}
-		}
-	}
+
+	readableColumns := table.ReadableColumns()
+	numCols := len(readableColumns)
+	var systemColumns []catalog.Column
 	if hasSystemColumns {
-		cols = append(cols, table.SystemColumns()...)
+		systemColumns = table.SystemColumns()
+		numCols += len(systemColumns)
 	}
 
 	var err error
 	// Make sure that render expressions are deserialized right away so that we
 	// don't have to re-parse them multiple times.
 	if post.RenderExprs != nil {
-		args.populateTypes(cols)
+		// Populate all column types.
+		typs := args.typs[:0]
+		if cap(typs) >= numCols {
+			typs = typs[:numCols]
+		} else {
+			typs = make([]*types.T, numCols)
+		}
+		for i := range readableColumns {
+			typs[i] = readableColumns[i].GetType()
+			if invertedCol != nil && readableColumns[i].GetID() == invertedCol.GetID() {
+				typs[i] = invertedCol.GetType()
+			}
+		}
+		for i := range systemColumns {
+			typs[len(readableColumns)+i] = systemColumns[i].GetType()
+		}
 		for i := range post.RenderExprs {
 			// It is ok to use the evalCtx of the flowCtx since it won't be
 			// mutated (we are not evaluating the expressions). It's also ok to
 			// update post in-place even if flowCtx.PreserveFlowSpecs is true
 			// since we're not really mutating the render expressions.
-			post.RenderExprs[i].LocalExpr, err = helper.ProcessExpr(post.RenderExprs[i], flowCtx.EvalCtx, args.typs)
+			post.RenderExprs[i].LocalExpr, err = helper.ProcessExpr(post.RenderExprs[i], flowCtx.EvalCtx, typs)
 			if err != nil {
 				return args, neededColumns, err
 			}
@@ -172,31 +158,39 @@ func populateTableArgsLegacy(
 
 	// Now find the set of columns that are actually needed based on the
 	// post-processing spec.
-	neededColumns = getNeededColumns(post, len(cols))
+	neededColumns = getNeededColumns(post, numCols)
 
-	// Prune away columns that aren't needed.
-	if neededColumns.Len() != len(cols) {
-		idxMap := make([]int, len(cols))
-		keepColIdx := 0
-		for idx, ok := neededColumns.Next(0); ok; idx, ok = neededColumns.Next(idx + 1) {
-			cols[keepColIdx] = cols[idx]
-			idxMap[idx] = keepColIdx
-			keepColIdx++
+	colIDs := make([]descpb.ColumnID, 0, neededColumns.Len())
+	for idx, ok := neededColumns.Next(0); ok; idx, ok = neededColumns.Next(idx + 1) {
+		if idx < len(readableColumns) {
+			colIDs = append(colIDs, readableColumns[idx].GetID())
+		} else {
+			colIDs = append(colIDs, systemColumns[idx-len(readableColumns)].GetID())
 		}
-		cols = cols[:keepColIdx]
+	}
+
+	// Remap the post processing spec.
+	if len(colIDs) != numCols {
+		idxMap := make([]int, numCols)
+		newIdx := 0
+		for idx, ok := neededColumns.Next(0); ok; idx, ok = neededColumns.Next(idx + 1) {
+			idxMap[idx] = newIdx
+			newIdx++
+		}
 		remapPostProcessSpec(post, idxMap, flowCtx.PreserveFlowSpecs)
 	}
 
 	*args = cFetcherTableArgs{
-		desc:             table,
-		index:            index,
-		isSecondaryIndex: !index.Primary(),
-		cols:             cols,
-		typs:             args.typs,
+		typs: args.typs,
 	}
-	args.populateTypes(cols)
-	for i := range cols {
-		args.ColIdxMap.Set(cols[i].GetID(), i)
+	if err := rowenc.InitIndexFetchSpec(
+		&args.spec, flowCtx.Codec(), table, index, colIDs,
+	); err != nil {
+		return nil, util.FastIntSet{}, err
+	}
+	args.populateTypes(args.spec.FetchedColumns)
+	for i := range args.spec.FetchedColumns {
+		args.ColIdxMap.Set(args.spec.FetchedColumns[i].ColumnID, i)
 	}
 
 	// Before we can safely use types from the table descriptor, we need to

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -212,7 +212,7 @@ func NewColBatchScan(
 		flowCtx.TraceKV,
 	}
 
-	if err = fetcher.Init(flowCtx.Codec(), allocator, kvFetcherMemAcc, tableArgs); err != nil {
+	if err = fetcher.Init(allocator, kvFetcherMemAcc, tableArgs); err != nil {
 		fetcher.Release()
 		return nil, err
 	}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -144,7 +144,7 @@ func (s *ColIndexJoin) Init(ctx context.Context) {
 		s.streamerInfo.Streamer.Init(
 			kvstreamer.OutOfOrder,
 			kvstreamer.Hints{UniqueRequests: true},
-			s.cf.maxKeysPerRow,
+			int(s.cf.table.spec.MaxKeysPerRow),
 		)
 	}
 }
@@ -478,7 +478,7 @@ func NewColIndexJoin(
 		flowCtx.TraceKV,
 	}
 	if err = fetcher.Init(
-		flowCtx.Codec(), fetcherAllocator, kvFetcherMemAcc, tableArgs,
+		fetcherAllocator, kvFetcherMemAcc, tableArgs,
 	); err != nil {
 		fetcher.Release()
 		return nil, err

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -55,6 +55,7 @@ func ConvertBatchError(ctx context.Context, tableDesc catalog.TableDescriptor, b
 			origPErr.GoError(),
 			pgcode.UnsatisfiableBoundedStaleness,
 		)
+
 	case *roachpb.ConditionFailedError:
 		if origPErr.Index == nil {
 			break
@@ -69,16 +70,30 @@ func ConvertBatchError(ctx context.Context, tableDesc catalog.TableDescriptor, b
 		}
 		key := result.Rows[0].Key
 		return NewUniquenessConstraintViolationError(ctx, tableDesc, key, v.ActualValue)
+
 	case *roachpb.WriteIntentError:
 		key := v.Intents[0].Key
-		return NewLockNotAvailableError(ctx, tableDesc, key, v.Reason)
+		decodeKeyFn := func() (tableName string, indexName string, colNames []string, values []string, err error) {
+			codec, index, err := decodeKeyCodecAndIndex(tableDesc, key)
+			if err != nil {
+				return "", "", nil, nil, err
+			}
+			var spec descpb.IndexFetchSpec
+			if err := rowenc.InitIndexFetchSpec(&spec, codec, tableDesc, index, nil /* fetchColumnIDs */); err != nil {
+				return "", "", nil, nil, err
+			}
+
+			colNames, values, err = decodeKeyValsUsingSpec(&spec, key)
+			return spec.TableName, spec.IndexName, colNames, values, err
+		}
+		return newLockNotAvailableError(v.Reason, decodeKeyFn)
 	}
 	return origPErr.GoError()
 }
 
 // ConvertFetchError attempts to map a key-value error generated during a
 // key-value fetch to a user friendly SQL error.
-func ConvertFetchError(ctx context.Context, desc catalog.TableDescriptor, err error) error {
+func ConvertFetchError(spec *descpb.IndexFetchSpec, err error) error {
 	var errs struct {
 		wi *roachpb.WriteIntentError
 		bs *roachpb.MinTimestampBoundUnsatisfiableError
@@ -86,7 +101,12 @@ func ConvertFetchError(ctx context.Context, desc catalog.TableDescriptor, err er
 	switch {
 	case errors.As(err, &errs.wi):
 		key := errs.wi.Intents[0].Key
-		return NewLockNotAvailableError(ctx, desc, key, errs.wi.Reason)
+		decodeKeyFn := func() (tableName string, indexName string, colNames []string, values []string, err error) {
+			colNames, values, err = decodeKeyValsUsingSpec(spec, key)
+			return spec.TableName, spec.IndexName, colNames, values, err
+		}
+		return newLockNotAvailableError(errs.wi.Reason, decodeKeyFn)
+
 	case errors.As(err, &errs.bs):
 		return pgerror.WithCandidateCode(
 			err,
@@ -122,32 +142,74 @@ func NewUniquenessConstraintViolationError(
 	)
 }
 
-// NewLockNotAvailableError creates an error that represents an inability to
-// acquire a lock.
-func NewLockNotAvailableError(
-	ctx context.Context,
-	tableDesc catalog.TableDescriptor,
-	key roachpb.Key,
+// decodeKeyValsUsingSpec decodes an index key and returns the key column names
+// and values.
+func decodeKeyValsUsingSpec(
+	spec *descpb.IndexFetchSpec, key roachpb.Key,
+) (colNames []string, values []string, err error) {
+	// We want the key columns without the suffix columns.
+	keyCols := spec.KeyColumns()
+	keyVals := make([]rowenc.EncDatum, len(keyCols))
+	if len(key) < int(spec.KeyPrefixLength) {
+		return nil, nil, errors.AssertionFailedf("invalid table key")
+	}
+	if _, _, err := rowenc.DecodeKeyValsUsingSpec(keyCols, key[spec.KeyPrefixLength:], keyVals); err != nil {
+		return nil, nil, err
+	}
+	colNames = make([]string, len(keyCols))
+	values = make([]string, len(keyCols))
+	for i := range keyCols {
+		colNames[i] = keyCols[i].Name
+		values[i] = keyVals[i].String(keyCols[i].Type)
+	}
+	return colNames, values, nil
+}
+
+// newLockNotAvailableError creates an error that represents an inability to
+// acquire a lock. It uses an IndexFetchSpec for the corresponding index (the
+// fetch columns in the spec are not used).
+func newLockNotAvailableError(
 	reason roachpb.WriteIntentError_Reason,
+	decodeKeyFn func() (tableName string, indexName string, colNames []string, values []string, err error),
 ) error {
 	baseMsg := "could not obtain lock on row"
 	if reason == roachpb.WriteIntentError_REASON_LOCK_TIMEOUT {
 		baseMsg = "canceling statement due to lock timeout on row"
 	}
-
-	index, colNames, values, err := DecodeRowInfo(ctx, tableDesc, key, nil, false)
+	tableName, indexName, colNames, values, err := decodeKeyFn()
 	if err != nil {
-		return pgerror.Wrapf(err, pgcode.LockNotAvailable,
-			"%s: got decoding error", baseMsg)
+		return pgerror.Wrapf(err, pgcode.LockNotAvailable, "%s: got decoding error", baseMsg)
 	}
-
 	return pgerror.Newf(pgcode.LockNotAvailable,
 		"%s (%s)=(%s) in %s@%s",
 		baseMsg,
 		strings.Join(colNames, ","),
 		strings.Join(values, ","),
-		tableDesc.GetName(),
-		index.GetName())
+		tableName,
+		indexName,
+	)
+}
+
+// decodeKeyCodecAndIndex extracts the codec and index from a key (for a
+// particular table).
+func decodeKeyCodecAndIndex(
+	tableDesc catalog.TableDescriptor, key roachpb.Key,
+) (keys.SQLCodec, catalog.Index, error) {
+	_, tenantID, err := keys.DecodeTenantPrefix(key)
+	if err != nil {
+		return keys.SQLCodec{}, nil, err
+	}
+	codec := keys.MakeSQLCodec(tenantID)
+	indexID, _, err := rowenc.DecodeIndexKeyPrefix(codec, tableDesc.GetID(), key)
+	if err != nil {
+		return keys.SQLCodec{}, nil, err
+	}
+	index, err := tableDesc.FindIndexWithID(indexID)
+	if err != nil {
+		return keys.SQLCodec{}, nil, err
+	}
+
+	return keys.MakeSQLCodec(tenantID), index, nil
 }
 
 // DecodeRowInfo takes a table descriptor, a key, and an optional value and
@@ -160,19 +222,7 @@ func DecodeRowInfo(
 	value *roachpb.Value,
 	allColumns bool,
 ) (_ catalog.Index, columnNames []string, columnValues []string, _ error) {
-	// Strip the tenant prefix and pretend to use the system tenant's SQL codec
-	// for the rest of this function. This is safe because the key is just used
-	// to decode the corresponding datums and never escapes this function.
-	codec := keys.SystemSQLCodec
-	key, _, err := keys.DecodeTenantPrefix(key)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	indexID, _, err := rowenc.DecodeIndexKeyPrefix(codec, tableDesc.GetID(), key)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	index, err := tableDesc.FindIndexWithID(indexID)
+	codec, index, err := decodeKeyCodecAndIndex(tableDesc, key)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -62,10 +62,6 @@ type tableInfo struct {
 	// -- Fields initialized once --
 	spec descpb.IndexFetchSpec
 
-	// Used to determine whether a key retrieved belongs to the span we
-	// want to scan.
-	desc catalog.TableDescriptor
-
 	// The set of indexes into spec.FetchedColumns that are required for columns
 	// in the value part.
 	neededValueColsByIdx util.FastIntSet
@@ -138,9 +134,6 @@ type FetcherTableArgs struct {
 //      // Process res.row
 //   }
 type Fetcher struct {
-	// codec is used to encode and decode sql keys.
-	codec keys.SQLCodec
-
 	table tableInfo
 
 	// reverse denotes whether or not the spans should be read in reverse
@@ -234,7 +227,6 @@ func (rf *Fetcher) Init(
 	memMonitor *mon.BytesMonitor,
 	tableArgs FetcherTableArgs,
 ) error {
-	rf.codec = codec
 	rf.reverse = reverse
 	rf.lockStrength = lockStrength
 	rf.lockWaitPolicy = lockWaitPolicy
@@ -255,7 +247,6 @@ func (rf *Fetcher) Init(
 
 	table := &rf.table
 	*table = tableInfo{
-		desc:       tableArgs.Desc,
 		row:        make(rowenc.EncDatumRow, len(tableArgs.Columns)),
 		decodedRow: make(tree.Datums, len(tableArgs.Columns)),
 
@@ -563,7 +554,7 @@ func (rf *Fetcher) setNextKV(kv roachpb.KeyValue, needsCopy bool) {
 func (rf *Fetcher) nextKey(ctx context.Context) (newRow bool, _ error) {
 	ok, kv, finalReferenceToBatch, err := rf.kvFetcher.NextKV(ctx, rf.mvccDecodeStrategy)
 	if err != nil {
-		return false, ConvertFetchError(ctx, rf.table.desc, err)
+		return false, ConvertFetchError(&rf.table.spec, err)
 	}
 	rf.setNextKV(kv, finalReferenceToBatch)
 

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1116,7 +1116,7 @@ func (rf *Fetcher) finalizeRow() error {
 					}
 				}
 				var indexColNames []string
-				for i := range table.spec.KeyAndSuffixColumns {
+				for i := range table.spec.KeyFullColumns() {
 					indexColNames = append(indexColNames, table.spec.KeyAndSuffixColumns[i].Name)
 				}
 				return errors.AssertionFailedf(

--- a/pkg/sql/rowenc/index_fetch.go
+++ b/pkg/sql/rowenc/index_fetch.go
@@ -57,7 +57,8 @@ func InitIndexFetchSpec(
 
 	families := table.GetFamilies()
 	for i := range families {
-		if f := &families[i]; f.DefaultColumnID != 0 {
+		f := &families[i]
+		if f.DefaultColumnID != 0 {
 			if s.FamilyDefaultColumns == nil {
 				s.FamilyDefaultColumns = oldFamilies[:0]
 			}
@@ -65,6 +66,9 @@ func InitIndexFetchSpec(
 				FamilyID:        f.ID,
 				DefaultColumnID: f.DefaultColumnID,
 			})
+		}
+		if f.ID > s.MaxFamilyID {
+			s.MaxFamilyID = f.ID
 		}
 	}
 
@@ -113,6 +117,7 @@ func InitIndexFetchSpec(
 			IndexFetchSpec_Column: mkCol(col, colID),
 			Direction:             dir,
 			IsComposite:           compositeIDs.Contains(colID),
+			IsInverted:            colID == invertedColumnID,
 		}
 	}
 

--- a/pkg/sql/rowenc/testdata/index-fetch
+++ b/pkg/sql/rowenc/testdata/index-fetch
@@ -31,35 +31,37 @@ columns:
   "num_key_suffix_columns": 0,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     },
     {
-      "name": "b",
       "column_id": 2,
+      "name": "b",
       "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
-      "name": "c",
       "column_id": 3,
+      "name": "c",
       "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     }
@@ -83,23 +85,25 @@ columns:
   "num_key_suffix_columns": 0,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "b",
       "column_id": 2,
+      "name": "b",
       "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     }
@@ -123,39 +127,42 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     },
     {
-      "name": "b",
       "column_id": 2,
+      "name": "b",
       "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     }
@@ -179,39 +186,42 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "b",
       "column_id": 2,
+      "name": "b",
       "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
-      "name": "d",
       "column_id": 4,
+      "name": "d",
       "type": "family: BoolFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 16\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     }
@@ -237,49 +247,53 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "c",
         "column_id": 3,
+        "name": "c",
         "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": true
+      "is_composite": true,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 1,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     },
     {
-      "name": "c",
       "column_id": 3,
+      "name": "c",
       "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     }
@@ -304,55 +318,59 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "c",
         "column_id": 3,
+        "name": "c",
         "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": true
+      "is_composite": true,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     },
     {
-      "name": "c",
       "column_id": 3,
+      "name": "c",
       "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
-      "name": "d",
       "column_id": 4,
+      "name": "d",
       "type": "family: BoolFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 16\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     }
@@ -398,6 +416,7 @@ columns:
   "num_key_suffix_columns": 0,
   "max_keys_per_row": 3,
   "key_prefix_length": 2,
+  "max_family_id": 2,
   "family_default_columns": [
     {
       "family_id": 0,
@@ -411,19 +430,20 @@ columns:
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }
@@ -447,6 +467,7 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 2,
   "family_default_columns": [
     {
       "family_id": 0,
@@ -460,29 +481,31 @@ columns:
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }
@@ -506,6 +529,7 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 2,
   "key_prefix_length": 2,
+  "max_family_id": 2,
   "family_default_columns": [
     {
       "family_id": 0,
@@ -519,29 +543,31 @@ columns:
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: StringFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 25\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }
@@ -565,6 +591,7 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 2,
   "family_default_columns": [
     {
       "family_id": 0,
@@ -578,29 +605,31 @@ columns:
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "c",
         "column_id": 3,
+        "name": "c",
         "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": true
+      "is_composite": true,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }
@@ -624,6 +653,7 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 2,
   "key_prefix_length": 2,
+  "max_family_id": 2,
   "family_default_columns": [
     {
       "family_id": 0,
@@ -637,29 +667,31 @@ columns:
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "c",
         "column_id": 3,
+        "name": "c",
         "type": "family: DecimalFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 1700\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": true
+      "is_composite": true,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "a",
         "column_id": 1,
+        "name": "a",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "a",
       "column_id": 1,
+      "name": "a",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }
@@ -694,39 +726,42 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "j",
         "column_id": 3,
+        "name": "j",
         "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": true
     },
     {
       "column": {
-        "name": "k",
         "column_id": 1,
+        "name": "k",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "j",
       "column_id": 3,
+      "name": "j",
       "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
-      "name": "k",
       "column_id": 1,
+      "name": "k",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }
@@ -751,55 +786,59 @@ columns:
   "num_key_suffix_columns": 1,
   "max_keys_per_row": 1,
   "key_prefix_length": 2,
+  "max_family_id": 0,
   "family_default_columns": null,
   "key_and_suffix_columns": [
     {
       "column": {
-        "name": "b",
         "column_id": 2,
+        "name": "b",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     },
     {
       "column": {
-        "name": "j",
         "column_id": 3,
+        "name": "j",
         "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": true
     },
     {
       "column": {
-        "name": "k",
         "column_id": 1,
+        "name": "k",
         "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
         "is_non_nullable": true
       },
       "direction": 0,
-      "is_composite": false
+      "is_composite": false,
+      "is_inverted": false
     }
   ],
   "fetched_columns": [
     {
-      "name": "j",
       "column_id": 3,
+      "name": "j",
       "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
-      "name": "b",
       "column_id": 2,
+      "name": "b",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
-      "name": "k",
       "column_id": 1,
+      "name": "k",
       "type": "family: IntFamily\nwidth: 64\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 20\ntime_precision_is_set: false\n",
       "is_non_nullable": true
     }


### PR DESCRIPTION
#### row: refactor error handling code

This change refactors the `row.Fetcher` error handling code to no
longer rely on the table descriptor. The interesting part is where we
decode key values for a locking error; we now use the `IndexFetchSpec`
and decode the key directly rather than setting up a fake fetcher
through `DecodeRowInfo`.

Release note: None

#### colfetcher: use IndexFetchSpec

This commit converts the cFetcher to use an IndexFetchSpec instead of
table and index descriptors.

Release note: None