### PR TITLE
cloud: redact user info whenever sanitizing uris

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -506,8 +506,6 @@ func changefeedJobDescription(
 		return "", err
 	}
 
-	cleanedSinkURI = redactUser(cleanedSinkURI)
-
 	c := &tree.CreateChangefeed{
 		Targets: changefeed.Targets,
 		SinkURI: tree.NewDString(cleanedSinkURI),
@@ -525,14 +523,6 @@ func changefeedJobDescription(
 	sort.Slice(c.Options, func(i, j int) bool { return c.Options[i].Key < c.Options[j].Key })
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(c, ann), nil
-}
-
-func redactUser(uri string) string {
-	u, _ := url.Parse(uri)
-	if u.User != nil {
-		u.User = url.User(`redacted`)
-	}
-	return u.String()
 }
 
 // validateNonNegativeDuration returns a nil error if optValue can be

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -125,6 +125,10 @@ func SanitizeExternalStorageURI(path string, extraParams []string) (string, erro
 		}
 	}
 
+	if uri.User != nil {
+		uri.User = url.User(`redacted`)
+	}
+
 	uri.RawQuery = params.Encode()
 	return uri.String(), nil
 }


### PR DESCRIPTION
#75174 did this only for changefeeds to have a quick backportable change
but probably this should be done everywhere. Pushing to run CI and see what
breaks.

Release note (enterprise change): UserInfo will now be redacted in sanitized URIs.