### PR TITLE
spanconfig: introduce spanconfig.Splitter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1371,13 +1371,13 @@ UI_OSS_MANIFESTS := $(subst .ccl,.oss,$(UI_CCL_MANIFESTS))
 # files. Normally, Make would run the recipe twice if dist/FOO.js and
 # FOO-manifest.js were both out-of-date. [0]
 #
-# XXX: Ideally we'd scope the dependency on $(UI_PROTOS*) to the appropriate
-# protos DLLs, but Make v3.81 has a bug that causes the dependency to be ignored
-# [1]. We're stuck with this workaround until Apple decides to update the
-# version of Make they ship with macOS or we require a newer version of Make.
-# Such a requirement would need to be strictly enforced, as the way this fails
-# is extremely subtle and doesn't present until the web UI is loaded in the
-# browser.
+# TODO(irfansharif): Ideally we'd scope the dependency on $(UI_PROTOS*) to the
+# appropriate protos DLLs, but Make v3.81 has a bug that causes the dependency
+# to be ignored [1]. We're stuck with this workaround until Apple decides to
+# update the version of Make they ship with macOS or we require a newer version
+# of Make. Such a requirement would need to be strictly enforced, as the way
+# this fails is extremely subtle and doesn't present until the web UI is loaded
+# in the browser.
 #
 # [0]: https://stackoverflow.com/a/3077254/1122351
 # [1]: http://savannah.gnu.org/bugs/?19108

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -38,6 +38,7 @@ ALL_TESTS = [
     "//pkg/ccl/serverccl:serverccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigcomparedccl:spanconfigcomparedccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigreconcilerccl:spanconfigreconcilerccl_test",
+    "//pkg/ccl/spanconfigccl/spanconfigsplitterccl:spanconfigsplitterccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl:spanconfigsqltranslatorccl_test",
     "//pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl:spanconfigsqlwatcherccl_test",
     "//pkg/ccl/sqlproxyccl/denylist:denylist_test",

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "spanconfigsplitterccl_test",
+    srcs = [
+        "datadriven_test.go",
+        "main_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    deps = [
+        "//pkg/base",
+        "//pkg/ccl/kvccl/kvtenantccl",
+        "//pkg/ccl/partitionccl",
+        "//pkg/ccl/utilccl",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigsplitter",
+        "//pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster",
+        "//pkg/sql/catalog/descpb",
+        "//pkg/testutils",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
@@ -1,0 +1,138 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package spanconfigsplitterccl
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsplitter"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDataDriven is a data-driven test for spanconfig.Splitter. It offers
+// the following commands:
+//
+// - "exec-sql"
+//   Executes the input SQL query.
+//
+// - "query-sql"
+//   Executes the input SQL query and prints the results.
+//
+// - "splits" [database=<str> table=<str>] [id=<int>]
+//   Generates the splits for the referenced object (named database + table, or
+//   descriptor id).
+//
+func TestDataDriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	scKnobs := &spanconfig.TestingKnobs{
+		// Instead of relying on the GC job to wait out TTLs and clear out descriptors,
+		// let's simply exclude dropped tables to simulate descriptors no longer existing.
+		// See comment on ExcludeDroppedDescriptorsFromLookup for more details.
+		ExcludeDroppedDescriptorsFromLookup: true,
+		// We run the reconciler manually in this test (through the span config
+		// test cluster).
+		ManagerDisableJobCreation: true,
+	}
+	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					SpanConfig: scKnobs,
+				},
+			},
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs, nil)
+		defer spanConfigTestCluster.Cleanup()
+
+		var tenant *spanconfigtestcluster.Tenant
+		if strings.Contains(path, "tenant") {
+			tenant = spanConfigTestCluster.InitializeTenant(ctx, roachpb.MakeTenantID(10))
+			tenant.Exec(`SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`)
+		} else {
+			tenant = spanConfigTestCluster.InitializeTenant(ctx, roachpb.SystemTenantID)
+		}
+
+		// TODO(irfansharif): Expose this through the test harness once we integrate
+		// it into the schema changer.
+		splitter := spanconfigsplitter.New(tenant.ExecCfg().Codec, scKnobs)
+
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "exec-sql":
+				tenant.Exec(d.Input)
+
+			case "query-sql":
+				rows := tenant.Query(d.Input)
+				output, err := sqlutils.RowsToDataDrivenOutput(rows)
+				require.NoError(t, err)
+				return output
+
+			case "splits":
+				// Parse the args to get the object ID we're looking to split.
+				var objID descpb.ID
+				switch {
+				case d.HasArg("id"):
+					var scanID int
+					d.ScanArgs(t, "id", &scanID)
+					objID = descpb.ID(scanID)
+				case d.HasArg("database"):
+					// NB: Name resolution for dropped descriptors does not work like
+					// you'd expect, i.e. it does not work at all. We have to look things
+					// up by ID first.
+					var dbName, tbName string
+					d.ScanArgs(t, "database", &dbName)
+					d.ScanArgs(t, "table", &tbName)
+					objID = tenant.LookupTableByName(ctx, dbName, tbName).GetID()
+				default:
+					d.Fatalf(t, "insufficient/improper args (%v) provided to split", d.CmdArgs)
+				}
+
+				splits, err := splitter.Splits(ctx, tenant.LookupTableDescriptorByID(ctx, objID))
+				require.NoError(t, err)
+
+				sort.Slice(splits, func(i, j int) bool {
+					return splits[i].Compare(splits[j]) < 0
+				})
+				var output strings.Builder
+				for _, split := range splits {
+					output.WriteString(fmt.Sprintf("%s\n", split))
+				}
+				return output.String()
+
+			default:
+				t.Fatalf("unknown command: %s", d.Cmd)
+			}
+
+			return ""
+		})
+	})
+}

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/main_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package spanconfigsplitterccl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/implicit_partitioning
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/implicit_partitioning
@@ -1,0 +1,38 @@
+exec-sql
+CREATE DATABASE db;
+----
+
+exec-sql
+SET experimental_enable_implicit_column_partitioning = true;
+----
+
+exec-sql
+CREATE TABLE db.partition_all_by_list (N1 INT PRIMARY KEY, S2 STRING) PARTITION ALL BY LIST (S2) (
+   PARTITION one VALUES IN ('mid'),
+   PARTITION two VALUES IN ('fin')
+);
+----
+
+splits database=db table=partition_all_by_list
+----
+/Table/106
+/Table/106/1
+/Table/106/1/"fin"
+/Table/106/1/"fin"/PrefixEnd
+/Table/106/1/"mid"
+/Table/106/1/"mid"/PrefixEnd
+/Table/106/2
+
+exec-sql
+CREATE TABLE db.partition_all_by_range(N1 INT PRIMARY KEY, S2 STRING) PARTITION ALL BY RANGE (S2) (
+  PARTITION one VALUES FROM (MINVALUE) TO ('mid'),
+  PARTITION two VALUES FROM ('mid') TO (MAXVALUE)
+)
+----
+
+splits database=db table=partition_all_by_range
+----
+/Table/107
+/Table/107/1
+/Table/107/1/"mid"
+/Table/107/2

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/indexes
@@ -1,0 +1,63 @@
+# Test splits for simple tables with indexes, dropping some and then adding
+# some new others.
+
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.t(i INT PRIMARY KEY, j INT);
+----
+
+# We should observe splits at the table start, index start, and start of
+# (non-existent) next index.
+splits database=db table=t
+----
+/Table/106
+/Table/106/1
+/Table/106/2
+
+# Create a bunch of indexes of the form idx<index ID>.
+exec-sql
+CREATE INDEX idx2 ON db.t (j);
+CREATE INDEX idx4 ON db.t (j);
+----
+
+# We should observe splits for each one, in addition to what we had earlier. We
+# should continue to observe a split at the next index ID.
+splits database=db table=t
+----
+/Table/106
+/Table/106/1
+/Table/106/2
+/Table/106/3
+/Table/106/4
+/Table/106/5
+
+# Drop and indexe to create a "gap" in the keyspace.
+exec-sql
+DROP INDEX db.t@idx2;
+----
+
+# The gap should appear. /Table/106/2 is there as that marks the end of the
+# first non-dropped index, and should extend to the next non-dropped index
+# start /Table/106/4.
+splits database=db table=t
+----
+/Table/106
+/Table/106/1
+/Table/106/2
+/Table/106/4
+/Table/106/5
+
+# Create another index to make sure it appears as expected.
+exec-sql
+CREATE INDEX idx6 ON db.t (j);
+----
+
+splits database=db table=t
+----
+/Table/106
+/Table/106/1
+/Table/106/2
+/Table/106/4
+/Table/106/5
+/Table/106/6
+/Table/106/7

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/partitions
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/partitions
@@ -1,0 +1,470 @@
+# Test a bunch of partitioned table variants.
+
+exec-sql
+CREATE DATABASE db;
+----
+
+# Our simplest case with zero partitions -- should only observe table boundary
+# and primary index start/end split points.
+exec-sql
+CREATE TABLE db.no_partitions(i INT PRIMARY KEY, j INT);
+----
+
+splits database=db table=no_partitions
+----
+/Table/106
+/Table/106/1
+/Table/106/2
+
+# Partitioning the primary index by range -- we should observe splits along
+# named values within the index.
+exec-sql
+CREATE TABLE db.range_partitions(i INT PRIMARY KEY, j INT) PARTITION BY RANGE (i) (
+  PARTITION less_than_five       VALUES FROM (MINVALUE) to (5),
+  PARTITION between_five_and_ten VALUES FROM (5) to (10),
+  PARTITION greater_than_ten     VALUES FROM (10) to (MAXVALUE)
+);
+----
+
+splits database=db table=range_partitions
+----
+/Table/107
+/Table/107/1
+/Table/107/1/5
+/Table/107/1/10
+/Table/107/2
+
+# Try the same thing on a secondary index.
+exec-sql
+CREATE INDEX idx ON db.range_partitions (j);
+ALTER INDEX db.range_partitions@idx PARTITION BY RANGE (j) (
+  PARTITION less_than_five       VALUES FROM (minvalue) to (5),
+  PARTITION between_five_and_ten VALUES FROM (5) to (10),
+  PARTITION greater_than_ten     VALUES FROM (10) to (maxvalue)
+);
+----
+
+splits database=db table=range_partitions
+----
+/Table/107
+/Table/107/1
+/Table/107/1/5
+/Table/107/1/10
+/Table/107/2
+/Table/107/2/5
+/Table/107/2/10
+/Table/107/3
+
+# Test partitioning by list, across unordered partitioning values, both
+# contiguous and otherwise. While here, also test for the default partition.
+exec-sql
+CREATE TABLE db.list_partitions(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
+  PARTITION one_and_five    VALUES IN (2, 5),
+  PARTITION four_and_three  VALUES IN (4, 3),
+  PARTITION just_nine       VALUES IN (9),
+  PARTITION everything_else VALUES IN (DEFAULT)
+);
+----
+
+# We should see subpartitions in the primary index for each value we're
+# partitioning by and the value after (marking the end of the partition). This
+# is not duplicated if the value after too appears across our lists. We should
+# also observe gaps where we fall back to the default config.
+splits database=db table=list_partitions
+----
+/Table/108
+/Table/108/1
+/Table/108/1/2
+/Table/108/1/3
+/Table/108/1/4
+/Table/108/1/5
+/Table/108/1/6
+/Table/108/1/9
+/Table/108/1/10
+/Table/108/2
+
+# Try the same thing on a secondary index.
+exec-sql
+CREATE INDEX idx ON db.list_partitions (j);
+ALTER INDEX db.list_partitions@idx PARTITION BY LIST (j) (
+  PARTITION one_and_five    VALUES IN (2, 5),
+  PARTITION four_and_three  VALUES IN (4, 3),
+  PARTITION just_nine       VALUES IN (9),
+  PARTITION everything_else VALUES IN (DEFAULT)
+);
+----
+
+splits database=db table=list_partitions
+----
+/Table/108
+/Table/108/1
+/Table/108/1/2
+/Table/108/1/3
+/Table/108/1/4
+/Table/108/1/5
+/Table/108/1/6
+/Table/108/1/9
+/Table/108/1/10
+/Table/108/2
+/Table/108/2/2
+/Table/108/2/3
+/Table/108/2/4
+/Table/108/2/5
+/Table/108/2/6
+/Table/108/2/9
+/Table/108/2/10
+/Table/108/3
+
+# Try the same thing but with only contiguous values.
+exec-sql
+CREATE TABLE db.list_partitions_contiguous(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
+  PARTITION three                   VALUES IN (3),
+  PARTITION four_and_five           VALUES IN (4, 5),
+  PARTITION six_and_everything_else VALUES IN (6, default)
+);
+----
+
+splits database=db table=list_partitions_contiguous
+----
+/Table/109
+/Table/109/1
+/Table/109/1/3
+/Table/109/1/4
+/Table/109/1/5
+/Table/109/1/6
+/Table/109/1/7
+/Table/109/2
+
+# Test partitioning by multiple column values, including with DEFAULTs. When
+# using DEFAULT in the second column, we should see splits along the first
+# column value (and the next, to mark its end). With a non-DEFAULT value for
+# the second column we should see it appear explicitly as a split key (and the
+# next value for the second column, to mark its end).
+exec-sql
+CREATE TABLE db.list_multi_column_partitions(i INT, j INT, PRIMARY KEY (i, j)) PARTITION BY LIST (i, j) (
+  PARTITION two_and_default VALUES IN ((2, DEFAULT)),
+  PARTITION six_and_seven VALUES IN ((6, 7)),
+  PARTITION four_and_eight VALUES IN ((4, 8)),
+  PARTITION default_and_default VALUES IN ((DEFAULT, DEFAULT))
+);
+----
+
+splits database=db table=list_multi_column_partitions
+----
+/Table/110
+/Table/110/1
+/Table/110/1/2
+/Table/110/1/3
+/Table/110/1/4/8
+/Table/110/1/4/9
+/Table/110/1/6/7
+/Table/110/1/6/8
+/Table/110/2
+
+# Try the same thing on a secondary index.
+exec-sql
+CREATE INDEX idx ON db.list_multi_column_partitions(i, j);
+ALTER INDEX db.list_multi_column_partitions@idx PARTITION BY LIST (i, j) (
+  PARTITION two_and_default VALUES IN ((2, DEFAULT)),
+  PARTITION six_and_seven VALUES IN ((6, 7)),
+  PARTITION four_and_eight VALUES IN ((4, 8)),
+  PARTITION default_and_default VALUES IN ((DEFAULT, DEFAULT))
+);
+----
+
+splits database=db table=list_multi_column_partitions
+----
+/Table/110
+/Table/110/1
+/Table/110/1/2
+/Table/110/1/3
+/Table/110/1/4/8
+/Table/110/1/4/9
+/Table/110/1/6/7
+/Table/110/1/6/8
+/Table/110/2
+/Table/110/2/2
+/Table/110/2/3
+/Table/110/2/4/8
+/Table/110/2/4/9
+/Table/110/2/6/7
+/Table/110/2/6/8
+/Table/110/3
+
+# We should be able to mix and patch partitioning. Each value partition should
+# be further subdivided by range.
+exec-sql
+CREATE TABLE db.list_then_range_partitions (
+    C1 STRING,
+    N2 INT,
+    PRIMARY KEY (C1, N2)
+) PARTITION BY LIST (C1) (
+    PARTITION P1C1 VALUES IN ('A', 'C')
+        PARTITION BY RANGE (N2) (
+            PARTITION P1C1N2 VALUES FROM (MINVALUE) TO (10),
+            PARTITION P2C1N2 VALUES FROM (10) TO (MAXVALUE)
+        ),
+    PARTITION P2C1 VALUES IN ('B', 'D')
+        PARTITION BY RANGE (N2) (
+            PARTITION P3C1N2 VALUES FROM (MINVALUE) TO (42),
+            PARTITION P4C1N2 VALUES FROM (42) TO (MAXVALUE)
+        )
+);
+----
+
+splits database=db table=list_then_range_partitions
+----
+/Table/111
+/Table/111/1
+/Table/111/1/"A"
+/Table/111/1/"A"/10
+/Table/111/1/"A"/PrefixEnd
+/Table/111/1/"B"
+/Table/111/1/"B"/42
+/Table/111/1/"B"/PrefixEnd
+/Table/111/1/"C"
+/Table/111/1/"C"/10
+/Table/111/1/"C"/PrefixEnd
+/Table/111/1/"D"
+/Table/111/1/"D"/42
+/Table/111/1/"D"/PrefixEnd
+/Table/111/2
+
+# Try the same thing on a secondary index.
+exec-sql
+CREATE INDEX idx ON db.list_then_range_partitions (C1, N2);
+ALTER INDEX db.list_then_range_partitions@idx PARTITION BY LIST (C1) (
+    PARTITION P1C1 VALUES IN ('A', 'C')
+        PARTITION BY RANGE (N2) (
+            PARTITION P1C1N2 VALUES FROM (MINVALUE) TO (10),
+            PARTITION P2C1N2 VALUES FROM (10) TO (MAXVALUE)
+        ),
+    PARTITION P2C1 VALUES IN ('B', 'D')
+        PARTITION BY RANGE (N2) (
+            PARTITION P3C1N2 VALUES FROM (MINVALUE) TO (42),
+            PARTITION P4C1N2 VALUES FROM (42) TO (MAXVALUE)
+        )
+);
+----
+
+splits database=db table=list_then_range_partitions
+----
+/Table/111
+/Table/111/1
+/Table/111/1/"A"
+/Table/111/1/"A"/10
+/Table/111/1/"A"/PrefixEnd
+/Table/111/1/"B"
+/Table/111/1/"B"/42
+/Table/111/1/"B"/PrefixEnd
+/Table/111/1/"C"
+/Table/111/1/"C"/10
+/Table/111/1/"C"/PrefixEnd
+/Table/111/1/"D"
+/Table/111/1/"D"/42
+/Table/111/1/"D"/PrefixEnd
+/Table/111/2
+/Table/111/2/"A"
+/Table/111/2/"A"/10
+/Table/111/2/"A"/PrefixEnd
+/Table/111/2/"B"
+/Table/111/2/"B"/42
+/Table/111/2/"B"/PrefixEnd
+/Table/111/2/"C"
+/Table/111/2/"C"/10
+/Table/111/2/"C"/PrefixEnd
+/Table/111/2/"D"
+/Table/111/2/"D"/42
+/Table/111/2/"D"/PrefixEnd
+/Table/111/3
+
+# We should be able to go arbitrarily deep with our partitioning, and not all
+# partitions need to be deeply nested.
+exec-sql
+CREATE TABLE db.list_then_list_then_range_partitions_mixed (
+    C1 STRING,
+    C2 STRING,
+    N3 INT,
+    PRIMARY KEY (C1, C2, N3)
+) PARTITION BY LIST (C1) (
+    PARTITION P1C1 VALUES IN ('A', 'C'),
+    PARTITION P2C1 VALUES IN ('B', 'D')
+        PARTITION BY LIST (C2) (
+            PARTITION P1C1C2 VALUES IN ('G', 'J')
+                PARTITION BY RANGE (N3) (
+                    PARTITION P1C1C2N3 VALUES FROM (MINVALUE) TO (10),
+                    PARTITION P2C1C2N3 VALUES FROM (10) TO (MAXVALUE)
+                ),
+            PARTITION P2C1C2 VALUES IN ('I', 'K')
+        ),
+    PARTITION P3C1 VALUES IN ('E', 'F')
+);
+----
+
+splits database=db table=list_then_list_then_range_partitions_mixed
+----
+/Table/112
+/Table/112/1
+/Table/112/1/"A"
+/Table/112/1/"A"/PrefixEnd
+/Table/112/1/"B"
+/Table/112/1/"B"/"G"
+/Table/112/1/"B"/"G"/10
+/Table/112/1/"B"/"G"/PrefixEnd
+/Table/112/1/"B"/"I"
+/Table/112/1/"B"/"I"/PrefixEnd
+/Table/112/1/"B"/"J"
+/Table/112/1/"B"/"J"/10
+/Table/112/1/"B"/"J"/PrefixEnd
+/Table/112/1/"B"/"K"
+/Table/112/1/"B"/"K"/PrefixEnd
+/Table/112/1/"B"/PrefixEnd
+/Table/112/1/"C"
+/Table/112/1/"C"/PrefixEnd
+/Table/112/1/"D"
+/Table/112/1/"D"/"G"
+/Table/112/1/"D"/"G"/10
+/Table/112/1/"D"/"G"/PrefixEnd
+/Table/112/1/"D"/"I"
+/Table/112/1/"D"/"I"/PrefixEnd
+/Table/112/1/"D"/"J"
+/Table/112/1/"D"/"J"/10
+/Table/112/1/"D"/"J"/PrefixEnd
+/Table/112/1/"D"/"K"
+/Table/112/1/"D"/"K"/PrefixEnd
+/Table/112/1/"D"/PrefixEnd
+/Table/112/1/"E"
+/Table/112/1/"E"/PrefixEnd
+/Table/112/1/"F"
+/Table/112/1/"F"/PrefixEnd
+/Table/112/2
+
+
+# Try the same thing on a secondary index.
+exec-sql
+CREATE INDEX idx ON db.list_then_list_then_range_partitions_mixed (C1, C2, N3);
+ALTER INDEX db.list_then_list_then_range_partitions_mixed@idx PARTITION BY LIST (C1) (
+    PARTITION P1C1 VALUES IN ('A', 'C'),
+    PARTITION P2C1 VALUES IN ('B', 'D')
+        PARTITION BY LIST (C2) (
+            PARTITION P1C1C2 VALUES IN ('G', 'J')
+                PARTITION BY RANGE (N3) (
+                    PARTITION P1C1C2N3 VALUES FROM (MINVALUE) TO (10),
+                    PARTITION P2C1C2N3 VALUES FROM (10) TO (MAXVALUE)
+                ),
+            PARTITION P2C1C2 VALUES IN ('I', 'K')
+        ),
+    PARTITION P3C1 VALUES IN ('E', 'F')
+);
+----
+
+splits database=db table=list_then_list_then_range_partitions_mixed
+----
+/Table/112
+/Table/112/1
+/Table/112/1/"A"
+/Table/112/1/"A"/PrefixEnd
+/Table/112/1/"B"
+/Table/112/1/"B"/"G"
+/Table/112/1/"B"/"G"/10
+/Table/112/1/"B"/"G"/PrefixEnd
+/Table/112/1/"B"/"I"
+/Table/112/1/"B"/"I"/PrefixEnd
+/Table/112/1/"B"/"J"
+/Table/112/1/"B"/"J"/10
+/Table/112/1/"B"/"J"/PrefixEnd
+/Table/112/1/"B"/"K"
+/Table/112/1/"B"/"K"/PrefixEnd
+/Table/112/1/"B"/PrefixEnd
+/Table/112/1/"C"
+/Table/112/1/"C"/PrefixEnd
+/Table/112/1/"D"
+/Table/112/1/"D"/"G"
+/Table/112/1/"D"/"G"/10
+/Table/112/1/"D"/"G"/PrefixEnd
+/Table/112/1/"D"/"I"
+/Table/112/1/"D"/"I"/PrefixEnd
+/Table/112/1/"D"/"J"
+/Table/112/1/"D"/"J"/10
+/Table/112/1/"D"/"J"/PrefixEnd
+/Table/112/1/"D"/"K"
+/Table/112/1/"D"/"K"/PrefixEnd
+/Table/112/1/"D"/PrefixEnd
+/Table/112/1/"E"
+/Table/112/1/"E"/PrefixEnd
+/Table/112/1/"F"
+/Table/112/1/"F"/PrefixEnd
+/Table/112/2
+/Table/112/2/"A"
+/Table/112/2/"A"/PrefixEnd
+/Table/112/2/"B"
+/Table/112/2/"B"/"G"
+/Table/112/2/"B"/"G"/10
+/Table/112/2/"B"/"G"/PrefixEnd
+/Table/112/2/"B"/"I"
+/Table/112/2/"B"/"I"/PrefixEnd
+/Table/112/2/"B"/"J"
+/Table/112/2/"B"/"J"/10
+/Table/112/2/"B"/"J"/PrefixEnd
+/Table/112/2/"B"/"K"
+/Table/112/2/"B"/"K"/PrefixEnd
+/Table/112/2/"B"/PrefixEnd
+/Table/112/2/"C"
+/Table/112/2/"C"/PrefixEnd
+/Table/112/2/"D"
+/Table/112/2/"D"/"G"
+/Table/112/2/"D"/"G"/10
+/Table/112/2/"D"/"G"/PrefixEnd
+/Table/112/2/"D"/"I"
+/Table/112/2/"D"/"I"/PrefixEnd
+/Table/112/2/"D"/"J"
+/Table/112/2/"D"/"J"/10
+/Table/112/2/"D"/"J"/PrefixEnd
+/Table/112/2/"D"/"K"
+/Table/112/2/"D"/"K"/PrefixEnd
+/Table/112/2/"D"/PrefixEnd
+/Table/112/2/"E"
+/Table/112/2/"E"/PrefixEnd
+/Table/112/2/"F"
+/Table/112/2/"F"/PrefixEnd
+/Table/112/3
+
+# A single default partition's splits should look no different than a table
+# with a single primary index.
+exec-sql
+CREATE TABLE db.list_default(N1 INT PRIMARY KEY) PARTITION BY LIST (N1) (
+  PARTITION every_thing VALUES IN (DEFAULT)
+);
+----
+
+splits database=db table=list_default
+----
+/Table/113
+/Table/113/1
+/Table/113/2
+
+
+# Try another variant with partitioning by default first and then by range. We
+# should observe subpartitions of the inner-most RANGE partition.
+exec-sql
+CREATE TABLE db.list_default_then_range (
+    N1 INT,
+    N2 INT,
+    PRIMARY KEY (N1, N2)
+) PARTITION BY LIST (N1) (
+    PARTITION P1N1 VALUES IN (DEFAULT)
+        PARTITION BY RANGE (N2) (
+            PARTITION P1N1N2 VALUES FROM (MINVALUE) TO (10),
+            PARTITION P2N1N2 VALUES FROM (10) TO (42),
+            PARTITION P3N1N2 VALUES FROM (42) TO (MAXVALUE)
+        )
+);
+----
+
+splits database=db table=list_default_then_range
+----
+/Table/114
+/Table/114/1
+/Table/114/1/10
+/Table/114/1/42
+/Table/114/2

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/tables
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/tables
@@ -1,0 +1,38 @@
+# Run the most basic split tests -- we should observe splits for non-dropped
+# tables at table start and index start + end boundaries.
+
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.t1();
+CREATE TABLE db.t2();
+----
+
+query-sql
+SELECT id FROM system.namespace WHERE name='t1'
+----
+106
+
+query-sql
+SELECT id FROM system.namespace WHERE name='t2'
+----
+107
+
+splits database=db table=t1
+----
+/Table/106
+/Table/106/1
+/Table/106/2
+
+splits database=db table=t2
+----
+/Table/107
+/Table/107/1
+/Table/107/2
+
+exec-sql
+DROP TABLE db.t2;
+----
+
+# Dropped tables should not observe any splits.
+splits id=107
+----

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/test
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/testdata/test
@@ -1,0 +1,21 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.partition_by_list(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
+  PARTITION one_and_five    VALUES IN (1, 5),
+  PARTITION four_and_three  VALUES IN (4, 3),
+  PARTITION everything_else VALUES IN (6, default)
+);
+----
+
+splits database=db table=partition_by_list
+----
+/Table/106
+/Table/106/1
+/Table/106/1/1
+/Table/106/1/2
+/Table/106/1/3
+/Table/106/1/4
+/Table/106/1/5
+/Table/106/1/6
+/Table/106/1/7
+/Table/106/2

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partitions
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partitions
@@ -1,0 +1,150 @@
+exec-sql
+CREATE DATABASE db;
+CREATE TABLE db.person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+----
+
+translate database=db table=person
+----
+/Table/10{6-7}                             range default
+
+exec-sql
+ALTER PARTITION default OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER PARTITION australia OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION north_america OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 3;
+----
+
+translate database=db table=person
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/"AU"}                       ttl_seconds=1
+/Table/106/1/"AU"{-/PrefixEnd}             ttl_seconds=2
+/Table/106/1/"{AU"/PrefixEnd-CA"}          ttl_seconds=1
+/Table/106/1/"CA"{-/PrefixEnd}             ttl_seconds=3
+/Table/106/1/"{CA"/PrefixEnd-NZ"}          ttl_seconds=1
+/Table/106/1/"NZ"{-/PrefixEnd}             ttl_seconds=2
+/Table/106/1/"{NZ"/PrefixEnd-US"}          ttl_seconds=1
+/Table/106/1/"US"{-/PrefixEnd}             ttl_seconds=3
+/Table/106/{1/"US"/PrefixEnd-2}            ttl_seconds=1
+/Table/10{6/2-7}                           range default
+
+exec-sql
+ALTER PARTITION old_au OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 4;
+ALTER PARTITION yung_au OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER PARTITION old_na OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 6;
+ALTER PARTITION yung_na OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 7;
+----
+
+translate database=db table=person
+----
+/Table/106{-/1}                            range default
+/Table/106/1{-/"AU"}                       ttl_seconds=1
+/Table/106/1/"AU"{-/9131}                  ttl_seconds=4
+/Table/106/1/"AU"/{9131-PrefixEnd}         ttl_seconds=5
+/Table/106/1/"{AU"/PrefixEnd-CA"}          ttl_seconds=1
+/Table/106/1/"CA"{-/9131}                  ttl_seconds=6
+/Table/106/1/"CA"/{9131-PrefixEnd}         ttl_seconds=7
+/Table/106/1/"{CA"/PrefixEnd-NZ"}          ttl_seconds=1
+/Table/106/1/"NZ"{-/9131}                  ttl_seconds=4
+/Table/106/1/"NZ"/{9131-PrefixEnd}         ttl_seconds=5
+/Table/106/1/"{NZ"/PrefixEnd-US"}          ttl_seconds=1
+/Table/106/1/"US"{-/9131}                  ttl_seconds=6
+/Table/106/1/"US"/{9131-PrefixEnd}         ttl_seconds=7
+/Table/106/{1/"US"/PrefixEnd-2}            ttl_seconds=1
+/Table/10{6/2-7}                           range default
+
+exec-sql
+CREATE TABLE db.list_default_then_range (
+    N1 INT,
+    N2 INT,
+    PRIMARY KEY (N1, N2)
+) PARTITION BY LIST (N1) (
+    PARTITION P1N1 VALUES IN (default)
+        PARTITION BY RANGE (N2) (
+            PARTITION P1N1N2 VALUES FROM (minvalue) TO (10),
+            PARTITION P2N1N2 VALUES FROM (10) TO (maxvalue)
+        )
+);
+ALTER PARTITION P1N1 OF TABLE db.list_default_then_range CONFIGURE ZONE USING gc.ttlseconds = 4;
+ALTER PARTITION P1N1N2 OF TABLE db.list_default_then_range CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER PARTITION P2N1N2 OF TABLE db.list_default_then_range CONFIGURE ZONE USING gc.ttlseconds = 6;
+----
+
+translate database=db table=list_default_then_range
+----
+/Table/107{-/1}                            range default
+/Table/107/1{-/10}                         ttl_seconds=5
+/Table/107/{1/10-2}                        ttl_seconds=6
+/Table/10{7/2-8}                           range default
+
+exec-sql
+CREATE TABLE db.list_multi_column_partitions(i INT, j INT, PRIMARY KEY (i, j)) PARTITION BY LIST (i, j) (
+  PARTITION six_and_seven VALUES IN ((6, 7)),
+  PARTITION default VALUES IN ((default, default))
+);
+----
+
+translate database=db table=list_multi_column_partitions
+----
+/Table/10{8-9}                             range default
+
+exec-sql
+ALTER TABLE db.list_multi_column_partitions CONFIGURE ZONE USING gc.ttlseconds = 3;
+ALTER PARTITION default OF TABLE db.list_multi_column_partitions CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER PARTITION six_and_seven OF TABLE db.list_multi_column_partitions CONFIGURE ZONE USING gc.ttlseconds = 2;
+----
+
+translate database=db table=list_multi_column_partitions
+----
+/Table/108{-/1}                            ttl_seconds=3
+/Table/108/1{-/6/7}                        ttl_seconds=1
+/Table/108/1/6/{7-8}                       ttl_seconds=2
+/Table/108/{1/6/8-2}                       ttl_seconds=1
+/Table/10{8/2-9}                           ttl_seconds=3
+
+exec-sql
+CREATE TABLE db.partition_by_list(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
+  PARTITION one_and_five    VALUES IN (1, 5),
+  PARTITION four_and_three  VALUES IN (4, 3),
+  PARTITION everything_else VALUES IN (6, default)
+);
+ALTER TABLE db.partition_by_list CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER PARTITION one_and_five OF TABLE db.partition_by_list CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION four_and_three OF TABLE db.partition_by_list CONFIGURE ZONE USING gc.ttlseconds = 3;
+ALTER PARTITION everything_else OF TABLE db.partition_by_list CONFIGURE ZONE USING gc.ttlseconds = 4;
+----
+
+translate database=db table=partition_by_list
+----
+/Table/109{-/1}                            ttl_seconds=1
+/Table/109/1{-/1}                          ttl_seconds=4
+/Table/109/1/{1-2}                         ttl_seconds=2
+/Table/109/1/{2-3}                         ttl_seconds=4
+/Table/109/1/{3-4}                         ttl_seconds=3
+/Table/109/1/{4-5}                         ttl_seconds=3
+/Table/109/1/{5-6}                         ttl_seconds=2
+/Table/109/1/{6-7}                         ttl_seconds=4
+/Table/109/{1/7-2}                         ttl_seconds=4
+/Table/109/{2-PrefixEnd}                   ttl_seconds=1

--- a/pkg/spanconfig/spanconfigsplitter/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsplitter/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "spanconfigsplitter",
+    srcs = ["splitter.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsplitter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/roachpb",
+        "//pkg/spanconfig",
+        "//pkg/sql/catalog",
+        "//pkg/sql/rowenc",
+        "//pkg/sql/sem/tree",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/spanconfig/spanconfigsplitter/splitter.go
+++ b/pkg/spanconfig/spanconfigsplitter/splitter.go
@@ -1,0 +1,333 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package spanconfigsplitter is able to split sql descriptors into its
+// constituent spans.
+package spanconfigsplitter
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+var _ spanconfig.Splitter = &Splitter{}
+
+// Splitter is the concrete implementation of spanconfig.Splitter.
+//
+// TODO(irfansharif): We could alternatively return only the number of split
+// points implied. It's possible to compute it without having to decode any keys
+// whatsoever. Consider our table hierarchy again:
+//
+// 		table -> index -> partition -> partition
+//
+// Where each partition is either a PARTITION BY LIST kind (where it can then be
+// further partitioned), or a PARTITION BY RANGE kind (no further partitioning
+// possible). We can classify each parent-child link into two types:
+//
+// (a) Contiguous      {index, list partition} -> range partition
+// (b) Non-contiguous  table -> index, {index, list partition} -> list partition
+//
+// - Contiguous links are the sort where each child span is contiguous with
+//   another, and that the set of all child spans encompass the parent's span.
+//   For an index that's partitioned by range:
+//
+// 		CREATE TABLE db.range(i INT PRIMARY KEY, j INT) PARTITION BY RANGE (i) (
+//  		PARTITION less_than_five       VALUES FROM (minvalue) to (5),
+//			PARTITION between_five_and_ten VALUES FROM (5) to (10),
+//			PARTITION greater_than_ten     VALUES FROM (10) to (maxvalue)
+//		);
+//
+//   With table ID as 106, the parent index span is /Table/106/{1-2}. The child
+//   spans are /Table/106/1{-/5}, /Table/106/1/{5-10} and /Table/106/{1/10-2}.
+//   They're contiguous and put together, they wholly encompass the parent span.
+//
+// - Non-contiguous links by contrast are when child spans are neither
+//   contiguous with respect to one another, and nor do they start and end at
+//   the parent span's boundaries. For a table with a secondary index:
+//
+//		CREATE TABLE db.t(i INT PRIMARY KEY, j INT);
+//		CREATE INDEX idx ON db.t (j);
+//		DROP INDEX db.t@idx;
+//		CREATE INDEX idx ON db.t (j);
+//
+//   With table ID as 106, the parent table span is /Table/10{6-7}. The child
+//   spans are /Table/106/{1-2} and /Table/106/{3-4}. Compared to the parent
+//   span, we're missing /Table/106{-/1}, /Table/106/{2-3}, /Table/10{6/4-7}.
+//
+// For N children:
+// - For a contiguous link, the number of splits equals the number of child
+//   elements (i.e. N).
+// - For a non-contiguous link, the number of splits equals N + 1 + N. For N
+//   children, there are N - 1 gaps. There are also 2 gaps at the start and end
+//   of the parent span. Summing that with the N children span themselves, we
+//   get to the formula above. This assumes that the N child elements aren't
+//   further subdivided, if they are (we can compute it recursively), the
+//   formula becomes N + 1 + Σ(grand child spans).
+type Splitter struct {
+	codec keys.SQLCodec
+	knobs *spanconfig.TestingKnobs
+}
+
+// New constructs and returns a Splitter.
+func New(codec keys.SQLCodec, knobs *spanconfig.TestingKnobs) *Splitter {
+	if knobs == nil {
+		knobs = &spanconfig.TestingKnobs{}
+	}
+	return &Splitter{
+		codec: codec,
+		knobs: knobs,
+	}
+}
+
+// Splits is part of the spanconfig.Splitter interface.
+func (s *Splitter) Splits(
+	ctx context.Context, table catalog.TableDescriptor,
+) ([]roachpb.Key, error) {
+	if s.knobs.ExcludeDroppedDescriptorsFromLookup && table.Dropped() {
+		return nil, nil // we're excluding this descriptor; nothing to do here
+	}
+
+	tableStartKey := s.codec.TablePrefix(uint32(table.GetID()))
+	tableEndKey := tableStartKey.PrefixEnd()
+	tableSpan := roachpb.Span{
+		Key:    tableStartKey,
+		EndKey: tableEndKey,
+	}
+
+	var indexSpans []roachpb.Span
+	if err := catalog.ForEachIndex(table, catalog.IndexOpts{}, func(index catalog.Index) error {
+		currentIndexSpan := table.IndexSpan(s.codec, index.GetID())
+
+		var emptyPrefix []tree.Datum
+		indexPartitionSpans, err := s.splitInner(partition{
+			Partitioning: index.GetPartitioning(),
+			table:        table,
+			index:        index,
+			prefixSpan:   currentIndexSpan,
+			prefixDatums: emptyPrefix,
+		})
+		if err != nil {
+			return err
+		}
+
+		{ // TODO(irfansharif): Should we only assert under test builds?
+			if len(indexPartitionSpans) == 0 {
+				return errors.AssertionFailedf("expected non-zero index partition spans")
+			}
+			sort.Sort(roachpb.Spans(indexPartitionSpans))
+			if firstKey := indexPartitionSpans[0].Key; !firstKey.Equal(currentIndexSpan.Key) {
+				return errors.AssertionFailedf("expected first partition key (%s) to match index start (%s)", firstKey, currentIndexSpan.Key)
+			}
+			if endKey := indexPartitionSpans[len(indexPartitionSpans)-1].EndKey; !endKey.Equal(currentIndexSpan.EndKey) {
+				return errors.AssertionFailedf("expected last partition end key (%s) to match index end (%s)", endKey, currentIndexSpan.EndKey)
+			}
+			for i := range indexPartitionSpans {
+				if i == 0 {
+					continue
+				}
+				if prev, cur := indexPartitionSpans[i-1], indexPartitionSpans[i]; !prev.EndKey.Equal(cur.Key) {
+					return errors.AssertionFailedf("expected partitions %s and %s to be adjacent", prev, cur)
+				}
+			}
+		}
+
+		indexSpans = append(indexSpans, indexPartitionSpans...) // [start of current index, ...) ... [..., end of current index)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	tableSpans, err := segment(tableSpan, indexSpans)
+	if err != nil {
+		return nil, err
+	}
+
+	splits := make([]roachpb.Key, len(tableSpans))
+	for i, sp := range tableSpans {
+		splits[i] = sp.Key
+	}
+	return splits, nil
+}
+
+func (s *Splitter) splitInner(part partition) ([]roachpb.Span, error) {
+	if part.prefixSpan.Equal(roachpb.Span{}) {
+		return nil, errors.AssertionFailedf("expected non-empty prefix span")
+	}
+
+	if part.NumColumns() == 0 {
+		return []roachpb.Span{part.prefixSpan}, nil // no partitioning
+	}
+
+	if part.NumRanges() > 0 {
+		var rangePartitionSpans []roachpb.Span
+		if err := part.ForEachRange(func(_ string, from, to []byte) error {
+			alloc := &tree.DatumAlloc{}
+			_, fromKey, err := rowenc.DecodePartitionTuple(
+				alloc, s.codec, part.table, part.index, part, from, part.prefixDatums)
+			if err != nil {
+				return err
+			}
+			_, toKey, err := rowenc.DecodePartitionTuple(
+				alloc, s.codec, part.table, part.index, part, to, part.prefixDatums)
+			if err != nil {
+				return err
+			}
+
+			rangePartitionSpans = append(rangePartitionSpans, roachpb.Span{
+				Key:    fromKey,
+				EndKey: toKey,
+			})
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		return rangePartitionSpans, nil
+	}
+
+	var listPartitionSpans []roachpb.Span
+	if err := part.ForEachList(func(name string, values [][]byte, subPartitioning catalog.Partitioning) error {
+		for _, valueEncBuf := range values {
+			alloc := &tree.DatumAlloc{}
+			t, keyPrefix, err := rowenc.DecodePartitionTuple(
+				alloc, s.codec, part.table, part.index, part, valueEncBuf, part.prefixDatums)
+			if err != nil {
+				return err
+			}
+
+			subPartitioningPrefix := roachpb.Key(keyPrefix)
+			subPartitioningPrefixSpan := roachpb.Span{
+				Key:    subPartitioningPrefix,
+				EndKey: subPartitioningPrefix.PrefixEnd(),
+			}
+			subPartition := partition{
+				Partitioning: subPartitioning,
+				table:        part.table,
+				index:        part.index,
+				prefixSpan:   subPartitioningPrefixSpan,
+				prefixDatums: append(part.prefixDatums, t.Datums...),
+			}
+			subPartitionSpans, err := s.splitInner(subPartition)
+			if err != nil {
+				return err
+			}
+
+			if len(subPartitionSpans) == 1 && subPartitionSpans[0].Equal(part.prefixSpan) {
+				if t.SpecialCount == 0 {
+					return errors.AssertionFailedf("expected partitioning by DEFAULT")
+				}
+
+				// NB: PARTITION BY LISTs can only have DEFAULT partition values (i.e.
+				// no {MIN,MAX}VALUE).
+				//
+				// A. A zero SpecialCount indicates that we're dealing partitions over
+				//    actual values; we can simply accumulate the sub-partition spans.
+				// B. If we do have a DEFAULT partitioning value and:
+				// 	  1. It isn't further sub-partitioned, the sub-partition span we get
+				//       is just our parent prefix span. We don't add it here -- below
+				//       we'll ensure that we're generating coverings for the entire
+				//       prefix.
+				//    2. It's further sub-partitioned, and:
+				//   		 i.  If all subsequent subpartitions are only PARTITION BY LISTs
+				//           over DEFAULT partition values, the span we get is just our
+				//           parent prefix span. We don't add it here for the same reason
+				//           as B1.
+				//       ii. If it's subpartitioned by RANGE or PARTITION BY LISTs over
+				//           non-DEFAULT partition values, we'll have meaningful
+				//           subpartition spans. We'll add them below.
+				continue
+			}
+
+			listPartitionSpans = append(listPartitionSpans, subPartitionSpans...)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if len(listPartitionSpans) == 0 {
+		return []roachpb.Span{part.prefixSpan}, nil // no sub partitioning
+	}
+
+	return segment(part.prefixSpan, listPartitionSpans)
+}
+
+// segment returns takes in an outer span [a,z) and a list of inner spans that
+// are wholly enclosed by the outer span, and returns a list of segments of the
+// form (after sorting inner first):
+//
+//  [outer-start, inner[0]-start)
+//  [inner[0]-start, inner[0]-end)
+//  [inner[0]-end, inner[1]-start)
+//  ...
+//  [inner[len(inner)-1]-end, outer-end)
+//
+func segment(outer roachpb.Span, inner []roachpb.Span) ([]roachpb.Span, error) {
+	sort.Sort(roachpb.Spans(inner))
+
+	var gapSpans []roachpb.Span
+	for i := range inner {
+		if !outer.Contains(inner[i]) {
+			return nil, errors.AssertionFailedf("expected %s to contain %s", outer, inner[i])
+		}
+		var gapSpan roachpb.Span
+		if i == 0 {
+			gapSpan = roachpb.Span{ // gap between start of outer span to first inner span
+				Key:    outer.Key,
+				EndKey: inner[i].Key,
+			}
+		} else {
+			gapSpan = roachpb.Span{ // gap between consecutive partition spans
+				Key:    inner[i-1].EndKey,
+				EndKey: inner[i].Key,
+			}
+		}
+		gapSpans = append(gapSpans, gapSpan)
+	}
+
+	if len(inner) > 0 {
+		gapSpans = append(gapSpans, roachpb.Span{ // gap between end of last inner partition span and end of outer span
+			Key:    inner[len(inner)-1].EndKey,
+			EndKey: outer.EndKey,
+		})
+	}
+
+	var result []roachpb.Span
+	result = append(result, inner...)
+	for _, gapSpan := range gapSpans {
+		if !gapSpan.Valid() {
+			// It's possible for the inner adjacent to one another, so for the "gaps"
+			// between them to be non-existent. It's also possible for the "gaps" at
+			// the start and end of the outer span to be empty. We filter out these
+			// invalid gaps.
+			continue
+		}
+		result = append(result, gapSpan)
+	}
+	return result, nil
+}
+
+// partition groups together everything needed to determine the split points of
+// a given partition.
+type partition struct {
+	catalog.Partitioning // partition itself
+
+	table        catalog.TableDescriptor // table the partition is part of
+	index        catalog.Index           // index being partitioned
+	prefixSpan   roachpb.Span            // keyspan being partitioned
+	prefixDatums []tree.Datum            // datums for partitioning columns in the prefix (non-empty for subpartitions)
+}

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/distsql",

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/tenant_state.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/tenant_state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
@@ -147,29 +148,49 @@ func (s *Tenant) WithMutableTableDescriptor(
 	}))
 }
 
+// descLookupFlags is the set of look up flags used when fetching descriptors.
+var descLookupFlags = tree.CommonLookupFlags{
+	IncludeDropped: true,
+	IncludeOffline: true,
+	AvoidLeased:    true, // we want consistent reads
+}
+
+// LookupTableDescriptorByID returns the table identified by the given ID.
+func (s *Tenant) LookupTableDescriptorByID(
+	ctx context.Context, id descpb.ID,
+) (desc catalog.TableDescriptor) {
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	require.NoError(s.t, sql.DescsTxn(ctx, &execCfg, func(
+		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
+	) error {
+		var err error
+		desc, err = descsCol.GetImmutableTableByID(ctx, txn, id,
+			tree.ObjectLookupFlags{
+				CommonLookupFlags: descLookupFlags,
+			},
+		)
+		return err
+	}))
+	return desc
+}
+
 // LookupTableByName returns the table descriptor identified by the given name.
 func (s *Tenant) LookupTableByName(
 	ctx context.Context, dbName string, tbName string,
 ) (desc catalog.TableDescriptor) {
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
-	require.NoError(s.t, sql.DescsTxn(ctx, &execCfg,
-		func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
-			var err error
-			_, desc, err = descsCol.GetMutableTableByName(ctx, txn,
-				tree.NewTableNameWithSchema(tree.Name(dbName), "public", tree.Name(tbName)),
-				tree.ObjectLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{
-						Required:       true,
-						IncludeOffline: true,
-						AvoidLeased:    true,
-					},
-				},
-			)
-			if err != nil {
-				return err
-			}
-			return nil
-		}))
+	require.NoError(s.t, sql.DescsTxn(ctx, &execCfg, func(
+		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
+	) error {
+		var err error
+		_, desc, err = descsCol.GetImmutableTableByName(ctx, txn,
+			tree.NewTableNameWithSchema(tree.Name(dbName), "public", tree.Name(tbName)),
+			tree.ObjectLookupFlags{
+				CommonLookupFlags: descLookupFlags,
+			},
+		)
+		return err
+	}))
 	return desc
 }
 
@@ -182,17 +203,14 @@ func (s *Tenant) LookupDatabaseByName(
 	require.NoError(s.t, sql.DescsTxn(ctx, &execCfg,
 		func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
 			var err error
-			desc, err = descsCol.GetMutableDatabaseByName(ctx, txn, dbName,
+			desc, err = descsCol.GetImmutableDatabaseByName(ctx, txn, dbName,
 				tree.DatabaseLookupFlags{
 					Required:       true,
 					IncludeOffline: true,
 					AvoidLeased:    true,
 				},
 			)
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		}))
 	return desc
 }


### PR DESCRIPTION
Splitter returns the set of all possible split points for the given
table descriptor. It steps through every "unit" that we can apply
configurations over (table, indexes, partitions and sub-partitions) and
figures out the actual key boundaries that we may need to split over.
For example:
```
  CREATE TABLE db.parts(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
    PARTITION one_and_five    VALUES IN (1, 5),
    PARTITION four_and_three  VALUES IN (4, 3),
    PARTITION everything_else VALUES IN (6, default)
  );
```
Assuming a table ID of 108, we'd generate:
```
  /Table/108
  /Table/108/1
  /Table/108/1/1
  /Table/108/1/2
  /Table/108/1/3
  /Table/108/1/4
  /Table/108/1/5
  /Table/108/1/6
  /Table/108/1/7
  /Table/108/2
```

This is going to serve as the underlying library for #70555. In a future
commit we'll introduce two system tables, one for all tenants (both
guest and host) and one on just the host.

The first will be maintained by the SQL pod, using the library, as part
of every schema change operation. We'll record in it a single row
containing the total number of splits the pod's currently using up by
comparing the before/after of a descriptor operation to see if the
commit would add or reduce the number of necessary splits. We'll abort
the txn if it's over a pre-set limit (INF for the host tenant, and using
a KV-settable-only cluster setting for guests: #73857).

The second table will be used only for KV's internal book keeping,
sitting behind the KVAccessor interface. We'll use it to hard reject
RPCs installing span configs that induce splits more than a tenant is
allowed to. With the SQL pods coordinating using the KV-set limits, this
would only happen as a result of faulty SQL code.

Put together, we'll have a co-operative form of per-tenant split limits.

Release note: None