### PR TITLE
distsql: improve flow cleanup

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -376,7 +376,7 @@ func (ds *ServerImpl) setupFlow(
 	// to restore the original value which can have data races under stress.
 	isVectorized := req.EvalContext.SessionData.VectorizeMode != sessiondatapb.VectorizeOff
 	f := newFlow(
-		flowCtx, ds.flowRegistry, rowSyncFlowConsumer, batchSyncFlowConsumer,
+		flowCtx, sp, ds.flowRegistry, rowSyncFlowConsumer, batchSyncFlowConsumer,
 		localState.LocalProcs, isVectorized, onFlowCleanup, req.StatementSQL,
 	)
 	opt := flowinfra.FuseNormally
@@ -493,6 +493,7 @@ func (ds *ServerImpl) newFlowContext(
 
 func newFlow(
 	flowCtx execinfra.FlowCtx,
+	sp *tracing.Span,
 	flowReg *flowinfra.FlowRegistry,
 	rowSyncFlowConsumer execinfra.RowReceiver,
 	batchSyncFlowConsumer execinfra.BatchReceiver,
@@ -501,7 +502,7 @@ func newFlow(
 	onFlowCleanup func(),
 	statementSQL string,
 ) flowinfra.Flow {
-	base := flowinfra.NewFlowBase(flowCtx, flowReg, rowSyncFlowConsumer, batchSyncFlowConsumer, localProcessors, onFlowCleanup, statementSQL)
+	base := flowinfra.NewFlowBase(flowCtx, sp, flowReg, rowSyncFlowConsumer, batchSyncFlowConsumer, localProcessors, onFlowCleanup, statementSQL)
 	if isVectorized {
 		return colflow.NewVectorizedFlow(base)
 	}

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -44,6 +44,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 	}
 	base := flowinfra.NewFlowBase(
 		flowCtx,
+		nil, /* sp */
 		nil, /* flowReg */
 		nil, /* rowSyncFlowConsumer */
 		nil, /* batchSyncFlowConsumer */


### PR DESCRIPTION
FlowBase.Cleanup(ctx) was closing the tracing span from ctx, if any.
This was assuming that the respective ctx is the one associated with the
flow, and that the flow always has a span. These are brittle
assumptions; in particular, I intend to avoid opening spans for local
flows when there's no particular reason to (i.e. when not collecting
stats), to save on their cost.

This patch has the Flow explicitly keep track of which Span it owns, if
any.

Release note: None