### PR TITLE
release-21.2: colexec: use top K sort only for K <= 5000 with bytes-like types

### DIFF
--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -268,7 +268,7 @@ func NewExternalSorter(
 	}
 	inputPartitioner := newInputPartitioningOperator(sortUnlimitedAllocator, input, inputTypes, inMemSortPartitionLimit)
 	var inMemSorter colexecop.ResettableOperator
-	if topK > 0 {
+	if topK > 0 && ShouldUseTopK(topK, inputTypes) {
 		inMemSorter = NewTopKSorter(sortUnlimitedAllocator, inputPartitioner, inputTypes, ordering.Columns, topK, inMemSortOutputLimit)
 	} else {
 		var err error

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -15,6 +15,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -23,6 +24,25 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
+
+const maxKWithBytesLikeType = 5000
+
+// ShouldUseTopK returns true if the top K sorter should be used; if false is
+// returned, the general sorter should be used instead. k is assumed to be
+// non-zero.
+func ShouldUseTopK(k uint64, inputTypes []*types.T) bool {
+	if k <= maxKWithBytesLikeType {
+		return true
+	}
+	for _, t := range inputTypes {
+		if typeconv.TypeFamilyToCanonicalTypeFamily(t.Family()) == types.BytesFamily {
+			// k is larger than maxKWithBytesLikeType and we have just found a
+			// bytes-like type, so we should not use the top K sorter.
+			return false
+		}
+	}
+	return true
+}
 
 const (
 	topKVecIdx  = 0
@@ -40,6 +60,11 @@ func NewTopKSorter(
 	k uint64,
 	maxOutputBatchMemSize int64,
 ) colexecop.ResettableOperator {
+	if !ShouldUseTopK(k, inputTypes) {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"tried to create the top K sorter when the general sorter is beneficial",
+		))
+	}
 	return &topKSorter{
 		allocator:             allocator,
 		OneInputNode:          colexecop.NewOneInputNode(input),

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -14,13 +14,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/stretchr/testify/require"
 )
 
 var topKSortTestCases []sortTestCase
@@ -74,5 +79,81 @@ func TestTopKSorter(t *testing.T) {
 		colexectestutils.RunTests(t, testAllocator, []colexectestutils.Tuples{tc.tuples}, tc.expected, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
 			return NewTopKSorter(testAllocator, input[0], tc.typs, tc.ordCols, tc.k, execinfra.DefaultMemoryLimit), nil
 		})
+	}
+}
+
+// TestTopKPlanning verifies that the top K sorter is planned only in case when
+// it is beneficial to do so.
+func TestTopKPlanning(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+
+	createSorter := func(
+		typs []*types.T,
+		k uint64,
+	) (colexecop.Operator, []*mon.BoundAccount, []*mon.BytesMonitor, []colexecop.Closer, error) {
+		spec := &execinfrapb.ProcessorSpec{
+			Input: []execinfrapb.InputSyncSpec{{ColumnTypes: typs}},
+			Core: execinfrapb.ProcessorCoreUnion{
+				Sorter: &execinfrapb.SorterSpec{
+					OutputOrdering: execinfrapb.Ordering{
+						Columns: []execinfrapb.Ordering_Column{{ColIdx: 0}},
+					},
+				},
+			},
+			Post: execinfrapb.PostProcessSpec{
+				Limit: k,
+			},
+			ResultTypes: typs,
+		}
+		args := &colexecargs.NewColOperatorArgs{
+			Spec:                spec,
+			Inputs:              colexectestutils.MakeInputs([]colexecop.Operator{nil}),
+			StreamingMemAccount: testMemAcc,
+		}
+		args.TestingKnobs.DiskSpillingDisabled = true
+		result, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)
+		return result.Root, result.OpAccounts, result.OpMonitors, result.ToClose, err
+	}
+
+	for _, tc := range []struct {
+		typs     []*types.T
+		k        uint64
+		topKUsed bool
+	}{
+		// No Bytes-like type, value of K doesn't matter.
+		{typs: []*types.T{types.Int}, k: 2 * maxKWithBytesLikeType, topKUsed: true},
+		// Bytes-like type with too large of a value of K.
+		{typs: []*types.T{types.Bytes}, k: 2 * maxKWithBytesLikeType, topKUsed: false},
+		// Bytes-like type with too large of a value of K.
+		{typs: []*types.T{types.Int, types.Bytes}, k: 2 * maxKWithBytesLikeType, topKUsed: false},
+		// Bytes-like type with reasonably small value of K.
+		{typs: []*types.T{types.Bytes}, k: maxKWithBytesLikeType, topKUsed: true},
+		// Bytes-like type with reasonably small value of K.
+		{typs: []*types.T{types.Int, types.Bytes}, k: maxKWithBytesLikeType, topKUsed: true},
+	} {
+		sorter, accounts, monitors, _, err := createSorter(tc.typs, tc.k)
+		require.NoError(t, err)
+		// We always plan a limitOp, which is redundant when the top K sorter is
+		// used.
+		_, isTopK := sorter.(*limitOp).Input.(*topKSorter)
+		require.Equal(t, tc.topKUsed, isTopK)
+		for _, a := range accounts {
+			a.Close(ctx)
+		}
+		for _, m := range monitors {
+			m.Stop(ctx)
+		}
 	}
 }


### PR DESCRIPTION
This commit makes it so that the top K sorter when bytes-like types are
present in the input schema is used only for values of K not exceeding
5000 (see https://github.com/cockroachdb/cockroach/issues/75536#issuecomment-1027599235
for justification of this number). Currently, the top K sort performance
can be terribly slow due to the need to copy large parts of the flat
bytes on each `Set` operation.

The change is made during the execution planning since we don't have the
corresponding `topk` operator in the optimizer before 22.1 cycle, and
this commit will go into 21.2 branch.

Informs: #75536.

Release note (performance improvement): Sorting data with bytes-like
types (BYTES, STRING, JSON, UUID) when LIMIT clause is specified has now
become more predictable (in some cases it got somewhat slower whereas in
others it got significantly faster).