### PR TITLE
sql: run planHooks in a new tracing span

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1667,5 +1667,5 @@ func getBackupDetailAndManifest(
 }
 
 func init() {
-	sql.AddPlanHook(backupPlanHook)
+	sql.AddPlanHook("backup", backupPlanHook)
 }

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -1023,5 +1023,5 @@ func (m ScheduledBackupExecutionArgs) MarshalJSONPB(marshaller *jsonpb.Marshaler
 }
 
 func init() {
-	sql.AddPlanHook(createBackupScheduleHook)
+	sql.AddPlanHook("schedule backup", createBackupScheduleHook)
 }

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -2450,5 +2450,5 @@ func restoreCreateDefaultPrimaryRegionEnums(
 }
 
 func init() {
-	sql.AddPlanHook(restorePlanHook)
+	sql.AddPlanHook("restore", restorePlanHook)
 }

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -741,5 +741,5 @@ func showBackupsInCollectionPlanHook(
 }
 
 func init() {
-	sql.AddPlanHook(showBackupPlanHook)
+	sql.AddPlanHook("show backup", showBackupPlanHook)
 }

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -64,7 +64,7 @@ var featureChangefeedEnabled = settings.RegisterBoolSetting(
 ).WithPublic()
 
 func init() {
-	sql.AddPlanHook(changefeedPlanHook)
+	sql.AddPlanHook("changefeed", changefeedPlanHook)
 	jobs.RegisterConstructor(
 		jobspb.TypeChangefeed,
 		func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {

--- a/pkg/ccl/importccl/import_planning.go
+++ b/pkg/ccl/importccl/import_planning.go
@@ -1192,5 +1192,5 @@ func (u *unsupportedStmtLogger) flush() error {
 }
 
 func init() {
-	sql.AddPlanHook(importPlanHook)
+	sql.AddPlanHook("import", importPlanHook)
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -146,7 +146,7 @@ func ingestionPlanHook(
 }
 
 func init() {
-	sql.AddPlanHook(ingestionPlanHook)
+	sql.AddPlanHook("ingestion", ingestionPlanHook)
 	jobs.RegisterConstructor(
 		jobspb.TypeStreamIngestion,
 		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_planning.go
@@ -262,5 +262,5 @@ func getReplicationStreamSpec(
 }
 
 func init() {
-	sql.AddPlanHook(createReplicationStreamHook)
+	sql.AddPlanHook("replication stream", createReplicationStreamHook)
 }

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2322,6 +2322,7 @@ func TestJobInTxn(t *testing.T) {
 	defer sql.ClearPlanHooks()
 	// Piggy back on BACKUP to be able to create a succeeding test job.
 	sql.AddPlanHook(
+		"test",
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,
 		) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
 			st, ok := stmt.(*tree.Backup)
@@ -2358,6 +2359,7 @@ func TestJobInTxn(t *testing.T) {
 	})
 	// Piggy back on RESTORE to be able to create a failing test job.
 	sql.AddPlanHook(
+		"test",
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,
 		) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
 			_, ok := stmt.(*tree.Restore)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -526,13 +526,13 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 	// upcoming IR work will provide unique numeric type tags, which will
 	// elegantly solve this.
 	for _, planHook := range planHooks {
-		if fn, header, subplans, avoidBuffering, err := planHook(ctx, stmt, p); err != nil {
+		if fn, header, subplans, avoidBuffering, err := planHook.fn(ctx, stmt, p); err != nil {
 			return nil, err
 		} else if fn != nil {
 			if avoidBuffering {
 				p.curPlan.avoidBuffering = true
 			}
-			return &hookFnNode{f: fn, header: header, subplans: subplans}, nil
+			return newHookFnNode(planHook.name, fn, header, subplans), nil
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
For some reason, plan hooks run in a new goroutine; that goroutine
communicates results through a channel, that's adapted to look like a
planNode by the hookFnNode. Before this patch, that goroutine was
capturing the caller's ctx, and hence the caller's tracing span. This
was leading to span-use-after-Finish because the goroutine in question
was sometimes outliving the caller. Although not written anywhere, I
think the expectation is that generally the goroutine will not outlive
the the hookFnNode by much, since hookFnNode.Next() is supposed to be
consumed fully. Still, at the very least, there were races related to
ctx cancellation, as the hookFnNode listens for cancellation in parallel
with the goroutine running (which is probably a bad idea).

This patch fixes ths span use-after-finish by giving the goroutine a new
span. I took the opportunity to give all the plan hooks names, and use
that as the span name. Since these hooks are all weirdos, it seems like
a good idea to particularly reflect them in the trace, regardless of the
bug that's being fixed.

Fixes #75425

Release note: None