### PR TITLE
bazel: avoid stamping --config=dev builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,7 +46,6 @@ build:crosslinuxarm --config=cross
 build:devdarwinx86_64 --platforms=//build/toolchains:darwin_x86_64
 build:devdarwinx86_64 --config=dev
 build:dev --define cockroach_bazel_dev=y
-build:dev --stamp --workspace_status_command=./build/bazelutil/stamp.sh
 build:dev --action_env=PATH
 build:dev --host_action_env=PATH
 


### PR DESCRIPTION
When used with a remote build cache, these stamps (despite being marked
as volatile), induce an unnecessary golink step when switching back and
forth between branches. See
https://github.com/bazelbuild/bazel/issues/10075. Opting out here shaves
a few precious seconds if the previously built binary is already
available.

Release note: None

Jira issue: CRDB-14749