### PR TITLE
roachprod: fix newlines in cluster creation output

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1982,6 +1982,9 @@ func (c *SyncedCluster) ParallelE(
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
 		fmt.Fprintf(out, "%s", display)
+		if l.File != nil {
+			fmt.Fprintf(out, "\n")
+		}
 	}
 	defer ticker.Stop()
 	complete := make([]bool, count)


### PR DESCRIPTION
This fixes cluster creation output when used by roachtest. Before:

```
grinaker-1643969948-01-n4cpu8: waiting for nodes to startgenerating ssh keydistributing ssh keyretrieving hostsscanning hostsdistributing known_hostsadding additional authorized keys10:21:09 test_runner.go:503: [w0] starting test: kv95/enc=false/nodes=3:1
```

After:

```
grinaker-1643970202-01-n4cpu8: waiting for nodes to start
generating ssh key
distributing ssh key
retrieving hosts
scanning hosts
distributing known_hosts
adding additional authorized keys
10:25:21 test_runner.go:503: [w0] starting test: kv95/enc=false/nodes=3:1
```

Release note: None