### PR TITLE
sql: error when setting timezone outside of postgres max utc offsets

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set_time_zone
+++ b/pkg/sql/logictest/testdata/logic_test/set_time_zone
@@ -231,3 +231,18 @@ query T
 SELECT TIME '05:40:00'::TIMETZ
 ----
 0000-01-01 05:40:00 +0000 UTC
+
+statement error pq: invalid value for parameter "timezone": "'168'": cannot find time zone "168": UTC timezone offset is out of range.
+SET TIME ZONE '168'
+
+statement error pq: invalid value for parameter "timezone": "'-168'": cannot find time zone "-168": UTC timezone offset is out of range.
+SET TIME ZONE '-168'
+
+statement error pq: invalid value for parameter "timezone": "'-0500'": cannot find time zone "-0500": UTC timezone offset is out of range.
+SET TIME ZONE '-0500'
+
+statement error pq: invalid value for parameter "timezone": "'0500'": cannot find time zone "0500": UTC timezone offset is out of range.
+SET TIME ZONE '0500'
+
+statement error pq: invalid value for parameter "timezone": "'-0500'": cannot find time zone "-0500": UTC timezone offset is out of range.
+SET TIME ZONE '-0500'

--- a/pkg/util/timeutil/time_zone_util.go
+++ b/pkg/util/timeutil/time_zone_util.go
@@ -23,7 +23,8 @@ import (
 const (
 	offsetBoundSecs = 167*60*60 + 59*60
 	// PG supports UTC hour offsets in the range [-167, 167].
-	maxUTCHourOffset = 167
+	maxUTCHourOffset          = 167
+	maxUTCHourOffsetInSeconds = maxUTCHourOffset * 60 * 60
 )
 
 var timezoneOffsetRegex = regexp.MustCompile(`(?i)^(GMT|UTC)?([+-])?(\d{1,3}(:[0-5]?\d){0,2})$`)
@@ -69,6 +70,9 @@ func TimeZoneStringToLocation(
 ) (*time.Location, error) {
 	offset, _, parsed := ParseTimeZoneOffset(locStr, std)
 	if parsed {
+		if offset < -maxUTCHourOffsetInSeconds || offset > maxUTCHourOffsetInSeconds {
+			return nil, errors.New("UTC timezone offset is out of range.")
+		}
 		return TimeZoneOffsetToLocation(offset), nil
 	}
 


### PR DESCRIPTION
Release note (sql change): Previously, users would be able to set
a UTC timezone offset of greater than 167 or less than -167. This
now returns an error.

Example:

SET TIME ZONE '168'
Gives error:
invalid value for parameter "timezone": "'168'": cannot find time zone "168": UTC timezone offset is out of range.

SET TIME ZONE '-168'
Gives error:
invalid value for parameter "timezone": "'-168'": cannot find time zone "-168": UTC timezone offset is out of range.

Fixes https://github.com/cockroachdb/cockroach/issues/75168

Note: If a user has already set a UTC timezone offset outside of these bounds, it will be unchanged. 