### PR TITLE
ui: add console log to Loading component

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/loading/loading.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/loading/loading.spec.tsx
@@ -24,6 +24,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={false}
+            page={"Test"}
             error={null}
             render={() => <SomeComponent />}
           />,
@@ -37,6 +38,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={true}
+            page={"Test"}
             error={null}
             render={() => <SomeComponent />}
           />,
@@ -53,6 +55,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={false}
+            page={"Test"}
             error={Error("some error message")}
             render={() => <SomeComponent />}
           />,
@@ -68,6 +71,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={true}
+            page={"Test"}
             error={Error("some error message")}
             render={() => <SomeComponent />}
           />,
@@ -82,6 +86,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={true}
+            page={"Test"}
             error={Error("some error message")}
             render={() => <SomeComponent />}
             renderError={() => <SomeCustomErrorComponent />}
@@ -101,6 +106,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={false}
+            page={"Test"}
             error={errors}
             render={() => <SomeComponent />}
           />,
@@ -132,6 +138,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={false}
+            page={"Test"}
             error={errors}
             render={() => <SomeComponent />}
           />,
@@ -157,6 +164,7 @@ describe("<Loading>", () => {
         const wrapper = mount(
           <Loading
             loading={false}
+            page={"Test"}
             error={[null, null, null]}
             render={() => <SomeComponent />}
           />,

--- a/pkg/ui/workspaces/cluster-ui/src/loading/loading.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/loading/loading.tsx
@@ -23,6 +23,7 @@ import { Anchor } from "../anchor";
 
 interface LoadingProps {
   loading: boolean;
+  page: string;
   error?: Error | Error[] | null;
   className?: string;
   image?: string;
@@ -65,6 +66,7 @@ export const Loading: React.FC<LoadingProps> = props => {
   // Check for `error` before `loading`, since tests for `loading` often return
   // true even if CachedDataReducer has an error and is no longer really "loading".
   if (errors) {
+    console.error(`Error Loading ${props.page}: ${errors}`);
     // - map Error to InlineAlert props. RestrictedPermissions handled as "info" message;
     // - group errors by intend to show separate alerts per intent.
     const errorAlerts = chain(errors)

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -204,6 +204,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
         >
           <Loading
             loading={_.isNil(this.props.session)}
+            page={"sessions details"}
             error={this.props.sessionError}
             render={this.renderContent}
             renderError={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -223,6 +223,7 @@ export class SessionsPage extends React.Component<
       <div className={sessionsPageCx("sessions-page")}>
         <Loading
           loading={isNil(this.props.sessions)}
+          page={"sessions"}
           error={this.props.sessionsError}
           render={this.renderSessions}
           renderError={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -443,6 +443,7 @@ export class StatementDetails extends React.Component<
         <section className={cx("section", "section--container")}>
           <Loading
             loading={_.isNil(this.props.statement)}
+            page={"statement details"}
             error={this.props.statementsError}
             render={this.renderContent}
             renderError={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -653,6 +653,7 @@ export class StatementsPage extends React.Component<
         </PageConfig>
         <Loading
           loading={isNil(this.props.statements)}
+          page={"statements"}
           error={this.props.statementsError}
           render={() => this.renderStatements(regions)}
           renderError={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -222,6 +222,7 @@ export class TransactionDetails extends React.Component<
         </section>
         <Loading
           error={error}
+          page={"transaction details"}
           loading={
             statementsForTransaction.length == 0 || transactionText.length == 0
           }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -418,6 +418,7 @@ export class TransactionsPage extends React.Component<
         </PageConfig>
         <Loading
           loading={!this.props?.data}
+          page={"transactions"}
           error={this.props?.error}
           render={() => {
             const { pagination } = this.state;

--- a/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -88,6 +88,7 @@ export class ClusterVisualization extends React.Component<
         </div>
         <Loading
           loading={!this.props.licenseDataExists}
+          page={"containers"}
           error={this.props.clusterDataError}
           render={() => <NodeCanvasContent tiers={tiers} />}
         />

--- a/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
@@ -90,6 +90,7 @@ class NodeCanvasContainer extends React.Component<
     return (
       <Loading
         loading={!this.props.dataExists}
+        page={"node canvas container"}
         error={this.props.dataErrors}
         render={() => (
           <NodeCanvas

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/dataDistribution/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/dataDistribution/index.tsx
@@ -184,6 +184,7 @@ export class DataDistributionPage extends React.Component<
             loading={
               !this.props.dataDistribution.data || !this.props.localityTree
             }
+            page={"data distribution"}
             error={[
               this.props.dataDistribution.lastError,
               ...this.props.localityTreeErrors,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
@@ -186,6 +186,7 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
         <section className="section l-columns">
           <Loading
             loading={!events}
+            page={"events"}
             error={lastError}
             render={this.renderContent.bind(this)}
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeLogs/index.tsx
@@ -104,6 +104,7 @@ export class Logs extends React.Component<LogProps & RouteComponentProps, {}> {
         <section className="section">
           <Loading
             loading={!this.props.logs.data}
+            page={"node logs"}
             error={this.props.logs.lastError}
             render={this.renderContent}
           />

--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.tsx
@@ -248,6 +248,7 @@ export class JobsTable extends React.Component<JobsTableProps> {
         <section className="section">
           <Loading
             loading={!this.props.jobs || !this.props.jobs.data}
+            page={"jobs"}
             error={this.props.jobs && this.props.jobs.lastError}
             render={() => (
               <JobTable

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -112,7 +112,11 @@ class JobDetails extends React.Component<JobsTableProps, {}> {
           )}`}</h3>
         </div>
         <section className="section section--container">
-          <Loading loading={_.isNil(job)} render={this.renderContent} />
+          <Loading
+            loading={_.isNil(job)}
+            page={"job details"}
+            render={this.renderContent}
+          />
         </section>
       </div>
     );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/certificates/index.tsx
@@ -212,6 +212,7 @@ export class Certificates extends React.Component<CertificatesProps, {}> {
         <section className="section">
           <Loading
             loading={!this.props.certificates}
+            page={"certificates"}
             error={this.props.lastError}
             render={this.renderContent}
           />

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/localities/index.tsx
@@ -131,6 +131,7 @@ export class Localities extends React.Component<LocalitiesProps, {}> {
           loading={
             !this.props.localityStatus.data || !this.props.locationStatus.data
           }
+          page={"localities"}
           error={[
             this.props.localityStatus.lastError,
             this.props.locationStatus.lastError,

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
@@ -468,6 +468,7 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
         <h3 className="base-heading">Network Diagnostics</h3>
         <Loading
           loading={!contentAvailable(nodesSummary)}
+          page={"network"}
           error={this.props.nodeSummaryErrors}
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           render={() => (

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/index.tsx
@@ -214,6 +214,7 @@ export class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
         <h1 className="base-heading">Problem Ranges Report</h1>
         <Loading
           loading={isLoading(this.props.problemRanges)}
+          page={"problems range"}
           error={this.props.problemRanges && this.props.problemRanges.lastError}
           render={() => (
             <div>

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/allocator.tsx
@@ -90,6 +90,7 @@ export default class AllocatorOutput extends React.Component<
         <h2 className="base-heading">Simulated Allocator Output{fromNodeID}</h2>
         <Loading
           loading={!allocator || allocator.inFlight}
+          page={"allocator"}
           error={allocator && allocator.lastError}
           render={this.renderContent}
         />

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/connectionsTable.tsx
@@ -37,6 +37,7 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
       <h2 className="base-heading">Connections {viaNodeID}</h2>
       <Loading
         loading={!range || range.inFlight}
+        page={"connections"}
         error={range && range.lastError}
         render={() => (
           <table className="connections-table">

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/logTable.tsx
@@ -158,6 +158,7 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
         <h2 className="base-heading">Range Log</h2>
         <Loading
           loading={!log || log.inFlight}
+          page={"log table"}
           error={log && log.lastError}
           render={this.renderContent}
         />

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/settings/index.tsx
@@ -96,6 +96,7 @@ export class Settings extends React.Component<SettingsProps> {
         <h1 className="base-heading">Cluster Settings</h1>
         <Loading
           loading={!this.props.settings.data}
+          page={"container settings"}
           error={this.props.settings.lastError}
           render={() => (
             <div>

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/stores/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/stores/index.tsx
@@ -115,6 +115,7 @@ export class Stores extends React.Component<StoresProps, {}> {
         <h2 className="base-heading">{header} stores</h2>
         <Loading
           loading={this.props.loading}
+          page={"containers stores"}
           error={this.props.lastError}
           render={this.renderContent}
         />


### PR DESCRIPTION
Previously, errors where not being logged to datadog.
This commits add logs to Loading component so if
the user hits and error we can see the log in Datadog.

Fixes #75637

Release note: None