### PR TITLE
distsql: cleanup log tag annotation

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -397,8 +397,8 @@ func (ds *ServerImpl) setupFlow(
 		return ctx, nil, nil, err
 	}
 	if !f.IsLocal() {
-		flowCtx.AddLogTag("f", f.GetFlowCtx().ID.Short())
-		flowCtx.AnnotateCtx(ctx)
+		flowCtx.AmbientContext.AddLogTag("f", f.GetFlowCtx().ID.Short())
+		ctx = flowCtx.AmbientContext.AnnotateCtx(ctx)
 		telemetry.Inc(sqltelemetry.DistSQLExecCounter)
 	}
 	if f.IsVectorized() {
@@ -669,7 +669,7 @@ func (ds *ServerImpl) flowStreamInt(
 	}
 	defer cleanup()
 	log.VEventf(ctx, 1, "connected inbound stream %s/%d", flowID.Short(), streamID)
-	return streamStrategy.Run(f.AnnotateCtx(ctx), stream, msg, f)
+	return streamStrategy.Run(f.AmbientContext.AnnotateCtx(ctx), stream, msg, f)
 }
 
 // FlowStream is part of the execinfrapb.DistSQLServer interface.

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -30,7 +30,7 @@ import (
 // FlowCtx encompasses the configuration parameters needed for various flow
 // components.
 type FlowCtx struct {
-	log.AmbientContext
+	AmbientContext log.AmbientContext
 
 	Cfg *ServerConfig
 


### PR DESCRIPTION
A context annotation was not doing what it wanted; it was inadvertently
a no-op.

This patch also makes FlowCtx.AmbientCtx not be embedded. Embedded
AmbientCtxs are annoying because one can't easily find where they're
used.

Release note: None