### PR TITLE
server: use constant for filtering internal stmt stats

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -97,7 +97,7 @@ func getFilterAndParams(
 	buffer.WriteString(testingKnobs.GetAOSTClause())
 
 	// Filter out internal statements by app name.
-	buffer.WriteString(" WHERE app_name NOT LIKE '$ internal%'")
+	buffer.WriteString(fmt.Sprintf(" WHERE app_name NOT LIKE '%s%%'", catconstants.InternalAppNamePrefix))
 
 	if start != nil {
 		buffer.WriteString(" AND aggregated_ts >= $1")

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1989,9 +1989,8 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 				continue
 			}
 			if strings.HasPrefix(respStatement.Key.KeyData.App, catconstants.InternalAppNamePrefix) {
-				// We ignore internal queries, these are not relevant for the
-				// validity of this test.
-				continue
+				// CombinedStatementStats should filter out internal queries.
+				t.Fatalf("unexpected internal query: %s", respStatement.Key.KeyData.Query)
 			}
 			if strings.HasPrefix(respStatement.Key.KeyData.Query, "ALTER USER") {
 				// Ignore the ALTER USER ... VIEWACTIVITY statement.


### PR DESCRIPTION
Previously, the internal app name prefix was hard-coded
into the query used to fetch combined stmt/txn stats.
This commit replaces that usage with the pre-existing
internal app prefix defined in constants.

Release note: None