### PR TITLE
kv/bulk: fix accidental minkey predicate

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -352,7 +352,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 				// NB: Passing 'hour' here is technically illegal until 19.2 is
 				// active, but the value will be ignored before that, and we don't
 				// have access to the cluster version here.
-				if err := b.db.SplitAndScatter(ctx, splitAt, hour, nil); err != nil {
+				if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
 					log.Warningf(ctx, "%v", err)
 				}
 			}
@@ -404,7 +404,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 					// NB: Passing 'hour' here is technically illegal until 19.2 is
 					// active, but the value will be ignored before that, and we don't
 					// have access to the cluster version here.
-					if err := b.db.SplitAndScatter(ctx, splitAt, hour, nil); err != nil {
+					if err := b.db.SplitAndScatter(ctx, splitAt, hour); err != nil {
 						log.Warningf(ctx, "failed to split and scatter during ingest: %+v", err)
 					}
 					b.flushCounts.splitWait += timeutil.Since(beforeSplit)


### PR DESCRIPTION
In a last minute change to #74816 I switched from []predicate to ...predicate but unfortunately forgot to remove the nil arg in batcher. It still compiled but semantically went from predicates=[] to predicates=[nil], which is not at all the same.

Release note: none.