### PR TITLE
kvserver: use `ClearRawRange` to truncate very large Raft logs

### DIFF
--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -13,6 +13,7 @@ package kvserver
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -20,12 +21,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/datadriven"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +42,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 	datadriven.Walk(t, testutils.TestDataPath(t, "truncated_state"), func(t *testing.T, path string) {
 		const rangeID = 12
 		loader := stateloader.Make(rangeID)
+		prefixBuf := &loader.RangeIDPrefixBuf
 		eng := storage.NewDefaultInMemForTesting()
 		defer eng.Close()
 
@@ -50,9 +53,9 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 				d.ScanArgs(t, "index", &prevTruncatedState.Index)
 				d.ScanArgs(t, "term", &prevTruncatedState.Term)
 				return ""
+
 			case "put":
-				var index uint64
-				var term uint64
+				var index, term uint64
 				d.ScanArgs(t, "index", &index)
 				d.ScanArgs(t, "term", &term)
 
@@ -61,13 +64,12 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 					Term:  term,
 				}
 
-				assert.NoError(t, loader.SetRaftTruncatedState(ctx, eng, truncState))
+				require.NoError(t, loader.SetRaftTruncatedState(ctx, eng, truncState))
 				return ""
+
 			case "handle":
 				var buf bytes.Buffer
-
-				var index uint64
-				var term uint64
+				var index, term uint64
 				d.ScanArgs(t, "index", &index)
 				d.ScanArgs(t, "term", &term)
 
@@ -75,28 +77,57 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 					Index: index,
 					Term:  term,
 				}
-
 				currentTruncatedState, err := loader.LoadRaftTruncatedState(ctx, eng)
-				assert.NoError(t, err)
-				apply, err := handleTruncatedStateBelowRaftPreApply(ctx, &currentTruncatedState, suggestedTruncatedState, loader, eng)
-				if err != nil {
-					return err.Error()
+				require.NoError(t, err)
+
+				// Write log entries at start, middle, end, and above the truncated interval.
+				if suggestedTruncatedState.Index > currentTruncatedState.Index {
+					indexes := []uint64{
+						currentTruncatedState.Index + 1,                                       // start
+						(suggestedTruncatedState.Index + currentTruncatedState.Index + 1) / 2, // middle
+						suggestedTruncatedState.Index,                                         // end
+						suggestedTruncatedState.Index + 1,                                     // new head
+					}
+					for _, idx := range indexes {
+						meta := enginepb.MVCCMetadata{RawBytes: make([]byte, 8)}
+						binary.BigEndian.PutUint64(meta.RawBytes, idx)
+						value, err := protoutil.Marshal(&meta)
+						require.NoError(t, err)
+						require.NoError(t, eng.PutUnversioned(prefixBuf.RaftLogKey(idx), value))
+					}
 				}
 
+				// Apply truncation.
+				apply, err := handleTruncatedStateBelowRaftPreApply(ctx, &currentTruncatedState, suggestedTruncatedState, loader, eng)
+				require.NoError(t, err)
 				fmt.Fprintf(&buf, "apply: %t\n", apply)
 
+				// Check the truncated state.
 				key := keys.RaftTruncatedStateKey(rangeID)
 				var truncatedState roachpb.RaftTruncatedState
 				ok, err := storage.MVCCGetProto(ctx, eng, key, hlc.Timestamp{}, &truncatedState, storage.MVCCGetOptions{})
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				require.True(t, ok)
-				fmt.Fprintf(&buf, "%s -> index=%d term=%d\n", key, truncatedState.Index, truncatedState.Term)
+				fmt.Fprintf(&buf, "state: %s -> index=%d term=%d\n", key, truncatedState.Index, truncatedState.Term)
+
+				// Find the first untruncated log entry (the log head).
+				res, err := storage.MVCCScan(ctx, eng,
+					prefixBuf.RaftLogPrefix().Clone(),
+					prefixBuf.RaftLogPrefix().PrefixEnd(),
+					hlc.Timestamp{},
+					storage.MVCCScanOptions{MaxKeys: 1})
+				require.NoError(t, err)
+				var head roachpb.Key
+				if len(res.KVs) > 0 {
+					head = res.KVs[0].Key
+				}
+				fmt.Fprintf(&buf, "head: %s\n", head)
+
 				return buf.String()
+
 			default:
+				return fmt.Sprintf("unsupported: %s", d.Cmd)
 			}
-			return fmt.Sprintf("unsupported: %s", d.Cmd)
 		})
 	})
 }

--- a/pkg/kv/kvserver/testdata/truncated_state/truncated_state
+++ b/pkg/kv/kvserver/testdata/truncated_state/truncated_state
@@ -8,18 +8,28 @@ prev index=100 term=9
 handle index=150 term=9
 ----
 apply: true
-/Local/RangeID/12/u/RaftTruncatedState -> index=150 term=9
+state: /Local/RangeID/12/u/RaftTruncatedState -> index=150 term=9
+head: /Local/RangeID/12/u/RaftLog/logIndex:151
 
 # Simulate another truncation that moves forward.
 
 handle index=170 term=9
 ----
 apply: true
-/Local/RangeID/12/u/RaftTruncatedState -> index=170 term=9
+state: /Local/RangeID/12/u/RaftTruncatedState -> index=170 term=9
+head: /Local/RangeID/12/u/RaftLog/logIndex:171
 
 # ... and one that moves backwards and should not take effect.
 
 handle index=150 term=9
 ----
 apply: false
-/Local/RangeID/12/u/RaftTruncatedState -> index=170 term=9
+state: /Local/RangeID/12/u/RaftTruncatedState -> index=170 term=9
+head: /Local/RangeID/12/u/RaftLog/logIndex:171
+
+# A huge truncation (beyond raftLogTruncationClearRangeThreshold) also works.
+handle index=12345678901234567890 term=9
+----
+apply: true
+state: /Local/RangeID/12/u/RaftTruncatedState -> index=12345678901234567890 term=9
+head: /Local/RangeID/12/u/RaftLog/logIndex:12345678901234567891

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -174,6 +174,16 @@ func bytesPrefixEnd(b []byte) []byte {
 	return b
 }
 
+// Clone returns a copy of the key.
+func (k Key) Clone() Key {
+	if k == nil {
+		return nil
+	}
+	c := make(Key, len(k))
+	copy(c, k)
+	return c
+}
+
 // Next returns the next key in lexicographic sort order. The method may only
 // take a shallow copy of the Key, so both the receiver and the return
 // value should be treated as immutable after.

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -61,6 +61,17 @@ func makeSynTS(walltime int64, logical int32) hlc.Timestamp {
 	}
 }
 
+func TestKeyClone(t *testing.T) {
+	k := Key{0x01, 0x02, 0x03}
+	c := k.Clone()
+	require.Equal(t, k, c)
+
+	k[0] = 0xff
+	require.NotEqual(t, k, c)
+
+	require.Nil(t, Key(nil).Clone())
+}
+
 // TestKeyNext tests that the method for creating lexicographic
 // successors to byte slices works as expected.
 func TestKeyNext(t *testing.T) {


### PR DESCRIPTION
Raft log truncation was done using point deletes in a single Pebble
batch. If the number of entries to truncate was very large, this could
result in overflowing the Pebble batch, causing the node to panic. This
has been seen to happen e.g. when the snapshot rate was set very low,
effectively stalling snapshot transfers which in turn held up log
truncations for extended periods of time.

This patch uses a Pebble range tombstone if the number of entries to
truncate is very large (>100k). In most common cases, point deletes are
still used, to avoid writing too many range tombstones to Pebble.

Release note (bug fix): Fixed a bug which could cause nodes to crash
when truncating abnormally large Raft logs.