### PR TITLE
loqrecovery: add test for descriptor intent removal

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -209,6 +209,10 @@ func applyReplicaUpdate(
 		return PrepareReplicaReport{}, errors.Wrap(err, "loading MVCCStats")
 	}
 
+	// We need to abort the transaction and clean intent here because otherwise
+	// we won't be able to do MVCCPut later during recovery for the new
+	// descriptor. It should have no effect on the recovery process itself as
+	// transaction would be rolled back anyways.
 	if intent != nil {
 		// We rely on the property that transactions involving the range
 		// descriptor always start on the range-local descriptor's key. When there


### PR DESCRIPTION
Previously there was no test to verify we remove intent from
descriptor key during recovery. It was not clear why we are doing
that. This patch adds a test and clarifies the goal of intent
removal.

Release note: None