### PR TITLE
scripts: per-branch bump-pebble.sh script

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -4,21 +4,12 @@
 # version. The storage team bumps CockroachDB's Pebble dependency
 # frequently, and this script automates some of that work.
 #
-# To bump the master branch's Pebble dependency to the current pebble
-# repository's master branch HEAD, run:
+# To bump the Pebble dependency to the corresponding pebble branch HEAD, run:
 #
-#   ./scripts/bump-pebble.sh master
+#   ./scripts/bump-pebble.sh
 #
-# If you'd like to bump the Pebble version in a release branch, pass the
-# release branch name as the sole argument. The script expects there to
-# exist a corresponding branch on the Pebble repository, prefixed with
-# 'crl-'. To bump the `release-21.1` branch's Pebble version, run:
-#
-#   ./scripts/bump-pebble.sh release-21.1
-#
-# This command will construct a pull request bumping the Pebble version
-# to the current HEAD of the `crl-release-21.1` Pebble branch on the
-# Pebble repository.
+# Note that this script has different behaviour based on the branch on which it
+# is run.
 
 set -euo pipefail
 
@@ -26,11 +17,18 @@ echoerr() { printf "%s\n" "$*" >&2; }
 pushd() { builtin pushd "$@" > /dev/null; }
 popd() { builtin popd "$@" > /dev/null; }
 
-BRANCH=${1}
-PEBBLE_BRANCH=${BRANCH}
-if [ "$BRANCH" != "master" ]; then
-    PEBBLE_BRANCH="crl-$BRANCH"
+# NOTE: After a new release has been cut, update this to the appropriate
+# Cockroach branch name (i.e. release-22.2, etc.), and corresponding Pebble
+# branch name (e.g. crl-release-21.2, etc.).
+BRANCH=master
+PEBBLE_BRANCH=master
+
+# The script can only be run from a specific branch.
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "$BRANCH" ]; then
+  echo "This script must be run from the $BRANCH branch."
+  exit 1
 fi
+
 COCKROACH_DIR="$(go env GOPATH)/src/github.com/cockroachdb/cockroach"
 PEBBLE_DIR="$(go env GOPATH)/src/github.com/cockroachdb/pebble"
 VENDORED_DIR="$COCKROACH_DIR/vendor"


### PR DESCRIPTION
Currently, the master branch, in addition to each release branch relies
on the same `bump-pebbble.sh` from the master branch. There are subtle
differences between master and the release branches (i.e. build system)
that ends up breaking the script as the changes are introduced on the
master branch but not backported to the release branches.

One solution to this problem is to continue to maintain one script on
the master branch, but include switching logic for each release branch
to account for the differences.

An alternative approach is to have a script per release branch. Rather
than having switching logic, the script has the appropriate logic for
that branch. When a new release branch is cut, the script inherits the
most up-to-date logic from master, and all that needs to change is the
name of the branch and the corresponding Pebble branch.

Pin the `bump-pebble.sh` script to the master branch. The script will
error out if it is run from a different branch.

Release note: None