### PR TITLE
kv: add HottestReplicasForTenant capability to KV Store

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -209,6 +209,71 @@ RegionsResponse describes the available regions.
 
 
 
+## NodesList
+
+
+
+NodesList returns all available nodes with their addresses.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+NodesListRequest requests list of all nodes.
+The nodes are KV nodes when the cluster is a single
+tenant cluster or the host cluster in case of multi-tenant
+clusters.
+The nodes are SQL instances in case of multi-tenant
+clusters.
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+NodesListResponse contains a list of all nodes with their addresses.
+The nodes are KV nodes when the cluster is a single
+tenant cluster or the host cluster in case of multi-tenant
+clusters.
+The nodes are SQL instances in case of multi-tenant
+clusters.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| nodes | [NodeDetails](#cockroach.server.serverpb.NodesListResponse-cockroach.server.serverpb.NodeDetails) | repeated | nodes contains a list of NodeDetails. Each individual node within the list is a SQL node in case of a tenant server and KV nodes in case of a KV server. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodesListResponse-cockroach.server.serverpb.NodeDetails"></a>
+#### NodeDetails
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [int32](#cockroach.server.serverpb.NodesListResponse-int32) |  | node_id is a unique identifier for the node. This corresponds to SQL instance ID for a tenant server and KV node id for for a KV server. | [reserved](#support-status) |
+| address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.NodesListResponse-cockroach.util.UnresolvedAddr) |  | address is the RPC address for a KV node. This will be set to null for a tenant server node. | [reserved](#support-status) |
+| sql_address | [cockroach.util.UnresolvedAddr](#cockroach.server.serverpb.NodesListResponse-cockroach.util.UnresolvedAddr) |  | sql_address is the SQL address for a node. | [reserved](#support-status) |
+
+
+
+
+
+
 ## Nodes
 
 `GET /_status/nodes`

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1450,6 +1450,14 @@ Can be set to 1 to ensure only one node is polled for data at a time.
 `,
 	}
 
+	ZipTenant = FlagInfo{
+		Name: "tenant",
+		Description: `
+Set this flag to true to indicate the cockroach server to fetch debug data
+from is a tenant server. Default value is false.
+`,
+	}
+
 	StmtDiagDeleteAll = FlagInfo{
 		Name:        "all",
 		Description: `Delete all bundles.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -333,6 +333,10 @@ type zipContext struct {
 
 	// The log/heap/etc files to include.
 	files fileSelection
+
+	// tenant is set to true to indicate that debug data
+	// needs to be collected from a tenant server.
+	tenant bool
 }
 
 // setZipContextDefaults set the default values in zipCtx.  This

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -679,6 +679,7 @@ func init() {
 		boolFlag(f, &zipCtx.redactLogs, cliflags.ZipRedactLogs)
 		durationFlag(f, &zipCtx.cpuProfDuration, cliflags.ZipCPUProfileDuration)
 		intFlag(f, &zipCtx.concurrency, cliflags.ZipConcurrency)
+		boolFlag(f, &zipCtx.tenant, cliflags.ZipTenant)
 	}
 	// List-files + Zip commands.
 	for _, cmd := range []*cobra.Command{debugZipCmd, debugListFilesCmd} {

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 )
 
 func init() {
@@ -29,8 +30,8 @@ func TestMain(m *testing.M) {
 	// CLI tests are sensitive to the server version, but test binaries don't have
 	// a version injected. Pretend to be a very up-to-date version.
 	defer build.TestingOverrideTag("v999.0.0")()
-
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }
 

--- a/pkg/cli/testdata/zip/testzip_tenant
+++ b/pkg/cli/testdata/zip/testzip_tenant
@@ -1,0 +1,52 @@
+zip
+----
+debug zip --concurrency=1 --tenant /dev/null
+[cluster] establishing RPC connection to ...
+[cluster] retrieving the node status to get the SQL address... done
+[cluster] using SQL address: ...
+[cluster] creating output file /dev/null... done
+[cluster] retrieving SQL data for crdb_internal.cluster_contention_events... writing output: debug/crdb_internal.cluster_contention_events.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_distsql_flows... writing output: debug/crdb_internal.cluster_distsql_flows.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_database_privileges... writing output: debug/crdb_internal.cluster_database_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_queries... writing output: debug/crdb_internal.cluster_queries.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_sessions... writing output: debug/crdb_internal.cluster_sessions.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_settings... writing output: debug/crdb_internal.cluster_settings.txt... done
+[cluster] retrieving SQL data for crdb_internal.cluster_transactions... writing output: debug/crdb_internal.cluster_transactions.txt... done
+[cluster] retrieving SQL data for crdb_internal.default_privileges... writing output: debug/crdb_internal.default_privileges.txt... done
+[cluster] retrieving SQL data for crdb_internal.jobs... writing output: debug/crdb_internal.jobs.txt... done
+[cluster] retrieving SQL data for system.jobs... writing output: debug/system.jobs.txt... done
+[cluster] retrieving SQL data for system.descriptor... writing output: debug/system.descriptor.txt... done
+[cluster] retrieving SQL data for system.namespace... writing output: debug/system.namespace.txt... done
+[cluster] retrieving SQL data for system.scheduled_jobs... writing output: debug/system.scheduled_jobs.txt... done
+[cluster] retrieving SQL data for system.settings... writing output: debug/system.settings.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_schema_statements... writing output: debug/crdb_internal.create_schema_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_statements... writing output: debug/crdb_internal.create_statements.txt... done
+[cluster] retrieving SQL data for "".crdb_internal.create_type_statements... writing output: debug/crdb_internal.create_type_statements.txt... done
+[cluster] retrieving SQL data for crdb_internal.regions... writing output: debug/crdb_internal.regions.txt... done
+[cluster] retrieving SQL data for crdb_internal.schema_changes... writing output: debug/crdb_internal.schema_changes.txt... done
+[cluster] retrieving SQL data for crdb_internal.partitions... writing output: debug/crdb_internal.partitions.txt... done
+[cluster] retrieving SQL data for crdb_internal.zones... writing output: debug/crdb_internal.zones.txt... done
+[cluster] retrieving SQL data for crdb_internal.invalid_objects... writing output: debug/crdb_internal.invalid_objects.txt... done
+[cluster] retrieving SQL data for crdb_internal.index_usage_statistics... writing output: debug/crdb_internal.index_usage_statistics.txt... done
+[cluster] retrieving SQL data for crdb_internal.table_indexes... writing output: debug/crdb_internal.table_indexes.txt... done
+[cluster] requesting nodes... received response... converting to JSON... writing binary output: debug/nodes.json... done
+[node 1] node status... converting to JSON... writing binary output: debug/nodes/1/status.json... done
+[node 1] using SQL connection URL: postgresql://...
+[node 1] retrieving SQL data for crdb_internal.feature_usage... writing output: debug/nodes/1/crdb_internal.feature_usage.txt... done
+[node 1] retrieving SQL data for crdb_internal.leases... writing output: debug/nodes/1/crdb_internal.leases.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_build_info... writing output: debug/nodes/1/crdb_internal.node_build_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_contention_events... writing output: debug/nodes/1/crdb_internal.node_contention_events.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_distsql_flows... writing output: debug/nodes/1/crdb_internal.node_distsql_flows.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_inflight_trace_spans... writing output: debug/nodes/1/crdb_internal.node_inflight_trace_spans.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_metrics... writing output: debug/nodes/1/crdb_internal.node_metrics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_queries... writing output: debug/nodes/1/crdb_internal.node_queries.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_runtime_info... writing output: debug/nodes/1/crdb_internal.node_runtime_info.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_sessions... writing output: debug/nodes/1/crdb_internal.node_sessions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_statement_statistics... writing output: debug/nodes/1/crdb_internal.node_statement_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transaction_statistics... writing output: debug/nodes/1/crdb_internal.node_transaction_statistics.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_transactions... writing output: debug/nodes/1/crdb_internal.node_transactions.txt... done
+[node 1] retrieving SQL data for crdb_internal.node_txn_stats... writing output: debug/nodes/1/crdb_internal.node_txn_stats.txt... done
+[node 1] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/nodes/1/crdb_internal.active_range_feeds.txt... done
+[node 1] requesting data for debug/nodes/1/details... received response... converting to JSON... writing binary output: debug/nodes/1/details.json... done
+[cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
+[cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
-	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -30,11 +30,19 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// makePreNodeZipRequests defines the zipRequests (API requests) that are to be
+// makePerNodeZipRequests defines the zipRequests (API requests) that are to be
 // performed once per node.
-func makePerNodeZipRequests(
-	prefix, id string, admin serverpb.AdminClient, status serverpb.StatusClient,
-) []zipRequest {
+func makePerNodeZipRequests(prefix, id string, status serverpb.StatusClient) []zipRequest {
+	if zipCtx.tenant {
+		return []zipRequest{
+			{
+				fn: func(ctx context.Context) (interface{}, error) {
+					return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id})
+				},
+				pathName: prefix + "/details",
+			},
+		}
+	}
 	return []zipRequest{
 		{
 			fn: func(ctx context.Context) (interface{}, error) {
@@ -55,6 +63,27 @@ func makePerNodeZipRequests(
 			pathName: prefix + "/enginestats",
 		},
 	}
+}
+
+// Tables collected from each tenant SQL node in a debug zip.
+var debugZipTablesPerTenantNode = []string{
+	"crdb_internal.feature_usage",
+
+	"crdb_internal.leases",
+
+	"crdb_internal.node_build_info",
+	"crdb_internal.node_contention_events",
+	"crdb_internal.node_distsql_flows",
+	"crdb_internal.node_inflight_trace_spans",
+	"crdb_internal.node_metrics",
+	"crdb_internal.node_queries",
+	"crdb_internal.node_runtime_info",
+	"crdb_internal.node_sessions",
+	"crdb_internal.node_statement_statistics",
+	"crdb_internal.node_transaction_statistics",
+	"crdb_internal.node_transactions",
+	"crdb_internal.node_txn_stats",
+	"crdb_internal.active_range_feeds",
 }
 
 // Tables collected from each node in a debug zip using SQL.
@@ -94,9 +123,10 @@ var debugZipTablesPerNode = []string{
 // This is called first and in isolation, before other zip operations
 // possibly influence the nodes.
 func (zc *debugZipContext) collectCPUProfiles(
-	ctx context.Context, nodeList []statuspb.NodeStatus, livenessByNodeID nodeLivenesses,
+	ctx context.Context, nodeList []serverpb.NodeDetails, livenessByNodeID nodeLivenesses,
 ) error {
-	if zipCtx.cpuProfDuration <= 0 {
+	// TODO(rima): Collect profiles for tenant SQL nodes.
+	if zipCtx.cpuProfDuration <= 0 || zipCtx.tenant {
 		// Nothing to do; return early.
 		return nil
 	}
@@ -112,7 +142,8 @@ func (zc *debugZipContext) collectCPUProfiles(
 	// NB: this takes care not to produce non-deterministic log output.
 	resps := make([]profData, len(nodeList))
 	for i := range nodeList {
-		if livenessByNodeID[nodeList[i].Desc.NodeID] == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
+		nodeID := roachpb.NodeID(nodeList[i].NodeID)
+		if livenessByNodeID[nodeID] == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
 			continue
 		}
 		wg.Add(1)
@@ -127,7 +158,7 @@ func (zc *debugZipContext) collectCPUProfiles(
 			var pd profData
 			err := contextutil.RunWithTimeout(ctx, "fetch cpu profile", zc.timeout+zipCtx.cpuProfDuration, func(ctx context.Context) error {
 				resp, err := zc.status.Profile(ctx, &serverpb.ProfileRequest{
-					NodeId:  fmt.Sprintf("%d", nodeList[i].Desc.NodeID),
+					NodeId:  fmt.Sprintf("%d", nodeID),
 					Type:    serverpb.ProfileRequest_CPU,
 					Seconds: secs,
 					Labels:  true,
@@ -153,7 +184,7 @@ func (zc *debugZipContext) collectCPUProfiles(
 		if len(pd.data) == 0 && pd.err == nil {
 			continue // skipped node
 		}
-		nodeID := nodeList[i].Desc.NodeID
+		nodeID := nodeList[i].NodeID
 		prefix := fmt.Sprintf("%s/%s", nodesPrefix, fmt.Sprintf("%d", nodeID))
 		s := zc.clusterPrinter.start("profile for node %d", nodeID)
 		if err := zc.z.createRawOrError(s, prefix+"/cpu.pprof", pd.data, pd.err); err != nil {
@@ -164,25 +195,26 @@ func (zc *debugZipContext) collectCPUProfiles(
 }
 
 func (zc *debugZipContext) collectPerNodeData(
-	ctx context.Context, node statuspb.NodeStatus, livenessByNodeID nodeLivenesses,
+	ctx context.Context, node serverpb.NodeDetails, livenessByNodeID nodeLivenesses,
 ) error {
-	nodeID := node.Desc.NodeID
+	nodeID := roachpb.NodeID(node.NodeID)
 
-	liveness := livenessByNodeID[nodeID]
-	if liveness == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
-		// Decommissioned + process terminated. Let's not waste time
-		// on this node.
-		//
-		// NB: we still inspect DECOMMISSIONING nodes (marked as
-		// decommissioned but the process is still alive) to get a
-		// chance to collect their log files.
-		//
-		// NB: we still inspect DEAD nodes because even though they
-		// don't heartbeat their liveness record their process might
-		// still be up and willing to deliver some log files.
-		return nil
+	if livenessByNodeID != nil {
+		liveness := livenessByNodeID[nodeID]
+		if liveness == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
+			// Decommissioned + process terminated. Let's not waste time
+			// on this node.
+			//
+			// NB: we still inspect DECOMMISSIONING nodes (marked as
+			// decommissioned but the process is still alive) to get a
+			// chance to collect their log files.
+			//
+			// NB: we still inspect DEAD nodes because even though they
+			// don't heartbeat their liveness record their process might
+			// still be up and willing to deliver some log files.
+			return nil
+		}
 	}
-
 	nodePrinter := zipCtx.newZipReporter("node %d", nodeID)
 	id := fmt.Sprintf("%d", nodeID)
 	prefix := fmt.Sprintf("%s/%s", nodesPrefix, id)
@@ -206,11 +238,18 @@ func (zc *debugZipContext) collectPerNodeData(
 	// not work and if it doesn't, we let the invalid curSQLConn get
 	// used anyway so that anything that does *not* need it will
 	// still happen.
-	sqlAddr := node.Desc.CheckedSQLAddress()
+	sqlAddr := node.SQLAddress
+	if sqlAddr.IsEmpty() {
+		sqlAddr = node.Address
+	}
 	curSQLConn := guessNodeURL(zc.firstNodeSQLConn.GetURL(), sqlAddr.AddressField)
 	nodePrinter.info("using SQL connection URL: %s", curSQLConn.GetURL())
 
-	for _, table := range debugZipTablesPerNode {
+	debugZipTables := debugZipTablesPerNode
+	if zipCtx.tenant {
+		debugZipTables = debugZipTablesPerTenantNode
+	}
+	for _, table := range debugZipTables {
 		query := fmt.Sprintf(`SELECT * FROM %s`, table)
 		if override, ok := customQuery[table]; ok {
 			query = override
@@ -220,7 +259,7 @@ func (zc *debugZipContext) collectPerNodeData(
 		}
 	}
 
-	perNodeZipRequests := makePerNodeZipRequests(prefix, id, zc.admin, zc.status)
+	perNodeZipRequests := makePerNodeZipRequests(prefix, id, zc.status)
 
 	for _, r := range perNodeZipRequests {
 		if err := zc.runZipRequest(ctx, nodePrinter, r); err != nil {
@@ -228,6 +267,13 @@ func (zc *debugZipContext) collectPerNodeData(
 		}
 	}
 
+	if zipCtx.tenant {
+		// Return early for tenant servers since subsequent endpoints (stacks, profiles etc.)
+		// are not yet supported for tenants.
+		// TODO(rima): Remove this section once all endpoints are supported for
+		// tenants.
+		return nil
+	}
 	var stacksData []byte
 	s := nodePrinter.start("requesting stacks")
 	requestErr := zc.runZipFn(ctx, s,

--- a/pkg/cli/zip_tenant_test.go
+++ b/pkg/cli/zip_tenant_test.go
@@ -1,0 +1,157 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/datadriven"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// Dummy import to pull in kvtenantccl. This allows us to start tenants.
+// We need ccl functionality in order to test debug zip for serverless.
+var _ = kvtenantccl.Connector{}
+
+// TestTenantZipContainsAllInternalTables verifies that we don't add new internal tables
+// without also taking them into account in a `debug zip`. If this test fails,
+// add your table to either of the []string slices referenced in the test (which
+// are used by `debug zip`) or add it as an exception after having verified that
+// it indeed should not be collected (this is rare).
+// NB: if you're adding a new one, you'll also have to update TestZip.
+func TestTenantZipContainsAllInternalTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	_, db := serverutils.StartTenant(
+		t,
+		tc.Server(0),
+		base.TestTenantArgs{TenantID: serverutils.TestTenantID()},
+	)
+	defer db.Close()
+
+	rows, err := db.Query(`
+SELECT concat('crdb_internal.', table_name) as name
+FROM [ SELECT table_name FROM [ SHOW TABLES FROM crdb_internal ] ]
+WHERE
+table_name NOT IN (
+	-- allowlisted tables that don't need to be in debug zip
+	'backward_dependencies',
+	'builtin_functions',
+	'cluster_contended_keys',
+	'cluster_contended_indexes',
+	'cluster_contended_tables',
+	'cluster_inflight_traces',
+	'cross_db_references',
+	'databases',
+	'forward_dependencies',
+  'gossip_alerts',
+  'gossip_liveness',
+  'gossip_network',
+  'gossip_nodes',
+	'index_columns',
+  'kv_node_liveness',
+  'kv_node_status',
+  'kv_store_status',
+	'lost_descriptors_with_data',
+	'table_columns',
+	'table_row_statistics',
+	'ranges',
+	'ranges_no_leases',
+	'predefined_comments',
+	'session_trace',
+	'session_variables',
+	'tables',
+	'cluster_statement_statistics',
+	'cluster_transaction_statistics',
+	'statement_statistics',
+	'transaction_statistics',
+	'tenant_usage_details'
+)
+ORDER BY name ASC`)
+	assert.NoError(t, err)
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		assert.NoError(t, rows.Scan(&table))
+		tables = append(tables, table)
+	}
+	tables = append(
+		tables,
+		"system.jobs",
+		"system.descriptor",
+		"system.namespace",
+		"system.scheduled_jobs",
+		"system.settings",
+	)
+	sort.Strings(tables)
+
+	var exp []string
+	exp = append(exp, debugZipTablesPerTenantNode...)
+	for _, t := range debugZipTablesPerTenant {
+		t = strings.TrimPrefix(t, `"".`)
+		exp = append(exp, t)
+	}
+	sort.Strings(exp)
+
+	assert.Equal(t, exp, tables)
+}
+
+// TestTenantZip tests the operation of zip over serverless clusters.
+func TestTenantZip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderRace(t, "test too slow under race")
+
+	dir, cleanupFn := testutils.TempDir(t)
+	defer cleanupFn()
+
+	c := NewCLITest(TestCLIParams{
+		StoreSpecs: []base.StoreSpec{{
+			Path: dir,
+		}},
+		Multitenant: true,
+		Insecure:    true,
+	})
+	defer c.Cleanup()
+
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --tenant " + os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Strip any non-deterministic messages.
+	out = eraseNonDeterministicZipOutput(out)
+
+	// We use datadriven simply to read the golden output file; we don't actually
+	// run any commands. Using datadriven allows TESTFLAGS=-rewrite.
+	datadriven.RunTest(t,
+		testutils.TestDataPath(t, "zip", "testzip_tenant"),
+		func(t *testing.T, td *datadriven.TestData) string {
+			return out
+		},
+	)
+}

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -76,7 +76,6 @@ table_name NOT IN (
 	'databases',
 	'forward_dependencies',
 	'index_columns',
-	'interleaved',
 	'lost_descriptors_with_data',
 	'table_columns',
 	'table_row_statistics',

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -308,6 +308,40 @@ message RegionsResponse {
   map<string, Region> regions = 1;
 }
 
+// NodesListRequest requests list of all nodes.
+// The nodes are KV nodes when the cluster is a single
+// tenant cluster or the host cluster in case of multi-tenant
+// clusters.
+// The nodes are SQL instances in case of multi-tenant
+// clusters.
+message NodesListRequest {}
+
+message NodeDetails {
+  // node_id is a unique identifier for the node. This corresponds
+  // to SQL instance ID for a tenant server and KV node id for
+  // for a KV server.
+  int32 node_id = 1 [(gogoproto.customname) = "NodeID"];
+  // address is the RPC address for a KV node. This will be set to
+  // null for a tenant server node.
+  util.UnresolvedAddr address = 2 [(gogoproto.nullable) = false];
+  // sql_address is the SQL address for a node.
+  util.UnresolvedAddr sql_address = 3 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "SQLAddress"];
+}
+
+// NodesListResponse contains a list of all nodes with their addresses.
+// The nodes are KV nodes when the cluster is a single
+// tenant cluster or the host cluster in case of multi-tenant
+// clusters.
+// The nodes are SQL instances in case of multi-tenant
+// clusters.
+message NodesListResponse {
+  // nodes contains a list of NodeDetails. Each individual node within
+  // the list is a SQL node in case of a tenant server and KV nodes in
+  // case of a KV server.
+  repeated NodeDetails nodes = 1 [(gogoproto.nullable) = false];
+}
+
 message NodeRequest {
   // node_id is a string so that "local" can be used to specify that no
   // forwarding is necessary.
@@ -1435,6 +1469,9 @@ service Status {
 
   // RegionsRequest retrieves all available regions.
   rpc Regions(RegionsRequest) returns (RegionsResponse) {}
+
+  // NodesList returns all available nodes with their addresses.
+  rpc NodesList(NodesListRequest) returns (NodesListResponse) {}
 
   // Nodes returns status info for all commissioned nodes. Decommissioned nodes
   // are not included, except in rare cases where the node doing the

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1349,6 +1349,32 @@ func regionsResponseFromNodesResponse(nr *serverpb.NodesResponse) *serverpb.Regi
 	return ret
 }
 
+// NodesList returns a list of nodes with their corresponding addresses.
+func (s *statusServer) NodesList(
+	ctx context.Context, _ *serverpb.NodesListRequest,
+) (*serverpb.NodesListResponse, error) {
+	// The node status contains details about the command line, network
+	// addresses, env vars etc which are admin-only.
+	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		return nil, err
+	}
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+	statuses, _, err := s.getNodeStatuses(ctx, 0 /* limit */, 0 /* offset */)
+	if err != nil {
+		return nil, err
+	}
+	resp := &serverpb.NodesListResponse{
+		Nodes: make([]serverpb.NodeDetails, len(statuses)),
+	}
+	for i, status := range statuses {
+		resp.Nodes[i].NodeID = int32(status.Desc.NodeID)
+		resp.Nodes[i].Address = status.Desc.Address
+		resp.Nodes[i].SQLAddress = status.Desc.SQLAddress
+	}
+	return resp, nil
+}
+
 // Nodes returns all node statuses.
 //
 // Do not use this method inside the server code! Use
@@ -1506,12 +1532,9 @@ func (s *statusServer) ListNodesInternal(
 	return resp, err
 }
 
-func (s *statusServer) nodesHelper(
+func (s *statusServer) getNodeStatuses(
 	ctx context.Context, limit, offset int,
-) (*serverpb.NodesResponse, int, error) {
-	ctx = propagateGatewayMetadata(ctx)
-	ctx = s.AnnotateCtx(ctx)
-
+) (statuses []statuspb.NodeStatus, next int, _ error) {
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
 
@@ -1522,7 +1545,6 @@ func (s *statusServer) nodesHelper(
 		return nil, 0, status.Errorf(codes.Internal, err.Error())
 	}
 
-	var next int
 	var rows []kv.KeyValue
 	if len(b.Results[0].Rows) > 0 {
 		var rowsInterface interface{}
@@ -1530,14 +1552,28 @@ func (s *statusServer) nodesHelper(
 		rows = rowsInterface.([]kv.KeyValue)
 	}
 
-	resp := serverpb.NodesResponse{
-		Nodes: make([]statuspb.NodeStatus, len(rows)),
-	}
+	statuses = make([]statuspb.NodeStatus, len(rows))
 	for i, row := range rows {
-		if err := row.ValueProto(&resp.Nodes[i]); err != nil {
+		if err := row.ValueProto(&statuses[i]); err != nil {
 			log.Errorf(ctx, "%v", err)
 			return nil, 0, status.Errorf(codes.Internal, err.Error())
 		}
+	}
+	return statuses, next, nil
+}
+
+func (s *statusServer) nodesHelper(
+	ctx context.Context, limit, offset int,
+) (*serverpb.NodesResponse, int, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	statuses, next, err := s.getNodeStatuses(ctx, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp := serverpb.NodesResponse{
+		Nodes: statuses,
 	}
 
 	clock := s.admin.server.clock

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
@@ -887,4 +889,71 @@ func (t *tenantStatusServer) TableIndexStats(
 
 	return getTableIndexUsageStats(ctx, req, t.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics(),
 		t.sqlServer.internalExecutor)
+}
+
+// Details returns information for a given instance ID such as
+// the instance address and build info.
+func (t *tenantStatusServer) Details(
+	ctx context.Context, req *serverpb.DetailsRequest,
+) (*serverpb.DetailsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = t.AnnotateCtx(ctx)
+
+	if err := t.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		return nil, err
+	}
+
+	if t.sqlServer.SQLInstanceID() == 0 {
+		return nil, status.Errorf(codes.Unavailable, "instanceID not set")
+	}
+
+	instanceID, local, err := t.parseInstanceID(req.NodeId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+	if !local {
+		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)
+		status, err := t.dialPod(ctx, instanceID, instance.InstanceAddr)
+		if err != nil {
+			return nil, err
+		}
+		return status.Details(ctx, req)
+	}
+	localInstance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, t.sqlServer.SQLInstanceID())
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "local instance unavailable")
+	}
+	resp := &serverpb.DetailsResponse{
+		NodeID:     roachpb.NodeID(instanceID),
+		BuildInfo:  build.GetInfo(),
+		SQLAddress: util.MakeUnresolvedAddr("", localInstance.InstanceAddr),
+	}
+
+	return resp, nil
+}
+
+func (t *tenantStatusServer) NodesList(
+	ctx context.Context, req *serverpb.NodesListRequest,
+) (*serverpb.NodesListResponse, error) {
+	// The node status contains details about the command line, network
+	// addresses, env vars etc which are admin-only.
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = t.AnnotateCtx(ctx)
+
+	if _, err := t.privilegeChecker.requireAdminUser(ctx); err != nil {
+		return nil, err
+	}
+	instances, err := t.sqlServer.sqlInstanceProvider.GetAllInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var resp serverpb.NodesListResponse
+	for _, instance := range instances {
+		nodeDetails := serverpb.NodeDetails{
+			NodeID:     int32(instance.InstanceID),
+			SQLAddress: util.MakeUnresolvedAddr("", instance.InstanceAddr),
+		}
+		resp.Nodes = append(resp.Nodes, nodeDetails)
+	}
+	return &resp, err
 }

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -52,7 +52,9 @@ func (mr *MockCatalogMockRecorder) AddSyntheticDescriptor(arg0 interface{}) *gom
 }
 
 // GetFullyQualifiedName mocks base method.
-func (m *MockCatalog) GetFullyQualifiedName(arg0 context.Context, arg1 catid.DescID) (string, error) {
+func (m *MockCatalog) GetFullyQualifiedName(
+	arg0 context.Context, arg1 catid.DescID,
+) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFullyQualifiedName", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -67,7 +69,9 @@ func (mr *MockCatalogMockRecorder) GetFullyQualifiedName(arg0, arg1 interface{})
 }
 
 // MustReadImmutableDescriptor mocks base method.
-func (m *MockCatalog) MustReadImmutableDescriptor(arg0 context.Context, arg1 catid.DescID) (catalog.Descriptor, error) {
+func (m *MockCatalog) MustReadImmutableDescriptor(
+	arg0 context.Context, arg1 catid.DescID,
+) (catalog.Descriptor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MustReadImmutableDescriptor", arg0, arg1)
 	ret0, _ := ret[0].(catalog.Descriptor)
@@ -76,13 +80,17 @@ func (m *MockCatalog) MustReadImmutableDescriptor(arg0 context.Context, arg1 cat
 }
 
 // MustReadImmutableDescriptor indicates an expected call of MustReadImmutableDescriptor.
-func (mr *MockCatalogMockRecorder) MustReadImmutableDescriptor(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCatalogMockRecorder) MustReadImmutableDescriptor(
+	arg0, arg1 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustReadImmutableDescriptor", reflect.TypeOf((*MockCatalog)(nil).MustReadImmutableDescriptor), arg0, arg1)
 }
 
 // MustReadMutableDescriptor mocks base method.
-func (m *MockCatalog) MustReadMutableDescriptor(arg0 context.Context, arg1 catid.DescID) (catalog.MutableDescriptor, error) {
+func (m *MockCatalog) MustReadMutableDescriptor(
+	arg0 context.Context, arg1 catid.DescID,
+) (catalog.MutableDescriptor, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MustReadMutableDescriptor", arg0, arg1)
 	ret0, _ := ret[0].(catalog.MutableDescriptor)
@@ -337,7 +345,12 @@ func (m *MockBackfiller) EXPECT() *MockBackfillerMockRecorder {
 }
 
 // BackfillIndex mocks base method.
-func (m *MockBackfiller) BackfillIndex(arg0 context.Context, arg1 scexec.BackfillProgress, arg2 scexec.BackfillProgressWriter, arg3 catalog.TableDescriptor) error {
+func (m *MockBackfiller) BackfillIndex(
+	arg0 context.Context,
+	arg1 scexec.BackfillProgress,
+	arg2 scexec.BackfillProgressWriter,
+	arg3 catalog.TableDescriptor,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BackfillIndex", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -345,13 +358,17 @@ func (m *MockBackfiller) BackfillIndex(arg0 context.Context, arg1 scexec.Backfil
 }
 
 // BackfillIndex indicates an expected call of BackfillIndex.
-func (mr *MockBackfillerMockRecorder) BackfillIndex(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBackfillerMockRecorder) BackfillIndex(
+	arg0, arg1, arg2, arg3 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackfillIndex", reflect.TypeOf((*MockBackfiller)(nil).BackfillIndex), arg0, arg1, arg2, arg3)
 }
 
 // MaybePrepareDestIndexesForBackfill mocks base method.
-func (m *MockBackfiller) MaybePrepareDestIndexesForBackfill(arg0 context.Context, arg1 scexec.BackfillProgress, arg2 catalog.TableDescriptor) (scexec.BackfillProgress, error) {
+func (m *MockBackfiller) MaybePrepareDestIndexesForBackfill(
+	arg0 context.Context, arg1 scexec.BackfillProgress, arg2 catalog.TableDescriptor,
+) (scexec.BackfillProgress, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybePrepareDestIndexesForBackfill", arg0, arg1, arg2)
 	ret0, _ := ret[0].(scexec.BackfillProgress)
@@ -360,7 +377,9 @@ func (m *MockBackfiller) MaybePrepareDestIndexesForBackfill(arg0 context.Context
 }
 
 // MaybePrepareDestIndexesForBackfill indicates an expected call of MaybePrepareDestIndexesForBackfill.
-func (mr *MockBackfillerMockRecorder) MaybePrepareDestIndexesForBackfill(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBackfillerMockRecorder) MaybePrepareDestIndexesForBackfill(
+	arg0, arg1, arg2 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePrepareDestIndexesForBackfill", reflect.TypeOf((*MockBackfiller)(nil).MaybePrepareDestIndexesForBackfill), arg0, arg1, arg2)
 }
@@ -417,7 +436,9 @@ func (mr *MockBackfillTrackerMockRecorder) FlushFractionCompleted(arg0 interface
 }
 
 // GetBackfillProgress mocks base method.
-func (m *MockBackfillTracker) GetBackfillProgress(arg0 context.Context, arg1 scexec.Backfill) (scexec.BackfillProgress, error) {
+func (m *MockBackfillTracker) GetBackfillProgress(
+	arg0 context.Context, arg1 scexec.Backfill,
+) (scexec.BackfillProgress, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackfillProgress", arg0, arg1)
 	ret0, _ := ret[0].(scexec.BackfillProgress)
@@ -426,13 +447,17 @@ func (m *MockBackfillTracker) GetBackfillProgress(arg0 context.Context, arg1 sce
 }
 
 // GetBackfillProgress indicates an expected call of GetBackfillProgress.
-func (mr *MockBackfillTrackerMockRecorder) GetBackfillProgress(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackfillTrackerMockRecorder) GetBackfillProgress(
+	arg0, arg1 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackfillProgress", reflect.TypeOf((*MockBackfillTracker)(nil).GetBackfillProgress), arg0, arg1)
 }
 
 // SetBackfillProgress mocks base method.
-func (m *MockBackfillTracker) SetBackfillProgress(arg0 context.Context, arg1 scexec.BackfillProgress) error {
+func (m *MockBackfillTracker) SetBackfillProgress(
+	arg0 context.Context, arg1 scexec.BackfillProgress,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetBackfillProgress", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -440,7 +465,9 @@ func (m *MockBackfillTracker) SetBackfillProgress(arg0 context.Context, arg1 sce
 }
 
 // SetBackfillProgress indicates an expected call of SetBackfillProgress.
-func (mr *MockBackfillTrackerMockRecorder) SetBackfillProgress(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBackfillTrackerMockRecorder) SetBackfillProgress(
+	arg0, arg1 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBackfillProgress", reflect.TypeOf((*MockBackfillTracker)(nil).SetBackfillProgress), arg0, arg1)
 }
@@ -469,7 +496,9 @@ func (m *MockIndexSpanSplitter) EXPECT() *MockIndexSpanSplitterMockRecorder {
 }
 
 // MaybeSplitIndexSpans mocks base method.
-func (m *MockIndexSpanSplitter) MaybeSplitIndexSpans(arg0 context.Context, arg1 catalog.TableDescriptor, arg2 catalog.Index) error {
+func (m *MockIndexSpanSplitter) MaybeSplitIndexSpans(
+	arg0 context.Context, arg1 catalog.TableDescriptor, arg2 catalog.Index,
+) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaybeSplitIndexSpans", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -477,7 +506,9 @@ func (m *MockIndexSpanSplitter) MaybeSplitIndexSpans(arg0 context.Context, arg1 
 }
 
 // MaybeSplitIndexSpans indicates an expected call of MaybeSplitIndexSpans.
-func (mr *MockIndexSpanSplitterMockRecorder) MaybeSplitIndexSpans(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockIndexSpanSplitterMockRecorder) MaybeSplitIndexSpans(
+	arg0, arg1, arg2 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeSplitIndexSpans", reflect.TypeOf((*MockIndexSpanSplitter)(nil).MaybeSplitIndexSpans), arg0, arg1, arg2)
 }
@@ -506,7 +537,9 @@ func (m *MockPeriodicProgressFlusher) EXPECT() *MockPeriodicProgressFlusherMockR
 }
 
 // StartPeriodicUpdates mocks base method.
-func (m *MockPeriodicProgressFlusher) StartPeriodicUpdates(arg0 context.Context, arg1 scexec.BackfillProgressFlusher) func() error {
+func (m *MockPeriodicProgressFlusher) StartPeriodicUpdates(
+	arg0 context.Context, arg1 scexec.BackfillProgressFlusher,
+) func() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartPeriodicUpdates", arg0, arg1)
 	ret0, _ := ret[0].(func() error)
@@ -514,7 +547,9 @@ func (m *MockPeriodicProgressFlusher) StartPeriodicUpdates(arg0 context.Context,
 }
 
 // StartPeriodicUpdates indicates an expected call of StartPeriodicUpdates.
-func (mr *MockPeriodicProgressFlusherMockRecorder) StartPeriodicUpdates(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPeriodicProgressFlusherMockRecorder) StartPeriodicUpdates(
+	arg0, arg1 interface{},
+) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartPeriodicUpdates", reflect.TypeOf((*MockPeriodicProgressFlusher)(nil).StartPeriodicUpdates), arg0, arg1)
 }


### PR DESCRIPTION
As part of an initiative to create debug.zip support for tenants
in multitenant deployments of CockroachDB, we will need to add
support to fetch a hot ranges report for a specific tenant within
the KV layer. This will involve a HotRangesForTenant endpoint on
both the tenant status and KV status servers, connected via the
tenant connector interface.

The KV status server implementation will be unable to use the
existing `HottestReplicas()` function defined on the KV store,
as this uses the `replicaRankings` generated periodically as a
part of the KV Store's gossip procedure, which contains replicas
that span all tenants. What we need is similar functionality that
filters the hottest replicas down to just those that belong to
a specific tenant. This will need to be generated on demand.

This patch adds this functionality to the KV store. Follow up
patches will add the status server endpoints and hook things up
to debug.zip.

Release note: none