### PR TITLE
row: disable streamer by default

### DIFF
--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -175,6 +175,10 @@ func TestStreamerTightBudget(t *testing.T) {
 	_, err = db.Exec(fmt.Sprintf("SET distsql_workmem = '%dB'", blobSize))
 	require.NoError(t, err)
 
+	// TODO(yuzefovich): remove this once the streamer is enabled by default.
+	_, err = db.Exec("SET CLUSTER SETTING sql.distsql.use_streamer.enabled = true;")
+	require.NoError(t, err)
+
 	// Perform an index join to read the blobs.
 	query := "EXPLAIN ANALYZE SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"
 	maximumMemoryUsageRegex := regexp.MustCompile(`maximum memory usage: (\d+\.\d+) MiB`)

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -38,7 +38,7 @@ var useStreamerEnabled = settings.RegisterBoolSetting(
 	"determines whether the usage of the Streamer API is allowed. "+
 		"Enabling this will increase the speed of lookup/index joins "+
 		"while adhering to memory limits.",
-	true,
+	false,
 )
 
 // TxnKVStreamer handles retrieval of key/values.


### PR DESCRIPTION
Recently there has been an increase in timeouts of the logic tests. I looked
into the last five failed builds on the staging branch, and in three of them
we had a logic test timeout, and for all of them I see a couple of Streamer
goroutines stuck for tens of minutes. Thus, this commit disables the
streamer by default temporarily.

Informs: #75708.

Release note: None