### PR TITLE
colexec: fix premature span closing

### DIFF
--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -215,7 +215,7 @@ func (s *ParallelUnorderedSynchronizer) init() {
 			span := s.tracingSpans[inputIdx]
 			defer func() {
 				if span != nil {
-					span.Finish()
+					defer span.Finish()
 				}
 				if int(atomic.AddUint32(&s.numFinishedInputs, 1)) == len(s.inputs) {
 					close(s.batchCh)


### PR DESCRIPTION
The parallel unordered synchronizer was closing the span of an input
before calling input.Close(), which uses that span.

Release note: None