### PR TITLE
logictestccl: fix stale issue number in TODO

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -1,5 +1,5 @@
 # LogicTest: multiregion-9node-3region-3azs
-# TODO(#69265): enable multiregion-9node-3region-3azs-tenant.
+# TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
 
 # Set the closed timestamp interval to be short to shorten the amount of time
 # we need to wait for the system config to propagate.

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1,5 +1,5 @@
 # LogicTest: multiregion-9node-3region-3azs
-# TODO(#69265): enable multiregion-9node-3region-3azs-tenant and/or revert
+# TODO(#75864): enable multiregion-9node-3region-3azs-tenant and/or revert
 # the commit that split these changes out.
 
 # Set the closed timestamp interval to be short to shorten the amount of time


### PR DESCRIPTION
We closed #69265 in favour of #70558, and the only remaining work
left to address locality aware planning for tenants is captured
in #75864.

Release note: None