### PR TITLE
kvprober: add probes for problem ranges

### DIFF
--- a/pkg/kv/kvprober/planner.go
+++ b/pkg/kv/kvprober/planner.go
@@ -275,3 +275,15 @@ func meta2KVsToPlanImpl(kvs []kv.KeyValue) ([]Step, error) {
 
 	return plans, nil
 }
+
+type problemTrackerPlanner struct {
+	tracker *problemTracker
+}
+
+func newProblemTrackerPlanner(tracker *problemTracker) *problemTrackerPlanner {
+	return &problemTrackerPlanner{tracker: tracker}
+}
+
+func (p *problemTrackerPlanner) next(ctx context.Context) (Step, error) {
+	return p.tracker.next()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -683,7 +683,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Settings:                st,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 	})
-	registry.AddMetricStruct(kvProber.Metrics())
+	for _, metrics := range kvProber.Metrics() {
+		registry.AddMetricStruct(metrics)
+	}
 
 	settingsWriter := newSettingsCacheWriter(engines[0], stopper)
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{


### PR DESCRIPTION
Note: this is a quick sketch to check whether I'm thinking about the problem correctly. The code is probably not great! I'll clean this up and add tests after getting some feedback on the general approach.

The kvprober provides good coverage of issues that affect many ranges,
but has a lower probability of detecting individual bad ranges. To
improve coverage of the latter case, remember failed ranges from the
existing prober and probe them more frequently in a second pair of probe
loops.

Resolves #74407.

Release note (<category, see below>): <what> <show> <why>