### PR TITLE
sql: alias idle_session_timeout to idle_in_session_timeout

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4675,6 +4675,7 @@ force_savepoint_restart                               off
 foreign_key_cascades_limit                            10000
 idle_in_session_timeout                               0
 idle_in_transaction_session_timeout                   0
+idle_session_timeout                                  0
 index_recommendations_enabled                         off
 inject_retry_errors_enabled                           off
 integer_datetimes                                     on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4092,6 +4092,7 @@ force_savepoint_restart                               off                 NULL  
 foreign_key_cascades_limit                            10000               NULL      NULL        NULL        string
 idle_in_session_timeout                               0                   NULL      NULL        NULL        string
 idle_in_transaction_session_timeout                   0                   NULL      NULL        NULL        string
+idle_session_timeout                                  0                   NULL      NULL        NULL        string
 index_recommendations_enabled                         off                 NULL      NULL        NULL        string
 inject_retry_errors_enabled                           off                 NULL      NULL        NULL        string
 integer_datetimes                                     on                  NULL      NULL        NULL        string
@@ -4206,6 +4207,7 @@ force_savepoint_restart                               off                 NULL  
 foreign_key_cascades_limit                            10000               NULL  user     NULL      10000               10000
 idle_in_session_timeout                               0                   NULL  user     NULL      0s                  0s
 idle_in_transaction_session_timeout                   0                   NULL  user     NULL      0s                  0s
+idle_session_timeout                                  0                   NULL  user     NULL      0s                  0s
 index_recommendations_enabled                         off                 NULL  user     NULL      on                  on
 inject_retry_errors_enabled                           off                 NULL  user     NULL      off                 off
 integer_datetimes                                     on                  NULL  user     NULL      on                  on
@@ -4315,6 +4317,7 @@ force_savepoint_restart                               NULL    NULL     NULL     
 foreign_key_cascades_limit                            NULL    NULL     NULL     NULL        NULL
 idle_in_session_timeout                               NULL    NULL     NULL     NULL        NULL
 idle_in_transaction_session_timeout                   NULL    NULL     NULL     NULL        NULL
+idle_session_timeout                                  NULL    NULL     NULL     NULL        NULL
 index_recommendations_enabled                         NULL    NULL     NULL     NULL        NULL
 inject_retry_errors_enabled                           NULL    NULL     NULL     NULL        NULL
 integer_datetimes                                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -394,13 +394,23 @@ SHOW idle_in_session_timeout
 ----
 10000
 
+query T
+SHOW idle_session_timeout
+----
+10000
+
 statement ok
-SET idle_in_session_timeout = 10000
+SET idle_session_timeout = 100000
 
 query T
 SHOW idle_in_session_timeout
 ----
-10000
+100000
+
+query T
+SHOW idle_session_timeout
+----
+100000
 
 statement ok
 SET idle_in_session_timeout = 0;

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -70,6 +70,7 @@ force_savepoint_restart                               off
 foreign_key_cascades_limit                            10000
 idle_in_session_timeout                               0
 idle_in_transaction_session_timeout                   0
+idle_session_timeout                                  0
 index_recommendations_enabled                         off
 inject_retry_errors_enabled                           off
 integer_datetimes                                     on

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1937,6 +1937,11 @@ func init() {
 	for k, v := range DummyVars {
 		varGen[k] = v
 	}
+
+	// Alias `idle_session_timeout` to match the PG 14 name.
+	// We create `idle_in_session_timeout` before its existence.
+	varGen[`idle_session_timeout`] = varGen[`idle_in_session_timeout`]
+
 	// Initialize delegate.ValidVars.
 	for v := range varGen {
 		delegate.ValidVars[v] = struct{}{}


### PR DESCRIPTION
Resolves #75984

Release note (sql change): Alias the `idle_session_timeout` session
variable with the `idle_in_session_timeout` variable - the former of
which aligns with the PG14 name and the latter introduced by us
beforehand. Setting or getting either session variable will alter or
return the same thing.