### PR TITLE
vendor: bump Pebble to 19e11cfe195f

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1263,10 +1263,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "e411c1b5f5c7d2ef9dc337615de7b51051a182bba9c298f540d74d95d8a8f279",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220201221612-38b68e17aa97",
+        sha256 = "945bf10361af6d85419d8e02ad93ec49b3bf6f2e60599296f2fa8091dcf83111",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220203230416-19e11cfe195f",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220201221612-38b68e17aa97.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220203230416-19e11cfe195f.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220201221612-38b68e17aa97
+	github.com/cockroachdb/pebble v0.0.0-20220203230416-19e11cfe195f
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220201221612-38b68e17aa97 h1:zHSurQDtRibMUCQnJhUeV96D5tO8Vq9L39L/xr4BayI=
-github.com/cockroachdb/pebble v0.0.0-20220201221612-38b68e17aa97/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220203230416-19e11cfe195f h1:AhOD3m/cV+YeDtzJytgHoxn6b89yPXHg7or48EiXTps=
+github.com/cockroachdb/pebble v0.0.0-20220203230416-19e11cfe195f/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.1/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -55,10 +55,9 @@ func (noopSyncCloser) Close() error {
 // MakeBackupSSTWriter creates a new SSTWriter tailored for backup SSTs which
 // are typically only ever iterated in their entirety.
 func MakeBackupSSTWriter(f io.Writer) SSTWriter {
-	opts := DefaultPebbleOptions().MakeWriterOptions(0)
+	opts := DefaultPebbleOptions().MakeWriterOptions(0, sstable.TableFormatRocksDBv2)
 	// Don't need BlockPropertyCollectors for backups.
 	opts.BlockPropertyCollectors = nil
-	opts.TableFormat = sstable.TableFormatRocksDBv2
 
 	// Disable bloom filters since we only ever iterate backups.
 	opts.FilterPolicy = nil
@@ -76,12 +75,11 @@ func MakeBackupSSTWriter(f io.Writer) SSTWriter {
 // These SSTs have bloom filters enabled (as set in DefaultPebbleOptions) and
 // format set to RocksDBv2.
 func MakeIngestionSSTWriter(f writeCloseSyncer) SSTWriter {
-	opts := DefaultPebbleOptions().MakeWriterOptions(0)
+	opts := DefaultPebbleOptions().MakeWriterOptions(0, sstable.TableFormatRocksDBv2)
 	// TODO(sumeer): we should use BlockPropertyCollectors here if the cluster
 	// version permits (which is also reflected in the store's roachpb.Version
 	// and pebble.FormatMajorVersion).
 	opts.BlockPropertyCollectors = nil
-	opts.TableFormat = sstable.TableFormatRocksDBv2
 	opts.MergerName = "nullptr"
 	sst := sstable.NewWriter(f, opts)
 	return SSTWriter{fw: sst, f: f}


### PR DESCRIPTION
19e11cfe sstable: extend property collector API for suffix rewrites
f526c71f db: integrate range keys into indexed batches
116d0b3d compaction: avoid arbitrary grandparent overlap
a860bbad compaction: don't split outputs within a user key
6c9f7128 *: infer `sstable.TableFormat` from `FormatMajorVerison`

Release note: none.