### PR TITLE
sql/tests: skip TestMonotonicInserts

### DIFF
--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -77,6 +77,7 @@ type mtClient struct {
 //   https://github.com/jepsen-io/jepsen/blob/master/cockroachdb/src/jepsen/cockroach/monotonic.clj
 func TestMonotonicInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 68784, "flaky test")
 
 	for _, distSQLMode := range []sessiondatapb.DistSQLExecMode{
 		sessiondatapb.DistSQLOff, sessiondatapb.DistSQLOn,


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/68784

It seems like the change in 9c89a20501ba9bdf4f95aba3fba0983397f62618
did not entirely fix things.

This test is flaky since it often fails after retrying a transaction 50
times without success.

Release note: None