### PR TITLE
server: reduce API discrepancies between SQL-only servers and regular servers

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
@@ -159,9 +159,9 @@ func (c tenantCluster) tenantConn(idx serverIdx) *sqlutils.SQLRunner {
 }
 
 func (c tenantCluster) tenantHTTPClient(t *testing.T, idx serverIdx) *httpClient {
-	client, err := c.tenant(idx).tenant.RPCContext().GetHTTPClient()
+	client, err := c.tenant(idx).tenant.GetAdminAuthenticatedHTTPClient()
 	require.NoError(t, err)
-	return &httpClient{t: t, client: client, baseURL: "https://" + c[idx].tenant.HTTPAddr()}
+	return &httpClient{t: t, client: client, baseURL: c[idx].tenant.AdminURL()}
 }
 
 func (c tenantCluster) tenantSQLStats(idx serverIdx) *persistedsqlstats.PersistedSQLStats {

--- a/pkg/ccl/serverccl/tenant_vars_test.go
+++ b/pkg/ccl/serverccl/tenant_vars_test.go
@@ -48,7 +48,7 @@ func TestTenantVars(t *testing.T) {
 	})
 
 	startNowNanos := timeutil.Now().UnixNano()
-	url := "https://" + tenant.HTTPAddr() + "/_status/load"
+	url := tenant.AdminURL() + "/_status/load"
 	client := http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -120,7 +120,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 
 	initGEOS(ctx)
 
-	sqlServer, _, _, err := server.StartTenant(
+	sqlServer, err := server.StartTenant(
 		ctx,
 		stopper,
 		clusterName,

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "init.go",
         "init_handshake.go",
         "listen_and_update_addrs.go",
+        "load_endpoint.go",
         "loopback.go",
         "loss_of_quorum.go",
         "migration.go",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "tenant_status.go",
         "testing_knobs.go",
         "testserver.go",
+        "testserver_http.go",
         "user.go",
     ],
     cgo = True,

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "sticky_engine.go",
         "tcp_keepalive_manager.go",
         "tenant.go",
+        "tenant_admin.go",
         "tenant_status.go",
         "testing_knobs.go",
         "testserver.go",

--- a/pkg/server/api_v2_auth.go
+++ b/pkg/server/api_v2_auth.go
@@ -50,7 +50,7 @@ func newAuthenticationV2Server(
 
 	authServer := &authenticationV2Server{
 		sqlServer:  s.sqlServer,
-		authServer: newAuthenticationServer(s),
+		authServer: newAuthenticationServer(s.cfg.Config, s.sqlServer),
 		mux:        simpleMux,
 		ctx:        ctx,
 		basePath:   basePath,

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -94,14 +95,16 @@ var webSessionTimeout = settings.RegisterDurationSetting(
 ).WithPublic()
 
 type authenticationServer struct {
-	server *Server
+	cfg       *base.Config
+	sqlServer *SQLServer
 }
 
 // newAuthenticationServer allocates and returns a new REST server for
 // authentication APIs.
-func newAuthenticationServer(s *Server) *authenticationServer {
+func newAuthenticationServer(cfg *base.Config, s *SQLServer) *authenticationServer {
 	return &authenticationServer{
-		server: s,
+		cfg:       cfg,
+		sqlServer: s,
 	}
 }
 
@@ -256,8 +259,8 @@ func (s *authenticationServer) UserLoginFromSSO(
 
 	exists, _, canLoginDBConsole, _, _, _, err := sql.GetUserSessionInitInfo(
 		ctx,
-		s.server.sqlServer.execCfg,
-		s.server.sqlServer.execCfg.InternalExecutor,
+		s.sqlServer.execCfg,
+		s.sqlServer.execCfg.InternalExecutor,
 		username,
 		"", /* databaseName */
 	)
@@ -291,7 +294,7 @@ func (s *authenticationServer) createSessionFor(
 		ID:     id,
 		Secret: secret,
 	}
-	return EncodeSessionCookie(cookieValue, !s.server.cfg.DisableTLSForHTTP)
+	return EncodeSessionCookie(cookieValue, !s.cfg.DisableTLSForHTTP)
 }
 
 // UserLogout allows a user to terminate their currently active session.
@@ -315,7 +318,7 @@ func (s *authenticationServer) UserLogout(
 	}
 
 	// Revoke the session.
-	if n, err := s.server.sqlServer.internalExecutor.ExecEx(
+	if n, err := s.sqlServer.internalExecutor.ExecEx(
 		ctx,
 		"revoke-auth-session",
 		nil, /* txn */
@@ -365,7 +368,7 @@ WHERE id = $1`
 		isRevoked    bool
 	)
 
-	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
+	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx,
 		"lookup-auth-session",
 		nil, /* txn */
@@ -392,7 +395,7 @@ WHERE id = $1`
 		return false, "", nil
 	}
 
-	if now := s.server.clock.PhysicalTime(); !now.Before(expiresAt) {
+	if now := s.sqlServer.execCfg.Clock.PhysicalTime(); !now.Before(expiresAt) {
 		return false, "", nil
 	}
 
@@ -421,8 +424,8 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 ) (valid bool, expired bool, err error) {
 	exists, _, canLoginDBConsole, _, _, pwRetrieveFn, err := sql.GetUserSessionInitInfo(
 		ctx,
-		s.server.sqlServer.execCfg,
-		s.server.sqlServer.execCfg.InternalExecutor,
+		s.sqlServer.execCfg,
+		s.sqlServer.execCfg.InternalExecutor,
 		username,
 		"", /* databaseName */
 	)
@@ -451,7 +454,7 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 		// pushes clusters upgraded from a previous version into using
 		// SCRAM-SHA-256.
 		sql.MaybeUpgradeStoredPasswordHash(ctx,
-			s.server.sqlServer.execCfg,
+			s.sqlServer.execCfg,
 			username,
 			password, hashedPassword)
 	}
@@ -483,7 +486,7 @@ func (s *authenticationServer) newAuthSession(
 		return 0, nil, err
 	}
 
-	expiration := s.server.clock.PhysicalTime().Add(webSessionTimeout.Get(&s.server.st.SV))
+	expiration := s.sqlServer.execCfg.Clock.PhysicalTime().Add(webSessionTimeout.Get(&s.sqlServer.execCfg.Settings.SV))
 
 	insertSessionStmt := `
 INSERT INTO system.web_sessions ("hashedSecret", username, "expiresAt")
@@ -492,7 +495,7 @@ RETURNING id
 `
 	var id int64
 
-	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
+	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx,
 		"create-auth-session",
 		nil, /* txn */

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -181,6 +181,14 @@ type BaseConfig struct {
 
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
+
+	// EnableWebSessionAuthentication enables session-based authentication for
+	// the Admin API's HTTP endpoints.
+	EnableWebSessionAuthentication bool
+
+	// EnableDemoLoginEndpoint enables the HTTP GET endpoint for user logins,
+	// which a feature unique to the demo shell.
+	EnableDemoLoginEndpoint bool
 }
 
 // MakeBaseConfig returns a BaseConfig with default values.
@@ -192,17 +200,19 @@ func MakeBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 		clusterID: &base.ClusterIDContainer{},
 		serverID:  &base.NodeIDContainer{},
 	}
+	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
 	baseCfg := BaseConfig{
-		Tracer:             tr,
-		idProvider:         idsProvider,
-		IDContainer:        idsProvider.serverID,
-		ClusterIDContainer: idsProvider.clusterID,
-		AmbientCtx:         log.MakeServerAmbientContext(tr, idsProvider),
-		Config:             new(base.Config),
-		Settings:           st,
-		MaxOffset:          MaxOffsetType(base.DefaultMaxClockOffset),
-		DefaultZoneConfig:  zonepb.DefaultZoneConfig(),
-		StorageEngine:      storage.DefaultStorageEngine,
+		Tracer:                         tr,
+		idProvider:                     idsProvider,
+		IDContainer:                    idsProvider.serverID,
+		ClusterIDContainer:             idsProvider.clusterID,
+		AmbientCtx:                     log.MakeServerAmbientContext(tr, idsProvider),
+		Config:                         new(base.Config),
+		Settings:                       st,
+		MaxOffset:                      MaxOffsetType(base.DefaultMaxClockOffset),
+		DefaultZoneConfig:              zonepb.DefaultZoneConfig(),
+		StorageEngine:                  storage.DefaultStorageEngine,
+		EnableWebSessionAuthentication: !disableWebLogin,
 	}
 	// We use the tag "n" here for both KV nodes and SQL instances,
 	// using the knowledge that the value part of a SQL instance ID
@@ -321,28 +331,18 @@ type KVConfig struct {
 	// in a timely fashion, typically 30s after the server starts listening.
 	DelayedBootstrapFn func()
 
-	// EnableWebSessionAuthentication enables session-based authentication for
-	// the Admin API's HTTP endpoints.
-	EnableWebSessionAuthentication bool
-
-	// EnableDemoLoginEndpoint enables the HTTP GET endpoint for user logins,
-	// which a feature unique to the demo shell.
-	EnableDemoLoginEndpoint bool
-
 	enginesCreated bool
 }
 
 // MakeKVConfig returns a KVConfig with default values.
 func MakeKVConfig(storeSpec base.StoreSpec) KVConfig {
-	disableWebLogin := envutil.EnvOrDefaultBool("COCKROACH_DISABLE_WEB_LOGIN", false)
 	kvCfg := KVConfig{
-		DefaultSystemZoneConfig:        zonepb.DefaultSystemZoneConfig(),
-		CacheSize:                      DefaultCacheSize,
-		ScanInterval:                   defaultScanInterval,
-		ScanMinIdleTime:                defaultScanMinIdleTime,
-		ScanMaxIdleTime:                defaultScanMaxIdleTime,
-		EventLogEnabled:                defaultEventLogEnabled,
-		EnableWebSessionAuthentication: !disableWebLogin,
+		DefaultSystemZoneConfig: zonepb.DefaultSystemZoneConfig(),
+		CacheSize:               DefaultCacheSize,
+		ScanInterval:            defaultScanInterval,
+		ScanMinIdleTime:         defaultScanMinIdleTime,
+		ScanMaxIdleTime:         defaultScanMaxIdleTime,
+		EventLogEnabled:         defaultEventLogEnabled,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},
@@ -707,7 +707,7 @@ func (cfg *Config) FilterGossipBootstrapAddresses(ctx context.Context) []util.Un
 
 // RequireWebSession indicates whether the server should require authentication
 // sessions when serving admin API requests.
-func (cfg *Config) RequireWebSession() bool {
+func (cfg *BaseConfig) RequireWebSession() bool {
 	return !cfg.Insecure && cfg.EnableWebSessionAuthentication
 }
 

--- a/pkg/server/load_endpoint.go
+++ b/pkg/server/load_endpoint.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// Construct a handler responsible for serving the instant values of selected
+// load metrics. These include user and system CPU time currently.
+// TODO(knz): this should probably include memory usage too somehow.
+func makeStatusLoadHandler(
+	ctx context.Context, rsr *status.RuntimeStatSampler,
+) func(http.ResponseWriter, *http.Request) {
+	cpuUserNanos := metric.NewGauge(rsr.CPUUserNS.GetMetadata())
+	cpuSysNanos := metric.NewGauge(rsr.CPUSysNS.GetMetadata())
+	cpuNowNanos := metric.NewGauge(rsr.CPUNowNS.GetMetadata())
+	registry := metric.NewRegistry()
+	registry.AddMetric(cpuUserNanos)
+	registry.AddMetric(cpuSysNanos)
+	registry.AddMetric(cpuNowNanos)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		userTimeMillis, sysTimeMillis, err := status.GetCPUTime(ctx)
+		if err != nil {
+			// Just log but don't return an error to match the _status/vars metrics handler.
+			log.Ops.Errorf(ctx, "unable to get cpu usage: %v", err)
+		}
+
+		// cpuTime.{User,Sys} are in milliseconds, convert to nanoseconds.
+		utime := userTimeMillis * 1e6
+		stime := sysTimeMillis * 1e6
+		cpuUserNanos.Update(utime)
+		cpuSysNanos.Update(stime)
+		cpuNowNanos.Update(timeutil.Now().UnixNano())
+
+		exporter := metric.MakePrometheusExporter()
+		exporter.ScrapeRegistry(registry, true)
+		if err := exporter.PrintAsText(w); err != nil {
+			log.Errorf(r.Context(), "%v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/pkg/server/purge_auth_session.go
+++ b/pkg/server/purge_auth_session.go
@@ -57,8 +57,8 @@ var (
 // startPurgeOldSessions runs an infinite loop in a goroutine
 // which regularly deletes old rows in the system.web_sessions table.
 func startPurgeOldSessions(ctx context.Context, s *authenticationServer) error {
-	return s.server.stopper.RunAsyncTask(ctx, "purge-old-sessions", func(context.Context) {
-		settingsValues := &s.server.st.SV
+	return s.sqlServer.stopper.RunAsyncTask(ctx, "purge-old-sessions", func(context.Context) {
+		settingsValues := &s.sqlServer.execCfg.Settings.SV
 		period := webSessionPurgePeriod.Get(settingsValues)
 
 		timer := timeutil.NewTimer()
@@ -70,7 +70,7 @@ func startPurgeOldSessions(ctx context.Context, s *authenticationServer) error {
 			case <-timer.C:
 				timer.Read = true
 				s.purgeOldSessions(ctx)
-			case <-s.server.stopper.ShouldQuiesce():
+			case <-s.sqlServer.stopper.ShouldQuiesce():
 				return
 			case <-ctx.Done():
 				return
@@ -108,9 +108,9 @@ ORDER BY random()
 LIMIT $2
 RETURNING 1
 `
-		settingsValues   = &s.server.st.SV
-		internalExecutor = s.server.sqlServer.internalExecutor
-		currTime         = s.server.clock.PhysicalTime()
+		settingsValues   = &s.sqlServer.execCfg.Settings.SV
+		internalExecutor = s.sqlServer.internalExecutor
+		currTime         = s.sqlServer.execCfg.Clock.PhysicalTime()
 
 		purgeTTL          = webSessionPurgeTTL.Get(settingsValues)
 		autoLogoutTimeout = webSessionAutoLogoutTimeout.Get(settingsValues)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -636,7 +636,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// TODO(tbg): give adminServer only what it needs (and avoid circular deps).
 	adminAuthzCheck := &adminPrivilegeChecker{ie: internalExecutor}
 	sAdmin := newAdminServer(lateBoundServer, adminAuthzCheck, internalExecutor)
-	sHTTP := newHTTPServer(cfg)
+	sHTTP := newHTTPServer(cfg.BaseConfig)
 	sessionRegistry := sql.NewSessionRegistry()
 	flowScheduler := flowinfra.NewFlowScheduler(cfg.AmbientCtx, stopper, st)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1401,12 +1401,12 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// endpoints served by gwMux by the HTTP cookie authentication
 	// check.
 	if err := s.http.setupRoutes(ctx,
-		s.authentication,                      /* authnServer */
-		s.adminAuthzCheck,                     /* adminAuthzCheck */
-		gwMux,                                 /* handleRequestsUnauthenticated */
-		http.HandlerFunc(s.status.handleVars), /* handleStatusVarsUnauthenticated */
-		s.debug,                               /* handleDebugUnauthenticated */
-		newAPIV2Server(ctx, s),                /* apiServer */
+		s.authentication,       /* authnServer */
+		s.adminAuthzCheck,      /* adminAuthzCheck */
+		s.recorder,             /* metricSource */
+		gwMux,                  /* handleRequestsUnauthenticated */
+		s.debug,                /* handleDebugUnauthenticated */
+		newAPIV2Server(ctx, s), /* apiServer */
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -56,7 +56,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigkvsubscriber"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/gcjob" // register jobs declared outside of pkg/sql
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
@@ -659,8 +658,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		internalExecutor,
 	)
 
-	contentionRegistry := contention.NewRegistry()
-
 	var jobAdoptionStopFile string
 	for _, spec := range cfg.Stores.Specs {
 		if !spec.InMemory && spec.Path != "" {
@@ -706,7 +703,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		registry:                 registry,
 		recorder:                 recorder,
 		sessionRegistry:          sessionRegistry,
-		contentionRegistry:       contentionRegistry,
 		flowScheduler:            flowScheduler,
 		circularInternalExecutor: internalExecutor,
 		circularJobRegistry:      jobRegistry,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -660,14 +660,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 
 	contentionRegistry := contention.NewRegistry()
-	// TODO(tbg): don't pass all of Server into this to avoid this hack.
-	sAuth := newAuthenticationServer(lateBoundServer)
-	for i, gw := range []grpcGatewayServer{sAdmin, sStatus, sAuth, &sTS} {
-		if reflect.ValueOf(gw).IsNil() {
-			return nil, errors.Errorf("%d: nil", i)
-		}
-		gw.RegisterService(grpcServer.Server)
-	}
 
 	var jobAdoptionStopFile string
 	for _, spec := range cfg.Stores.Specs {
@@ -730,6 +722,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	sAuth := newAuthenticationServer(cfg.Config, sqlServer)
+	for i, gw := range []grpcGatewayServer{sAdmin, sStatus, sAuth, &sTS} {
+		if reflect.ValueOf(gw).IsNil() {
+			return nil, errors.Errorf("%d: nil", i)
+		}
+		gw.RegisterService(grpcServer.Server)
+	}
+
 	sStatus.setStmtDiagnosticsRequester(sqlServer.execCfg.StmtDiagnosticsRecorder)
 	sStatus.baseStatusServer.sqlServer = sqlServer
 	debugServer := debug.NewServer(cfg.BaseConfig.AmbientCtx, st, sqlServer.pgServer.HBADebugFn(), sStatus)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1404,6 +1404,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 		s.authentication,       /* authnServer */
 		s.adminAuthzCheck,      /* adminAuthzCheck */
 		s.recorder,             /* metricSource */
+		s.runtime,              /* runtimeStatsSampler */
 		gwMux,                  /* handleRequestsUnauthenticated */
 		s.debug,                /* handleDebugUnauthenticated */
 		newAPIV2Server(ctx, s), /* apiServer */

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -119,8 +119,10 @@ func (s *httpServer) setupRoutes(
 	// Same for /_status/load.
 	s.mux.Handle(loadStatusVars, http.HandlerFunc(makeStatusLoadHandler(ctx, runtimeStatSampler)))
 
-	// The new "v2" HTTP API tree.
-	s.mux.Handle(apiV2Path, apiServer)
+	if apiServer != nil {
+		// The new "v2" HTTP API tree.
+		s.mux.Handle(apiV2Path, apiServer)
+	}
 
 	// Register debugging endpoints.
 	handleDebugAuthenticated := handleDebugUnauthenticated

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -30,11 +30,11 @@ import (
 )
 
 type httpServer struct {
-	cfg Config
+	cfg BaseConfig
 	mux http.ServeMux
 }
 
-func newHTTPServer(cfg Config) *httpServer {
+func newHTTPServer(cfg BaseConfig) *httpServer {
 	return &httpServer{cfg: cfg}
 }
 

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cmux"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
+	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -49,6 +50,7 @@ func (s *httpServer) setupRoutes(
 	authnServer *authenticationServer,
 	adminAuthzCheck *adminPrivilegeChecker,
 	metricSource metricMarshaler,
+	runtimeStatSampler *status.RuntimeStatSampler,
 	handleRequestsUnauthenticated http.Handler,
 	handleDebugUnauthenticated http.Handler,
 	apiServer *apiV2Server,
@@ -114,6 +116,8 @@ func (s *httpServer) setupRoutes(
 	s.mux.Handle(adminHealth, handleRequestsUnauthenticated)
 	// The /_status/vars endpoint is not authenticated either. Useful for monitoring.
 	s.mux.Handle(statusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings}.handleVars))
+	// Same for /_status/load.
+	s.mux.Handle(loadStatusVars, http.HandlerFunc(makeStatusLoadHandler(ctx, runtimeStatSampler)))
 
 	// The new "v2" HTTP API tree.
 	s.mux.Handle(apiV2Path, apiServer)

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -48,8 +48,8 @@ func (s *httpServer) setupRoutes(
 	ctx context.Context,
 	authnServer *authenticationServer,
 	adminAuthzCheck *adminPrivilegeChecker,
+	metricSource metricMarshaler,
 	handleRequestsUnauthenticated http.Handler,
-	handleStatusVarsUnauthenticated http.Handler,
 	handleDebugUnauthenticated http.Handler,
 	apiServer *apiV2Server,
 ) error {
@@ -113,7 +113,7 @@ func (s *httpServer) setupRoutes(
 	// (This simply mirrors /health and exists for backward compatibility.)
 	s.mux.Handle(adminHealth, handleRequestsUnauthenticated)
 	// The /_status/vars endpoint is not authenticated either. Useful for monitoring.
-	s.mux.Handle(statusVars, handleStatusVarsUnauthenticated)
+	s.mux.Handle(statusVars, http.HandlerFunc(varsHandler{metricSource, s.cfg.Settings}.handleVars))
 
 	// The new "v2" HTTP API tree.
 	s.mux.Handle(apiV2Path, apiServer)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -255,9 +255,6 @@ type sqlServerArgs struct {
 	// Used for SHOW/CANCEL QUERIE(S)/SESSION(S).
 	sessionRegistry *sql.SessionRegistry
 
-	// Used to track the contention events on this node.
-	contentionRegistry *contention.Registry
-
 	// Used to track the DistSQL flows scheduled on this node but initiated on
 	// behalf of other nodes.
 	flowScheduler *flowinfra.FlowScheduler
@@ -656,7 +653,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		SQLStatusServer:         cfg.sqlStatusServer,
 		RegionsServer:           cfg.regionsServer,
 		SessionRegistry:         cfg.sessionRegistry,
-		ContentionRegistry:      cfg.contentionRegistry,
+		ContentionRegistry:      contention.NewRegistry(),
 		SQLLiveness:             cfg.sqlLivenessProvider,
 		JobRegistry:             jobRegistry,
 		VirtualSchemas:          virtualSchemas,

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1771,10 +1771,6 @@ func (h varsHandler) handleVars(w http.ResponseWriter, r *http.Request) {
 	telemetry.Inc(telemetryPrometheusVars)
 }
 
-func (s *statusServer) handleVars(w http.ResponseWriter, r *http.Request) {
-	varsHandler{s.metricSource, s.st}.handleVars(w, r)
-}
-
 // Ranges returns range info for the specified node.
 func (s *statusServer) Ranges(
 	ctx context.Context, req *serverpb.RangesRequest,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1198,7 +1198,7 @@ func TestRaftDebug(t *testing.T) {
 }
 
 // TestStatusVars verifies that prometheus metrics are available via the
-// /_status/vars endpoint.
+// /_status/vars and /_status/load endpoints.
 func TestStatusVars(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1209,6 +1209,11 @@ func TestStatusVars(t *testing.T) {
 		t.Fatal(err)
 	} else if !bytes.Contains(body, []byte("# TYPE sql_bytesout counter\nsql_bytesout")) {
 		t.Errorf("expected sql_bytesout, got: %s", body)
+	}
+	if body, err := getText(s, s.AdminURL()+statusPrefix+"load"); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Contains(body, []byte("# TYPE sys_cpu_user_ns gauge\nsys_cpu_user_ns")) {
+		t.Errorf("expected sys_cpu_user_ns, got: %s", body)
 	}
 }
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -183,10 +183,11 @@ func StartTenant(
 	// SpanResolver.
 	s.execCfg.DistSQLPlanner.SetSQLInstanceInfo(roachpb.NodeDescriptor{NodeID: 0})
 
+	authServer := newAuthenticationServer(baseCfg.Config, s)
+
 	// Register and start gRPC service on pod. This is separate from the
 	// gRPC + Gateway services configured below.
-	// TODO(knz): add the authentication service here.
-	for _, gw := range []grpcGatewayServer{tenantAdminServer, tenantStatusServer} {
+	for _, gw := range []grpcGatewayServer{tenantAdminServer, tenantStatusServer, authServer} {
 		gw.RegisterService(grpcMain.Server)
 	}
 	startRPCServer(background)
@@ -205,8 +206,7 @@ func StartTenant(
 		return nil, "", "", err
 	}
 
-	// TODO(knz): add the authentication endpoint here.
-	for _, gw := range []grpcGatewayServer{tenantAdminServer, tenantStatusServer} {
+	for _, gw := range []grpcGatewayServer{tenantAdminServer, tenantStatusServer, authServer} {
 		if err := gw.RegisterGateway(gwCtx, gwMux, conn); err != nil {
 			return nil, "", "", err
 		}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -61,10 +60,28 @@ func StartTenant(
 	kvClusterName string, // NB: gone after https://github.com/cockroachdb/cockroach/issues/42519
 	baseCfg BaseConfig,
 	sqlCfg SQLConfig,
-) (sqlServer *SQLServer, pgAddr string, httpAddr string, _ error) {
+) (sqlServer *SQLServer, err error) {
+	sqlServer, _, _, _, err = startTenantInternal(ctx, stopper, kvClusterName, baseCfg, sqlCfg)
+	return
+}
+
+// startTenantInternal is used to build TestServers.
+func startTenantInternal(
+	ctx context.Context,
+	stopper *stop.Stopper,
+	kvClusterName string, // NB: gone after https://github.com/cockroachdb/cockroach/issues/42519
+	baseCfg BaseConfig,
+	sqlCfg SQLConfig,
+) (
+	sqlServer *SQLServer,
+	authServer *authenticationServer,
+	pgAddr string,
+	httpAddr string,
+	_ error,
+) {
 	err := ApplyTenantLicense()
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
 	// Inform the server identity provider that we're operating
@@ -73,11 +90,11 @@ func StartTenant(
 
 	args, err := makeTenantSQLServerArgs(ctx, stopper, kvClusterName, baseCfg, sqlCfg)
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 	err = args.ValidateAddrs(ctx)
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 	args.monitorAndMetrics = newRootSQLMemoryMonitor(monitorAndMetricsOptions{
 		memoryPoolSize:          args.MemoryPoolSize,
@@ -115,7 +132,7 @@ func StartTenant(
 	baseCfg.AdvertiseAddr = baseCfg.SQLAdvertiseAddr
 	pgL, startRPCServer, err := startListenRPCAndSQL(ctx, background, baseCfg, stopper, grpcMain)
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
 	{
@@ -129,34 +146,15 @@ func StartTenant(
 		}
 		if err := args.stopper.RunAsyncTask(background, "wait-quiesce-pgl", waitQuiesce); err != nil {
 			waitQuiesce(background)
-			return nil, "", "", err
+			return nil, nil, "", "", err
 		}
 	}
 
 	serverTLSConfig, err := args.rpcContext.GetUIServerTLSConfig()
 	if err != nil {
-		return nil, "", "", err
-	}
-	httpL, err := ListenAndUpdateAddrs(ctx, &args.Config.HTTPAddr, &args.Config.HTTPAdvertiseAddr, "http")
-	if err != nil {
-		return nil, "", "", err
-	}
-	if serverTLSConfig != nil {
-		httpL = tls.NewListener(httpL, serverTLSConfig)
+		return nil, nil, "", "", err
 	}
 
-	{
-		waitQuiesce := func(ctx context.Context) {
-			<-args.stopper.ShouldQuiesce()
-			_ = httpL.Close()
-		}
-		if err := args.stopper.RunAsyncTask(background, "wait-quiesce-http", waitQuiesce); err != nil {
-			waitQuiesce(background)
-			return nil, "", "", err
-		}
-	}
-	pgLAddr := pgL.Addr().String()
-	httpLAddr := httpL.Addr().String()
 	args.advertiseAddr = baseCfg.AdvertiseAddr
 	// The tenantStatusServer needs access to the sqlServer,
 	// but we also need the same object to set up the sqlServer.
@@ -169,21 +167,22 @@ func StartTenant(
 		args.sessionRegistry, args.flowScheduler, baseCfg.Settings, nil,
 		args.rpcContext, args.stopper,
 	)
-	tenantAdminServer := newTenantAdminServer(baseCfg.AmbientCtx)
 
 	args.sqlStatusServer = tenantStatusServer
 	s, err := newSQLServer(ctx, args)
 	tenantStatusServer.sqlServer = s
 
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
+
+	tenantAdminServer := newTenantAdminServer(baseCfg.AmbientCtx, s)
 
 	// TODO(asubiotto): remove this. Right now it is needed to initialize the
 	// SpanResolver.
 	s.execCfg.DistSQLPlanner.SetSQLInstanceInfo(roachpb.NodeDescriptor{NodeID: 0})
 
-	authServer := newAuthenticationServer(baseCfg.Config, s)
+	authServer = newAuthenticationServer(baseCfg.Config, s)
 
 	// Register and start gRPC service on pod. This is separate from the
 	// gRPC + Gateway services configured below.
@@ -200,54 +199,55 @@ func StartTenant(
 		args.rpcContext,
 		s.stopper,
 		grpcMain,
-		pgLAddr,
+		baseCfg.AdvertiseAddr,
 	)
 	if err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
 	for _, gw := range []grpcGatewayServer{tenantAdminServer, tenantStatusServer, authServer} {
 		if err := gw.RegisterGateway(gwCtx, gwMux, conn); err != nil {
-			return nil, "", "", err
+			return nil, nil, "", "", err
 		}
+	}
+
+	debugServer := debug.NewServer(baseCfg.AmbientCtx, args.Settings, s.pgServer.HBADebugFn(), s.execCfg.SQLStatusServer)
+	adminAuthzCheck := &adminPrivilegeChecker{ie: s.execCfg.InternalExecutor}
+
+	httpServer := newHTTPServer(baseCfg)
+
+	httpServer.handleHealth(gwMux)
+
+	// TODO(knz): Add support for the APIv2 tree here.
+	if err := httpServer.setupRoutes(ctx,
+		authServer,      /* authnServer */
+		adminAuthzCheck, /* adminAuthzCheck */
+		args.recorder,   /* metricSource */
+		args.runtime,    /* runtimeStatSampler */
+		gwMux,           /* handleRequestsUnauthenticated */
+		debugServer,     /* handleDebugUnauthenticated */
+		nil,             /* apiServer */
+	); err != nil {
+		return nil, nil, "", "", err
+	}
+
+	connManager := netutil.MakeServer(
+		args.stopper,
+		serverTLSConfig,                          // tlsConfig
+		http.HandlerFunc(httpServer.baseHandler), // handler
+	)
+	if err := httpServer.start(ctx, background, connManager, serverTLSConfig, args.stopper); err != nil {
+		return nil, nil, "", "", err
 	}
 
 	args.recorder.AddNode(
 		args.registry,
 		roachpb.NodeDescriptor{},
 		timeutil.Now().UnixNano(),
-		pgLAddr,   // advertised addr
-		httpLAddr, // http addr
-		pgLAddr,   // sql addr
+		baseCfg.AdvertiseAddr,     // advertised addr
+		baseCfg.HTTPAdvertiseAddr, // http addr
+		baseCfg.SQLAdvertiseAddr,  // sql addr
 	)
-
-	// TODO(knz): use httpServer here instead.
-	mux := http.NewServeMux()
-	debugServer := debug.NewServer(baseCfg.AmbientCtx, args.Settings, s.pgServer.HBADebugFn(), s.execCfg.SQLStatusServer)
-	mux.Handle("/", debugServer)
-	mux.Handle("/_status/", gwMux)
-	mux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
-		// Return Bad Request if called with arguments.
-		if err := req.ParseForm(); err != nil || len(req.Form) != 0 {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-			return
-		}
-	})
-	f := varsHandler{metricSource: args.recorder, st: args.Settings}.handleVars
-	mux.Handle(statusVars, http.HandlerFunc(f))
-	ff := makeStatusLoadHandler(ctx, args.runtime)
-	mux.Handle(loadStatusVars, http.HandlerFunc(ff))
-
-	connManager := netutil.MakeServer(
-		args.stopper,
-		serverTLSConfig, // tlsConfig
-		mux,             // handler
-	)
-	if err := args.stopper.RunAsyncTask(background, "serve-http", func(ctx context.Context) {
-		netutil.FatalIfUnexpected(connManager.Serve(httpL))
-	}); err != nil {
-		return nil, "", "", err
-	}
 
 	const (
 		socketFile = "" // no unix socket
@@ -264,7 +264,7 @@ func StartTenant(
 		args.runtime,
 		args.sessionRegistry,
 	); err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
 	if err := s.preStart(ctx,
@@ -275,7 +275,7 @@ func StartTenant(
 		socketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
 	externalUsageFn := func(ctx context.Context) multitenant.ExternalUsage {
@@ -295,7 +295,7 @@ func StartTenant(
 		ctx, args.stopper, s.SQLInstanceID(), s.sqlLivenessSessionID,
 		externalUsageFn, nextLiveInstanceIDFn,
 	); err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
 	if err := s.startServeSQL(ctx,
@@ -303,10 +303,10 @@ func StartTenant(
 		s.connManager,
 		s.pgL,
 		socketFile); err != nil {
-		return nil, "", "", err
+		return nil, nil, "", "", err
 	}
 
-	return s, pgLAddr, httpLAddr, nil
+	return s, authServer, baseCfg.SQLAddr, baseCfg.HTTPAddr, nil
 }
 
 func makeTenantSQLServerArgs(

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigkvaccessor"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
@@ -101,7 +100,6 @@ func startTenantInternal(
 		histogramWindowInterval: args.HistogramWindowInterval(),
 		settings:                args.Settings,
 	})
-	args.contentionRegistry = contention.NewRegistry()
 
 	// Initialize gRPC server for use on shared port with pg
 	grpcMain := newGRPCServer(args.rpcContext)

--- a/pkg/server/tenant_admin.go
+++ b/pkg/server/tenant_admin.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// TODO(azhng): The implementation for tenantAdminServer here will need to be updated
+//  once we have pod-to-pod communication implemented. After all dependencies that are
+//  unavailable to tenants have been removed, we can likely remove tenant admin server
+//  entirely and use the normal admin server.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc"
+)
+
+type tenantAdminServer struct {
+	log.AmbientContext
+	serverpb.UnimplementedAdminServer
+}
+
+// We require that `tenantAdminServer` implement
+// `serverpb.AdminServer` even though we only have partial
+// implementation, in order to serve some endpoints on tenants.
+var _ serverpb.AdminServer = &tenantAdminServer{}
+
+func (t *tenantAdminServer) RegisterService(g *grpc.Server) {
+	serverpb.RegisterAdminServer(g, t)
+}
+
+func (t *tenantAdminServer) RegisterGateway(
+	ctx context.Context, mux *gwruntime.ServeMux, conn *grpc.ClientConn,
+) error {
+	ctx = t.AnnotateCtx(ctx)
+	return serverpb.RegisterAdminHandler(ctx, mux, conn)
+}
+
+var _ grpcGatewayServer = &tenantAdminServer{}
+
+func newTenantAdminServer(ambientCtx log.AmbientContext) *tenantAdminServer {
+	return &tenantAdminServer{AmbientContext: ambientCtx}
+}
+
+// TODO(knz): add Drain implementation here.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -108,13 +108,13 @@ func makeTestBaseConfig(st *cluster.Settings, tr *tracing.Tracer) BaseConfig {
 	baseCfg.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	baseCfg.User = security.NodeUserName()
+	// Enable web session authentication.
+	baseCfg.EnableWebSessionAuthentication = true
 	return baseCfg
 }
 
 func makeTestKVConfig() KVConfig {
 	kvCfg := MakeKVConfig(base.DefaultTestStoreSpec)
-	// Enable web session authentication.
-	kvCfg.EnableWebSessionAuthentication = true
 	return kvCfg
 }
 

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -1,0 +1,154 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+// httpTestServer is embedded in TestServer / TenantServer to
+// provide the HTTP API subset of TestTenantInterface.
+type httpTestServer struct {
+	t struct {
+		// We need a sub-struct to avoid ambiguous overlap with the fields
+		// of *Server, which are also embedded in TestServer.
+		authentication *authenticationServer
+		sqlServer      *SQLServer
+	}
+
+	// authClient is an http.Client that has been authenticated to access the
+	// Admin UI.
+	authClient [2]struct {
+		httpClient http.Client
+		cookie     *serverpb.SessionCookie
+		once       sync.Once
+		err        error
+	}
+}
+
+// AdminURL implements TestServerInterface.
+func (ts *httpTestServer) AdminURL() string {
+	return ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL().String()
+}
+
+// GetHTTPClient implements TestServerInterface.
+func (ts *httpTestServer) GetHTTPClient() (http.Client, error) {
+	return ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
+}
+
+// GetAdminAuthenticatedHTTPClient implements the TestServerInterface.
+func (ts *httpTestServer) GetAdminAuthenticatedHTTPClient() (http.Client, error) {
+	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
+	return httpClient, err
+}
+
+// GetAuthenticatedHTTPClient implements the TestServerInterface.
+func (ts *httpTestServer) GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error) {
+	authUser := authenticatedUserName()
+	if !isAdmin {
+		authUser = authenticatedUserNameNoAdmin()
+	}
+	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authUser, isAdmin)
+	return httpClient, err
+}
+
+func (ts *httpTestServer) getAuthenticatedHTTPClientAndCookie(
+	authUser security.SQLUsername, isAdmin bool,
+) (http.Client, *serverpb.SessionCookie, error) {
+	authIdx := 0
+	if isAdmin {
+		authIdx = 1
+	}
+	authClient := &ts.authClient[authIdx]
+	authClient.once.Do(func() {
+		// Create an authentication session for an arbitrary admin user.
+		authClient.err = func() error {
+			// The user needs to exist as the admin endpoints will check its role.
+			if err := ts.createAuthUser(authUser, isAdmin); err != nil {
+				return err
+			}
+
+			id, secret, err := ts.t.authentication.newAuthSession(context.TODO(), authUser)
+			if err != nil {
+				return err
+			}
+			rawCookie := &serverpb.SessionCookie{
+				ID:     id,
+				Secret: secret,
+			}
+			// Encode a session cookie and store it in a cookie jar.
+			cookie, err := EncodeSessionCookie(rawCookie, false /* forHTTPSOnly */)
+			if err != nil {
+				return err
+			}
+			cookieJar, err := cookiejar.New(nil)
+			if err != nil {
+				return err
+			}
+			url, err := url.Parse(ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL().String())
+			if err != nil {
+				return err
+			}
+			cookieJar.SetCookies(url, []*http.Cookie{cookie})
+			// Create an httpClient and attach the cookie jar to the client.
+			authClient.httpClient, err = ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
+			if err != nil {
+				return err
+			}
+			rawCookieBytes, err := protoutil.Marshal(rawCookie)
+			if err != nil {
+				return err
+			}
+			authClient.httpClient.Transport = &v2AuthDecorator{
+				RoundTripper: authClient.httpClient.Transport,
+				session:      base64.StdEncoding.EncodeToString(rawCookieBytes),
+			}
+			authClient.httpClient.Jar = cookieJar
+			authClient.cookie = rawCookie
+			return nil
+		}()
+	})
+
+	return authClient.httpClient, authClient.cookie, authClient.err
+}
+
+func (ts *httpTestServer) createAuthUser(userName security.SQLUsername, isAdmin bool) error {
+	if _, err := ts.t.sqlServer.internalExecutor.ExecEx(context.TODO(),
+		"create-auth-user", nil,
+		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		fmt.Sprintf("CREATE USER %s", userName.Normalized()),
+	); err != nil {
+		return err
+	}
+	if isAdmin {
+		// We can't use the GRANT statement here because we don't want
+		// to rely on CCL code.
+		if _, err := ts.t.sqlServer.internalExecutor.ExecEx(context.TODO(),
+			"grant-admin", nil,
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			"INSERT INTO system.role_members (role, member, \"isAdmin\") VALUES ('admin', $1, true)", userName.Normalized(),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -20,7 +20,6 @@ package serverutils
 import (
 	"context"
 	gosql "database/sql"
-	"net/http"
 	"net/url"
 	"testing"
 
@@ -128,19 +127,6 @@ type TestServerInterface interface {
 	// It is the caller's responsibility to make sure no queries are being run
 	// with DistSQL at the same time.
 	SetDistSQLSpanResolver(spanResolver interface{})
-
-	// AdminURL returns the URL for the admin UI.
-	AdminURL() string
-	// GetHTTPClient returns an http client configured with the client TLS
-	// config required by the TestServer's configuration.
-	GetHTTPClient() (http.Client, error)
-	// GetAdminAuthenticatedHTTPClient returns an http client which has been
-	// authenticated to access Admin API methods (via a cookie).
-	// The user has admin privileges.
-	GetAdminAuthenticatedHTTPClient() (http.Client, error)
-	// GetAuthenticatedHTTPClient returns an http client which has been
-	// authenticated to access Admin API methods (via a cookie).
-	GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error)
 
 	// MustGetSQLCounter returns the value of a counter metric from the server's
 	// SQL Executor. Runs in O(# of metrics) time, which is fine for test code.

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -15,6 +15,7 @@ package serverutils
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -105,6 +106,19 @@ type TestTenantInterface interface {
 	// using the same context details as the server. This should not
 	// be used in non-test code.
 	AmbientCtx() log.AmbientContext
+
+	// AdminURL returns the URL for the admin UI.
+	AdminURL() string
+	// GetHTTPClient returns an http client configured with the client TLS
+	// config required by the TestServer's configuration.
+	GetHTTPClient() (http.Client, error)
+	// GetAdminAuthenticatedHTTPClient returns an http client which has been
+	// authenticated to access Admin API methods (via a cookie).
+	// The user has admin privileges.
+	GetAdminAuthenticatedHTTPClient() (http.Client, error)
+	// GetAuthenticatedHTTPClient returns an http client which has been
+	// authenticated to access Admin API methods (via a cookie).
+	GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error)
 
 	// TODO(irfansharif): We'd benefit from an API to construct a *gosql.DB, or
 	// better yet, a *sqlutils.SQLRunner. We use it all the time, constructing


### PR DESCRIPTION
As of this PR, all the RPCs are left unimplemented (by inheriting from UnimplementedAdminServer).

This also serves the UI (DB Console) on SQL servers, using the same code as regular servers.

Now we can incrementally add more API endpoints as needed.