### PR TITLE
serverccl: fix TestTenantWithDecommissionedID flake

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "serverccl_test",
-    size = "large",
+    size = "medium",
     srcs = [
         "admin_test.go",
         "main_test.go",
@@ -25,6 +25,7 @@ go_test(
         "//pkg/ccl/kvccl",
         "//pkg/ccl/utilccl",
         "//pkg/ccl/utilccl/licenseccl",
+        "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb:with-mocks",
         "//pkg/security",
@@ -36,7 +37,6 @@ go_test(
         "//pkg/sql/distsql",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util",


### PR DESCRIPTION
Previously, the test could flake if a transaction included the recently
decommissioned node. Now, instead of creating a server to decommission it,
a non-existent server is marked as decommissioned. As a side effect of
this change, fewer test servers are needed, the test is ~5x faster, and
the test passes under stress.

Fixes #75923 

Release note: none