### PR TITLE
sql: disallow type cast from ENUM to BYTES

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1617,3 +1617,17 @@ query T
 SELECT _enum FROM t58889 WHERE _enum::greeting58889 IN (NULL, 'hi':::greeting58889);
 ----
 hi
+
+subtest cast_from_enum_to_bytes
+
+statement ok
+CREATE TYPE myenum AS ENUM ('foo', 'bar');
+
+statement error invalid cast: myenum -> bytes
+SELECT 'foo'::myenum::bytes;
+
+statement error invalid cast: myenum -> bytes
+SELECT 'foo'::myenum::bytea;
+
+statement error invalid cast: myenum -> bytes
+SELECT 'foo'::myenum::blob;

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -1347,16 +1347,6 @@ func lookupCast(src, tgt *types.T, intervalStyleEnabled, dateStyleEnabled bool) 
 				maxContext: CastContextImplicit,
 				volatility: VolatilityImmutable,
 			}, true
-		case types.BytesFamily:
-			// Casts from byte types to enums are immutable and allowed in
-			// explicit contexts.
-			// TODO(mgartner): We may not want to support the cast from BYTES to
-			// ENUM because Postgres does not support it, and it's been the
-			// source of at least one minor bug (see #74316).
-			return cast{
-				maxContext: CastContextExplicit,
-				volatility: VolatilityImmutable,
-			}, true
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/74316

Release note (sql): Disallow type cast from ENUM to BYTES