### PR TITLE
release-20.2: server: CancelSession propagates gateway metadata

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2112,6 +2112,9 @@ func (s *statusServer) ListSessions(
 func (s *statusServer) CancelSession(
 	ctx context.Context, req *serverpb.CancelSessionRequest,
 ) (*serverpb.CancelSessionResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, grpcstatus.Errorf(codes.InvalidArgument, err.Error())


### PR DESCRIPTION
Backport 1/1 commits from #75814.

/cc @cockroachdb/release

---

Fixes #75758.

Previously, HTTP session cancelation requests from the DB Console were
routed to the proper node without passing along the gateway metadata
necessary for authentication. This enabled users without the
`CANCELQUERY` option to cancel the sessions of other users, which they
should not have had permission to do.

This commit addresses that issue by properly propagating that gateway
metadata in the CancelSession endpoint.

Release note (bug fix): The CancelSession endpoint now correctly
propagates gateway metadata when forwarding requests.

---

Release justification: Category 3: Fixes for high-priority or high-severity bugs in existing functionality