### PR TITLE
backupccl: bump file buffer size to 128MiB but with dynamic growth

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -97,6 +97,7 @@ func newTestHelper(t *testing.T) (*testHelper, func()) {
 	require.NotNil(t, th.cfg)
 	th.sqlDB = sqlutils.MakeSQLRunner(db)
 	th.server = s
+	th.sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB'`)
 
 	return th, func() {
 		dirCleanupFn()

--- a/pkg/ccl/backupccl/helpers_test.go
+++ b/pkg/ccl/backupccl/helpers_test.go
@@ -80,6 +80,12 @@ func backupRestoreTestSetupWithParams(
 	bankData := bank.FromConfig(numAccounts, numAccounts, payloadSize, splits)
 
 	sqlDB = sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	// Set the max buffer size to something low to prevent backup/restore tests
+	// from hitting OOM errors. If any test cares about this setting in
+	// particular, they will override it inline after setting up the test cluster.
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '16MiB'`)
+
 	sqlDB.Exec(t, `CREATE DATABASE data`)
 	l := workloadsql.InsertsDataLoader{BatchSize: 1000, Concurrency: 4}
 	if _, err := workloadsql.Setup(ctx, sqlDB.DB.(*gosql.DB), bankData, l); err != nil {


### PR DESCRIPTION
This change bumps the `bulkio.backup.merge_file_buffer_size` value
to 128MiB from its previous default of 16MiB. This setting determines
the maximum byte size of ssts that can be buffered during a backup
before the queue needs to be flushed.

Instead of always using 128MiB, we incrementally grow the
boundaccount associated with the backup processor from 32MiB
to the cluster settings value, in increments of 32MiB.

Release note (sql change): `bulkio.backup.merge_file_buffer_size`
default value has been changed from 16MiB to 128MiB. This value determines
the maximum byte size of SSTs that we buffer before forcing a flush
during a backup.