### PR TITLE
kvstreamer: fix a bug with incorrect processing of empty scan responses

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -38,10 +38,11 @@ import (
 func getStreamer(
 	ctx context.Context, s serverutils.TestServerInterface, limitBytes int64, acc *mon.BoundAccount,
 ) *Streamer {
+	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
 	return NewStreamer(
 		s.DistSenderI().(*kvcoord.DistSender),
 		s.Stopper(),
-		kv.NewTxn(ctx, s.DB(), s.NodeID()),
+		kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), rootTxn.GetLeafTxnInputState(ctx)),
 		cluster.MakeTestingClusterSettings(),
 		lock.WaitPolicy(0),
 		limitBytes,
@@ -421,4 +422,91 @@ func TestStreamerWideRows(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStreamerEmptyScans verifies that the Streamer behaves correctly when
+// Scan requests return empty responses.
+func TestStreamerEmptyScans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Start a cluster with large --max-sql-memory parameter so that the
+	// Streamer isn't hitting the root budget exceeded error.
+	const rootPoolSize = 1 << 30 /* 1GiB */
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		SQLMemoryPoolSize: rootPoolSize,
+	})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	// Create a dummy table for which we know the encoding of valid keys.
+	// Although not strictly necessary, we set up two column families since with
+	// a single family in production a Get request would have been used.
+	_, err := db.Exec("CREATE TABLE t (pk INT PRIMARY KEY, k INT, blob STRING, INDEX (k), FAMILY (pk, k), FAMILY (blob))")
+	require.NoError(t, err)
+
+	// Split the table into 5 ranges and populate the range cache.
+	for pk := 1; pk < 5; pk++ {
+		_, err = db.Exec(fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES(%d)", pk))
+		require.NoError(t, err)
+	}
+	_, err = db.Exec("SELECT count(*) from t")
+	require.NoError(t, err)
+
+	makeScanRequest := func(start, end int) roachpb.RequestUnion {
+		var res roachpb.RequestUnion
+		var scan roachpb.ScanRequest
+		var union roachpb.RequestUnion_Scan
+		makeKey := func(pk int) []byte {
+			// These numbers essentially make a key like '/t/primary/pk'.
+			return []byte{240, 137, byte(136 + pk)}
+		}
+		scan.Key = makeKey(start)
+		scan.EndKey = makeKey(end)
+		union.Scan = &scan
+		res.Value = &union
+		return res
+	}
+
+	getStreamer := func() *Streamer {
+		s := getStreamer(ctx, s, math.MaxInt64, nil /* acc */)
+		// There are two column families in the table.
+		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 2 /* maxKeysPerRow */)
+		return s
+	}
+
+	t.Run("scan single range", func(t *testing.T) {
+		streamer := getStreamer()
+		defer streamer.Close()
+
+		// Scan the row with pk=0.
+		reqs := make([]roachpb.RequestUnion, 1)
+		reqs[0] = makeScanRequest(0, 1)
+		require.NoError(t, streamer.Enqueue(ctx, reqs, nil /* enqueueKeys */))
+		results, err := streamer.GetResults(ctx)
+		require.NoError(t, err)
+		// We expect a single empty Scan response.
+		require.Equal(t, 1, len(results))
+	})
+
+	t.Run("scan multiple ranges", func(t *testing.T) {
+		streamer := getStreamer()
+		defer streamer.Close()
+
+		// Scan the rows with pk in range [1, 4).
+		reqs := make([]roachpb.RequestUnion, 1)
+		reqs[0] = makeScanRequest(1, 4)
+		require.NoError(t, streamer.Enqueue(ctx, reqs, nil /* enqueueKeys */))
+		// We expect an empty response for each range.
+		var numResults int
+		for {
+			results, err := streamer.GetResults(ctx)
+			require.NoError(t, err)
+			numResults += len(results)
+			if len(results) == 0 {
+				break
+			}
+		}
+		require.Equal(t, 3, numResults)
+	})
 }

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -92,10 +92,12 @@ func TestStreamerLimitations(t *testing.T) {
 		streamer := getStreamer()
 		defer streamer.Close()
 		streamer.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */)
-		get := roachpb.NewGet(roachpb.Key("key"), false /* forUpdate */)
+		// Use a Scan request for this test case because Gets of non-existent
+		// keys aren't added to the results.
+		scan := roachpb.NewScan(roachpb.Key("key"), roachpb.Key("key1"), false /* forUpdate */)
 		reqs := []roachpb.RequestUnion{{
-			Value: &roachpb.RequestUnion_Get{
-				Get: get.(*roachpb.GetRequest),
+			Value: &roachpb.RequestUnion_Scan{
+				Scan: scan.(*roachpb.ScanRequest),
 			},
 		}}
 		require.NoError(t, streamer.Enqueue(ctx, reqs, nil /* enqueueKeys */))

--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -175,10 +175,6 @@ func TestStreamerTightBudget(t *testing.T) {
 	_, err = db.Exec(fmt.Sprintf("SET distsql_workmem = '%dB'", blobSize))
 	require.NoError(t, err)
 
-	// TODO(yuzefovich): remove this once the streamer is enabled by default.
-	_, err = db.Exec("SET CLUSTER SETTING sql.distsql.use_streamer.enabled = true;")
-	require.NoError(t, err)
-
 	// Perform an index join to read the blobs.
 	query := "EXPLAIN ANALYZE SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"
 	maximumMemoryUsageRegex := regexp.MustCompile(`maximum memory usage: (\d+\.\d+) MiB`)

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -467,11 +467,16 @@ func (f *txnKVFetcher) nextBatch(
 			if len(t.BatchResponses) > 0 {
 				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
+			// Note that t.Rows and batchResp might be nil when the ScanResponse
+			// is empty, and the caller (the KVFetcher) will skip over it.
 			return true, t.Rows, batchResp, nil
 		case *roachpb.ReverseScanResponse:
 			if len(t.BatchResponses) > 0 {
 				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
+			// Note that t.Rows and batchResp might be nil when the
+			// ReverseScanResponse is empty, and the caller (the KVFetcher) will
+			// skip over it.
 			return true, t.Rows, batchResp, nil
 		case *roachpb.GetResponse:
 			if t.IntentValue != nil {

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -38,7 +38,7 @@ var useStreamerEnabled = settings.RegisterBoolSetting(
 	"determines whether the usage of the Streamer API is allowed. "+
 		"Enabling this will increase the speed of lookup/index joins "+
 		"while adhering to memory limits.",
-	false,
+	true,
 )
 
 // TxnKVStreamer handles retrieval of key/values.
@@ -120,6 +120,8 @@ func (f *TxnKVStreamer) proceedWithLastResult(
 	if len(f.lastResultState.remainingBatches) == 0 {
 		f.processedScanResponse()
 	}
+	// Note that scan.Rows and batchResp might be nil when the ScanResponse is
+	// empty, and the caller (the KVFetcher) will skip over it.
 	return false, scan.Rows, batchResp, nil
 }
 


### PR DESCRIPTION
**kvstreamer: fix a bug with incorrect processing of empty scan responses**

Previously, the `Streamer` could get stuck indefinitely when a response
for a Scan request came back empty - namely the response neither had no
bytes inside nor ResumeSpan set (this is the case when there is no data
in the key span to scan). This would lead to `GetResults` call being
stuck thinking there are more responses to come back, and none would
show up.

This is now fixed by creating a Result with an empty Scan response
inside of it. This approach makes it easier to support Scans that span
multiple ranges and the last range has no data in it - we want to be
able to set Complete field on such an empty Result.

Since this was the only known bug with the `Streamer` implementation,
the streamer is now used by default again.

Fixes: #75708.

Release note: None

**kvstreamer: minor cleanup**

This commit replaces the last buffered channel we had in the `Streamer`
code in favor of a condition variable which simplifies the control flow
a bit.

Additionally, this commit refactors the code so that empty Get responses
are not returned which allows us to clean up `TxnKVStreamer` a bit. Care
has to be taken so that we still signal the client's goroutine waiting
for results when an empty Get response comes back (similar to the bug
fixed by the previous commit).

Also, the tracking of the "number of outstanding requests" in
`TxnKVStreamer` has been removed since it provided little value (and
probably was broken anyway).

Release note: None