### PR TITLE
dev: add ./dev ui watch for live-reloading of db-console and cluster-ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1436,7 +1436,7 @@ ui-watch ui-watch-secure: $(UI_CCL_DLLS) pkg/ui/yarn.opt.installed
   # `node-run.sh` wrapper is removed because this command is supposed to be run in dev environment (not in docker of CI)
   # so it is safe to run yarn commands directly to preserve formatting and colors for outputs
 	yarn --cwd pkg/ui/workspaces/cluster-ui build:watch & \
-	yarn --cwd pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --env.dist=ccl --port $(PORT) --mode "development" $(WEBPACK_DEV_SERVER_FLAGS)
+	yarn --cwd pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --env.dist=ccl --env.WEBPACK_SERVE --port $(PORT) --mode "development" $(WEBPACK_DEV_SERVER_FLAGS)
 
 .PHONY: ui-clean
 ui-clean: ## Remove build artifacts.

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "main.go",
         "merge_test_xmls.go",
         "test.go",
+        "ui.go",
         "util.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/dev",

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -123,23 +123,18 @@ Typical usage:
 	)
 	// Add all the shared flags.
 	var debugVar bool
-	for _, subCmd := range ret.cli.Commands() {
-		subCmd.Flags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev")
-	}
-	for _, subCmd := range ret.cli.Commands() {
-		isDoctor := subCmd.Name() == "doctor"
-
-		subCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-			if !isTesting && !isDoctor {
-				if err := ret.checkDoctorStatus(cmd.Context()); err != nil {
-					return err
-				}
+	ret.cli.PersistentFlags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev")
+	ret.cli.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		isDoctor := cmd.Name() == "doctor"
+		if !isTesting && !isDoctor {
+			if err := ret.checkDoctorStatus(cmd.Context()); err != nil {
+				return err
 			}
-			if debugVar {
-				ret.log.SetOutput(stdos.Stderr)
-			}
-			return nil
 		}
+		if debugVar {
+			ret.log.SetOutput(stdos.Stderr)
+		}
+		return nil
 	}
 
 	return &ret

--- a/pkg/cmd/dev/dev.go
+++ b/pkg/cmd/dev/dev.go
@@ -120,7 +120,9 @@ Typical usage:
 		makeTestLogicCmd(ret.testlogic),
 		makeLintCmd(ret.lint),
 		makeTestCmd(ret.test),
+		makeUICmd(&ret),
 	)
+
 	// Add all the shared flags.
 	var debugVar bool
 	ret.cli.PersistentFlags().BoolVar(&debugVar, "debug", false, "enable debug logging for dev")

--- a/pkg/cmd/dev/testdata/recording/ui.txt
+++ b/pkg/cmd/dev/testdata/recording/ui.txt
@@ -1,0 +1,48 @@
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
+----
+
+
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
+----
+
+
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000 --https
+----
+
+
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://example.crdb.io:4848 --port 3000
+----
+
+
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+----
+
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345
+----

--- a/pkg/cmd/dev/testdata/ui.txt
+++ b/pkg/cmd/dev/testdata/ui.txt
@@ -1,0 +1,29 @@
+dev ui watch
+----
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
+
+dev ui watch --oss
+----
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
+
+dev ui watch --secure
+----
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000 --https
+
+dev ui watch --db http://example.crdb.io:4848
+----
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://example.crdb.io:4848 --port 3000
+
+dev ui watch --port 12345
+----
+bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/cluster-ui build:watch
+yarn --silent --cwd go/src/github.com/cockroachdb/cockroach/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -1,0 +1,192 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// ossFlag is the name of the boolean long (GNU-style) flag that builds only the open-source parts of the UI
+	ossFlag = "oss"
+)
+
+// makeUICmd initializes the top-level 'ui' subcommand
+func makeUICmd(d *dev) *cobra.Command {
+	uiCmd := &cobra.Command{
+		Use:   "ui",
+		Short: "Runs UI-related tasks",
+		Long:  "Builds UI & runs UI-related commands to ease development flows",
+	}
+
+	uiCmd.AddCommand(makeUIWatchCmd(d))
+
+	return uiCmd
+}
+
+// UIDirectories contains the absolute path to the root of each UI sub-project.
+type UIDirectories struct {
+	// clusterUI is the absolute path to ./pkg/ui/workspaces/cluster-ui
+	clusterUI string
+	// dbConsole is the absolute path to ./pkg/ui/workspaces/db-console
+	dbConsole string
+}
+
+// getUIDirs computes the absolute path to the root of each UI sub-project.
+func getUIDirs(d *dev) (*UIDirectories, error) {
+	workspace, err := d.getWorkspace(d.cli.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	return &UIDirectories{
+		clusterUI: path.Join(workspace, "./pkg/ui/workspaces/cluster-ui"),
+		dbConsole: path.Join(workspace, "./pkg/ui/workspaces/db-console"),
+	}, nil
+}
+
+// makeUIWatchCmd initializes the 'ui watch' subcommand, which sets up a live-reloading HTTP server for db-console and a
+// file-watching rebuilder for cluster-ui.
+func makeUIWatchCmd(d *dev) *cobra.Command {
+	const (
+		// portFlag is the name of the long (GNU-style) flag that controls which port webpack's dev server listens on
+		portFlag = "port"
+		// dbTargetFlag is the name of the long (GNU-style) flag that determines which DB instance to proxy to
+		dbTargetFlag = "db"
+		// secureFlag is the name of the boolean long (GNU-style) flag that makes webpack's dev server use HTTPS
+		secureFlag = "secure"
+	)
+
+	watchCmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Watches for file changes and automatically rebuilds",
+		Long: `Starts a local web server that watches for JS file changes, automatically regenerating the UI
+
+Replaces 'make ui-watch'.`,
+		Args: cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, commandLine []string) error {
+			// Create a context that cancels when OS signals come in
+			ctx, stop := signal.NotifyContext(d.cli.Context(), os.Interrupt, os.Kill)
+			defer stop()
+
+			isOss, err := cmd.Flags().GetBool(ossFlag)
+			if err != nil {
+				return err
+			}
+
+			// Build prerequisites for db-console and cluster-ui
+			args := []string{
+				"build",
+				"//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
+			}
+			if !isOss {
+				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl")
+			}
+			logCommand("bazel", args...)
+			err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
+
+			if err != nil {
+				log.Fatalf("failed to build UI watch prerequisites: %v", err)
+				return err
+			}
+
+			// Extract remaining flags
+			portNumber, err := cmd.Flags().GetInt16(portFlag)
+			if err != nil {
+				log.Fatalf("unexpected error: %v", err)
+				return err
+			}
+			port := fmt.Sprint(portNumber)
+			dbTarget, err := cmd.Flags().GetString(dbTargetFlag)
+			if err != nil {
+				log.Fatalf("unexpected error: %v", err)
+				return err
+			}
+			_, err = url.Parse(dbTarget)
+			if err != nil {
+				log.Fatalf("invalid format for --%s argument: %v", dbTargetFlag, err)
+				return err
+			}
+			secure := mustGetFlagBool(cmd, secureFlag)
+
+			// `yarn` is required to be on a user's path, since it won't run via Bazel
+			err = d.ensureBinaryInPath("yarn")
+			if err != nil {
+				return err
+			}
+
+			dirs, err := getUIDirs(d)
+			if err != nil {
+				log.Fatalf("unable to find cluster-ui and db-console directories: %v", err)
+				return err
+			}
+
+			// Start the cluster-ui watch task
+			nbExec := d.exec.AsNonBlocking()
+			err = nbExec.CommandContextInheritingStdStreams(ctx, "yarn", "--silent", "--cwd", dirs.clusterUI, "build:watch")
+			if err != nil {
+				log.Fatalf("Unable to watch cluster-ui for changes: %v", err)
+				return err
+			}
+
+			var webpackDist string
+			if isOss {
+				webpackDist = "oss"
+			} else {
+				webpackDist = "ccl"
+			}
+
+			args = []string{
+				"--silent",
+				"--cwd",
+				dirs.dbConsole,
+				"webpack-dev-server",
+				"--config", "webpack.app.js",
+				"--mode", "development",
+				// Polyfill WEBPACK_SERVE for webpack v4; it's set in webpack v5 via `webpack serve`
+				"--env.WEBPACK_SERVE",
+				"--env.dist=" + webpackDist,
+				"--env.target=" + dbTarget,
+				"--port", port,
+			}
+			if secure {
+				args = append(args, "--https")
+			}
+
+			// Start the db-console web server + watcher
+			err = nbExec.CommandContextInheritingStdStreams(ctx, "yarn", args...)
+			if err != nil {
+				log.Fatalf("Unable to serve db-console: %v", err)
+				return err
+			}
+
+			// Wait for OS signals to cancel if we're not in test-mode
+			if !isTesting {
+				<-ctx.Done()
+			}
+
+			return nil
+		},
+	}
+
+	watchCmd.Flags().Int16P(portFlag, "p", 3000, "port to serve UI on")
+	watchCmd.Flags().String(dbTargetFlag, "http://localhost:8080", "url to proxy DB requests to")
+	watchCmd.Flags().Bool(secureFlag, false, "serve via HTTPS")
+	watchCmd.Flags().Bool(ossFlag, false, "build only the open-source parts of the UI")
+
+	return watchCmd
+}

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -12,7 +12,7 @@
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
     "build:typescript": "tsc",
-    "build:watch": "webpack --watch --mode=development",
+    "build:watch": "webpack --watch --mode=development --env.WEBPACK_WATCH",
     "tsc:watch": "tsc --watch",
     "ci": "jest --ci -i",
     "clean": "rm -rf  ./dist/*",

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -14,152 +14,158 @@ const WebpackBar = require("webpackbar");
 const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
 // tslint:disable:object-literal-sort-keys
-module.exports = {
-  entry: path.resolve(__dirname, "./src/index.ts"),
+module.exports = (env, argv) => {
+  env = env || {};
 
-  output: {
-    path: path.resolve(__dirname, "dist/js"),
-    filename: "main.js",
-    library: "adminUI",
-    libraryTarget: "umd",
-  },
+  return {
+    name: "cluster-ui",
+    entry: path.resolve(__dirname, "./src/index.ts"),
 
-  // Enable sourcemaps for debugging webpack's output.
-  devtool: "source-map",
-
-  resolve: {
-    modules: [
-      'node_modules',
-      path.join(__dirname, 'src/fonts'),
-    ],
-    extensions: [".ts", ".tsx", ".js", ".jsx", ".less"],
-    alias: {
-      src: path.resolve(__dirname, "src"),
+    output: {
+      path: path.resolve(__dirname, "dist/js"),
+      filename: "main.js",
+      library: "adminUI",
+      libraryTarget: "umd",
     },
-  },
 
-  module: {
-    rules: [
-      {
-        test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-        use: {
-          loader: "url-loader",
-          options: {
-            limit: true,
-          }
-        },
-        exclude: /node_modules/,
+    // Enable sourcemaps for debugging webpack's output.
+    devtool: "source-map",
+
+    resolve: {
+      modules: [
+        'node_modules',
+        path.join(__dirname, 'src/fonts'),
+      ],
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".less"],
+      alias: {
+        src: path.resolve(__dirname, "src"),
       },
-      // Styles in current project use SCSS preprocessing language with CSS modules.
-      // They have to follow file naming convention: [filename].module.scss
-      {
-        test: /\.module\.scss$/,
-        exclude: /node_modules/,
-        use: [
-          "style-loader",
-          {
-            loader: "css-loader",
+    },
+
+    module: {
+      rules: [
+        {
+          test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
+          use: {
+            loader: "url-loader",
             options: {
-              modules: {
-                localIdentName: "[local]--[hash:base64:5]",
-              }
-            },
-          },
-          "sass-loader"
-        ],
-      },
-      // Ant design styles defined as global styles with .scss files which don't follow
-      // internal convention to have .module.scss extension. That's why we need one more sass
-      // loader which matches SCSS files without .module suffix. Note, it doesn't exclude node_modules
-      // dir so it can access external dependencies.
-      {
-        test: /(?<!\.module)\.scss/,
-        use: ["style-loader", "css-loader", "sass-loader"],
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.(ts|js)x?$/,
-        use: [
-          "babel-loader",
-          {
-            loader: "astroturf/loader",
-            options: {extension: ".module.scss"},
-          },
-        ],
-        exclude: [
-          /node_modules/,
-          /db-console\/src\/js/,
-        ],
-      },
-      // Preprocess LESS styles required by external components
-      // (react-select)
-      {
-        use: [
-          "style-loader",
-          "css-loader",
-          {
-            loader: "less-loader",
-            options: {
-              lessOptions: {
-                javascriptEnabled: true
-              }
+              limit: true,
             }
           },
-        ],
-        test: /\.less$/,
-      },
-      // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-      {
-        enforce: "pre",
-        test: /\.js$/,
-        loader: "source-map-loader",
-        exclude: [
-          /node_modules/,
-          /db-console\/src\/js/,
-        ],
-      },
-      {
-        test: /\.css$/,
-        use: ["style-loader", "css-loader"],
-        exclude: /node_modules/,
-      },
+          exclude: /node_modules/,
+        },
+        // Styles in current project use SCSS preprocessing language with CSS modules.
+        // They have to follow file naming convention: [filename].module.scss
+        {
+          test: /\.module\.scss$/,
+          exclude: /node_modules/,
+          use: [
+            "style-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  localIdentName: "[local]--[hash:base64:5]",
+                }
+              },
+            },
+            "sass-loader"
+          ],
+        },
+        // Ant design styles defined as global styles with .scss files which don't follow
+        // internal convention to have .module.scss extension. That's why we need one more sass
+        // loader which matches SCSS files without .module suffix. Note, it doesn't exclude node_modules
+        // dir so it can access external dependencies.
+        {
+          test: /(?<!\.module)\.scss/,
+          use: ["style-loader", "css-loader", "sass-loader"],
+          exclude: /node_modules/,
+        },
+        {
+          test: /\.(ts|js)x?$/,
+          use: [
+            "babel-loader",
+            {
+              loader: "astroturf/loader",
+              options: {extension: ".module.scss"},
+            },
+          ],
+          exclude: [
+            /node_modules/,
+            /db-console\/src\/js/,
+          ],
+        },
+        // Preprocess LESS styles required by external components
+        // (react-select)
+        {
+          use: [
+            "style-loader",
+            "css-loader",
+            {
+              loader: "less-loader",
+              options: {
+                lessOptions: {
+                  javascriptEnabled: true
+                }
+              }
+            },
+          ],
+          test: /\.less$/,
+        },
+        // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+        {
+          enforce: "pre",
+          test: /\.js$/,
+          loader: "source-map-loader",
+          exclude: [
+            /node_modules/,
+            /db-console\/src\/js/,
+          ],
+        },
+        {
+          test: /\.css$/,
+          use: ["style-loader", "css-loader"],
+          exclude: /node_modules/,
+        },
+      ],
+    },
+
+    plugins: [
+      new WebpackBar({
+        name: "cluster-ui",
+        color: "cyan",
+        reporters: [ env.WEBPACK_WATCH ? "basic" : "fancy" ],
+        profile: true,
+      }),
+      new MomentLocalesPlugin(),
+      new webpack.NormalModuleReplacementPlugin(
+        /node_modules\/antd\/lib\/style\/index\.less/,
+        path.resolve(__dirname, "src/core/antd-patch.less"),
+      ),
     ],
-  },
 
-  plugins: [
-    new WebpackBar({
-      name: "cluster-ui",
-      color: "cyan",
-      profile: true,
-    }),
-    new MomentLocalesPlugin(),
-    new webpack.NormalModuleReplacementPlugin(
-      /node_modules\/antd\/lib\/style\/index\.less/,
-      path.resolve(__dirname, "src/core/antd-patch.less"),
-    ),
-  ],
-
-  // When importing a module whose path matches one of the following, just
-  // assume a corresponding global variable exists and use that instead.
-  // This is important because it allows us to avoid bundling all of our
-  // dependencies, which allows browsers to cache those libraries between builds.
-  externals: {
-    protobufjs: "protobufjs",
-    react: {
-      commonjs: "react",
-      commonjs2: "react",
-      amd: "react",
-      root: "React",
+    // When importing a module whose path matches one of the following, just
+    // assume a corresponding global variable exists and use that instead.
+    // This is important because it allows us to avoid bundling all of our
+    // dependencies, which allows browsers to cache those libraries between builds.
+    externals: {
+      protobufjs: "protobufjs",
+      react: {
+        commonjs: "react",
+        commonjs2: "react",
+        amd: "react",
+        root: "React",
+      },
+      "react-dom": {
+        commonjs: "react-dom",
+        commonjs2: "react-dom",
+        amd: "react-dom",
+        root: "ReactDom",
+      },
+      "react-router-dom": "react-router-dom",
+      "react-redux": "react-redux",
+      "redux-saga": "redux-saga",
+      "redux": "redux",
     },
-    "react-dom": {
-      commonjs: "react-dom",
-      commonjs2: "react-dom",
-      amd: "react-dom",
-      root: "ReactDom",
-    },
-    "react-router-dom": "react-router-dom",
-    "react-redux": "react-redux",
-    "redux-saga": "redux-saga",
-    "redux": "redux",
-  },
-}
+  };
+};

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -40,7 +40,8 @@ function shouldProxy(reqPath) {
 
 // tslint:disable:object-literal-sort-keys
 module.exports = (env, argv) => {
-  const isBazelBuild = env && env.is_bazel_build;
+  env = env || {};
+  const isBazelBuild = env.is_bazel_build;
 
   let localRoots = [path.resolve(__dirname)];
   if (env.dist === "ccl") {
@@ -65,6 +66,7 @@ module.exports = (env, argv) => {
     new WebpackBar({
       name: "db-console",
       color: "orange",
+      reporters: [ (env.WEBPACK_WATCH || env.WEBPACK_SERVE) ? "basic" : "fancy" ],
       profile: true,
     }),
   ];

--- a/pkg/ui/workspaces/db-console/webpack.app.js
+++ b/pkg/ui/workspaces/db-console/webpack.app.js
@@ -85,7 +85,7 @@ module.exports = (env, argv) => {
   }
 
   // Exclude DLLPlugin when build with Bazel because bazel handles caching on its own
-  if (!isBazelBuild) {
+  if (!isBazelBuild && !env.WEBPACK_WATCH && !env.WEBPACK_SERVE) {
     plugins = plugins.concat([
       // See "DLLs for speedy builds" in the README for details.
       new webpack.DllReferencePlugin({


### PR DESCRIPTION
Before Bazel was introduced, UI devs would quickly iterate on changes by running the `make ui-watch` target, which builds the protobuf client prerequisites and launches two webpack commands in parallel. Critically, those webpack commands are long-running processes that don't emit production-ready JS bundles. Because Bazel doesn't support running multiple executable targets in parallel, a replacement for `make ui-watch` must live at least partially outside of the Bazel environment. Add a new subcommand `./dev ui watch` to replace the previous `ui-watch` Makefile target, so that development workflows are minimally impacted when Make is fully deprecated.

Note: While there's currently only one sub-subcommand in `./dev ui`, others will likely be added in the future to support common UI development tasks that either don't fit into the standard `./dev build` and `./dev test` commands, or to support build/test commands that need additional UI-specific arguments.

fixes #73305 