### PR TITLE
sql: support bucket_count storage parameter

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -214,9 +214,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 				if d.PrimaryKey {
 					// Translate this operation into an ALTER PRIMARY KEY command.
 					alterPK := &tree.AlterTableAlterPrimaryKey{
-						Columns: d.Columns,
-						Sharded: d.Sharded,
-						Name:    d.Name,
+						Columns:       d.Columns,
+						Sharded:       d.Sharded,
+						Name:          d.Name,
+						StorageParams: d.StorageParams,
 					}
 					if err := params.p.AlterPrimaryKey(
 						params.ctx,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1533,7 +1533,7 @@ func NewTableDesc(
 				if n.PartitionByTable.ContainsPartitions() {
 					return nil, pgerror.New(pgcode.FeatureNotSupported, "sharded indexes don't support partitioning")
 				}
-				buckets, err := tabledesc.EvalShardBucketCount(ctx, semaCtx, evalCtx, d.PrimaryKey.ShardBuckets)
+				buckets, err := tabledesc.EvalShardBucketCount(ctx, semaCtx, evalCtx, d.PrimaryKey.ShardBuckets, d.PrimaryKey.StorageParams)
 				if err != nil {
 					return nil, err
 				}
@@ -1658,12 +1658,13 @@ func NewTableDesc(
 			d.Sharded.ShardBuckets,
 			&desc,
 			idx,
+			d.StorageParams,
 			true /* isNewTable */)
 		if err != nil {
 			return nil, err
 		}
 
-		buckets, err := tabledesc.EvalShardBucketCount(ctx, semaCtx, evalCtx, d.Sharded.ShardBuckets)
+		buckets, err := tabledesc.EvalShardBucketCount(ctx, semaCtx, evalCtx, d.Sharded.ShardBuckets, d.StorageParams)
 		if err != nil {
 			return nil, err
 		}
@@ -2692,12 +2693,30 @@ func validateUniqueConstraintParamsForCreateTable(n *tree.CreateTable) error {
 	for _, def := range n.Defs {
 		switch d := def.(type) {
 		case *tree.ColumnTableDef:
-			if err := paramparse.ValidateUniqueConstraintParams(d.PrimaryKey.StorageParams, true /* isPK */); err != nil {
+			if err := paramparse.ValidateUniqueConstraintParams(
+				d.PrimaryKey.StorageParams,
+				paramparse.UniqueConstraintParamContext{
+					IsPrimaryKey: true,
+					IsSharded:    d.PrimaryKey.Sharded,
+				}); err != nil {
 				return err
 			}
 		case *tree.UniqueConstraintTableDef:
-			if err := paramparse.ValidateUniqueConstraintParams(d.IndexTableDef.StorageParams, d.PrimaryKey); err != nil {
+			if err := paramparse.ValidateUniqueConstraintParams(
+				d.IndexTableDef.StorageParams,
+				paramparse.UniqueConstraintParamContext{
+					IsPrimaryKey: d.PrimaryKey,
+					IsSharded:    d.Sharded != nil,
+				},
+			); err != nil {
 				return err
+			}
+		case *tree.IndexTableDef:
+			if d.Sharded == nil && d.StorageParams.GetVal(`bucket_count`) != nil {
+				return pgerror.New(
+					pgcode.InvalidParameterValue,
+					`"bucket_count" storage param should only be set with "USING HASH" for hash sharded index`,
+				)
 			}
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1367,13 +1367,35 @@ a  b  k
 subtest test_storage_params_validation
 
 statement ok
-CREATE TABLE t_bad_param (
+CREATE TABLE t_test_param (
   a INT PRIMARY KEY,
-  b INT NOT NULL
+  b INT NOT NULL,
+  FAMILY fam_0_a_b (a, b)
 );
 
 statement error pq: invalid storage param "s2_max_level" on primary key
-ALTER TABLE t_bad_param ALTER PRIMARY KEY USING COLUMNS (b) WITH (s2_max_level=20);
+ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) WITH (s2_max_level=20);
 
 statement error pq: invalid storage param "s2_max_level" on primary key
-ALTER TABLE t_bad_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH (s2_max_level=20);
+ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH (s2_max_level=20);
+
+statement error pq: "bucket_count" storage param should only be set with "USING HASH" for hash sharded index
+ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) WITH (bucket_count=5);
+
+statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
+ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5);
+
+statement ok
+ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH (bucket_count=5);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_test_param]
+----
+CREATE TABLE public.t_test_param (
+   a INT8 NOT NULL,
+   b INT8 NOT NULL,
+   crdb_internal_b_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
+   CONSTRAINT t_test_param_pkey PRIMARY KEY (b ASC) USING HASH WITH BUCKET_COUNT = 5,
+   UNIQUE INDEX t_test_param_a_key (a ASC),
+   FAMILY fam_0_a_b (a, b)
+)

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -362,3 +362,34 @@ SET CLUSTER SETTING jobs.registry.interval.cancel = DEFAULT;
 # Restore the schema changer state back.
 statement ok
 SET experimental_use_new_schema_changer = $schema_changer_state
+
+subtest test_bucket_count_storage_param
+
+statement ok
+CREATE TABLE t_hash (
+  pk INT PRIMARY KEY,
+  a INT,
+  b INT,
+  FAMILY fam_0_pk_a_b (pk, a, b)
+);
+
+statement ok
+CREATE INDEX idx_t_hash_a ON t_hash (a) USING HASH WITH (bucket_count=5);
+
+statement ok
+CREATE UNIQUE INDEX idx_t_hash_b ON t_hash (b) USING HASH WITH (bucket_count=5);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_hash]
+----
+CREATE TABLE public.t_hash (
+   pk INT8 NOT NULL,
+   a INT8 NULL,
+   b INT8 NULL,
+   crdb_internal_a_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
+   crdb_internal_b_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
+   CONSTRAINT t_hash_pkey PRIMARY KEY (pk ASC),
+   INDEX idx_t_hash_a (a ASC) USING HASH WITH BUCKET_COUNT = 5,
+   UNIQUE INDEX idx_t_hash_b (b ASC) USING HASH WITH BUCKET_COUNT = 5,
+   FAMILY fam_0_pk_a_b (pk, a, b)
+)

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -731,6 +731,17 @@ CREATE TABLE t_bad_param (
   a INT PRIMARY KEY USING HASH WITH (s2_max_level=20)
 );
 
+statement error pq: "bucket_count" storage param should only be set with "USING HASH" for hash sharded index
+CREATE TABLE t_bad_param (
+  a INT PRIMARY KEY WITH (bucket_count=5)
+);
+
+statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
+CREATE TABLE t_bad_param (
+  a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5)
+);
+
+
 statement error pq: invalid storage param "s2_max_level" on primary key
 CREATE TABLE t_bad_param (
   a INT NOT NULL,
@@ -741,6 +752,18 @@ statement error pq: invalid storage param "s2_max_level" on primary key
 CREATE TABLE t_bad_param (
   a INT NOT NULL,
   PRIMARY KEY (a) USING HASH WITH (s2_max_level=20)
+);
+
+statement error pq: "bucket_count" storage param should only be set with "USING HASH" for hash sharded index
+CREATE TABLE t_bad_param (
+  a INT NOT NULL,
+  PRIMARY KEY (a) WITH (bucket_count=5)
+);
+
+statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
+CREATE TABLE t_bad_param (
+  a INT NOT NULL,
+  PRIMARY KEY (a) USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5)
 );
 
 statement error pq: invalid storage param "s2_max_level" on primary key
@@ -755,6 +778,18 @@ CREATE TABLE t_bad_param (
   CONSTRAINT t_bad_param_pkey PRIMARY KEY (a) USING HASH WITH (s2_max_level=20)
 );
 
+statement error pq: "bucket_count" storage param should only be set with "USING HASH" for hash sharded index
+CREATE TABLE t_bad_param (
+  a INT NOT NULL,
+  CONSTRAINT t_bad_param_pkey PRIMARY KEY (a) WITH (bucket_count=5)
+);
+
+statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
+CREATE TABLE t_bad_param (
+  a INT NOT NULL,
+  CONSTRAINT t_bad_param_pkey PRIMARY KEY (a) USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5)
+);
+
 statement error pq: invalid storage param "s2_max_level" on unique index
 CREATE TABLE t_bad_param (
   a INT,
@@ -765,6 +800,30 @@ statement error pq: invalid storage param "s2_max_level" on unique index
 CREATE TABLE t_bad_param (
   a INT,
   UNIQUE INDEX (a) USING HASH WITH (s2_max_level=20)
+);
+
+statement error pq: "bucket_count" storage param should only be set with "USING HASH" for hash sharded index
+CREATE TABLE t_bad_param (
+  a INT,
+  UNIQUE INDEX (a) WITH (bucket_count=5)
+);
+
+statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
+CREATE TABLE t_bad_param (
+  a INT,
+  UNIQUE INDEX (a) USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5)
+);
+
+statement error pq: "bucket_count" storage param should only be set with "USING HASH" for hash sharded index
+CREATE TABLE t_bad_param (
+  a INT,
+  INDEX (a) WITH (bucket_count=5)
+);
+
+statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
+CREATE TABLE t_bad_param (
+  a INT,
+  INDEX (a) USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5)
 );
 
 statement ok
@@ -783,4 +842,41 @@ CREATE TABLE t_bad_param (
   PRIMARY KEY (a) WITH (s2_max_level=20)
 ) AS SELECT * FROM t_source;
 
+statement ok
+CREATE TABLE t_good_hash_indexes_1 (
+ a INT PRIMARY KEY USING HASH WITH (bucket_count=5),
+ b INT,
+ c INT,
+ INDEX (b) USING HASH WITH (bucket_count=5),
+ FAMILY "primary" (a, b, c)
+);
 
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_good_hash_indexes_1];
+----
+CREATE TABLE public.t_good_hash_indexes_1 (
+  crdb_internal_a_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  b INT8 NULL,
+  c INT8 NULL,
+  crdb_internal_b_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
+  CONSTRAINT t_good_hash_indexes_1_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 5,
+  INDEX t_good_hash_indexes_1_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 5,
+  FAMILY "primary" (a, b, c)
+)
+
+statement ok
+CREATE TABLE t_good_hash_indexes_2 (
+ a INT,
+ PRIMARY KEY (a) USING HASH WITH (bucket_count=5)
+);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_good_hash_indexes_2];
+----
+CREATE TABLE public.t_good_hash_indexes_2 (
+    a INT8 NOT NULL,
+    crdb_internal_a_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
+    CONSTRAINT t_good_hash_indexes_2_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 5,
+    FAMILY "primary" (a)
+)

--- a/pkg/sql/paramparse/paramobserver.go
+++ b/pkg/sql/paramparse/paramobserver.go
@@ -472,6 +472,10 @@ func (po *IndexStorageParamObserver) onSet(
 		return po.applyS2ConfigSetting(evalCtx, key, expr, 1, 32)
 	case `geometry_min_x`, `geometry_max_x`, `geometry_min_y`, `geometry_max_y`:
 		return po.applyGeometryIndexSetting(evalCtx, key, expr)
+	// `bucket_count` is handled in schema changer when creating hash sharded
+	// indexes.
+	case `bucket_count`:
+		return nil
 	case `vacuum_cleanup_index_scale_factor`,
 		`buffering`,
 		`fastupdate`,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -196,7 +196,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		if rel.IsLocalityRegionalByRow() {
 			panic(pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes are not compatible with REGIONAL BY ROW tables"))
 		}
-		buckets, err := tabledesc.EvalShardBucketCount(b, b.SemaCtx(), b.EvalCtx(), n.Sharded.ShardBuckets)
+		buckets, err := tabledesc.EvalShardBucketCount(b, b.SemaCtx(), b.EvalCtx(), n.Sharded.ShardBuckets, n.StorageParams)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1412,6 +1412,18 @@ func (o *StorageParams) Format(ctx *FmtCtx) {
 	}
 }
 
+// GetVal returns corresponding value if a key exists, otherwise nil is
+// returned.
+func (o *StorageParams) GetVal(key string) Expr {
+	k := Name(key)
+	for _, param := range *o {
+		if param.Key == k {
+			return param.Value
+		}
+	}
+	return nil
+}
+
 // CreateTableOnCommitSetting represents the CREATE TABLE ... ON COMMIT <action>
 // parameters.
 type CreateTableOnCommitSetting uint32


### PR DESCRIPTION
A follow up of pr #75971 .
Will send another pr to update `SHOW CREATE` output.

Release note (sql change): `bucket_count` storage parameter is added.
To create hash sharded index, now we may use the new syntax:
`USING HASH WITH (bucket_count=xxx)`. `bucket_count` storage param can
only be use together with `USING HASH`. The old `WITH BUCKET_COUNT=xxx`
syntax is still supported for backward compatibility. However, only
either the old or new syntax can be used, but not both. Err is returned
for clause like `USING HASH WITH BUCKET_COUNT=5 WITH (bucket_count=5).