### PR TITLE
kvserver: stop reconciling lease count imbalances in the `StoreRebalancer`

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -553,9 +553,8 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		}
 
 		// Don't bother moving ranges whose QPS is below some small fraction of the
-		// store's QPS (unless the store has extra ranges to spare anyway). It's
-		// just unnecessary churn with no benefit to move ranges responsible for,
-		// for example, 1 qps on a store with 5000 qps.
+		// store's QPS. It's just unnecessary churn with no benefit to move ranges
+		// responsible for, for example, 1 qps on a store with 5000 qps.
 		const minQPSFraction = .001
 		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction {
 			log.VEventf(

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -440,12 +440,10 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		}
 
 		// Don't bother moving leases whose QPS is below some small fraction of the
-		// store's QPS (unless the store has extra leases to spare anyway). It's
-		// just unnecessary churn with no benefit to move leases responsible for,
-		// for example, 1 qps on a store with 5000 qps.
+		// store's QPS. It's just unnecessary churn with no benefit to move leases
+		// responsible for, for example, 1 qps on a store with 5000 qps.
 		const minQPSFraction = .001
-		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction &&
-			float64(localDesc.Capacity.LeaseCount) <= storeList.candidateLeases.mean {
+		if replWithStats.qps < localDesc.Capacity.QueriesPerSecond*minQPSFraction {
 			log.VEventf(ctx, 3, "r%d's %.2f qps is too little to matter relative to s%d's %.2f total qps",
 				replWithStats.repl.RangeID, replWithStats.qps, localDesc.StoreID, localDesc.Capacity.QueriesPerSecond)
 			continue


### PR DESCRIPTION
Generally, the `StoreRebalancer` doesn't try to attempt lease transfers for
replicas that account for less than 0.1% of the store's total QPS. However, it
allows such lease transfers if the store has a higher than average number of
leases. This is fraught because of the following reasons:

1. It doesn't adhere to any padding. It will do these tiny lease transfers
until the store has less than or equal to the average number of leases.
2. Additionally, "average" here means the average across the cluster, not just
the stores that have replicas for the range. This is clearly not good, as this
doesn't translate well to heterogeneously loaded clusters.
3. These lease transfers also don't adhere to
`kv.allocator.min_lease_transfer_interval`. This means they are not rate
limited like the lease transfers done by the replicateQueue.

This patch fixes this behavior. This patch is similar to #64559.

Noticed while running a tpcc workload on a multi-region cluster, but on a
database constrained to a single region. This was done to simulate a
"heterogeneously loaded cluster".

Release note: None
