### PR TITLE
release-21.2: server: extend the HTTP endpoint definitions

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
@@ -11,7 +11,6 @@ package statusccl
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -73,12 +72,12 @@ func TestTenantGRPCServices(t *testing.T) {
 		require.NotEmpty(t, resp.Statements)
 	})
 
-	httpClient, err := tenant.RPCContext().GetHTTPClient()
+	httpClient, err := tenant.GetAdminAuthenticatedHTTPClient()
 	require.NoError(t, err)
+	defer httpClient.CloseIdleConnections()
 
 	t.Run("gRPC Gateway is running", func(t *testing.T) {
-		resp, err := httpClient.Get("https://" + tenant.HTTPAddr() + "/_status/statements")
-		defer http.DefaultClient.CloseIdleConnections()
+		resp, err := httpClient.Get(tenant.AdminURL() + "/_status/statements")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
@@ -98,8 +97,7 @@ func TestTenantGRPCServices(t *testing.T) {
 	defer connTenant2.Close()
 
 	t.Run("statements endpoint fans out request to multiple pods", func(t *testing.T) {
-		resp, err := httpClient.Get("https://" + tenant2.HTTPAddr() + "/_status/statements")
-		defer http.DefaultClient.CloseIdleConnections()
+		resp, err := httpClient.Get(tenant2.AdminURL() + "/_status/statements")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
@@ -115,8 +113,11 @@ func TestTenantGRPCServices(t *testing.T) {
 	defer connTenant3.Close()
 
 	t.Run("fanout of statements endpoint is segregated by tenant", func(t *testing.T) {
-		resp, err := httpClient.Get("https://" + tenant3.HTTPAddr() + "/_status/statements")
-		defer http.DefaultClient.CloseIdleConnections()
+		httpClient3, err := tenant3.GetAdminAuthenticatedHTTPClient()
+		require.NoError(t, err)
+		defer httpClient3.CloseIdleConnections()
+
+		resp, err := httpClient3.Get(tenant3.AdminURL() + "/_status/statements")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
@@ -154,9 +155,9 @@ func TestTenantGRPCServices(t *testing.T) {
 	})
 
 	t.Run("sessions endpoint is available", func(t *testing.T) {
-		resp, err := httpClient.Get("https://" + tenant.HTTPAddr() + "/_status/sessions")
-		defer http.DefaultClient.CloseIdleConnections()
+		resp, err := httpClient.Get(tenant.AdminURL() + "/_status/sessions")
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		require.Equal(t, 200, resp.StatusCode)
 	})
 }

--- a/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
@@ -161,9 +161,9 @@ func (c tenantCluster) tenantConn(idx serverIdx) *sqlutils.SQLRunner {
 }
 
 func (c tenantCluster) tenantHTTPClient(t *testing.T, idx serverIdx) *httpClient {
-	client, err := c.tenant(idx).tenant.RPCContext().GetHTTPClient()
+	client, err := c.tenant(idx).tenant.GetAdminAuthenticatedHTTPClient()
 	require.NoError(t, err)
-	return &httpClient{t: t, client: client, baseURL: "https://" + c[idx].tenant.HTTPAddr()}
+	return &httpClient{t: t, client: client, baseURL: c[idx].tenant.AdminURL()}
 }
 
 func (c tenantCluster) tenantSQLStats(idx serverIdx) *persistedsqlstats.PersistedSQLStats {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "tenant_status.go",
         "testing_knobs.go",
         "testserver.go",
+        "testserver_http.go",
         "user.go",
     ],
     cgo = True,

--- a/pkg/server/api_v2_auth.go
+++ b/pkg/server/api_v2_auth.go
@@ -50,7 +50,7 @@ func newAuthenticationV2Server(
 
 	authServer := &authenticationV2Server{
 		sqlServer:  s.sqlServer,
-		authServer: newAuthenticationServer(s),
+		authServer: newAuthenticationServer(s.cfg.Config, s.sqlServer),
 		mux:        simpleMux,
 		ctx:        ctx,
 		basePath:   basePath,

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -94,14 +95,16 @@ var webSessionTimeout = settings.RegisterDurationSetting(
 ).WithPublic()
 
 type authenticationServer struct {
-	server *Server
+	cfg       *base.Config
+	sqlServer *SQLServer
 }
 
 // newAuthenticationServer allocates and returns a new REST server for
 // authentication APIs.
-func newAuthenticationServer(s *Server) *authenticationServer {
+func newAuthenticationServer(cfg *base.Config, s *SQLServer) *authenticationServer {
 	return &authenticationServer{
-		server: s,
+		cfg:       cfg,
+		sqlServer: s,
 	}
 }
 
@@ -256,8 +259,8 @@ func (s *authenticationServer) UserLoginFromSSO(
 
 	exists, _, canLoginDBConsole, _, _, _, _, err := sql.GetUserSessionInitInfo(
 		ctx,
-		s.server.sqlServer.execCfg,
-		s.server.sqlServer.execCfg.InternalExecutor,
+		s.sqlServer.execCfg,
+		s.sqlServer.execCfg.InternalExecutor,
 		username,
 		"", /* databaseName */
 	)
@@ -291,7 +294,7 @@ func (s *authenticationServer) createSessionFor(
 		ID:     id,
 		Secret: secret,
 	}
-	return EncodeSessionCookie(cookieValue, !s.server.cfg.DisableTLSForHTTP)
+	return EncodeSessionCookie(cookieValue, !s.cfg.DisableTLSForHTTP)
 }
 
 // UserLogout allows a user to terminate their currently active session.
@@ -315,7 +318,7 @@ func (s *authenticationServer) UserLogout(
 	}
 
 	// Revoke the session.
-	if n, err := s.server.sqlServer.internalExecutor.ExecEx(
+	if n, err := s.sqlServer.internalExecutor.ExecEx(
 		ctx,
 		"revoke-auth-session",
 		nil, /* txn */
@@ -365,7 +368,7 @@ WHERE id = $1`
 		isRevoked    bool
 	)
 
-	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
+	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx,
 		"lookup-auth-session",
 		nil, /* txn */
@@ -392,7 +395,7 @@ WHERE id = $1`
 		return false, "", nil
 	}
 
-	if now := s.server.clock.PhysicalTime(); !now.Before(expiresAt) {
+	if now := s.sqlServer.execCfg.Clock.PhysicalTime(); !now.Before(expiresAt) {
 		return false, "", nil
 	}
 
@@ -421,8 +424,8 @@ func (s *authenticationServer) verifyPasswordDBConsole(
 ) (valid bool, expired bool, err error) {
 	exists, _, canLoginDBConsole, _, validUntil, _, pwRetrieveFn, err := sql.GetUserSessionInitInfo(
 		ctx,
-		s.server.sqlServer.execCfg,
-		s.server.sqlServer.execCfg.InternalExecutor,
+		s.sqlServer.execCfg,
+		s.sqlServer.execCfg.InternalExecutor,
 		username,
 		"", /* databaseName */
 	)
@@ -471,7 +474,7 @@ func (s *authenticationServer) newAuthSession(
 		return 0, nil, err
 	}
 
-	expiration := s.server.clock.PhysicalTime().Add(webSessionTimeout.Get(&s.server.st.SV))
+	expiration := s.sqlServer.execCfg.Clock.PhysicalTime().Add(webSessionTimeout.Get(&s.sqlServer.execCfg.Settings.SV))
 
 	insertSessionStmt := `
 INSERT INTO system.web_sessions ("hashedSecret", username, "expiresAt")
@@ -480,7 +483,7 @@ RETURNING id
 `
 	var id int64
 
-	row, err := s.server.sqlServer.internalExecutor.QueryRowEx(
+	row, err := s.sqlServer.internalExecutor.QueryRowEx(
 		ctx,
 		"create-auth-session",
 		nil, /* txn */

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -109,7 +109,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -708,14 +708,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		flowScheduler,
 		internalExecutor,
 	)
-	// TODO(tbg): don't pass all of Server into this to avoid this hack.
-	sAuth := newAuthenticationServer(lateBoundServer)
-	for i, gw := range []grpcGatewayServer{sAdmin, sStatus, sAuth, &sTS} {
-		if reflect.ValueOf(gw).IsNil() {
-			return nil, errors.Errorf("%d: nil", i)
-		}
-		gw.RegisterService(grpcServer.Server)
-	}
 
 	var jobAdoptionStopFile string
 	for _, spec := range cfg.Stores.Specs {
@@ -775,6 +767,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	sAuth := newAuthenticationServer(cfg.Config, sqlServer)
+	for i, gw := range []grpcGatewayServer{sAdmin, sStatus, sAuth, &sTS} {
+		if reflect.ValueOf(gw).IsNil() {
+			return nil, errors.Errorf("%d: nil", i)
+		}
+		gw.RegisterService(grpcServer.Server)
+	}
+
 	sStatus.setStmtDiagnosticsRequester(sqlServer.execCfg.StmtDiagnosticsRecorder)
 	sStatus.baseStatusServer.sqlServer = sqlServer
 	debugServer := debug.NewServer(st, sqlServer.pgServer.HBADebugFn(), sStatus)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -98,13 +98,13 @@ func makeTestBaseConfig(st *cluster.Settings) BaseConfig {
 	baseCfg.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	baseCfg.User = security.NodeUserName()
+	// Enable web session authentication.
+	baseCfg.EnableWebSessionAuthentication = true
 	return baseCfg
 }
 
 func makeTestKVConfig() KVConfig {
 	kvCfg := MakeKVConfig(base.DefaultTestStoreSpec)
-	// Enable web session authentication.
-	kvCfg.EnableWebSessionAuthentication = true
 	return kvCfg
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -13,14 +13,10 @@ package server
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/http"
-	"net/http/cookiejar"
-	"net/url"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -40,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -56,7 +51,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
@@ -295,14 +289,8 @@ type TestServer struct {
 	params base.TestServerArgs
 	// server is the embedded Cockroach server struct.
 	*Server
-	// authClient is an http.Client that has been authenticated to access the
-	// Admin UI.
-	authClient [2]struct {
-		httpClient http.Client
-		cookie     *serverpb.SessionCookie
-		once       sync.Once
-		err        error
-	}
+	// httpTestServer provides the HTTP APIs of TestTenantInterface.
+	*httpTestServer
 }
 
 // Node returns the Node as an interface{}.
@@ -487,6 +475,7 @@ type TestTenant struct {
 	Cfg      *BaseConfig
 	sqlAddr  string
 	httpAddr string
+	*httpTestServer
 }
 
 // SQLAddr is part of the TestTenantInterface interface.
@@ -596,14 +585,25 @@ func (ts *TestServer) StartTenant(
 	if params.RPCHeartbeatInterval != 0 {
 		baseCfg.RPCHeartbeatInterval = params.RPCHeartbeatInterval
 	}
-	sqlServer, addr, httpAddr, err := StartTenant(
+	sqlServer, authServer, addr, httpAddr, err := startTenantInternal(
 		ctx,
 		stopper,
 		ts.Cfg.ClusterName,
 		baseCfg,
 		sqlCfg,
 	)
-	return &TestTenant{SQLServer: sqlServer, Cfg: &baseCfg, sqlAddr: addr, httpAddr: httpAddr}, err
+
+	hts := &httpTestServer{}
+	hts.t.authentication = authServer
+	hts.t.sqlServer = sqlServer
+
+	return &TestTenant{
+		SQLServer:      sqlServer,
+		Cfg:            &baseCfg,
+		sqlAddr:        addr,
+		httpAddr:       httpAddr,
+		httpTestServer: hts,
+	}, err
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should
@@ -708,16 +708,6 @@ func (ts *TestServer) WriteSummaries() error {
 	return ts.node.writeNodeStatus(context.TODO(), time.Hour, false)
 }
 
-// AdminURL implements TestServerInterface.
-func (ts *TestServer) AdminURL() string {
-	return ts.Cfg.AdminURL().String()
-}
-
-// GetHTTPClient implements TestServerInterface.
-func (ts *TestServer) GetHTTPClient() (http.Client, error) {
-	return ts.Server.rpcContext.GetHTTPClient()
-}
-
 // UpdateChecker implements TestServerInterface.
 func (ts *TestServer) UpdateChecker() interface{} {
 	return ts.Server.updates
@@ -740,22 +730,6 @@ func authenticatedUserNameNoAdmin() security.SQLUsername {
 	return security.MakeSQLUsernameFromPreNormalizedString(authenticatedUserNoAdmin)
 }
 
-// GetAdminAuthenticatedHTTPClient implements the TestServerInterface.
-func (ts *TestServer) GetAdminAuthenticatedHTTPClient() (http.Client, error) {
-	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
-	return httpClient, err
-}
-
-// GetAuthenticatedHTTPClient implements the TestServerInterface.
-func (ts *TestServer) GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error) {
-	authUser := authenticatedUserName()
-	if !isAdmin {
-		authUser = authenticatedUserNameNoAdmin()
-	}
-	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authUser, isAdmin)
-	return httpClient, err
-}
-
 type v2AuthDecorator struct {
 	http.RoundTripper
 
@@ -765,88 +739,6 @@ type v2AuthDecorator struct {
 func (v *v2AuthDecorator) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Add(apiV2AuthHeader, v.session)
 	return v.RoundTripper.RoundTrip(r)
-}
-
-func (ts *TestServer) getAuthenticatedHTTPClientAndCookie(
-	authUser security.SQLUsername, isAdmin bool,
-) (http.Client, *serverpb.SessionCookie, error) {
-	authIdx := 0
-	if isAdmin {
-		authIdx = 1
-	}
-	authClient := &ts.authClient[authIdx]
-	authClient.once.Do(func() {
-		// Create an authentication session for an arbitrary admin user.
-		authClient.err = func() error {
-			// The user needs to exist as the admin endpoints will check its role.
-			if err := ts.createAuthUser(authUser, isAdmin); err != nil {
-				return err
-			}
-
-			id, secret, err := ts.authentication.newAuthSession(context.TODO(), authUser)
-			if err != nil {
-				return err
-			}
-			rawCookie := &serverpb.SessionCookie{
-				ID:     id,
-				Secret: secret,
-			}
-			// Encode a session cookie and store it in a cookie jar.
-			cookie, err := EncodeSessionCookie(rawCookie, false /* forHTTPSOnly */)
-			if err != nil {
-				return err
-			}
-			cookieJar, err := cookiejar.New(nil)
-			if err != nil {
-				return err
-			}
-			url, err := url.Parse(ts.AdminURL())
-			if err != nil {
-				return err
-			}
-			cookieJar.SetCookies(url, []*http.Cookie{cookie})
-			// Create an httpClient and attach the cookie jar to the client.
-			authClient.httpClient, err = ts.rpcContext.GetHTTPClient()
-			if err != nil {
-				return err
-			}
-			rawCookieBytes, err := protoutil.Marshal(rawCookie)
-			if err != nil {
-				return err
-			}
-			authClient.httpClient.Transport = &v2AuthDecorator{
-				RoundTripper: authClient.httpClient.Transport,
-				session:      base64.StdEncoding.EncodeToString(rawCookieBytes),
-			}
-			authClient.httpClient.Jar = cookieJar
-			authClient.cookie = rawCookie
-			return nil
-		}()
-	})
-
-	return authClient.httpClient, authClient.cookie, authClient.err
-}
-
-func (ts *TestServer) createAuthUser(userName security.SQLUsername, isAdmin bool) error {
-	if _, err := ts.Server.sqlServer.internalExecutor.ExecEx(context.TODO(),
-		"create-auth-user", nil,
-		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-		"CREATE USER $1", userName.Normalized(),
-	); err != nil {
-		return err
-	}
-	if isAdmin {
-		// We can't use the GRANT statement here because we don't want
-		// to rely on CCL code.
-		if _, err := ts.Server.sqlServer.internalExecutor.ExecEx(context.TODO(),
-			"grant-admin", nil,
-			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
-			"INSERT INTO system.role_members (role, member, \"isAdmin\") VALUES ('admin', $1, true)", userName.Normalized(),
-		); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // MustGetSQLCounter implements TestServerInterface.
@@ -1326,6 +1218,12 @@ func (testServerFactoryImpl) New(params base.TestServerArgs) (interface{}, error
 
 	// Our context must be shared with our server.
 	ts.Cfg = &ts.Server.cfg
+
+	// The HTTP APIs on TestTenantInterface are implemented by
+	// httpTestServer.
+	ts.httpTestServer = &httpTestServer{}
+	ts.httpTestServer.t.authentication = ts.Server.authentication
+	ts.httpTestServer.t.sqlServer = ts.Server.sqlServer
 
 	return ts, nil
 }

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -1,0 +1,154 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+// httpTestServer is embedded in TestServer / TenantServer to
+// provide the HTTP API subset of TestTenantInterface.
+type httpTestServer struct {
+	t struct {
+		// We need a sub-struct to avoid ambiguous overlap with the fields
+		// of *Server, which are also embedded in TestServer.
+		authentication *authenticationServer
+		sqlServer      *SQLServer
+	}
+
+	// authClient is an http.Client that has been authenticated to access the
+	// Admin UI.
+	authClient [2]struct {
+		httpClient http.Client
+		cookie     *serverpb.SessionCookie
+		once       sync.Once
+		err        error
+	}
+}
+
+// AdminURL implements TestServerInterface.
+func (ts *httpTestServer) AdminURL() string {
+	return ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL().String()
+}
+
+// GetHTTPClient implements TestServerInterface.
+func (ts *httpTestServer) GetHTTPClient() (http.Client, error) {
+	return ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
+}
+
+// GetAdminAuthenticatedHTTPClient implements the TestServerInterface.
+func (ts *httpTestServer) GetAdminAuthenticatedHTTPClient() (http.Client, error) {
+	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
+	return httpClient, err
+}
+
+// GetAuthenticatedHTTPClient implements the TestServerInterface.
+func (ts *httpTestServer) GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error) {
+	authUser := authenticatedUserName()
+	if !isAdmin {
+		authUser = authenticatedUserNameNoAdmin()
+	}
+	httpClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authUser, isAdmin)
+	return httpClient, err
+}
+
+func (ts *httpTestServer) getAuthenticatedHTTPClientAndCookie(
+	authUser security.SQLUsername, isAdmin bool,
+) (http.Client, *serverpb.SessionCookie, error) {
+	authIdx := 0
+	if isAdmin {
+		authIdx = 1
+	}
+	authClient := &ts.authClient[authIdx]
+	authClient.once.Do(func() {
+		// Create an authentication session for an arbitrary admin user.
+		authClient.err = func() error {
+			// The user needs to exist as the admin endpoints will check its role.
+			if err := ts.createAuthUser(authUser, isAdmin); err != nil {
+				return err
+			}
+
+			id, secret, err := ts.t.authentication.newAuthSession(context.TODO(), authUser)
+			if err != nil {
+				return err
+			}
+			rawCookie := &serverpb.SessionCookie{
+				ID:     id,
+				Secret: secret,
+			}
+			// Encode a session cookie and store it in a cookie jar.
+			cookie, err := EncodeSessionCookie(rawCookie, false /* forHTTPSOnly */)
+			if err != nil {
+				return err
+			}
+			cookieJar, err := cookiejar.New(nil)
+			if err != nil {
+				return err
+			}
+			url, err := url.Parse(ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL().String())
+			if err != nil {
+				return err
+			}
+			cookieJar.SetCookies(url, []*http.Cookie{cookie})
+			// Create an httpClient and attach the cookie jar to the client.
+			authClient.httpClient, err = ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
+			if err != nil {
+				return err
+			}
+			rawCookieBytes, err := protoutil.Marshal(rawCookie)
+			if err != nil {
+				return err
+			}
+			authClient.httpClient.Transport = &v2AuthDecorator{
+				RoundTripper: authClient.httpClient.Transport,
+				session:      base64.StdEncoding.EncodeToString(rawCookieBytes),
+			}
+			authClient.httpClient.Jar = cookieJar
+			authClient.cookie = rawCookie
+			return nil
+		}()
+	})
+
+	return authClient.httpClient, authClient.cookie, authClient.err
+}
+
+func (ts *httpTestServer) createAuthUser(userName security.SQLUsername, isAdmin bool) error {
+	if _, err := ts.t.sqlServer.internalExecutor.ExecEx(context.TODO(),
+		"create-auth-user", nil,
+		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+		fmt.Sprintf("CREATE USER %s", userName.Normalized()),
+	); err != nil {
+		return err
+	}
+	if isAdmin {
+		// We can't use the GRANT statement here because we don't want
+		// to rely on CCL code.
+		if _, err := ts.t.sqlServer.internalExecutor.ExecEx(context.TODO(),
+			"grant-admin", nil,
+			sessiondata.InternalExecutorOverride{User: security.RootUserName()},
+			"INSERT INTO system.role_members (role, member, \"isAdmin\") VALUES ('admin', $1, true)", userName.Normalized(),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -14,6 +14,8 @@
 package serverutils
 
 import (
+	"net/http"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 )
@@ -56,4 +58,17 @@ type TestTenantInterface interface {
 
 	// RPCContext returns the *rpc.Context
 	RPCContext() *rpc.Context
+
+	// AdminURL returns the URL for the admin UI.
+	AdminURL() string
+	// GetHTTPClient returns an http client configured with the client TLS
+	// config required by the TestServer's configuration.
+	GetHTTPClient() (http.Client, error)
+	// GetAdminAuthenticatedHTTPClient returns an http client which has been
+	// authenticated to access Admin API methods (via a cookie).
+	// The user has admin privileges.
+	GetAdminAuthenticatedHTTPClient() (http.Client, error)
+	// GetAuthenticatedHTTPClient returns an http client which has been
+	// authenticated to access Admin API methods (via a cookie).
+	GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error)
 }


### PR DESCRIPTION
This is a scaled down version of #75852, which focuses on tighter checks on the SQL/debug endpoints.

