### PR TITLE
cli: fix error handling on show constraint cli command

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1179,8 +1179,11 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		}
 		return c.invalidSyntax(errState)
 	case `\dd`:
-		c.concatLines = `SHOW CONSTRAINTS FROM ` + cmd[1] + ` WITH COMMENT`
-		return cliRunStatement
+		if len(cmd) == 2 {
+			c.concatLines = `SHOW CONSTRAINTS FROM ` + cmd[1] + ` WITH COMMENT`
+			return cliRunStatement
+		}
+		return c.invalidSyntax(errState)
 	case `\connect`, `\c`:
 		return c.handleConnect(cmd[1:], loopState, errState)
 


### PR DESCRIPTION
The `\dd` cli command would cause a panic if the command was used
without a table being specified afterwards. This fix adds the
appropriate error handling.

No release note since `\dd` is new functionality in 22.1.

Release note: None