### PR TITLE
sql: support RESET ALL statement

### DIFF
--- a/docs/generated/sql/bnf/reset_session_stmt.bnf
+++ b/docs/generated/sql/bnf/reset_session_stmt.bnf
@@ -1,3 +1,4 @@
 reset_session_stmt ::=
 	'RESET' session_var
 	| 'RESET' 'SESSION' session_var
+	| 'RESET_ALL' 'ALL'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -579,6 +579,7 @@ pause_all_jobs_stmt ::=
 reset_session_stmt ::=
 	'RESET' session_var
 	| 'RESET' 'SESSION' session_var
+	| 'RESET_ALL' 'ALL'
 
 reset_csetting_stmt ::=
 	'RESET' 'CLUSTER' 'SETTING' var_name

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -743,6 +743,20 @@ SHOW tracing.custom
 ----
 ijk
 
+# Test that RESET ALL changes custom options to empty strings.
+statement ok
+RESET ALL
+
+query T
+SHOW tracing.custom
+----
+·
+
+query T
+SHOW custom_option.set_sql
+----
+·
+
 statement error unrecognized configuration parameter "custom_option.does_not_yet_exist"
 SHOW custom_option.does_not_yet_exist
 

--- a/pkg/sql/logictest/testdata/logic_test/set_role
+++ b/pkg/sql/logictest/testdata/logic_test/set_role
@@ -357,6 +357,15 @@ root  root  root  root
 statement ok
 SET ROLE testuser
 
+# Verify that RESET ALL does *not* affect role.
+statement ok
+RESET ALL
+
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
+----
+testuser  testuser  root  root
+
 query T
 SELECT user_name FROM crdb_internal.node_sessions
 WHERE active_queries LIKE 'SELECT user_name%'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4600,6 +4600,10 @@ reset_session_stmt:
   {
     $$.val = &tree.SetVar{Name: $3, Values:tree.Exprs{tree.DefaultVal{}}, Reset: true}
   }
+| RESET_ALL ALL
+  {
+    $$.val = &tree.SetVar{ResetAll: true, Reset: true}
+  }
 | RESET error // SHOW HELP: RESET
 
 // %Help: RESET CLUSTER SETTING - reset a cluster setting to its default value

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1755,6 +1755,19 @@ func TestRoleDefaultSettings(t *testing.T) {
 			expectedSearchPath: "f",
 		},
 		{
+			// RESET after connecting should go back to the per-role default setting.
+			setupStmt:          "",
+			postConnectStmt:    "SET search_path = 'new'; RESET search_path;",
+			expectedSearchPath: "f",
+		},
+		{
+			// RESET should use the query param as the default if it was provided.
+			setupStmt:             "",
+			searchPathOptOverride: "g",
+			postConnectStmt:       "SET search_path = 'new'; RESET ALL;",
+			expectedSearchPath:    "g",
+		},
+		{
 			setupStmt:          "ALTER ROLE testuser IN DATABASE defaultdb SET search_path = DEFAULT",
 			expectedSearchPath: "c",
 		},

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -39,10 +39,16 @@ type setVarNode struct {
 	typedValues []tree.TypedExpr
 }
 
+// resetAllNode represents a RESET ALL statement.
+type resetAllNode struct{}
+
 // SetVar sets session variables.
 // Privileges: None.
 //   Notes: postgres/mysql do not require privileges for session variables (some exceptions).
 func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) {
+	if n.ResetAll {
+		return &resetAllNode{}, nil
+	}
 	if n.Name == "" {
 		// A client has sent the reserved internal syntax SET ROW ...,
 		// or the user entered `SET "" = foo`. Reject it.
@@ -181,6 +187,45 @@ func getSessionVarDefaultString(
 func (n *setVarNode) Next(_ runParams) (bool, error) { return false, nil }
 func (n *setVarNode) Values() tree.Datums            { return nil }
 func (n *setVarNode) Close(_ context.Context)        {}
+
+func (n *resetAllNode) startExec(params runParams) error {
+	for varName, v := range varGen {
+		if v.Set == nil && v.RuntimeSet == nil && v.SetWithPlanner == nil {
+			continue
+		}
+		// For Postgres compatibility, Don't reset `role` here.
+		if varName == "role" {
+			continue
+		}
+		_, defVal := getSessionVarDefaultString(
+			varName,
+			v,
+			params.p.sessionDataMutatorIterator.sessionDataMutatorBase,
+		)
+		if err := params.p.SetSessionVar(params.ctx, varName, defVal, false /* isLocal */); err != nil {
+			return err
+		}
+	}
+	for varName := range params.SessionData().CustomOptions {
+		_, v, err := getSessionVar(varName, false /* missingOK */)
+		if err != nil {
+			return err
+		}
+		_, defVal := getSessionVarDefaultString(
+			varName,
+			v,
+			params.p.sessionDataMutatorIterator.sessionDataMutatorBase,
+		)
+		if err := params.p.SetSessionVar(params.ctx, varName, defVal, false /* isLocal */); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (n *resetAllNode) Next(_ runParams) (bool, error) { return false, nil }
+func (n *resetAllNode) Values() tree.Datums            { return nil }
+func (n *resetAllNode) Close(_ context.Context)        {}
 
 func getStringVal(evalCtx *tree.EvalContext, name string, values []tree.TypedExpr) (string, error) {
 	if len(values) != 1 {

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -218,6 +218,7 @@ func (v *planVisitor) visitInternal(plan planNode, name string) {
 	case *createViewNode:
 	case *setVarNode:
 	case *setClusterSettingNode:
+	case *resetAllNode:
 
 	case *delayedNode:
 		if n.plan != nil {
@@ -416,6 +417,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&renameTableNode{}):                "rename table",
 	reflect.TypeOf(&reparentDatabaseNode{}):           "reparent database",
 	reflect.TypeOf(&renderNode{}):                     "render",
+	reflect.TypeOf(&resetAllNode{}):                   "reset all",
 	reflect.TypeOf(&RevokeRoleNode{}):                 "revoke role",
 	reflect.TypeOf(&rowCountNode{}):                   "count",
 	reflect.TypeOf(&rowSourceToPlanNode{}):            "row source to plan node",


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/75435

Release note (sql change): Support for the RESET ALL statement was
added. This statement resets the values of all session variables to
their default values.