### PR TITLE
util/tracing: don't return recordings for non-recording spans

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -158,7 +158,7 @@ func (m *mockInternalClient) Batch(
 	log.Eventf(ctx, "mockInternalClient processing batch")
 	br := &roachpb.BatchResponse{}
 	br.Error = m.pErr
-	if rec := sp.GetRecording(tracing.RecordingVerbose); rec != nil {
+	if rec := sp.GetConfiguredRecording(); rec != nil {
 		br.CollectedSpans = append(br.CollectedSpans, rec...)
 	}
 	return br, nil

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -973,7 +973,7 @@ func (m *monitor) runSync(opName string, fn func(context.Context)) {
 		opName: opName,
 		ctx:    ctx,
 		collect: func() tracing.Recording {
-			return sp.GetRecording(tracing.RecordingVerbose)
+			return sp.GetConfiguredRecording()
 		},
 		cancel: sp.Finish,
 	}
@@ -990,7 +990,7 @@ func (m *monitor) runAsync(opName string, fn func(context.Context)) (cancel func
 		opName: opName,
 		ctx:    ctx,
 		collect: func() tracing.Recording {
-			return sp.GetRecording(tracing.RecordingVerbose)
+			return sp.GetConfiguredRecording()
 		},
 		cancel: sp.Finish,
 	}

--- a/pkg/migration/migrationmanager/manager_external_test.go
+++ b/pkg/migration/migrationmanager/manager_external_test.go
@@ -173,7 +173,7 @@ RETURNING id;`).Scan(&secondID))
 		// no processors actually create their own spans). Instead, a different
 		// way to observe the status of the migration manager should be
 		// introduced and should be used here.
-		rec := sp.GetRecording(tracing.RecordingVerbose)
+		rec := sp.GetConfiguredRecording()
 		if tracing.FindMsgInRecording(rec, "found existing migration job") > 0 {
 			return nil
 		}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1094,7 +1094,7 @@ func (n *Node) setupSpanForIncomingRPC(
 			return
 		}
 
-		rec = newSpan.FinishAndGetRecording(newSpan.RecordingType())
+		rec = newSpan.FinishAndGetConfiguredRecording()
 		if rec != nil {
 			// Decide if the trace for this RPC, if any, will need to be redacted. It
 			// needs to be redacted if the response goes to a tenant. In case the request

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -251,16 +251,13 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 
 // GetTraceData returns the trace data.
 func GetTraceData(ctx context.Context) []tracingpb.RecordedSpan {
-	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		return sp.GetRecording(tracing.RecordingVerbose)
-	}
-	return nil
+	return tracing.SpanFromContext(ctx).GetConfiguredRecording()
 }
 
 // GetTraceDataAsMetadata returns the trace data as execinfrapb.ProducerMetadata
 // object.
 func GetTraceDataAsMetadata(span *tracing.Span) *execinfrapb.ProducerMetadata {
-	if trace := span.GetRecording(tracing.RecordingVerbose); len(trace) > 0 {
+	if trace := span.GetConfiguredRecording(); len(trace) > 0 {
 		meta := execinfrapb.GetProducerMeta()
 		meta.TraceData = trace
 		return meta

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -666,7 +666,7 @@ func (pb *ProcessorBaseNoHelper) moveToTrailingMeta() {
 				pb.span.RecordStructured(stats)
 			}
 		}
-		if trace := pb.span.GetRecording(pb.span.RecordingType()); trace != nil {
+		if trace := pb.span.GetConfiguredRecording(); trace != nil {
 			pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
 		}
 	}

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -260,9 +260,9 @@ func (ih *instrumentationHelper) Finish(
 	// Note that in case of implicit transactions, the trace contains the auto-commit too.
 	var trace tracing.Recording
 	if ih.shouldFinishSpan {
-		trace = ih.sp.FinishAndGetRecording(ih.sp.RecordingType())
+		trace = ih.sp.FinishAndGetConfiguredRecording()
 	} else {
-		trace = ih.sp.GetRecording(ih.sp.RecordingType())
+		trace = ih.sp.GetConfiguredRecording()
 	}
 
 	if ih.withStatementTrace != nil {

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -437,7 +437,7 @@ func TestLimitScans(t *testing.T) {
 	// scans from the same key as the DistSender retries scans when it detects
 	// splits.
 	re := regexp.MustCompile(fmt.Sprintf(`querying next range at /Table/%d/1(\S.*)?`, tableDesc.GetID()))
-	spans := sp.GetRecording(tracing.RecordingVerbose)
+	spans := sp.GetConfiguredRecording()
 	ranges := make(map[string]struct{})
 	for _, span := range spans {
 		if span.Operation == tableReaderProcName {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1543,7 +1543,7 @@ func ContextWithRecordingSpan(
 			if rec != nil {
 				return rec
 			}
-			rec = sp.FinishAndGetRecording(RecordingVerbose)
+			rec = sp.FinishAndGetConfiguredRecording()
 			return rec
 		}
 }

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -63,7 +63,17 @@ func TestTracingOffRecording(t *testing.T) {
 }
 
 func TestTracerRecording(t *testing.T) {
-	tr := NewTracer()
+	ctx := context.Background()
+	tr := NewTracerWithOpt(ctx, WithTracingMode(TracingModeActiveSpansRegistry))
+
+	// Check that a span that was not configured to record returns nil for its
+	// recording.
+	sNonRecording := tr.StartSpan("not recording")
+	require.Equal(t, RecordingOff, sNonRecording.RecordingType())
+	require.Nil(t, sNonRecording.GetConfiguredRecording())
+	require.Nil(t, sNonRecording.GetRecording(RecordingVerbose))
+	require.Nil(t, sNonRecording.GetRecording(RecordingStructured))
+	require.Nil(t, sNonRecording.FinishAndGetConfiguredRecording())
 
 	s1 := tr.StartSpan("a", WithRecording(RecordingStructured))
 	if s1.IsNoop() {


### PR DESCRIPTION
This patch makes sp.GetRecording() return nil if the span was not
recording. This is already what the documentation on GetRecording() was
implying, but the actual behavior was different: a non-recording span
(that's not a no-op span) would return a non-nil recording consisting
only of the the span's metadata. This behavior is not necessarily
unreasonable, but it turns out it's a bit dangerous from a performance
perspective - there's a cost (e.g. some allocations) for generating this
recording, and it was too easy for unsuspecting callers to pay that when
they didn't want to. In particular, DistSQL was indiscriminently calling
GetRecording() (through its GetTraceData* utilities), and paying this
measurable cost unintentionally.

Eliminating this cost is particularly important when the Tracer is
configured in the "active spans registry" tracing mode; when not in that
mode, all the spans would be no-ops and the GetRecording calls were
shortcircuited anyway. This is seen in BenchmarkTracing//trace=on,
particularly on "3node/scan" which was the benchmark with the bigest
difference between tracing on and off.

name                              old time/op    new time/op    delta
Tracing/1node/scan/trace=on-32       214µs ± 4%     206µs ± 5%    ~     (p=0.222 n=5+5)
Tracing/1node/insert/trace=on-32     338µs ± 5%     334µs ± 4%    ~     (p=0.690 n=5+5)
Tracing/3node/scan/trace=on-32       515µs ± 3%     484µs ± 3%  -6.11%  (p=0.008 n=5+5)
Tracing/3node/insert/trace=on-32     635µs ± 1%     627µs ± 1%    ~     (p=0.095 n=5+5)

name                              old alloc/op   new alloc/op   delta
Tracing/1node/scan/trace=on-32      27.2kB ± 2%    25.6kB ± 2%  -5.94%  (p=0.008 n=5+5)
Tracing/1node/insert/trace=on-32    45.2kB ± 2%    45.5kB ± 2%    ~     (p=0.690 n=5+5)
Tracing/3node/scan/trace=on-32      83.2kB ± 3%    79.7kB ± 5%    ~     (p=0.095 n=5+5)
Tracing/3node/insert/trace=on-32     102kB ± 2%     103kB ± 1%    ~     (p=0.548 n=5+5)

name                              old allocs/op  new allocs/op  delta
Tracing/1node/scan/trace=on-32         242 ± 1%       229 ± 0%  -5.37%  (p=0.000 n=5+4)
Tracing/1node/insert/trace=on-32       338 ± 1%       339 ± 1%    ~     (p=0.563 n=5+5)
Tracing/3node/scan/trace=on-32         819 ± 1%       788 ± 6%    ~     (p=0.135 n=5+5)
Tracing/3node/insert/trace=on-32       871 ± 0%       880 ± 0%  +0.99%  (p=0.016 n=4+5)

Release note: None