### PR TITLE
migration/migrations: skip TestEnsureSpanConfigReconciliation

### DIFF
--- a/pkg/migration/migrations/migrate_span_configs_test.go
+++ b/pkg/migration/migrations/migrate_span_configs_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -34,6 +35,7 @@ import (
 // span config reconciliation attempt, blocking until it occurs.
 func TestEnsureSpanConfigReconciliation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 75849, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #75849

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None