### PR TITLE
spanconfigkvaccessor: implement system span config RPCS

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -196,6 +196,7 @@ ALL_TESTS = [
     "//pkg/spanconfig/spanconfigsqlwatcher:spanconfigsqlwatcher_test",
     "//pkg/spanconfig/spanconfigstore:spanconfigstore_test",
     "//pkg/spanconfig/spanconfigtestutils:spanconfigtestutils_test",
+    "//pkg/spanconfig/systemspanconfig:systemspanconfig_test",
     "//pkg/sql/catalog/catalogkeys:catalogkeys_test",
     "//pkg/sql/catalog/catformat:catformat_test",
     "//pkg/sql/catalog/catprivilege:catprivilege_test",

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
@@ -11,7 +11,7 @@ upsert /{Min-System/NodeLiveness}          ttl_seconds=3600 num_replicas=5
 upsert /System/NodeLiveness{-Max}          ttl_seconds=600 num_replicas=5
 upsert /System/{NodeLivenessMax-tsd}       range system
 upsert /System{/tsd-tse}                   range default
-upsert /System{tse-/Max}                   range system
+upsert /System{tse-/SystemSpanConfigKeys}  range system
 upsert /Table/{SystemConfigSpan/Start-4}   database system (host)
 upsert /Table/{4-5}                        database system (host)
 upsert /Table/{5-6}                        database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
@@ -13,7 +13,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system
 ...
 
 # Adding an explicit zone configuration for the timeseries range should work
@@ -48,8 +48,8 @@ mutations
 ----
 delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       range default
-delete /System{tse-/Max}
-upsert /System{tse-/Max}                   range default
+delete /System{tse-/SystemSpanConfigKeys}
+upsert /System{tse-/SystemSpanConfigKeys}  range default
 
 state limit=5
 ----
@@ -57,7 +57,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          ttl_seconds=42
-/System{tse-/Max}                          range default
+/System{tse-/SystemSpanConfigKeys}         range default
 ...
 
 # Ensure that discarding other named zones behave as expected (reparenting them
@@ -80,7 +80,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range default
+/System{tse-/SystemSpanConfigKeys}         range default
 ...
 
 
@@ -106,8 +106,8 @@ delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       ttl_seconds=50
 delete /System{/tsd-tse}
 upsert /System{/tsd-tse}                   ttl_seconds=50
-delete /System{tse-/Max}
-upsert /System{tse-/Max}                   ttl_seconds=50
+delete /System{tse-/SystemSpanConfigKeys}
+upsert /System{tse-/SystemSpanConfigKeys}  ttl_seconds=50
 delete /Table/5{6-7}
 upsert /Table/5{6-7}                       ttl_seconds=50
 
@@ -117,7 +117,7 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              ttl_seconds=50
 /System{/tsd-tse}                          ttl_seconds=50
-/System{tse-/Max}                          ttl_seconds=50
+/System{tse-/SystemSpanConfigKeys}         ttl_seconds=50
 ...
 
 state offset=46
@@ -150,8 +150,8 @@ mutations
 ----
 delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       ttl_seconds=100
-delete /System{tse-/Max}
-upsert /System{tse-/Max}                   ttl_seconds=100
+delete /System{tse-/SystemSpanConfigKeys}
+upsert /System{tse-/SystemSpanConfigKeys}  ttl_seconds=100
 
 state limit=5
 ----
@@ -159,5 +159,5 @@ state limit=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              ttl_seconds=100
 /System{/tsd-tse}                          ttl_seconds=50
-/System{tse-/Max}                          ttl_seconds=100
+/System{tse-/SystemSpanConfigKeys}         ttl_seconds=100
 ...

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate
@@ -24,7 +24,7 @@ full-translate
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system
 /Table/{SystemConfigSpan/Start-4}          database system (host)
 /Table/{4-5}                               database system (host)
 /Table/{5-6}                               database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
@@ -40,7 +40,7 @@ full-translate
 /System/NodeLiveness{-Max}                 range default
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range default
+/System{tse-/SystemSpanConfigKeys}         range default
 /Table/{SystemConfigSpan/Start-4}          database system (host)
 /Table/{4-5}                               database system (host)
 /Table/{5-6}                               database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/named_zones
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/named_zones
@@ -47,4 +47,4 @@ translate named-zone=liveness
 translate named-zone=system
 ----
 /System/{NodeLivenessMax-tsd}              range system
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -75,4 +75,3 @@ translate database=db
 /Table/56/{2-3}                            ttl_seconds=1 num_replicas=7 num_voters=5 pts=[3]
 /Table/5{6/3-7}                            num_replicas=7 num_voters=5 pts=[3]
 /Table/5{7-8}                              num_replicas=7
-

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
@@ -109,7 +109,7 @@ full-translate
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
-/System{tse-/Max}                          range system
+/System{tse-/SystemSpanConfigKeys}         range system
 /Table/{SystemConfigSpan/Start-4}          ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/{4-5}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true
 /Table/{5-6}                               ignore_strict_gc=true num_replicas=7 rangefeed_enabled=true

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -293,7 +293,31 @@ var (
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 	// TimeseriesKeyMax is the maximum value for any timeseries data.
 	TimeseriesKeyMax = TimeseriesPrefix.PrefixEnd()
-
+	//
+	// SystemSpanConfigPrefix is the key prefix for all system span config data.
+	//
+	// We sort this at the end of the system keyspace to easily be able to exclude
+	// it from the span configuration that applies over the system keyspace. This
+	// is important because spans carved out from this range are used to store
+	// system span configurations in the `system.span_configurations` table, and
+	// as such, have special meaning associated with them; nothing is stored in
+	// the range itself.
+	SystemSpanConfigPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("\xffsys-scfg")))
+	// SystemSpanConfigEntireKeyspace is the key prefix used to denote that the
+	// associated system span configuration applies over the entire keyspace
+	// (including all secondary tenants).
+	SystemSpanConfigEntireKeyspace = roachpb.Key(makeKey(SystemSpanConfigPrefix, roachpb.RKey("host/all")))
+	// SystemSpanConfigHostOnTenantKeyspace is the key prefix used to denote that
+	// the associated system span configuration was applied by the host tenant
+	// over the keyspace of a secondary tenant.
+	SystemSpanConfigHostOnTenantKeyspace = roachpb.Key(makeKey(SystemSpanConfigPrefix, roachpb.RKey("host/ten/")))
+	// SystemSpanConfigSecondaryTenantOnEntireKeyspace is the key prefix used to
+	// denote that the associated system span configuration was applied by a
+	// secondary tenant over its entire keyspace.
+	SystemSpanConfigSecondaryTenantOnEntireKeyspace = roachpb.Key(makeKey(SystemSpanConfigPrefix, roachpb.RKey("ten/")))
+	// SystemSpanConfigKeyMax is the maximum value for any system span config key.
+	SystemSpanConfigKeyMax = SystemSpanConfigPrefix.PrefixEnd()
+	//
 	// 3. System tenant SQL keys
 	//
 	// TODO(nvanbenschoten): Figure out what to do with all of these. At a

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -245,17 +245,18 @@ var _ = [...]interface{}{
 	// 	2. System keys: This is where we store global, system data which is
 	// 	replicated across the cluster.
 	SystemPrefix,
-	NodeLivenessPrefix,  // "\x00liveness-"
-	BootstrapVersionKey, // "bootstrap-version"
-	descIDGenerator,     // "desc-idgen"
-	NodeIDGenerator,     // "node-idgen"
-	RangeIDGenerator,    // "range-idgen"
-	StatusPrefix,        // "status-"
-	StatusNodePrefix,    // "status-node-"
-	StoreIDGenerator,    // "store-idgen"
-	MigrationPrefix,     // "system-version/"
-	MigrationLease,      // "system-version/lease"
-	TimeseriesPrefix,    // "tsd"
+	NodeLivenessPrefix,     // "\x00liveness-"
+	BootstrapVersionKey,    // "bootstrap-version"
+	descIDGenerator,        // "desc-idgen"
+	NodeIDGenerator,        // "node-idgen"
+	RangeIDGenerator,       // "range-idgen"
+	StatusPrefix,           // "status-"
+	StatusNodePrefix,       // "status-node-"
+	StoreIDGenerator,       // "store-idgen"
+	MigrationPrefix,        // "system-version/"
+	MigrationLease,         // "system-version/lease"
+	TimeseriesPrefix,       // "tsd"
+	SystemSpanConfigPrefix, // "xffsys-scfg"
 	SystemMax,
 
 	// 	3. System tenant SQL keys: This is where we store all system-tenant

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -128,6 +128,10 @@ var (
 				ppFunc: timeseriesKeyPrint,
 				PSFunc: parseUnsupported,
 			},
+			{Name: "/SystemSpanConfigKeys", prefix: SystemSpanConfigPrefix,
+				ppFunc: decodeKeyPrint,
+				PSFunc: parseUnsupported,
+			},
 		}},
 		{Name: "/NamespaceTable", start: NamespaceTableMin, end: NamespaceTableMax, Entries: []DictEntry{
 			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: parseUnsupported},

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -37,6 +37,12 @@ var (
 	// TimeseriesSpan holds all the timeseries data in the cluster.
 	TimeseriesSpan = roachpb.Span{Key: TimeseriesPrefix, EndKey: TimeseriesKeyMax}
 
+	// SystemSpanConfigSpan is part of the system keyspace that is used to carve
+	// out spans for system span configurations. No data is stored in these spans,
+	// instead, special meaning is assigned to them when stored in
+	// `system.span_configurations`.
+	SystemSpanConfigSpan = roachpb.Span{Key: SystemSpanConfigPrefix, EndKey: SystemSpanConfigKeyMax}
+
 	// SystemConfigSpan is the range of system objects which will be gossiped.
 	SystemConfigSpan = roachpb.Span{Key: SystemConfigSplitKey, EndKey: SystemConfigTableDataMax}
 

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -205,6 +205,25 @@ message SystemSpanConfigEntry {
   SystemSpanConfig system_span_config = 2 [(gogoproto.nullable) = false];
 }
 
+
+// Config is a union type for span configurations and system span
+// configurations.
+message Config {
+  option(gogoproto.equal) = true;
+  oneof union {
+    SpanConfig span_config = 1;
+    SystemSpanConfig system_span_config = 2;
+  }
+};
+
+// SystemSpanConfigurationsTableEntry is the proto corresponding to what is
+// stored in the `system.span_configurations` table.
+message SystemSpanConfigurationsTableEntry {
+  Span span = 1 [(gogoproto.nullable) = false];
+  Config config = 2 [(gogoproto.nullable) = false];
+};
+
+
 // GetSpanConfigsRequest is used to fetch the span configurations over the
 // specified keyspans.
 message GetSpanConfigsRequest {

--- a/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/security",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
+        "//pkg/spanconfig/systemspanconfig",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
@@ -1,0 +1,71 @@
+# Walk through a full set of scenarios pertaining to  system span configs.
+
+# Test with an empty slate.
+kvaccessor-system-scfgs-get
+----
+
+kvaccessor-system-scfgs-update
+delete [cluster]
+----
+err: expected to delete 1 row(s), deleted 0
+
+kvaccessor-system-scfgs-update
+delete [tenant 10]
+----
+err: expected to delete 1 row(s), deleted 0
+
+# Verify that writing, reading, and deleting a single entry behaves as expected.
+kvaccessor-system-scfgs-update
+upsert [cluster]:C
+----
+ok
+
+kvaccessor-system-scfgs-get
+----
+[cluster]:C
+
+kvaccessor-system-scfgs-update
+delete [cluster]
+----
+ok
+
+# Verify writing and getting multiple entries works as expected.
+kvaccessor-system-scfgs-update
+upsert [cluster]:C
+upsert [tenant 10]:B
+----
+ok
+
+kvaccessor-system-scfgs-get
+----
+[cluster]:C
+[tenant 10]:B
+
+# Verify updating existing entries and adding new entries works as expected.
+kvaccessor-system-scfgs-update
+upsert [cluster]:D
+upsert [tenant 20]:E
+upsert [tenant 30]:F
+----
+ok
+
+
+kvaccessor-system-scfgs-get
+----
+[cluster]:D
+[tenant 10]:B
+[tenant 20]:E
+[tenant 30]:F
+
+
+# Verify deleting some of the entries works as expected.
+kvaccessor-system-scfgs-update
+delete [cluster]
+delete [tenant 10]
+----
+ok
+
+kvaccessor-system-scfgs-get
+----
+[tenant 20]:E
+[tenant 30]:F

--- a/pkg/spanconfig/spanconfigkvsubscriber/span_config_decoder.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/span_config_decoder.go
@@ -75,9 +75,15 @@ func (sd *spanConfigDecoder) decode(kv roachpb.KeyValue) (entry roachpb.SpanConf
 		entry.Span.EndKey = []byte(tree.MustBeDBytes(endKey))
 	}
 	if config := datums[2]; config != tree.DNull {
-		if err := protoutil.Unmarshal([]byte(tree.MustBeDBytes(config)), &entry.Config); err != nil {
+		var conf roachpb.Config
+		if err := protoutil.Unmarshal([]byte(tree.MustBeDBytes(config)), &conf); err != nil {
 			return roachpb.SpanConfigEntry{}, err
 		}
+		spanConfig := conf.GetSpanConfig()
+		if spanConfig == nil {
+			return roachpb.SpanConfigEntry{}, errors.AssertionFailedf("config corresponding to span %s did not contain span config", entry.Span)
+		}
+		entry.Config = *conf.GetSpanConfig()
 	}
 
 	return entry, nil

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -209,6 +209,10 @@ func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 		// Add spans for the system range without the timeseries and
 		// liveness ranges, which are individually captured above.
 		//
+		// We also don't apply configurations over the SystemSpanConfigSpan; spans
+		// carved from this range have no data, instead, associated configurations
+		// for these spans have special meaning in `system.span_configurations`.
+		//
 		// Note that the NodeLivenessSpan sorts before the rest of the system
 		// keyspace, so the first span here starts at the end of the
 		// NodeLivenessSpan.
@@ -218,7 +222,7 @@ func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 		})
 		spans = append(spans, roachpb.Span{
 			Key:    keys.TimeseriesSpan.EndKey,
-			EndKey: keys.SystemMax,
+			EndKey: keys.SystemSpanConfigSpan.Key,
 		})
 	case zonepb.TenantsZoneName: // nothing to do.
 	default:

--- a/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/roachpb:with-mocks",
         "//pkg/spanconfig",
         "//pkg/sql/catalog/descpb",
+        "//pkg/util/hlc",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +36,69 @@ var spanRe = regexp.MustCompile(`^\[(\w+),\s??(\w+)\)$`)
 // configRe matches a single word. It's a shorthand for declaring a unique
 // config.
 var configRe = regexp.MustCompile(`^(\w+)$`)
+
+// targetRe matches strings of the form "[cluster]" or "[tenant <id>]".
+var targetRe = regexp.MustCompile(`^\[(cluster|(tenant) (\d*))]$`)
+
+// systemSpanConfigRe matches a single letter. It's a shorthand for declaring
+// a unique system span config.
+var systemSpanConfigRe = regexp.MustCompile(`^\s??(\w)$`)
+
+// parseTarget is a helper function that constructs a
+// roachpb.SystemSpanConfigTarget from a string of the form "[cluster]" or
+// "[tenant <id>]".
+func parseTarget(t *testing.T, target string) roachpb.SystemSpanConfigTarget {
+	if !targetRe.MatchString(target) {
+		t.Fatalf("expected %s to match target regex", target)
+	}
+	matches := targetRe.FindStringSubmatch(target)
+	const tenantPrefix = "tenant"
+	if matches[1] == "cluster" {
+		return roachpb.SystemSpanConfigTarget{}
+	} else if matches[2] == tenantPrefix {
+		id, err := strconv.Atoi(matches[3])
+		require.NoError(t, err)
+		tenID := roachpb.MakeTenantID(uint64(id))
+		return roachpb.SystemSpanConfigTarget{
+			TenantID: &tenID,
+		}
+	}
+	t.Fatalf("unkown target: %v %q %d", matches, matches[3], len(matches))
+	return roachpb.SystemSpanConfigTarget{}
+}
+
+// parseSystemSpanConfig is a helper function that constructs SystemSpanConfigs
+// using strings of the systemSpanConfigRe regex form.
+func parseSystemSpanConfig(t *testing.T, conf string) roachpb.SystemSpanConfig {
+	if !systemSpanConfigRe.MatchString(conf) {
+		t.Fatalf("expected %s to match system span config regex", conf)
+	}
+	matches := systemSpanConfigRe.FindStringSubmatch(conf)
+	return roachpb.SystemSpanConfig{
+		ProtectionPolicies: []roachpb.ProtectionPolicy{
+			{
+				ProtectedTimestamp: hlc.Timestamp{
+					WallTime: int64(matches[1][0]),
+				},
+			},
+		},
+	}
+}
+
+// parseSystemSpanConfig entry parses the given string and returns a
+// roachpb.SystemSpanConfigEntry.
+func parseSystemSpanConfigEntry(t *testing.T, entry string) roachpb.SystemSpanConfigEntry {
+	parts := strings.Split(entry, ":")
+	if len(parts) != 2 {
+		t.Fatalf("expected single %q separator", ":")
+	}
+	target := parseTarget(t, parts[0])
+	conf := parseSystemSpanConfig(t, parts[1])
+	return roachpb.SystemSpanConfigEntry{
+		SystemSpanConfigTarget: target,
+		SystemSpanConfig:       conf,
+	}
+}
 
 // ParseSpan is helper function that constructs a roachpb.Span from a string of
 // the form "[start, end)".
@@ -146,6 +210,42 @@ func ParseKVAccessorUpdateArguments(
 	return toDelete, toUpsert
 }
 
+// ParseKVAccessorUpdateSystemSpanConfigsArguments is a helper function that
+// parses datadriven kvaccessor-system-scfgs-update arguments into the
+// relevant system span configs. The input is of the following form:
+//
+//    upsert [cluster]:C
+//    upsert [tenant: id]:B
+// 		delete [cluster]
+//    delete [tenant: id]
+//
+func ParseKVAccessorUpdateSystemSpanConfigsArguments(
+	t *testing.T, input string,
+) ([]roachpb.SystemSpanConfigTarget, []roachpb.SystemSpanConfigEntry) {
+	var toDelete []roachpb.SystemSpanConfigTarget
+	var toUpsert []roachpb.SystemSpanConfigEntry
+	for _, line := range strings.Split(input, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		const upsertPrefix, deletePrefix = "upsert ", "delete "
+		switch {
+		case strings.HasPrefix(line, deletePrefix):
+			line = strings.TrimPrefix(line, line[:len(deletePrefix)])
+			toDelete = append(toDelete, parseTarget(t, line))
+		case strings.HasPrefix(line, upsertPrefix):
+			line = strings.TrimPrefix(line, line[:len(upsertPrefix)])
+			toUpsert = append(toUpsert, parseSystemSpanConfigEntry(t, line))
+		default:
+			t.Fatalf("malformed line %q, expected to find prefix %q or %q",
+				line, upsertPrefix, deletePrefix)
+		}
+	}
+	return toDelete, toUpsert
+}
+
 // ParseStoreApplyArguments is a helper function that parses datadriven
 // store update arguments. The input is of the following form:
 //
@@ -184,6 +284,13 @@ func PrintSpan(sp roachpb.Span) string {
 	return fmt.Sprintf("[%s,%s)", string(sp.Key), string(sp.EndKey))
 }
 
+func printTarget(target roachpb.SystemSpanConfigTarget) string {
+	if target.TenantID == nil {
+		return "[cluster]"
+	}
+	return fmt.Sprintf("[tenant %d]", target.TenantID.InternalValue)
+}
+
 // PrintSpanConfig is a helper function that transforms roachpb.SpanConfig into
 // a readable string. The span config is assumed to have been constructed by the
 // ParseSpanConfig helper above.
@@ -191,13 +298,29 @@ func PrintSpanConfig(conf roachpb.SpanConfig) string {
 	return conf.Constraints[0].Constraints[0].Key // see ParseConfig for what a "tagged" roachpb.SpanConfig translates to
 }
 
+// printSystemSpanConfig is a helper function that decodes a
+// roachpb.SystemSpanConfig constructed using parseSystemSpanConfig.
+func printSystemSpanConfig(conf roachpb.SystemSpanConfig) string {
+	// See parseSystemSpanConfig for why we do this.
+	return string(int(conf.ProtectionPolicies[0].ProtectedTimestamp.WallTime))
+}
+
 // PrintSpanConfigEntry is a helper function that transforms
 // roachpb.SpanConfigEntry into a string of the form "[start, end):config". The
 // entry is assumed to either have been constructed using ParseSpanConfigEntry
-// above, or the constituen span and config to have been constructed using the
+// above, or the constituent span and config to have been constructed using the
 // Parse{Span,Config} helpers above.
 func PrintSpanConfigEntry(entry roachpb.SpanConfigEntry) string {
 	return fmt.Sprintf("%s:%s", PrintSpan(entry.Span), PrintSpanConfig(entry.Config))
+}
+
+// PrintSystemSpanConfigEntry isa helper function that transforms a
+// roachpb.SystemSpanConfigEntry into a string of the form "[target]:config".
+// The entry is assumed to have been constructed using
+// parseSystemSpanConfigEntry above, or the constituent span and config have
+// been constructed using parse{Target,SystemSpanConfig} helpers above.
+func PrintSystemSpanConfigEntry(entry roachpb.SystemSpanConfigEntry) string {
+	return fmt.Sprintf("%s:%s", printTarget(entry.SystemSpanConfigTarget), printSystemSpanConfig(entry.SystemSpanConfig))
 }
 
 // PrintSpanConfigDiffedAgainstDefaults is a helper function that diffs the given

--- a/pkg/spanconfig/systemspanconfig/BUILD.bazel
+++ b/pkg/spanconfig/systemspanconfig/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "systemspanconfig",
+    srcs = [
+        "encoderdecoder.go",
+        "target.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/systemspanconfig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/roachpb:with-mocks",
+        "//pkg/util/encoding",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "systemspanconfig_test",
+    srcs = ["target_test.go"],
+    embed = [":systemspanconfig"],
+    deps = [
+        "//pkg/roachpb:with-mocks",
+        "//pkg/testutils",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/spanconfig/systemspanconfig/encoderdecoder.go
+++ b/pkg/spanconfig/systemspanconfig/encoderdecoder.go
@@ -72,3 +72,13 @@ func DecodeTarget(span roachpb.Span) (Target, error) {
 
 	return Target{}, errors.AssertionFailedf("did not find prefix")
 }
+
+// GetHostTenantOnTenantKeyspaceSpan returns the keyspan which contains all
+// host tenant installed system span configurations that target secondary
+// tenants.
+func GetHostTenantOnTenantKeyspaceSpan() roachpb.Span {
+	return roachpb.Span{
+		Key:    keys.SystemSpanConfigHostOnTenantKeyspace,
+		EndKey: keys.SystemSpanConfigHostOnTenantKeyspace.PrefixEnd(),
+	}
+}

--- a/pkg/spanconfig/systemspanconfig/encoderdecoder.go
+++ b/pkg/spanconfig/systemspanconfig/encoderdecoder.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package systemspanconfig
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/errwrap/testdata/src/github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+// EncodeTarget is used to convert a systemspanconfig.Target into a roachpb.Span
+// suitable for persistence in the `system.span_configurations` table.
+func EncodeTarget(target Target) roachpb.Span {
+	var k roachpb.Key
+
+	if target.TargeterTenantID == roachpb.SystemTenantID && target.TargeteeTenantID == roachpb.SystemTenantID {
+		k = keys.SystemSpanConfigEntireKeyspace
+	} else if target.TargeterTenantID == roachpb.SystemTenantID {
+		k = encoding.EncodeUvarintAscending(
+			keys.SystemSpanConfigHostOnTenantKeyspace, target.TargeteeTenantID.InternalValue,
+		)
+	} else {
+		k = encoding.EncodeUvarintAscending(
+			keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace, target.TargeterTenantID.InternalValue,
+		)
+	}
+	return roachpb.Span{Key: k, EndKey: k.PrefixEnd()}
+}
+
+// DecodeTarget converts the given span into a systemspanconfig.Target. An error
+// is returned if the span does not conform to the encoding used to store system
+// span configs in `system.span_configurations`.
+func DecodeTarget(span roachpb.Span) (Target, error) {
+	if bytes.HasPrefix(span.Key, keys.SystemSpanConfigEntireKeyspace) {
+		return MakeTarget(roachpb.SystemTenantID, roachpb.SystemTenantID)
+	}
+
+	// System span config was applied by the host tenant over a secondary
+	// tenant's entire keyspace.
+	if bytes.HasPrefix(span.Key, keys.SystemSpanConfigHostOnTenantKeyspace) {
+		tenIDBytes := span.Key[len(keys.SystemSpanConfigHostOnTenantKeyspace):]
+		_, tenIDRaw, err := encoding.DecodeUvarintAscending(tenIDBytes)
+		if err != nil {
+			return Target{}, err
+		}
+		tenID := roachpb.MakeTenantID(tenIDRaw)
+		return MakeTarget(roachpb.SystemTenantID, tenID)
+	}
+
+	// System span config was applied by a secondary tenant over its entire
+	// keyspace.
+	if bytes.HasPrefix(span.Key, keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace) {
+		tenIDBytes := span.Key[len(keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace):]
+		_, tenIDRaw, err := encoding.DecodeUvarintAscending(tenIDBytes)
+		if err != nil {
+			return Target{}, err
+		}
+		tenID := roachpb.MakeTenantID(tenIDRaw)
+		return MakeTarget(tenID, tenID)
+	}
+
+	return Target{}, errors.AssertionFailedf("did not find prefix")
+}

--- a/pkg/spanconfig/systemspanconfig/target.go
+++ b/pkg/spanconfig/systemspanconfig/target.go
@@ -1,0 +1,84 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package systemspanconfig
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// Target specifies the target of a system span configuration.
+type Target struct {
+	// TargeterTenantID is the ID of the tenant that specified the system span
+	// configuration.
+	TargeterTenantID roachpb.TenantID
+
+	// TargeteeTenantID is the ID of the tenant that the associated system span
+	// configuration applies to. If the host tenant is the targetee then the
+	// system span configuration applies over all ranges in the system (including
+	// those belonging to secondary tenants).
+	//
+	// Secondary tenants are only allowed to target themselves. The host tenant
+	// may use this field to target a specific secondary tenant.
+	TargeteeTenantID roachpb.TenantID
+}
+
+// MakeTargetUsingSourceContext constructs a new systemspanconfig.Target given a
+// roachp.SystemSpanConfigTarget. The TargeterTenantID is derived from the
+// context passed in.
+func MakeTargetUsingSourceContext(
+	ctx context.Context, target roachpb.SystemSpanConfigTarget,
+) (Target, error) {
+	var targeterTenantID roachpb.TenantID
+	var targeteeTenantID roachpb.TenantID
+	if tenID, ok := roachpb.TenantFromContext(ctx); ok {
+		targeterTenantID = tenID
+	} else {
+		targeterTenantID = roachpb.SystemTenantID
+	}
+
+	if target.TenantID != nil {
+		targeteeTenantID = *target.TenantID
+	} else {
+		targeteeTenantID = targeterTenantID
+	}
+
+	t := Target{
+		TargeterTenantID: targeterTenantID,
+		TargeteeTenantID: targeteeTenantID,
+	}
+	return t, t.validate()
+}
+
+// MakeTarget constructs a systemspanconfig.Target given a sourceTenantID and
+// targetTenantID.
+func MakeTarget(
+	targeterTenantID roachpb.TenantID, targeteeTenantID roachpb.TenantID,
+) (Target, error) {
+	t := Target{
+		TargeterTenantID: targeterTenantID,
+		TargeteeTenantID: targeteeTenantID,
+	}
+	return t, t.validate()
+}
+
+func (t *Target) validate() error {
+	if t.TargeterTenantID != roachpb.SystemTenantID && t.TargeterTenantID != t.TargeteeTenantID {
+		return errors.AssertionFailedf(
+			"secondary tenant %s cannot target another tenant with ID %s",
+			t.TargeterTenantID,
+			t.TargeteeTenantID,
+		)
+	}
+	return nil
+}

--- a/pkg/spanconfig/systemspanconfig/target_test.go
+++ b/pkg/spanconfig/systemspanconfig/target_test.go
@@ -1,0 +1,140 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package systemspanconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncodeDecodeTarget ensures that encoding/decoding a
+// systemspanconfig.Target is roundtripable.
+func TestEncodeDecodeTarget(t *testing.T) {
+	makeTargetOrFatal := func(targeterID roachpb.TenantID, targeteeID roachpb.TenantID) Target {
+		target, err := MakeTarget(targeterID, targeteeID)
+		require.NoError(t, err)
+		return target
+	}
+	for _, testTarget := range []Target{
+		// Tenant targeting its logical cluster.
+		makeTargetOrFatal(roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+		// System tenant targeting its logical cluster.
+		makeTargetOrFatal(roachpb.SystemTenantID, roachpb.SystemTenantID),
+		// System tenant targeting a secondary tenant.
+		makeTargetOrFatal(roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+	} {
+		target, err := DecodeTarget(EncodeTarget(testTarget))
+		require.NoError(t, err)
+		require.Equal(t, testTarget, target)
+	}
+}
+
+// TestTargetValidation ensures target.validate() works as expected.
+func TestTargetValidation(t *testing.T) {
+	for _, tc := range []struct {
+		targeterID roachpb.TenantID
+		targeteeID roachpb.TenantID
+		expErr     string
+	}{
+		{
+			// Secondary tenants cannot target the system tenant.
+			targeterID: roachpb.MakeTenantID(10),
+			targeteeID: roachpb.SystemTenantID,
+			expErr:     "secondary tenant 10 cannot target another tenant with ID",
+		},
+		{
+			// Secondary tenants cannot target other secondary tenants.
+			targeterID: roachpb.MakeTenantID(10),
+			targeteeID: roachpb.MakeTenantID(20),
+			expErr:     "secondary tenant 10 cannot target another tenant with ID",
+		},
+		// Test some valid targets.
+		{
+			// System tenant targeting secondary tenant is allowed.
+			targeterID: roachpb.SystemTenantID,
+			targeteeID: roachpb.MakeTenantID(20),
+		},
+		{
+			// System tenant targeting itself is allowed.
+			targeterID: roachpb.SystemTenantID,
+			targeteeID: roachpb.SystemTenantID,
+		},
+		{
+			// Secondary tenant targeting itself is allowed.
+			targeterID: roachpb.MakeTenantID(10),
+			targeteeID: roachpb.MakeTenantID(10),
+		},
+	} {
+		target := Target{
+			TargeterTenantID: tc.targeterID,
+			TargeteeTenantID: tc.targeteeID,
+		}
+		require.True(t, testutils.IsError(target.validate(), tc.expErr))
+	}
+}
+
+// TestMakeTargetUsingSourceContext ensures that the targeting tenant ID is
+// correctly inferred from a context when constructing a systemspanconfig.Target
+// from a roachpb.SystemSpanConfigTarget.
+func TestMakeTargetUsingSourceContext(t *testing.T) {
+	makeSystemSpanConfigTarget := func(tenantID roachpb.TenantID) roachpb.SystemSpanConfigTarget {
+		return roachpb.SystemSpanConfigTarget{
+			TenantID: &tenantID,
+		}
+	}
+	clusterTarget := roachpb.SystemSpanConfigTarget{}
+	for _, tc := range []struct {
+		tenantID               roachpb.TenantID
+		systemSpanConfigTarget roachpb.SystemSpanConfigTarget
+		expErr                 string
+	}{
+		{
+			tenantID:               roachpb.SystemTenantID,
+			systemSpanConfigTarget: makeSystemSpanConfigTarget(roachpb.MakeTenantID(10)),
+		},
+		{
+			tenantID:               roachpb.SystemTenantID,
+			systemSpanConfigTarget: clusterTarget,
+		},
+		{
+			tenantID:               roachpb.MakeTenantID(10),
+			systemSpanConfigTarget: clusterTarget,
+		},
+		// Invalid scenarios.
+		{
+			tenantID:               roachpb.MakeTenantID(10),
+			systemSpanConfigTarget: makeSystemSpanConfigTarget(roachpb.SystemTenantID),
+			expErr:                 "secondary tenant 10 cannot target another tenant with ID",
+		},
+		{
+			tenantID:               roachpb.MakeTenantID(10),
+			systemSpanConfigTarget: makeSystemSpanConfigTarget(roachpb.MakeTenantID(20)),
+			expErr:                 "secondary tenant 10 cannot target another tenant with ID",
+		},
+	} {
+		ctx := roachpb.NewContextForTenant(context.Background(), tc.tenantID)
+		target, err := MakeTargetUsingSourceContext(ctx, tc.systemSpanConfigTarget)
+		require.True(t, testutils.IsError(err, tc.expErr))
+		if tc.expErr != "" {
+			require.Equal(t, tc.tenantID, target.TargeterTenantID)
+			expectedTargeteeTenantID := tc.tenantID
+			if tc.systemSpanConfigTarget.TenantID != nil {
+				expectedTargeteeTenantID = *tc.systemSpanConfigTarget.TenantID
+			}
+			require.Equal(t, expectedTargeteeTenantID, target.TargeteeTenantID)
+		}
+		require.True(t, testutils.IsError(target.validate(), tc.expErr))
+	}
+}


### PR DESCRIPTION
This patch implements `GetSystemSpanConfigEntries` and
`UpdateSystemSpanConfigEntries` RPCs.

Release note: None


First commit from: https://github.com/cockroachdb/cockroach/pull/75641