### PR TITLE
release-21.2: sql,gcjob: add mechanism to destroy tenant synchronously

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -508,6 +508,7 @@ go_test(
         "telemetry_logging_test.go",
         "telemetry_test.go",
         "temporary_schema_test.go",
+        "tenant_test.go",
         "trace_test.go",
         "txn_restart_test.go",
         "txn_state_test.go",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2667,7 +2667,8 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		if err := ex.server.cfg.JobRegistry.Run(
 			ex.ctxHolder.connCtx,
 			ex.server.cfg.InternalExecutor,
-			ex.extraTxnState.jobs); err != nil {
+			ex.extraTxnState.jobs,
+		); err != nil {
 			handleErr(err)
 		}
 		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionEndPostCommitJob, timeutil.Now())

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -915,7 +915,7 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	*ex.planner.extendedEvalCtx.Jobs = append(*ex.planner.extendedEvalCtx.Jobs, jobIDs...)
+	ex.planner.extendedEvalCtx.Jobs.add(jobIDs...)
 	return nil
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1864,6 +1864,10 @@ const MaxSQLBytes = 1000
 
 type jobsCollection []jobspb.JobID
 
+func (jc *jobsCollection) add(ids ...jobspb.JobID) {
+	*jc = append(*jc, ids...)
+}
+
 // truncateStatementStringForTelemetry truncates the string
 // representation of a statement to a maximum length, so as to not
 // create unduly large logging and error payloads.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -430,7 +430,9 @@ func (c *DummyTenantOperator) CreateTenant(_ context.Context, _ uint64) error {
 }
 
 // DestroyTenant is part of the tree.TenantOperator interface.
-func (c *DummyTenantOperator) DestroyTenant(_ context.Context, _ uint64) error {
+func (c *DummyTenantOperator) DestroyTenant(
+	ctx context.Context, tenantID uint64, synchronous bool,
+) error {
 	return errors.WithStack(errEvalTenant)
 }
 

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -96,7 +96,7 @@ func initializeProgress(
 	progress *jobspb.SchemaChangeGCProgress,
 ) error {
 	var update bool
-	if details.Tenant != nil {
+	if details.Tenant != nil && progress.Tenant == nil {
 		progress.Tenant = &jobspb.SchemaChangeGCProgress_TenantProgress{
 			Status: jobspb.SchemaChangeGCProgress_WAITING_FOR_GC,
 		}

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -284,6 +284,9 @@ func refreshTenant(
 	details *jobspb.SchemaChangeGCDetails,
 	progress *jobspb.SchemaChangeGCProgress,
 ) (expired bool, deadline time.Time) {
+	if progress.Tenant.Status != jobspb.SchemaChangeGCProgress_WAITING_FOR_GC {
+		return true, time.Time{}
+	}
 	tenantTTLSeconds := execCfg.DefaultZoneConfig.GC.TTLSeconds
 	tenID := details.Tenant.ID
 	cfg := execCfg.SystemConfig.GetSystemConfig()

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -145,7 +145,7 @@ func (evalCtx *extendedEvalContext) QueueJob(
 	if err != nil {
 		return nil, err
 	}
-	*evalCtx.Jobs = append(*evalCtx.Jobs, jobID)
+	evalCtx.Jobs.add(jobID)
 	return job, nil
 }
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3378,8 +3378,9 @@ type TenantOperator interface {
 	CreateTenant(ctx context.Context, tenantID uint64) error
 
 	// DestroyTenant attempts to uninstall an existing tenant from the system.
-	// It returns an error if the tenant does not exist.
-	DestroyTenant(ctx context.Context, tenantID uint64) error
+	// It returns an error if the tenant does not exist. If synchronous is true
+	// the gc job will not wait for a GC ttl.
+	DestroyTenant(ctx context.Context, tenantID uint64, synchronous bool) error
 
 	// GCTenant attempts to garbage collect a DROP tenant from the system. Upon
 	// success it also removes the tenant record.

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -330,7 +330,7 @@ func clearTenant(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Tena
 }
 
 // DestroyTenant implements the tree.TenantOperator interface.
-func (p *planner) DestroyTenant(ctx context.Context, tenID uint64) error {
+func (p *planner) DestroyTenant(ctx context.Context, tenID uint64, synchronous bool) error {
 	const op = "destroy"
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, op); err != nil {
 		return err
@@ -355,7 +355,14 @@ func (p *planner) DestroyTenant(ctx context.Context, tenID uint64) error {
 		return errors.Wrap(err, "destroying tenant")
 	}
 
-	return errors.Wrap(gcTenantJob(ctx, p.execCfg, p.txn, p.User(), tenID), "scheduling gc job")
+	jobID, err := gcTenantJob(ctx, p.execCfg, p.txn, p.User(), tenID, synchronous)
+	if err != nil {
+		return errors.Wrap(err, "scheduling gc job")
+	}
+	if synchronous {
+		p.extendedEvalCtx.Jobs.add(jobID)
+	}
+	return nil
 }
 
 // GCTenantSync clears the tenant's data and removes its record.
@@ -400,7 +407,8 @@ func gcTenantJob(
 	txn *kv.Txn,
 	user security.SQLUsername,
 	tenID uint64,
-) error {
+	synchronous bool,
+) (jobspb.JobID, error) {
 	// Queue a GC job that will delete the tenant data and finally remove the
 	// row from `system.tenants`.
 	gcDetails := jobspb.SchemaChangeGCDetails{}
@@ -408,18 +416,26 @@ func gcTenantJob(
 		ID:       tenID,
 		DropTime: timeutil.Now().UnixNano(),
 	}
+	progress := jobspb.SchemaChangeGCProgress{}
+	if synchronous {
+		progress.Tenant = &jobspb.SchemaChangeGCProgress_TenantProgress{
+			Status: jobspb.SchemaChangeGCProgress_DELETING,
+		}
+	}
 	gcJobRecord := jobs.Record{
 		Description:   fmt.Sprintf("GC for tenant %d", tenID),
 		Username:      user,
 		Details:       gcDetails,
-		Progress:      jobspb.SchemaChangeGCProgress{},
+		Progress:      progress,
 		NonCancelable: true,
 	}
+	jobID := execCfg.JobRegistry.MakeJobID()
 	if _, err := execCfg.JobRegistry.CreateJobWithTxn(
-		ctx, gcJobRecord, execCfg.JobRegistry.MakeJobID(), txn); err != nil {
-		return err
+		ctx, gcJobRecord, jobID, txn,
+	); err != nil {
+		return 0, err
 	}
-	return nil
+	return jobID, nil
 }
 
 // GCTenant implements the tree.TenantOperator interface.
@@ -443,7 +459,10 @@ func (p *planner) GCTenant(ctx context.Context, tenID uint64) error {
 		return errors.Errorf("tenant %d is not in state DROP", info.ID)
 	}
 
-	return gcTenantJob(ctx, p.ExecCfg(), p.Txn(), p.User(), tenID)
+	_, err := gcTenantJob(
+		ctx, p.ExecCfg(), p.Txn(), p.User(), tenID, false, /* synchronous */
+	)
+	return err
 }
 
 // UpdateTenantResourceLimits implements the tree.TenantOperator interface.

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDestroyTenantSynchronous tests that destroying a tenant synchronously
+// with crdb_internal.destroy_tenant(<ten_id>, true) works.
+func TestDestroyTenantSynchronous(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	tenantID := roachpb.MakeTenantID(10)
+	codec := keys.MakeSQLCodec(tenantID)
+	const tenantStateQuery = `
+SELECT id, active FROM system.tenants WHERE id = 10
+`
+	checkKVsExistForTenant := func(t *testing.T, shouldExist bool) {
+		rows, err := kvDB.Scan(
+			ctx, codec.TenantPrefix(), codec.TenantPrefix().PrefixEnd(),
+			1, /* maxRows */
+		)
+		require.NoError(t, err)
+		require.Equal(t, shouldExist, len(rows) > 0)
+	}
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create the tenant, make sure it has data and state.
+	tdb.Exec(t, "SELECT crdb_internal.create_tenant(10)")
+	tdb.CheckQueryResults(t, tenantStateQuery, [][]string{{"10", "true"}})
+	checkKVsExistForTenant(t, true /* shouldExist */)
+
+	// Destroy the tenant, make sure it does not have data and state.
+	tdb.Exec(t, "SELECT crdb_internal.destroy_tenant(10, true)")
+	tdb.CheckQueryResults(t, tenantStateQuery, [][]string{})
+	checkKVsExistForTenant(t, false /* shouldExist */)
+}


### PR DESCRIPTION
Backport 1/1 commits from #74464.

/cc @cockroachdb/release

---

Apparently this is important. The approach is to create the gc job in a state
where it believes the ttl has already expired and then to make sure that the
connExecutor waits for the GC job.

Fixes #73919.

Release note: None
