### PR TITLE
sql: block swapping primary keys if dependent fk references exist

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -475,6 +475,28 @@ func (p *planner) AlterPrimaryKey(
 		newIndexIDs = append(newIndexIDs, newIndex.ID)
 	}
 
+	// Determine if removing this index would lead to the uniqueness for a foreign
+	// key back reference, which will cause this swap operation to be blocked.
+	nonDropIndexes := tableDesc.NonDropIndexes()
+	remainingIndexes := make([]descpb.UniqueConstraint, 0, len(nonDropIndexes))
+	for i := range nonDropIndexes {
+		// We can't copy directly because of the interface conversion.
+		if nonDropIndexes[i].GetID() == tableDesc.GetPrimaryIndex().GetID() {
+			continue
+		}
+		remainingIndexes = append(remainingIndexes, nonDropIndexes[i])
+	}
+	remainingIndexes = append(remainingIndexes, newPrimaryIndexDesc)
+	err = p.tryRemoveFKBackReferences(
+		ctx,
+		tableDesc,
+		tableDesc.GetPrimaryIndex(),
+		tree.DropRestrict,
+		remainingIndexes)
+	if err != nil {
+		return err
+	}
+
 	swapArgs := &descpb.PrimaryKeySwap{
 		OldPrimaryIndexId:   tableDesc.GetPrimaryIndexID(),
 		NewPrimaryIndexId:   newPrimaryIndexDesc.ID,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2311,3 +2311,29 @@ table_id  name         state   refobjid
 
 statement ok
 DROP TABLE test_serial;
+
+# Tests for issue #71709, which happens when a primary index that is used to
+# enforce the uniqueness of a foreign key reference is dropped.
+subtest pk-swap-fk-ref
+
+statement ok
+CREATE TABLE pk_fk_src(id int8 primary key, legacy_id int8 not null);
+CREATE TABLE pk_fk_ref(a_id int8 references pk_fk_src (id));
+
+statement error "pk_fk_src_pkey" is referenced by foreign key from table "pk_fk_ref"
+BEGIN;
+ALTER TABLE pk_fk_src DROP CONSTRAINT "pk_fk_src_pkey";
+ALTER TABLE pk_fk_src ADD CONSTRAINT "pk_fk_src_pkey" PRIMARY KEY (legacy_id);
+COMMIT;
+
+statement ok
+ROLLBACK;
+
+statement error "pk_fk_src_pkey" is referenced by foreign key from table "pk_fk_ref"
+BEGIN;
+ALTER TABLE pk_fk_src DROP CONSTRAINT "pk_fk_src_pkey";
+ALTER TABLE pk_fk_src ADD CONSTRAINT "pk_fk_src_pkey_new" PRIMARY KEY (legacy_id);
+COMMIT;
+
+statement ok
+ROLLBACK;


### PR DESCRIPTION
Fixes: #71709

Previously, when swapping primary keys it was possible
to cause foreign key references to break by removing
the primary indexes enforcing uniqueness. To address
this, this patch will detect if any foreign key references
will lose their uniqueness with the removal of the
primary index.

Release note (bug fix): Swapping primary keys could
lead to scenarios where foreign key references could
lose their uniqueness.