### PR TITLE
release-21.1: server: CancelSession propagates gateway metadata

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2337,6 +2337,9 @@ func (s *statusServer) ListSessions(
 func (s *statusServer) CancelSession(
 	ctx context.Context, req *serverpb.CancelSessionRequest,
 ) (*serverpb.CancelSessionResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -87,6 +88,15 @@ func getStatusJSONProtoWithAdminOption(
 	ts serverutils.TestServerInterface, path string, response protoutil.Message, isAdmin bool,
 ) error {
 	return serverutils.GetJSONProtoWithAdminOption(ts, statusPrefix+path, response, isAdmin)
+}
+
+func postStatusJSONProtoWithAdminOption(
+	ts serverutils.TestServerInterface,
+	path string,
+	request, response protoutil.Message,
+	isAdmin bool,
+) error {
+	return serverutils.PostJSONProtoWithAdminOption(ts, statusPrefix+path, request, response, isAdmin)
 }
 
 // TestStatusLocalStacks verifies that goroutine stack traces are available
@@ -2529,4 +2539,28 @@ SET TRACING=off;
 
 	require.True(t, found,
 		"expect to find contention event for table %d, but found %+v", testTableID, resp)
+}
+
+func TestStatusCancelSessionGatewayMetadataPropagation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{})
+	defer testCluster.Stopper().Stop(ctx)
+
+	// Start a SQL session as admin on node 1.
+	sql0 := sqlutils.MakeSQLRunner(testCluster.ServerConn(0))
+	results := sql0.QueryStr(t, "SELECT session_id FROM [SHOW SESSIONS] LIMIT 1")
+	sessionID, err := hex.DecodeString(results[0][0])
+	require.NoError(t, err)
+
+	// Attempt to cancel that SQL session as non-admin over HTTP on node 2.
+	req := &serverpb.CancelSessionRequest{
+		SessionID: sessionID,
+	}
+	resp := &serverpb.CancelSessionResponse{}
+	err = postStatusJSONProtoWithAdminOption(testCluster.Server(1), "cancel_session/1", req, resp, false)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "status: 403 Forbidden")
 }


### PR DESCRIPTION
Backport 1/1 commits from #75814.

/cc @cockroachdb/release

---

Fixes #75758.

Previously, HTTP session cancelation requests from the DB Console were
routed to the proper node without passing along the gateway metadata
necessary for authentication. This enabled users without the
`CANCELQUERY` option to cancel the sessions of other users, which they
should not have had permission to do.

This commit addresses that issue by properly propagating that gateway
metadata in the CancelSession endpoint.

Release note (bug fix): The CancelSession endpoint now correctly
propagates gateway metadata when forwarding requests.

---

Release justification: Category 3: Fixes for high-priority or high-severity bugs in existing functionality