### PR TITLE
kv: reduce kv.rangefeed.concurrent_catchup_iterators to 16 by default

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -152,7 +152,7 @@ var concurrentRangefeedItersLimit = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"kv.rangefeed.concurrent_catchup_iterators",
 	"number of rangefeeds catchup iterators a store will allow concurrently before queueing",
-	64,
+	16,
 	settings.PositiveInt,
 )
 


### PR DESCRIPTION
Many of our largest users have found the need to tune this parameter
to lower values (often single-digit values). Here, I've lowered it to
a new, unprincipled value of 16.

Note that this limit is _per store_, so the actual number of
concurrent catchup scans allowed on a given server can be some
multiple of the value here.

Release note: The default value of
`kv.rangefeed_concurrent_catchup_iterators` has been lowered to 16 to
help avoid overload during CHANGEFEED restarts.