### PR TITLE
kvserver: fix assertion in qps-based rebalancing logic

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1483,6 +1483,17 @@ func (a *Allocator) TransferLeaseTarget(
 			)
 			return roachpb.ReplicaDescriptor{}
 		case shouldRebalance:
+			log.VEventf(
+				ctx,
+				5,
+				"r%d: should transfer lease (qps=%0.2f) from s%d (qps=%0.2f) to s%d (qps=%0.2f)",
+				leaseRepl.GetRangeID(),
+				leaseReplQPS,
+				leaseRepl.StoreID(),
+				storeDescMap[leaseRepl.StoreID()].Capacity.QueriesPerSecond,
+				bestStore,
+				storeDescMap[bestStore].Capacity.QueriesPerSecond,
+			)
 		default:
 			log.Fatalf(ctx, "unknown declineReason: %v", noRebalanceReason)
 		}

--- a/pkg/kv/kvserver/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator_scorer.go
@@ -971,6 +971,7 @@ func bestStoreToMinimizeQPSDelta(
 		return 0, existingNotOverfull
 	}
 
+	currentQPSDelta := getQPSDelta(storeQPSMap, domain)
 	// Simulate the coldest candidate's QPS after it receives a lease/replica for
 	// the range.
 	storeQPSMap[bestCandidate] += replQPS
@@ -993,7 +994,6 @@ func bestStoreToMinimizeQPSDelta(
 	// store to the coldest store is not going to reduce the delta between all
 	// these stores, but it is still a desirable action to take.
 
-	currentQPSDelta := getQPSDelta(storeQPSMap, domain)
 	newQPSDelta := getQPSDelta(storeQPSMap, domain)
 	if currentQPSDelta < newQPSDelta {
 		panic(


### PR DESCRIPTION
The qps-based rebalancing logic has an assertion at the end that ensures that
the qps delta between stores _after a rebalance_ is at least as good as the qps
delta between stores _before the rebalance_ (i.e. this assertion is supposed to
fire for any logic errors in our code).

This assertion was broken because we were computing the "current" delta (i.e.
before rebalance) incorrectly.

Release note: None