### PR TITLE
sql: fix error before setting sequence ownership on CREATE TABLE

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2238,6 +2238,9 @@ func newTableDesc(
 			n.Persistence,
 		)
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// We need to ensure sequence ownerships so that column owned sequences are
 	// correctly dropped when a column/table is dropped.
@@ -2250,7 +2253,7 @@ func newTableDesc(
 		}
 	}
 
-	return ret, err
+	return ret, nil
 }
 
 // replaceLikeTableOps processes the TableDefs in the input CreateTableNode,

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -643,6 +643,12 @@ subtest test_serial_ownership_create_table
 statement ok
 SET serial_normalization = sql_sequence;
 
+statement error "fillfactor" must be between 0 and 100
+CREATE TABLE test_ownership_invalid_fillfactor (
+        a INT PRIMARY KEY,
+        b SERIAL
+) with (fillfactor = 70000)
+
 statement ok
 CREATE TABLE test_serial (
 	a INT PRIMARY KEY,
@@ -659,8 +665,8 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name               state   refobjid
-124       test_serial_b_seq  PUBLIC  123
-123       test_serial        PUBLIC  NULL
+126       test_serial_b_seq  PUBLIC  125
+125       test_serial        PUBLIC  NULL
 
 statement ok
 DROP TABLE test_serial;
@@ -692,8 +698,8 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name               state   refobjid
-126       test_serial_b_seq  PUBLIC  125
-125       test_serial        PUBLIC  NULL
+128       test_serial_b_seq  PUBLIC  127
+127       test_serial        PUBLIC  NULL
 
 statement ok
 ALTER TABLE test_serial DROP COLUMN b;
@@ -708,7 +714,7 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name         state   refobjid
-125       test_serial  PUBLIC  NULL
+127       test_serial  PUBLIC  NULL
 
 statement ok
 DROP TABLE test_serial;


### PR DESCRIPTION
`6afe54eb6879c990ddfb9db55b1c37085f1bbab4` introduced a bug where a
CREATE TABLE could panic if sequence ownership requires being set but
the table descriptor creation errored out. This fixes that case.

Release note: None