### PR TITLE
Revert "bulk: bump default split-after size to 384mb"

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -93,7 +93,7 @@ func MakeBulkAdder(
 	if opts.SplitAndScatterAfter == nil {
 		// splitting _before_ hitting max reduces chance of auto-splitting after the
 		// range is full and is more expensive to split/move.
-		opts.SplitAndScatterAfter = func() int64 { return 384 << 20 }
+		opts.SplitAndScatterAfter = func() int64 { return 48 << 20 }
 	} else if opts.SplitAndScatterAfter() == kvserverbase.DisableExplicitSplits {
 		opts.SplitAndScatterAfter = nil
 	}


### PR DESCRIPTION
This reverts commit e12c9e65c457e035562e71621d164f04abb33728.

It is not yet understood why, but it appears to have been causing very
imbalanced ranges during IMPORTs and test failures. Revert it while we
investigate.

Release note: none.