### PR TITLE
bazel: run `yarn --check-files` to validate `node_modules` consistency

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -111,6 +111,17 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, additionalBazelArgs...)
 
 	if cross == "" {
+		// run "yarn --check-files" before any bazel target that includes UI to ensure that node_modules dir is consistent
+		// see related issue: https://github.com/cockroachdb/cockroach/issues/70867
+		for _, arg := range args {
+			if arg == "--config=with_ui" {
+				logCommand("bazel", "run", "@nodejs//:yarn", "--", "--check-files", "--cwd", "pkg/ui", "--offline")
+				if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "run", "@nodejs//:yarn", "--", "--check-files", "--cwd", "pkg/ui", "--offline"); err != nil {
+					return err
+				}
+				break
+			}
+		}
 		logCommand("bazel", args...)
 		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err
@@ -146,6 +157,12 @@ func (d *dev) crossBuild(
 	// but that's hard and I don't think it's necessary for now.
 	script.WriteString(fmt.Sprintf("bazel %s\n", strings.Join(bazelArgs, " ")))
 	script.WriteString(fmt.Sprintf("BAZELBIN=`bazel info bazel-bin --color=no --config=%s --config=ci`\n", crossConfig))
+	for _, arg := range bazelArgs {
+		if arg == "--config=with_ui" {
+			script.WriteString("bazel run @nodejs//:yarn -- --check-files --cwd pkg/ui --offline\n")
+			break
+		}
+	}
 	for _, target := range targets {
 		output := bazelutil.OutputOfBinaryRule(target.fullName, strings.Contains(crossConfig, "windows"))
 		script.WriteString(fmt.Sprintf("cp $BAZELBIN/%s /artifacts\n", output))

--- a/pkg/cmd/dev/testdata/build.txt
+++ b/pkg/cmd/dev/testdata/build.txt
@@ -57,6 +57,7 @@ ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroac
 
 dev build --skip-generate -- --verbose_failures --sandbox_debug
 ----
+bazel run @nodejs//:yarn -- --check-files --cwd pkg/ui --offline
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
 mkdir go/src/github.com/cockroachdb/cockroach/bin
 bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/recording/build.txt
+++ b/pkg/cmd/dev/testdata/recording/build.txt
@@ -144,6 +144,9 @@ rm go/src/github.com/cockroachdb/cockroach/cockroach-short
 ln -s /private/var/tmp/_bazel/99e666e4e674209ecdb66b46371278df/execroot/cockroach/bazel-out/darwin-fastbuild/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short go/src/github.com/cockroachdb/cockroach/cockroach-short
 ----
 
+bazel run @nodejs//:yarn -- --check-files --cwd pkg/ui --offline
+----
+
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
 ----
 


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/70867

Before, running `make build` and then `dev build` caused bazel build
to fail because of missing `node_modules` dependencies.

One of possible reasons of these might be in Make target `pkg/ui/yarn.installed`,
where `@types/node` module is removed manually after running `yarn install`
(`rm -rf pkg/ui/node_modules/@types/node`). It leads to the state where missing
package in `node_modules` cannot be found by `bazel`.

Current change resolves this issue by running `yarn --check-files` command
before every bazel build that includes ui, to ensure consistency of `node_modules`.

Release note: none