### PR TITLE
c-deps: disable autoreconf warnings for krb5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -619,7 +619,7 @@ $(JEMALLOC_DIR)/Makefile: $(C_DEPS_DIR)/jemalloc-rebuild $(JEMALLOC_SRC_DIR)/con
 $(KRB5_SRC_DIR)/src/configure.in: | bin/.submodules-initialized
 
 $(KRB5_SRC_DIR)/src/configure: $(KRB5_SRC_DIR)/src/configure.in
-	cd $(KRB5_SRC_DIR)/src && autoreconf
+	cd $(KRB5_SRC_DIR)/src && autoreconf -Wno-obsolete
 
 $(KRB5_DIR)/Makefile: $(C_DEPS_DIR)/krb5-rebuild $(KRB5_SRC_DIR)/src/configure
 	rm -rf $(KRB5_DIR)

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -143,6 +143,9 @@ configure_make(
     name = "libkrb5",
     autoreconf = True,
     autoreconf_directory = "src",
+    autoreconf_options = [
+        "-Wno-obsolete",
+    ],
     configure_command = "src/configure",
     configure_in_place = True,
     configure_options = [


### PR DESCRIPTION
`autoconf` in versions >= 2.70 [enables warnings for obsolete
commands][1]. This clogs the console output when building `libkrb5`,
either using `make` or with Bazel, when run on a system with a more
recent version of `autoconf`.

Disable the `autoconf` warnings for `krb5` with `-Wno-obsolete`, as
suggested in the release notes.

Release note: None

[1]: https://lwn.net/Articles/839395/