### PR TITLE
release-21.1: [CRDB-9007] sql: allow users to view SHOW RANGES with ZONECONFIG privilege

### DIFF
--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
@@ -27,7 +26,7 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 	if err != nil {
 		return nil, err
 	}
-	if err := d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
+	if err := checkPrivilegesForShowRanges(d, idx.Table()); err != nil {
 		return nil, err
 	}
 	if idx.Table().IsVirtualTable() {

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -16,11 +16,32 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
+
+func checkPrivilegesForShowRanges(d *delegator, table cat.Table) error {
+	// Basic requirement is SELECT privileges
+	if err := d.catalog.CheckPrivilege(d.ctx, table, privilege.SELECT); err != nil {
+		return err
+	}
+	hasAdmin, err := d.catalog.HasAdminRole(d.ctx)
+	if err != nil {
+		return err
+	}
+	// User needs to either have admin access or have the correct ZONECONFIG privilege
+	if hasAdmin {
+		return nil
+	}
+	if err := d.catalog.CheckPrivilege(d.ctx, table, privilege.ZONECONFIG); err != nil {
+		return pgerror.Wrapf(err, pgcode.InsufficientPrivilege, "only users with the ZONECONFIG privilege or the admin role can use SHOW RANGES on %s", table.Name())
+	}
+	return nil
+}
 
 // delegateShowRanges implements the SHOW RANGES statement:
 //   SHOW RANGES FROM TABLE t
@@ -63,9 +84,11 @@ func (d *delegator) delegateShowRanges(n *tree.ShowRanges) (tree.Statement, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
+
+	if err := checkPrivilegesForShowRanges(d, idx.Table()); err != nil {
 		return nil, err
 	}
+
 	if idx.Table().IsVirtualTable() {
 		return nil, errors.New("SHOW RANGES may not be called on a virtual table")
 	}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -492,7 +492,7 @@ select crdb_internal.get_vmodule()
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only users with the admin role are allowed to read crdb_internal.ranges
+query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 select * from crdb_internal.ranges
 
 query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_tenant
@@ -396,7 +396,7 @@ select crdb_internal.get_vmodule()
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only users with the admin role are allowed to read crdb_internal.ranges
+query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 select * from crdb_internal.ranges
 
 query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -584,3 +584,31 @@ query TT
 SELECT start_key, end_key FROM [SHOW RANGE FROM TABLE t63646 FOR ROW ('b')]
 ----
 /"\x80"  NULL
+
+# Test permissions for showing ranges with ZONECONFIG privilege
+
+user root
+
+statement ok
+GRANT SELECT ON TABLE t to testuser
+
+user testuser
+
+statement error only users with the ZONECONFIG privilege or the admin role can use SHOW RANGES on t
+SHOW RANGES FROM TABLE t
+
+statement error only users with the ZONECONFIG privilege or the admin role can use SHOW RANGES on t
+SHOW RANGES FROM INDEX t@idx
+
+user root
+
+statement ok
+GRANT ZONECONFIG ON TABLE t TO testuser
+
+user testuser
+
+statement ok
+SHOW RANGES FROM TABLE t
+
+statement ok
+SHOW RANGES FROM INDEX t@idx


### PR DESCRIPTION
Backport 1/1 commits from #75551.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/68369

Previously the SHOW RANGES query was limited to users with the admin role.
This was an issue because customers did not want to allow many users access
to the admin role. Therefore, the code has been altered so that users can now either
have access to the admin role or have the ZONECONFIG privilege in order to
view the ranges.

Release note (sql change): allow users who are not admin to SHOW RANGES if ZONECONFIG is granted


Release justification: per conversation on https://cockroachlabs.atlassian.net/browse/CRDB-9007 the change should be backported to 21.2 and 21.1

User (operator) who is not a member of admin role and doesn't have `ZONECONFIG` privilege:
![Screen Shot 2022-01-26 at 5 53 19 PM](https://user-images.githubusercontent.com/17861665/151261079-0f933903-f6c2-470d-9842-75200f0f5003.png)
![Screen Shot 2022-01-26 at 5 55 03 PM](https://user-images.githubusercontent.com/17861665/151261099-ebc92a88-d991-404e-a6d3-d12af6266c70.png)

After granting `ZONECONFIG`:
![Screen Shot 2022-01-26 at 5 55 18 PM](https://user-images.githubusercontent.com/17861665/151261155-ae14f928-429f-41aa-9e79-8cb3815c2335.png)
![Screen Shot 2022-01-26 at 5 55 40 PM](https://user-images.githubusercontent.com/17861665/151261179-ec8a25e5-93cd-406d-bacc-528beae3a262.png)

