### PR TITLE
jobs: enable marking jobs as idle for metrics

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -347,6 +347,7 @@ func (r *Registry) addAdoptedJob(
 	r.mu.adoptedJobs[jobID] = &adoptedJob{
 		sid:    sessionID,
 		cancel: cancel,
+		isIdle: false,
 	}
 	return false
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -756,6 +756,12 @@ func (j *Job) MakeSessionBoundInternalExecutor(
 	return j.registry.sessionBoundInternalExecutorFactory(ctx, sd)
 }
 
+// MarkIdle marks the job as Idle.  Idleness should not be toggled frequently
+// (no more than ~twice a minute) as the action is logged.
+func (j *Job) MarkIdle(isIdle bool) {
+	j.registry.MarkIdle(j, isIdle)
+}
+
 func (j *Job) runInTxn(
 	ctx context.Context, txn *kv.Txn, fn func(context.Context, *kv.Txn) error,
 ) error {

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -43,6 +43,7 @@ type Metrics struct {
 // JobTypeMetrics is a metric.Struct containing metrics for each type of job.
 type JobTypeMetrics struct {
 	CurrentlyRunning       *metric.Gauge
+	CurrentlyIdle          *metric.Gauge
 	ResumeCompleted        *metric.Counter
 	ResumeRetryError       *metric.Counter
 	ResumeFailed           *metric.Counter
@@ -60,6 +61,17 @@ func makeMetaCurrentlyRunning(typeStr string) metric.Metadata {
 	return metric.Metadata{
 		Name: fmt.Sprintf("jobs.%s.currently_running", typeStr),
 		Help: fmt.Sprintf("Number of %s jobs currently running in Resume or OnFailOrCancel state",
+			typeStr),
+		Measurement: "jobs",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_GAUGE,
+	}
+}
+
+func makeMetaCurrentlyIdle(typeStr string) metric.Metadata {
+	return metric.Metadata{
+		Name: fmt.Sprintf("jobs.%s.currently_idle", typeStr),
+		Help: fmt.Sprintf("Number of %s jobs currently considered Idle and can be freely shut down",
 			typeStr),
 		Measurement: "jobs",
 		Unit:        metric.Unit_COUNT,
@@ -184,6 +196,7 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 		typeStr := strings.ToLower(strings.Replace(jt.String(), " ", "_", -1))
 		m.JobMetrics[jt] = &JobTypeMetrics{
 			CurrentlyRunning:       metric.NewGauge(makeMetaCurrentlyRunning(typeStr)),
+			CurrentlyIdle:          metric.NewGauge(makeMetaCurrentlyIdle(typeStr)),
 			ResumeCompleted:        metric.NewCounter(makeMetaResumeCompeted(typeStr)),
 			ResumeRetryError:       metric.NewCounter(makeMetaResumeRetryError(typeStr)),
 			ResumeFailed:           metric.NewCounter(makeMetaResumeFailed(typeStr)),

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -46,7 +46,8 @@ import (
 // adoptedJobs represents a the epoch and cancelation of a job id being run
 // by the registry.
 type adoptedJob struct {
-	sid sqlliveness.SessionID
+	sid    sqlliveness.SessionID
+	isIdle bool
 	// Calling the func will cancel the context the job was resumed with.
 	cancel context.CancelFunc
 }
@@ -1122,6 +1123,9 @@ func (r *Registry) stepThroughStateMachine(
 			defer jm.CurrentlyRunning.Dec(1)
 			err = resumer.Resume(resumeCtx, execCtx)
 		}()
+
+		r.MarkIdle(job, false)
+
 		if err == nil {
 			jm.ResumeCompleted.Inc(1)
 			return r.stepThroughStateMachine(ctx, execCtx, resumer, job, StatusSucceeded, nil)
@@ -1282,6 +1286,28 @@ func (r *Registry) adoptionDisabled(ctx context.Context) bool {
 	return false
 }
 
+// MarkIdle marks a currently adopted job as Idle.
+// A single job should not toggle its idleness more than twice per-minute as it
+// is logged and may write to persisted job state in the future.
+func (r *Registry) MarkIdle(job *Job, isIdle bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if aj, ok := r.mu.adoptedJobs[job.ID()]; ok {
+		payload := job.Payload()
+		jobType := payload.Type()
+		jm := r.metrics.JobMetrics[jobType]
+		if aj.isIdle != isIdle {
+			log.Infof(r.serverCtx, "%s job %d: toggling idleness to %+v", jobType, job.ID(), isIdle)
+			if isIdle {
+				jm.CurrentlyIdle.Inc(1)
+			} else {
+				jm.CurrentlyIdle.Dec(1)
+			}
+			aj.isIdle = isIdle
+		}
+	}
+}
+
 func (r *Registry) cancelAllAdoptedJobs() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1395,4 +1421,12 @@ func (r *Registry) CheckPausepoint(name string) error {
 		}
 	}
 	return nil
+}
+
+// TestingIsJobIdle returns true if the job is adopted and currently idle.
+func (r *Registry) TestingIsJobIdle(jobID jobspb.JobID) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	adoptedJob := r.mu.adoptedJobs[jobID]
+	return adoptedJob != nil && adoptedJob.isIdle
 }

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -973,3 +973,133 @@ func TestRunWithoutLoop(t *testing.T) {
 	require.Equal(t, int64(N), atomic.LoadInt64(&ran))
 	require.Equal(t, int64(N/2), atomic.LoadInt64(&failure))
 }
+
+func TestJobIdleness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	intervalOverride := time.Millisecond
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		// Ensure no other jobs are created and adoptions and cancellations are quick
+		Knobs: base.TestingKnobs{
+			SpanConfig: &spanconfig.TestingKnobs{
+				ManagerDisableJobCreation: true,
+			},
+			JobsTestingKnobs: &TestingKnobs{
+				IntervalOverrides: TestingIntervalOverrides{
+					Adopt:  &intervalOverride,
+					Cancel: &intervalOverride,
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	r := s.JobRegistry().(*Registry)
+
+	resumeStartChan := make(chan struct{})
+	resumeErrChan := make(chan error)
+	defer close(resumeErrChan)
+	RegisterConstructor(jobspb.TypeImport, func(_ *Job, cs *cluster.Settings) Resumer {
+		return FakeResumer{
+			OnResume: func(ctx context.Context) error {
+				resumeStartChan <- struct{}{}
+				return <-resumeErrChan
+			},
+		}
+	})
+
+	currentlyIdle := r.MetricsStruct().JobMetrics[jobspb.TypeImport].CurrentlyIdle
+
+	createJob := func() *Job {
+		jobID := r.MakeJobID()
+		require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			_, err := r.CreateJobWithTxn(ctx, Record{
+				Details:  jobspb.ImportDetails{},
+				Progress: jobspb.ImportProgress{},
+			}, jobID, txn)
+			return err
+		}))
+		job, err := r.LoadJob(ctx, jobID)
+		require.NoError(t, err)
+		<-resumeStartChan
+		return job
+	}
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	waitUntilStatus := func(t *testing.T, jobID jobspb.JobID, status Status) {
+		tdb.CheckQueryResultsRetry(t,
+			fmt.Sprintf("SELECT status FROM [SHOW JOBS] WHERE job_id = %d", jobID),
+			[][]string{{string(status)}})
+	}
+
+	t.Run("MarkIdle", func(t *testing.T) {
+		job1 := createJob()
+		job2 := createJob()
+
+		require.False(t, r.TestingIsJobIdle(job1.ID()))
+
+		r.MarkIdle(job1, true)
+		r.MarkIdle(job2, true)
+		require.True(t, r.TestingIsJobIdle(job1.ID()))
+		require.Equal(t, int64(2), currentlyIdle.Value())
+
+		// Repeated calls should not increase metric
+		r.MarkIdle(job1, true)
+		r.MarkIdle(job1, true)
+		require.Equal(t, int64(2), currentlyIdle.Value())
+
+		r.MarkIdle(job1, false)
+		require.Equal(t, int64(1), currentlyIdle.Value())
+		require.False(t, r.TestingIsJobIdle(job1.ID()))
+		r.MarkIdle(job2, false)
+		require.Equal(t, int64(0), currentlyIdle.Value())
+
+		// Let the jobs complete
+		resumeErrChan <- nil
+		resumeErrChan <- nil
+	})
+
+	t.Run("idleness disabled on state updates", func(t *testing.T) {
+		for _, test := range []struct {
+			name   string
+			update func(jobID jobspb.JobID)
+		}{
+			{"pause", func(jobID jobspb.JobID) {
+				resumeErrChan <- MarkPauseRequestError(errors.Errorf("pause error"))
+				waitUntilStatus(t, jobID, StatusPaused)
+			}},
+			{"succeeded", func(jobID jobspb.JobID) {
+				resumeErrChan <- nil
+				waitUntilStatus(t, jobID, StatusSucceeded)
+			}},
+			{"failed", func(jobID jobspb.JobID) {
+				resumeErrChan <- errors.Errorf("error")
+				waitUntilStatus(t, jobID, StatusFailed)
+			}},
+			{"cancel", func(jobID jobspb.JobID) {
+				resumeErrChan <- errJobCanceled
+				waitUntilStatus(t, jobID, StatusCanceled)
+			}},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				job := createJob()
+
+				require.Equal(t, int64(0), currentlyIdle.Value())
+				r.MarkIdle(job, true)
+				require.Equal(t, int64(1), currentlyIdle.Value())
+
+				test.update(job.ID())
+
+				testutils.SucceedsSoon(t, func() error {
+					if r.TestingIsJobIdle(job.ID()) {
+						return errors.Errorf("waiting for job to unmark idle")
+					}
+					return nil
+				})
+				require.Equal(t, int64(0), currentlyIdle.Value())
+			})
+		}
+	})
+
+}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2665,6 +2665,26 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Currently Idle",
+				Metrics: []string{
+					"jobs.auto_create_stats.currently_idle",
+					"jobs.auto_span_config_reconciliation.currently_idle",
+					"jobs.auto_sql_stats_compaction.currently_idle",
+					"jobs.backup.currently_idle",
+					"jobs.changefeed.currently_idle",
+					"jobs.create_stats.currently_idle",
+					"jobs.import.currently_idle",
+					"jobs.migration.currently_idle",
+					"jobs.new_schema_change.currently_idle",
+					"jobs.restore.currently_idle",
+					"jobs.schema_change.currently_idle",
+					"jobs.schema_change_gc.currently_idle",
+					"jobs.stream_ingestion.currently_idle",
+					"jobs.stream_replication.currently_idle",
+					"jobs.typedesc_schema_change.currently_idle",
+				},
+			},
+			{
 				Title: "Auto Create Stats",
 				Metrics: []string{
 					"jobs.auto_create_stats.fail_or_cancel_completed",


### PR DESCRIPTION
In order to allow long-running / indefinite jobs to not continually
block a tenant from being treated as inactive in a serverless
environment, this change adds a MarkIdle API to the jobs registry which
increases / decreases a counter of currently idle jobs. An idle job
should be able to be shut down at any moment.  Through the CurrentlyIdle
and CurrentlyRunning jobs numbers serverless can determine if all jobs
are idle and the tenant can be safely shut down.  For now this is only
saved in-memory in the registry object, however we may transition to
saving in persisted job state as well in
the future.

Fixes #74747

Release note: None
