### PR TITLE
colexec: close the ordered sync used by the external sorter

### DIFF
--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -245,14 +245,17 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 
 func (o *OrderedSynchronizer) Close() error {
 	o.accountingHelper.Release()
+	var lastErr error
 	for _, input := range o.inputs {
-		input.ToClose.CloseAndLogOnErr(o.EnsureCtx(), "ordered synchronizer")
+		if err := input.ToClose.Close(); err != nil {
+			lastErr = err
+		}
 	}
 	if o.span != nil {
 		o.span.Finish()
 	}
 	*o = OrderedSynchronizer{}
-	return nil
+	return lastErr
 }
 
 func (o *OrderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -108,11 +108,14 @@ func (s *SerialUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata
 
 // Close is part of the colexecop.ClosableOperator interface.
 func (s *SerialUnorderedSynchronizer) Close() error {
+	var lastErr error
 	for _, input := range s.inputs {
-		input.ToClose.CloseAndLogOnErr(s.EnsureCtx(), "serial unordered synchronizer")
+		if err := input.ToClose.Close(); err != nil {
+			lastErr = err
+		}
 	}
 	if s.span != nil {
 		s.span.Finish()
 	}
-	return nil
+	return lastErr
 }


### PR DESCRIPTION
**colexec: close the ordered sync used by the external sorter**

Previously, we forgot to close the ordered synchronizer that is used by
the external sorter to merge already sorted partitions. This could
result in some tracing spans never being finished and is now fixed.

Release note: None

**colexec: return an error rather than logging it on Close in some cases**

This error eventually will be logged anyway, but we should try to
propagate it up the stack as much as possible.

Release note: None