### PR TITLE
storage: add initial experimental MVCC range tombstone primitives

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -468,6 +468,12 @@ func (s spanSetReader) NewMVCCIterator(
 	return NewIteratorAt(s.r.NewMVCCIterator(iterKind, opts), s.spans, s.ts)
 }
 
+func (s spanSetReader) NewMVCCRangeTombstoneIterator(
+	opts storage.RangeTombstoneIterOptions,
+) storage.MVCCRangeTombstoneIterator {
+	panic("not implemented")
+}
+
 func (s spanSetReader) NewEngineIterator(opts storage.IterOptions) storage.EngineIterator {
 	if !s.spansOnly {
 		log.Warningf(context.Background(),
@@ -597,6 +603,20 @@ func (s spanSetWriter) ClearIterRange(iter storage.MVCCIterator, start, end roac
 		return err
 	}
 	return s.w.ClearIterRange(iter, start, end)
+}
+
+func (s spanSetWriter) ExperimentalDeleteMVCCRange(rangeKey storage.MVCCRangeKey) error {
+	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
+		return err
+	}
+	return s.w.ExperimentalDeleteMVCCRange(rangeKey)
+}
+
+func (s spanSetWriter) ExperimentalClearMVCCRangeTombstone(rangeKey storage.MVCCRangeKey) error {
+	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
+		return err
+	}
+	return s.w.ExperimentalClearMVCCRangeTombstone(rangeKey)
 }
 
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "pebble_iterator.go",
         "pebble_merge.go",
         "pebble_mvcc_scanner.go",
+        "pebble_range_tombstone_iterator.go",
         "replicas_storage.go",
         "resource_limiter.go",
         "row_counter.go",

--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -63,8 +63,10 @@ go_test(
         "//pkg/roachpb:with-mocks",
         "//pkg/storage",
         "//pkg/util/hlc",
+        "//pkg/util/protoutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -314,3 +314,17 @@ message MVCCLogicalOp {
   MVCCAbortIntentOp  abort_intent  = 5;
   MVCCAbortTxnOp     abort_txn     = 6;
 }
+
+// MVCCRangeValue is a union of all ranged MVCC value types that are stored as
+// Pebble range keys.
+message MVCCRangeValue {
+  // NB: onlyone is ~3x faster than a Protobuf oneof due to fewer allocations.
+  option (gogoproto.onlyone) = true;
+
+  MVCCRangeTombstone tombstone = 1;
+}
+
+// MVCCRangeTombstone represents a range tombstone. It has no contents since it
+// is fully described by the MVCC range key (start,end,timestamp), and is only
+// used to determine the range value type.
+message MVCCRangeTombstone {}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMVCCHistories verifies that sequences of MVCC reads and writes
@@ -55,17 +56,20 @@ import (
 // resolve_intent t=<name> k=<key> [status=<txnstatus>]
 // check_intent   k=<key> [none]
 //
-// cput      [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [cond=<string>]
-// del       [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key>
-// del_range [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [max=<max>] [returnKeys]
-// get       [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inconsistent] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]]
-// increment [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inc=<val>]
-// put       [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
-// scan      [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [avoidExcess] [allowEmpty]
+// cput           [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [cond=<string>]
+// del            [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key>
+// del_range      [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [max=<max>] [returnKeys]
+// del_range_ts   [ts=<int>[,<int>]] k=<key> end=<key>
+// get            [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inconsistent] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]]
+// increment      [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inc=<val>]
+// put            [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
+// scan           [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [avoidExcess] [allowEmpty]
+// scan_range_ts  k=<key> end=<key> [ts=<int>[,<int>]]
 //
 // merge     [ts=<int>[,<int>]] k=<key> v=<string> [raw]
 //
 // clear_range    k=<key> end=<key>
+// clear_range_ts k=<key> end=<key> [ts=<int>[,<int>]]
 //
 // Where `<key>` can be a simple string, or a string
 // prefixed by the following characters:
@@ -112,8 +116,15 @@ func TestMVCCHistories(t *testing.T) {
 		defer engine.Close()
 
 		reportDataEntries := func(buf *redact.StringBuilder) error {
-			hasData := false
-			err := engine.MVCCIterate(span.Key, span.EndKey, MVCCKeyAndIntentsIterKind, func(r MVCCKeyValue) error {
+			rangeTombstones, err := MVCCScanRangeTombstones(
+				ctx, engine, span.Key, span.EndKey, hlc.Timestamp{})
+			require.NoError(t, err)
+			for _, rt := range rangeTombstones {
+				buf.Printf("range tombstone: %s\n", rt)
+			}
+			hasData := len(rangeTombstones) > 0
+
+			err = engine.MVCCIterate(span.Key, span.EndKey, MVCCKeyAndIntentsIterKind, func(r MVCCKeyValue) error {
 				hasData = true
 				if r.Key.Timestamp.IsEmpty() {
 					// Meta is at timestamp zero.
@@ -396,15 +407,18 @@ var commands = map[string]cmd{
 	// TODO(nvanbenschoten): test "resolve_intent_range".
 	"check_intent": {typReadOnly, cmdCheckIntent},
 
-	"clear_range": {typDataUpdate, cmdClearRange},
-	"cput":        {typDataUpdate, cmdCPut},
-	"del":         {typDataUpdate, cmdDelete},
-	"del_range":   {typDataUpdate, cmdDeleteRange},
-	"get":         {typReadOnly, cmdGet},
-	"increment":   {typDataUpdate, cmdIncrement},
-	"merge":       {typDataUpdate, cmdMerge},
-	"put":         {typDataUpdate, cmdPut},
-	"scan":        {typReadOnly, cmdScan},
+	"clear_range":    {typDataUpdate, cmdClearRange},
+	"clear_range_ts": {typDataUpdate, cmdClearRangeTombstone},
+	"cput":           {typDataUpdate, cmdCPut},
+	"del":            {typDataUpdate, cmdDelete},
+	"del_range":      {typDataUpdate, cmdDeleteRange},
+	"del_range_ts":   {typDataUpdate, cmdDeleteRangeTombstone},
+	"get":            {typReadOnly, cmdGet},
+	"increment":      {typDataUpdate, cmdIncrement},
+	"merge":          {typDataUpdate, cmdMerge},
+	"put":            {typDataUpdate, cmdPut},
+	"scan":           {typReadOnly, cmdScan},
+	"scan_range_ts":  {typReadOnly, cmdScanRangeTombstone},
 }
 
 func cmdTxnAdvance(e *evalCtx) error {
@@ -584,6 +598,16 @@ func cmdClearRange(e *evalCtx) error {
 	return e.engine.ClearMVCCRangeAndIntents(key, endKey)
 }
 
+func cmdClearRangeTombstone(e *evalCtx) error {
+	key, endKey := e.getKeyRange()
+	ts := e.getTs(nil)
+	return e.engine.ExperimentalClearMVCCRangeTombstone(MVCCRangeKey{
+		StartKey:  key,
+		EndKey:    endKey,
+		Timestamp: ts,
+	})
+}
+
 func cmdCPut(e *evalCtx) error {
 	txn := e.getTxn(optional)
 	ts := e.getTs(txn)
@@ -656,6 +680,24 @@ func cmdDeleteRange(e *evalCtx) error {
 		if resolve {
 			return e.resolveIntent(rw, key, txn, resolveStatus)
 		}
+		return nil
+	})
+}
+
+func cmdDeleteRangeTombstone(e *evalCtx) error {
+	key, endKey := e.getKeyRange()
+	ts := e.getTs(nil)
+
+	return e.withWriter("del_range", func(rw ReadWriter) error {
+		err := ExperimentalMVCCDeleteRangeUsingTombstone(e.ctx, rw, nil, key, endKey, ts, 0)
+		if err != nil {
+			return err
+		}
+		e.results.buf.Printf("del_range_ts: %s\n", MVCCRangeKey{
+			StartKey:  key,
+			EndKey:    endKey,
+			Timestamp: ts,
+		})
 		return nil
 	})
 }
@@ -822,6 +864,23 @@ func cmdScan(e *evalCtx) error {
 		e.results.buf.Printf("scan: %v-%v -> <no data>\n", key, endKey)
 	}
 	return err
+}
+
+func cmdScanRangeTombstone(e *evalCtx) error {
+	key, endKey := e.getKeyRange()
+	ts := e.getTs(nil)
+
+	tombstones, err := MVCCScanRangeTombstones(e.ctx, e.engine, key, endKey, ts)
+	if err != nil {
+		return err
+	}
+	for _, tombstone := range tombstones {
+		e.results.buf.Printf("scan_range_ts: %s\n", tombstone)
+	}
+	if len(tombstones) == 0 {
+		e.results.buf.Printf("scan_range_ts: %v-%v -> <no data>\n", key, endKey)
+	}
+	return nil
 }
 
 // evalCtx stored the current state of the environment of a running

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -287,3 +287,68 @@ func decodeMVCCTimestampSuffix(encodedTS []byte) (hlc.Timestamp, error) {
 	}
 	return decodeMVCCTimestamp(encodedTS[:encodedLen-1])
 }
+
+// MVCCRangeKey is an MVCC key span at a timestamp.
+type MVCCRangeKey struct {
+	StartKey  roachpb.Key
+	EndKey    roachpb.Key
+	Timestamp hlc.Timestamp
+}
+
+// Clone returns a copy of the range key.
+func (k MVCCRangeKey) Clone() MVCCRangeKey {
+	// k is already a copy, but needs key clones.
+	k.StartKey = k.StartKey.Clone()
+	k.EndKey = k.EndKey.Clone()
+	return k
+}
+
+// Compare returns -1 if this key is less than the given key, 0 if they're
+// equal, or 1 if the given key is greater than this. Comparison is by
+// start,timestamp,end, where larger timestamps sort before smaller ones except
+// empty ones which sort first (like elsewhere in MVCC).
+func (k MVCCRangeKey) Compare(o MVCCRangeKey) int {
+	if c := k.StartKey.Compare(o.StartKey); c != 0 {
+		return c
+	}
+	if k.Timestamp.IsEmpty() && !o.Timestamp.IsEmpty() {
+		return -1
+	} else if !k.Timestamp.IsEmpty() && o.Timestamp.IsEmpty() {
+		return 1
+	} else if k.Timestamp.Less(o.Timestamp) {
+		return 1
+	} else if !k.Timestamp.EqOrdering(o.Timestamp) {
+		return -1
+	}
+	return k.EndKey.Compare(o.EndKey)
+}
+
+// String formats the range key.
+func (k MVCCRangeKey) String() string {
+	s := roachpb.Span{Key: k.StartKey, EndKey: k.EndKey}.String()
+	if !k.Timestamp.IsEmpty() {
+		s += fmt.Sprintf("/%s", k.Timestamp)
+	}
+	return s
+}
+
+// Validate returns an error if the range key is invalid.
+func (k MVCCRangeKey) Validate() (err error) {
+	return errors.Wrapf(k.validate(), "invalid range key %s", k)
+}
+
+func (k MVCCRangeKey) validate() error {
+	if k.StartKey == nil {
+		return errors.Errorf("no start key")
+	}
+	if k.EndKey == nil {
+		return errors.Errorf("no end key")
+	}
+	if k.Timestamp.IsEmpty() {
+		return errors.Errorf("no timestamp")
+	}
+	if k.StartKey.Compare(k.EndKey) > 0 {
+		return errors.Errorf("start key %s is after end key %s", k.StartKey, k.EndKey)
+	}
+	return nil
+}

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -238,3 +238,94 @@ func BenchmarkDecodeMVCCKey(b *testing.B) {
 	}
 	benchmarkDecodeMVCCKeyResult = mvccKey // avoid compiler optimizing away function call
 }
+
+func TestMVCCRangeKeyString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testcases := map[string]struct {
+		rk     MVCCRangeKey
+		expect string
+	}{
+		"empty":           {MVCCRangeKey{}, "/Min"},
+		"only start":      {MVCCRangeKey{StartKey: roachpb.Key("foo")}, "foo"},
+		"only end":        {MVCCRangeKey{EndKey: roachpb.Key("foo")}, "{/Min-foo}"},
+		"only timestamp":  {MVCCRangeKey{Timestamp: hlc.Timestamp{Logical: 1}}, "/Min/0,1"},
+		"only span":       {MVCCRangeKey{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("z")}, "{a-z}"},
+		"all":             {MVCCRangeKey{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("z"), Timestamp: hlc.Timestamp{Logical: 1}}, "{a-z}/0,1"},
+		"all overlapping": {MVCCRangeKey{StartKey: roachpb.Key("ab"), EndKey: roachpb.Key("af"), Timestamp: hlc.Timestamp{Logical: 1}}, "a{b-f}/0,1"},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.rk.String())
+		})
+	}
+}
+
+func TestMVCCRangeKeyCompare(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ab1 := MVCCRangeKey{roachpb.Key("a"), roachpb.Key("b"), hlc.Timestamp{Logical: 1}}
+	ac1 := MVCCRangeKey{roachpb.Key("a"), roachpb.Key("c"), hlc.Timestamp{Logical: 1}}
+	ac2 := MVCCRangeKey{roachpb.Key("a"), roachpb.Key("c"), hlc.Timestamp{Logical: 2}}
+	bc0 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("c"), hlc.Timestamp{Logical: 0}}
+	bc1 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("c"), hlc.Timestamp{Logical: 1}}
+	bc3 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("c"), hlc.Timestamp{Logical: 3}}
+	bd4 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("d"), hlc.Timestamp{Logical: 4}}
+
+	testcases := map[string]struct {
+		a      MVCCRangeKey
+		b      MVCCRangeKey
+		expect int
+	}{
+		"equal":                 {ac1, ac1, 0},
+		"start lt":              {ac1, bc1, -1},
+		"start gt":              {bc1, ac1, 1},
+		"end lt":                {ab1, ac1, -1},
+		"end gt":                {ac1, ab1, 1},
+		"time lt":               {ac2, ac1, -1}, // MVCC timestamps sort in reverse order
+		"time gt":               {ac1, ac2, 1},  // MVCC timestamps sort in reverse order
+		"empty time lt set":     {bc0, bc1, -1}, // empty MVCC timestamps sort before non-empty
+		"set time gt empty":     {bc1, bc0, 1},  // empty MVCC timestamps sort before non-empty
+		"start time precedence": {ac2, bc3, -1},
+		"time end precedence":   {bd4, bc3, -1},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.a.Compare(tc.b))
+		})
+	}
+}
+
+func TestMVCCRangeKeyValidate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	a := roachpb.Key("a")
+	b := roachpb.Key("b")
+	blank := roachpb.Key("")
+	ts1 := hlc.Timestamp{Logical: 1}
+
+	testcases := map[string]struct {
+		rangeKey  MVCCRangeKey
+		expectErr string // empty if no error
+	}{
+		"valid":            {MVCCRangeKey{StartKey: a, EndKey: b, Timestamp: ts1}, ""},
+		"start at end":     {MVCCRangeKey{StartKey: a, EndKey: b, Timestamp: ts1}, ""},
+		"blank keys":       {MVCCRangeKey{StartKey: blank, EndKey: blank, Timestamp: ts1}, ""}, // equivalent to MinKey
+		"no start":         {MVCCRangeKey{EndKey: b, Timestamp: ts1}, "{/Min-b}/0,1: no start key"},
+		"no end":           {MVCCRangeKey{StartKey: a, Timestamp: ts1}, "a/0,1: no end key"},
+		"no timestamp":     {MVCCRangeKey{StartKey: a, EndKey: b}, "{a-b}: no timestamp"},
+		"empty":            {MVCCRangeKey{}, "/Min: no start key"},
+		"end before start": {MVCCRangeKey{StartKey: b, EndKey: a, Timestamp: ts1}, `{b-a}/0,1: start key "b" is after end key "a"`},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.rangeKey.Validate()
+			if tc.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			}
+		})
+	}
+}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5466,3 +5466,145 @@ func TestWillOverflow(t *testing.T) {
 		}
 	}
 }
+
+func TestMVCCRangeTombstoneIterator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	eng := NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	require.NoError(t, eng.ExperimentalDeleteMVCCRange(rangeKey("b", "c", 3)))
+	require.NoError(t, eng.ExperimentalDeleteMVCCRange(rangeKey("e", "g", 3)))
+	require.NoError(t, eng.ExperimentalDeleteMVCCRange(rangeKey("d", "f", 5)))
+	require.NoError(t, eng.ExperimentalDeleteMVCCRange(rangeKey("d", "f", 2)))
+	require.NoError(t, eng.ExperimentalDeleteMVCCRange(rangeKey("a", "m", 4)))
+	require.NoError(t, eng.ExperimentalDeleteMVCCRange(rangeKey("m", "z", 4)))
+
+	testcases := map[string]struct {
+		opts   RangeTombstoneIterOptions
+		expect []MVCCRangeKey
+	}{
+		"all tombstones": {
+			RangeTombstoneIterOptions{},
+			[]MVCCRangeKey{
+				rangeKey("b", "c", 3),
+				rangeKey("d", "f", 5),
+				rangeKey("d", "f", 2),
+				rangeKey("e", "g", 3),
+				rangeKey("a", "z", 4),
+			}},
+		"truncated tombstones": {
+			RangeTombstoneIterOptions{
+				LowerBound: roachpb.Key("c"),
+				UpperBound: roachpb.Key("e"),
+			},
+			[]MVCCRangeKey{
+				rangeKey("d", "e", 5),
+				rangeKey("c", "e", 4),
+				rangeKey("d", "e", 2),
+			}},
+		"truncation between tombstone bounds": {
+			RangeTombstoneIterOptions{
+				LowerBound: roachpb.Key("ccc"),
+				UpperBound: roachpb.Key("eee"),
+			},
+			[]MVCCRangeKey{
+				rangeKey("d", "eee", 5),
+				rangeKey("ccc", "eee", 4),
+				rangeKey("e", "eee", 3),
+				rangeKey("d", "eee", 2),
+			}},
+		"fragmented tombstones": {
+			RangeTombstoneIterOptions{
+				Fragmented: true,
+			},
+			[]MVCCRangeKey{
+				rangeKey("a", "b", 4),
+				rangeKey("b", "c", 4),
+				rangeKey("b", "c", 3),
+				rangeKey("c", "d", 4),
+				rangeKey("d", "e", 5),
+				rangeKey("d", "e", 4),
+				rangeKey("d", "e", 2),
+				rangeKey("e", "f", 5),
+				rangeKey("e", "f", 4),
+				rangeKey("e", "f", 3),
+				rangeKey("e", "f", 2),
+				rangeKey("f", "g", 4),
+				rangeKey("f", "g", 3),
+				rangeKey("g", "m", 4),
+				rangeKey("m", "z", 4),
+			}},
+		"empty interval": {
+			RangeTombstoneIterOptions{
+				LowerBound: roachpb.Key("A"),
+				UpperBound: roachpb.Key("Z"),
+			},
+			nil},
+		"zero-length interval": {
+			RangeTombstoneIterOptions{
+				LowerBound: roachpb.Key("c"),
+				UpperBound: roachpb.Key("c"),
+			},
+			nil},
+		"end after start": {
+			RangeTombstoneIterOptions{
+				LowerBound: roachpb.Key("e"),
+				UpperBound: roachpb.Key("d"),
+			},
+			nil},
+		"min timestamp": {
+			RangeTombstoneIterOptions{
+				MinTimestamp: hlc.Timestamp{Logical: 3},
+			},
+			[]MVCCRangeKey{
+				rangeKey("b", "c", 3),
+				rangeKey("d", "f", 5),
+				rangeKey("e", "g", 3),
+				rangeKey("a", "z", 4),
+			}},
+		"max timestamp": {
+			RangeTombstoneIterOptions{
+				MaxTimestamp: hlc.Timestamp{Logical: 3},
+			},
+			[]MVCCRangeKey{
+				rangeKey("b", "c", 3),
+				rangeKey("d", "f", 2),
+				rangeKey("e", "g", 3),
+			}},
+		"both timestamps": {
+			RangeTombstoneIterOptions{
+				MinTimestamp: hlc.Timestamp{Logical: 3},
+				MaxTimestamp: hlc.Timestamp{Logical: 3},
+			},
+			[]MVCCRangeKey{
+				rangeKey("b", "c", 3),
+				rangeKey("e", "g", 3),
+			}},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			var tombstones []MVCCRangeKey
+			iter := eng.NewMVCCRangeTombstoneIterator(tc.opts)
+			defer iter.Close()
+			for {
+				ok, err := iter.Valid()
+				require.NoError(t, err)
+				if !ok {
+					break
+				}
+				tombstones = append(tombstones, iter.Key())
+				iter.Next()
+			}
+			require.Equal(t, tc.expect, tombstones)
+		})
+	}
+}
+
+func rangeKey(start, end string, ts int) MVCCRangeKey {
+	return MVCCRangeKey{
+		StartKey:  roachpb.Key(start),
+		EndKey:    roachpb.Key(end),
+		Timestamp: hlc.Timestamp{Logical: int32(ts)},
+	}
+}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -481,6 +481,8 @@ func DefaultPebbleOptions() *pebble.Options {
 		TablePropertyCollectors:     PebbleTablePropertyCollectors,
 		BlockPropertyCollectors:     PebbleBlockPropertyCollectors,
 	}
+	// Used for experimental MVCC range tombstones.
+	opts.Experimental.RangeKeys = new(pebble.RangeKeysArena)
 	// Automatically flush 10s after the first range tombstone is added to a
 	// memtable. This ensures that we can reclaim space even when there's no
 	// activity on the database generating flushes.
@@ -993,6 +995,13 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIt
 	return iter
 }
 
+// NewMVCCRangeTombstoneIterator implements the Engine interface.
+func (p *Pebble) NewMVCCRangeTombstoneIterator(
+	opts RangeTombstoneIterOptions,
+) MVCCRangeTombstoneIterator {
+	return newPebbleRangeTombstoneIterator(p.db, opts)
+}
+
 // NewEngineIterator implements the Engine interface.
 func (p *Pebble) NewEngineIterator(opts IterOptions) EngineIterator {
 	iter := newPebbleIterator(p.db, nil, opts)
@@ -1106,6 +1115,30 @@ func (p *Pebble) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error
 		return err
 	}
 	return batch.Commit(true)
+}
+
+// ExperimentalDeleteMVCCRange implements the Engine interface.
+func (p *Pebble) ExperimentalDeleteMVCCRange(rangeKey MVCCRangeKey) error {
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	value, err := protoutil.Marshal(&enginepb.MVCCRangeValue{
+		Tombstone: &enginepb.MVCCRangeTombstone{},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal MVCC range tombstone %s", rangeKey)
+	}
+	return p.db.Experimental().RangeKeySet(rangeKey.StartKey, rangeKey.EndKey,
+		encodeMVCCTimestampSuffix(rangeKey.Timestamp), value, pebble.Sync)
+}
+
+// ExperimentalClearMVCCRangeTombstone implements the Engine interface.
+func (p *Pebble) ExperimentalClearMVCCRangeTombstone(rangeKey MVCCRangeKey) error {
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	return p.db.Experimental().RangeKeyUnset(rangeKey.StartKey, rangeKey.EndKey,
+		encodeMVCCTimestampSuffix(rangeKey.Timestamp), pebble.Sync)
 }
 
 // Merge implements the Engine interface.
@@ -1780,6 +1813,13 @@ func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 	return rv
 }
 
+// NewMVCCRangeTombstoneIterator implements the Engine interface.
+func (p *pebbleReadOnly) NewMVCCRangeTombstoneIterator(
+	opts RangeTombstoneIterOptions,
+) MVCCRangeTombstoneIterator {
+	return newPebbleRangeTombstoneIterator(p.parent.db, opts)
+}
+
 // NewEngineIterator implements the Engine interface.
 func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
 	if p.closed {
@@ -1879,6 +1919,14 @@ func (p *pebbleReadOnly) ClearMVCCRange(start, end MVCCKey) error {
 }
 
 func (p *pebbleReadOnly) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ExperimentalDeleteMVCCRange(_ MVCCRangeKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ExperimentalClearMVCCRangeTombstone(_ MVCCRangeKey) error {
 	panic("not implemented")
 }
 
@@ -2007,6 +2055,13 @@ func (p *pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 		iter = wrapInUnsafeIter(iter)
 	}
 	return iter
+}
+
+// NewMVCCRangeTombstoneIterator implements the Engine interface.
+func (p *pebbleSnapshot) NewMVCCRangeTombstoneIterator(
+	opts RangeTombstoneIterOptions,
+) MVCCRangeTombstoneIterator {
+	return newPebbleRangeTombstoneIterator(p.snapshot, opts)
 }
 
 // NewEngineIterator implements the Reader interface.

--- a/pkg/storage/pebble_range_tombstone_iterator.go
+++ b/pkg/storage/pebble_range_tombstone_iterator.go
@@ -1,0 +1,304 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
+)
+
+type incompleteTombstone struct {
+	startKey roachpb.Key
+	endKey   roachpb.Key
+	suffix   []byte
+}
+
+// complete builds a proper MVCCRangeKey range tombstone from an
+// incompleteTombstone. It takes ownership of the byte slices, so the caller
+// must not modify them afterwards.
+func (i *incompleteTombstone) complete() (MVCCRangeKey, error) {
+	timestamp, err := decodeMVCCTimestampSuffix(i.suffix)
+	if err != nil {
+		return MVCCRangeKey{}, err
+	}
+	tombstone := MVCCRangeKey{
+		StartKey:  i.startKey,
+		EndKey:    i.endKey,
+		Timestamp: timestamp,
+	}
+	if err := tombstone.Validate(); err != nil {
+		return MVCCRangeKey{}, err
+	}
+	return tombstone, nil
+}
+
+// pebbleRangeTombstoneIterator is an iterator over range tombstones. It uses a
+// Pebble range key iterator, decodes range keys, and defragments tombstones
+// into separate contiguous tombstones.
+//
+// The iteration order is EndKey,Timestamp rather than StartKey,Timestamp to
+// conserve memory: otherwise, e.g. a tombstone across the entire keyspan would
+// require all other tombstones to be buffered in memory before being emitted.
+type pebbleRangeTombstoneIterator struct {
+	iter                   *pebble.Iterator
+	lowerBound, upperBound roachpb.Key
+	minSuffix, maxSuffix   []byte
+	fragmented             bool
+	incomplete             []*incompleteTombstone // defragmentation buffer
+	complete               []MVCCRangeKey         // queued for emission
+	completeIdx            int                    // current Key()
+	err                    error
+}
+
+// newPebbleRangeTombstoneIterator sets up a new pebbleRangeTombstoneIterator
+// and seeks to the first range tombstone.
+func newPebbleRangeTombstoneIterator(
+	handle pebble.Reader, opts RangeTombstoneIterOptions,
+) *pebbleRangeTombstoneIterator {
+	pebbleOpts := &pebble.IterOptions{
+		KeyTypes: pebble.IterKeyTypeRangesOnly,
+	}
+	if len(opts.LowerBound) > 0 {
+		pebbleOpts.LowerBound = EncodeMVCCKey(MVCCKey{Key: opts.LowerBound})
+	}
+	if len(opts.UpperBound) > 0 {
+		pebbleOpts.UpperBound = EncodeMVCCKey(MVCCKey{Key: opts.UpperBound})
+	}
+	iter := &pebbleRangeTombstoneIterator{
+		iter:       handle.NewIter(pebbleOpts),
+		lowerBound: opts.LowerBound,
+		upperBound: opts.UpperBound,
+		minSuffix:  encodeMVCCTimestampSuffix(opts.MinTimestamp),
+		maxSuffix:  encodeMVCCTimestampSuffix(opts.MaxTimestamp),
+		fragmented: opts.Fragmented,
+		incomplete: make([]*incompleteTombstone, 0),
+		complete:   make([]MVCCRangeKey, 0),
+	}
+
+	// Seek the iterator to the lower bound and iterate until we've collected
+	// the first complete range tombstone (if any).
+	iter.iter.SeekGE(pebbleOpts.LowerBound)
+	iter.findCompleteTombstones()
+
+	return iter
+}
+
+// findCompleteTombstones processes range keys at the current iterator position
+// and any subsequent iterator positions until it completes one or more
+// tombstones, populating completeTombstones. Current completeTombstones are
+// discarded.
+func (p *pebbleRangeTombstoneIterator) findCompleteTombstones() {
+	p.complete = p.complete[:0]
+	p.completeIdx = 0
+	p.updateTombstones()
+
+	for len(p.complete) == 0 && p.iter.Valid() {
+		// NB: We update tombstones even if Next() fails or it invalidates the
+		// iterator, because there may be incomplete tombstones that become complete
+		// when the iterator is exhausted.
+		p.iter.Next()
+		p.updateTombstones()
+	}
+}
+
+// updateTombstones inspects the range keys at the current Pebble iterator
+// position, tracks tombstones in incompleteTombstones, and moves any
+// completed tombstones into completeTombstones.
+func (p *pebbleRangeTombstoneIterator) updateTombstones() {
+	var startKey, endKey roachpb.Key
+	var rangeKeys []pebble.RangeKeyData
+
+	// If the iterator is exhausted, we still want to complete any remaining
+	// incomplete tombstones.
+	if p.iter.Valid() {
+		startKey, endKey = p.iter.RangeBounds()
+		rangeKeys = p.iter.RangeKeys()
+
+		// TODO(erikgrinaker): Pebble does not yet truncate range keys to the
+		// LowerBound or UpperBound of the range, so we truncate them here.
+		if p.lowerBound != nil && bytes.Compare(startKey, p.lowerBound) < 0 {
+			startKey = p.lowerBound
+		}
+		if p.upperBound != nil && bytes.Compare(endKey, p.upperBound) > 0 {
+			endKey = p.upperBound
+		}
+	} else if err := p.iter.Error(); err != nil {
+		p.err = err
+		return
+	}
+
+	// TODO(erikgrinaker): Pebble does not yet respect UpperBound for range keys,
+	// so we handle it here temporarily by exhausting the iterator. If Pebble
+	// won't support this then we should mark the iterator as done instead.
+	if len(p.upperBound) > 0 && bytes.Compare(startKey, p.upperBound) >= 0 {
+		for p.iter.Next() {
+		}
+		startKey, endKey, rangeKeys = nil, nil, nil
+	}
+
+	// Both RangeKeys and incompleteTombstones are sorted in descending suffix
+	// order, so we iterate over them in lockstep and insert/update/delete
+	// incompleteTombstones as appropriate.
+	var tsIdx, rkIdx int
+	var rangeValue enginepb.MVCCRangeValue
+
+	for rkIdx < len(rangeKeys) {
+		rangeKey := rangeKeys[rkIdx]
+
+		// Filter rangekeys by suffix.
+		//
+		// TODO(erikgrinaker): This can be optimized by skipping unnecessary
+		// comparisons since rangeKeys is sorted by suffix. Maybe later.
+		if p.minSuffix != nil && bytes.Compare(rangeKey.Suffix, p.minSuffix) < 0 {
+			rkIdx++
+			continue
+		}
+		if p.maxSuffix != nil && bytes.Compare(rangeKey.Suffix, p.maxSuffix) > 0 {
+			rkIdx++
+			continue
+		}
+
+		// Make sure this range key is in fact a range tombstone. This check can be
+		// dropped if it hampers performance, since the only current range keys are
+		// range tombstones.
+		if err := protoutil.Unmarshal(rangeKey.Value, &rangeValue); err != nil {
+			p.err = errors.Wrapf(err, "failed to decode range value for %s-%s", startKey, endKey)
+			return
+		}
+		if rangeValue.Tombstone == nil {
+			p.err = errors.Errorf("found unknown range value at %s-%s: %s", startKey, endKey, rangeValue)
+			return
+		}
+
+		// If we're at the end of incompleteTombstones, this range tombstone must be new.
+		if tsIdx >= len(p.incomplete) {
+			p.incomplete = append(p.incomplete, &incompleteTombstone{
+				startKey: append(make([]byte, 0, len(startKey)), startKey...),
+				endKey:   append(make([]byte, 0, len(endKey)), endKey...),
+				suffix:   append(make([]byte, 0, len(rangeKey.Suffix)), rangeKey.Suffix...),
+			})
+			rkIdx++
+			tsIdx++
+			continue
+		}
+
+		incomplete := p.incomplete[tsIdx]
+		cmp := bytes.Compare(incomplete.suffix, rangeKey.Suffix)
+		switch {
+		// If the suffixes match and the key spans are adjacent or overlapping,
+		// this range key extends the incomplete tombstone.
+		case cmp == 0 && bytes.Compare(startKey, incomplete.endKey) <= 0:
+			incomplete.endKey = append(incomplete.endKey[:0], endKey...)
+			tsIdx++
+			rkIdx++
+
+		// This is a different tombstone at the same suffix: complete the existing
+		// tombstone and start a new one.
+		case cmp == 0:
+			complete, err := incomplete.complete()
+			if err != nil {
+				p.err = err
+				return
+			}
+			p.complete = append(p.complete, complete)
+
+			// NB: can't reuse slices, as they were placed in the completed tombstone.
+			incomplete.startKey = append(make([]byte, 0, len(startKey)), startKey...)
+			incomplete.endKey = append(make([]byte, 0, len(endKey)), endKey...)
+
+		// This incomplete tombstone is not present at this range key: complete it
+		// and remove it from the list, then try again.
+		case cmp == 1:
+			complete, err := incomplete.complete()
+			if err != nil {
+				p.err = err
+				return
+			}
+			p.complete = append(p.complete, complete)
+			p.incomplete = append(p.incomplete[:tsIdx],
+				p.incomplete[tsIdx+1:]...)
+
+		// This range key is a new incomplete tombstone: start tracking it.
+		case cmp == -1:
+			p.incomplete = append(p.incomplete[:tsIdx+1],
+				p.incomplete[tsIdx:]...)
+			p.incomplete[tsIdx] = &incompleteTombstone{
+				startKey: append(make(roachpb.Key, 0, len(startKey)), startKey...),
+				endKey:   append(make(roachpb.Key, 0, len(endKey)), endKey...),
+				suffix:   append(make([]byte, 0, len(rangeKey.Suffix)), rangeKey.Suffix...),
+			}
+			tsIdx++
+			rkIdx++
+
+		default:
+			p.err = errors.Errorf("unexpected comparison result %d", cmp)
+			return
+		}
+	}
+
+	// If the caller has requested tombstone fragments, we complete all tombstones
+	// we found during this iteration by resetting tsIdx to 0. The loop below will
+	// handle the rest.
+	if p.fragmented {
+		tsIdx = 0
+	}
+
+	// If there are any remaining incomplete tombstones, they must be complete:
+	// make them so.
+	for _, incomplete := range p.incomplete[tsIdx:] {
+		complete, err := incomplete.complete()
+		if err != nil {
+			p.err = err
+			return
+		}
+		p.complete = append(p.complete, complete)
+	}
+	p.incomplete = p.incomplete[:tsIdx]
+}
+
+// Close implements MVCCRangeTombstoneIterator.
+func (p *pebbleRangeTombstoneIterator) Close() {
+	_ = p.iter.Close()
+	p.complete = nil
+	p.completeIdx = 0
+}
+
+// Next implements MVCCRangeTombstoneIterator.
+func (p *pebbleRangeTombstoneIterator) Next() {
+	p.completeIdx++
+	if p.completeIdx >= len(p.complete) {
+		p.iter.Next()
+		// NB: Called even if Next() fails, because we may have incomplete
+		// tombstones that become complete when the iterator is exhausted.
+		p.findCompleteTombstones()
+	}
+}
+
+// Key implements MVCCRangeTombstoneIterator.
+func (p *pebbleRangeTombstoneIterator) Key() MVCCRangeKey {
+	return p.complete[p.completeIdx]
+}
+
+// Valid implements MVCCRangeTombstoneIterator.
+func (p *pebbleRangeTombstoneIterator) Valid() (bool, error) {
+	if p.err != nil {
+		return false, p.err
+	}
+	if err := p.iter.Error(); err != nil {
+		return false, err
+	}
+	return p.completeIdx < len(p.complete), nil
+}

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -118,6 +118,16 @@ func (fw *SSTWriter) ClearMVCCRange(start, end MVCCKey) error {
 	return fw.clearRange(start, end)
 }
 
+// ExperimentalDeleteMVCCRange implements the Writer interface.
+func (fw *SSTWriter) ExperimentalDeleteMVCCRange(_ MVCCRangeKey) error {
+	panic("ExperimentalDeleteMVCCRange is unsupported")
+}
+
+// ExperimentalClearMVCCRangeTombstone implements the Writer interface.
+func (fw *SSTWriter) ExperimentalClearMVCCRangeTombstone(_ MVCCRangeKey) error {
+	panic("ExperimentalClearMVCCRangeTombstone is unsupported")
+}
+
 func (fw *SSTWriter) clearRange(start, end MVCCKey) error {
 	if fw.fw == nil {
 		return errors.New("cannot call ClearRange on a closed writer")

--- a/pkg/storage/testdata/mvcc_histories/delete_range_tombstone
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_tombstone
@@ -1,0 +1,121 @@
+# TODO(erikgrinaker): The MVCC API does not respect range tombstones yet, so
+# we don't test point keys because they remain unaffected.
+# TODO(erikgrinaker): This needs conflict tests, implement later.
+
+# Write some range tombstones. Some will abut and merge.
+run ok
+del_range_ts k=b end=c ts=3
+del_range_ts k=e end=g ts=3
+del_range_ts k=d end=f ts=5
+del_range_ts k=d end=f ts=2
+del_range_ts k=m end=z ts=1
+del_range_ts k=a end=m ts=4
+del_range_ts k=m end=z ts=4
+----
+del_range_ts: {b-c}/3.000000000,0
+del_range_ts: {e-g}/3.000000000,0
+del_range_ts: {d-f}/5.000000000,0
+del_range_ts: {d-f}/2.000000000,0
+del_range_ts: {m-z}/1.000000000,0
+del_range_ts: {a-m}/4.000000000,0
+del_range_ts: {m-z}/4.000000000,0
+>> at end:
+range tombstone: {b-c}/3.000000000,0
+range tombstone: {d-f}/5.000000000,0
+range tombstone: {d-f}/2.000000000,0
+range tombstone: {e-g}/3.000000000,0
+range tombstone: {a-z}/4.000000000,0
+range tombstone: {m-z}/1.000000000,0
+
+# Scan all tombstones.
+run ok
+scan_range_ts k=a end=z
+----
+scan_range_ts: {b-c}/3.000000000,0
+scan_range_ts: {d-f}/5.000000000,0
+scan_range_ts: {d-f}/2.000000000,0
+scan_range_ts: {e-g}/3.000000000,0
+scan_range_ts: {a-z}/4.000000000,0
+scan_range_ts: {m-z}/1.000000000,0
+
+# Scan truncates tombstones to scan bounds.
+run ok
+scan_range_ts k=c end=e
+----
+scan_range_ts: {d-e}/5.000000000,0
+scan_range_ts: {c-e}/4.000000000,0
+scan_range_ts: {d-e}/2.000000000,0
+
+# Scan truncates tombstones to scan bounds when not on tombstone bounds.
+run ok
+scan_range_ts k=ccc end=eee
+----
+scan_range_ts: {d-eee}/5.000000000,0
+scan_range_ts: {ccc-eee}/4.000000000,0
+scan_range_ts: e{-ee}/3.000000000,0
+scan_range_ts: {d-eee}/2.000000000,0
+
+# Scan at a timestamp.
+run ok
+scan_range_ts k=a end=z ts=3
+----
+scan_range_ts: {b-c}/3.000000000,0
+scan_range_ts: {d-f}/2.000000000,0
+scan_range_ts: {e-g}/3.000000000,0
+scan_range_ts: {m-z}/1.000000000,0
+
+# Empty scans.
+run ok
+scan_range_ts k=A end=Z
+scan_range_ts k=c end=c
+scan_range_ts k=z end=a
+----
+scan_range_ts: "A"-"Z" -> <no data>
+scan_range_ts: "c"-"c" -> <no data>
+scan_range_ts: "z"-"a" -> <no data>
+
+# Remove some tombstones, both a non-existant one and a span across two
+# tombstones.
+run ok
+clear_range_ts k=a end=z ts=10
+clear_range_ts k=b end=g ts=3
+----
+>> at end:
+range tombstone: {d-f}/5.000000000,0
+range tombstone: {d-f}/2.000000000,0
+range tombstone: {a-z}/4.000000000,0
+range tombstone: {m-z}/1.000000000,0
+
+# Remove the middle section of the [a-z)@4 tombstone.
+run ok
+clear_range_ts k=k end=n ts=4
+----
+>> at end:
+range tombstone: {d-f}/5.000000000,0
+range tombstone: {d-f}/2.000000000,0
+range tombstone: {a-k}/4.000000000,0
+range tombstone: {n-z}/4.000000000,0
+range tombstone: {m-z}/1.000000000,0
+
+# Remove [a-z)@4 again to make sure clears are idempotent.
+run ok
+clear_range_ts k=k end=n ts=4
+----
+>> at end:
+range tombstone: {d-f}/5.000000000,0
+range tombstone: {d-f}/2.000000000,0
+range tombstone: {a-k}/4.000000000,0
+range tombstone: {n-z}/4.000000000,0
+range tombstone: {m-z}/1.000000000,0
+
+
+# Remove portions of the [a-k)@4 and [n-z)@4 tombstones in one operation.
+run ok
+clear_range_ts k=eee end=ttt ts=4
+----
+>> at end:
+range tombstone: {a-eee}/4.000000000,0
+range tombstone: {d-f}/5.000000000,0
+range tombstone: {d-f}/2.000000000,0
+range tombstone: {ttt-z}/4.000000000,0
+range tombstone: {m-z}/1.000000000,0


### PR DESCRIPTION
There is an alternative API in #76131, which I think I prefer. This exposes MVCC range keys as a first-class primitive, which is useful e.g. for backup/restore, rangefeed catchup scans, and other components that need to access range tombstones as distinct entities -- these can then take advantage of Pebble facilities such as combined iteration and range key masking.

---

This patch adds initial experimental primitives for MVCC range
tombstones, based on experimental Pebble range keys:

* Data structures for in-memory and on-disk representation:
  * `storage.MVCCRangeKey`
  * `enginepb.MVCCRangeValue`
  * `enginepb.MVCCRangeTombstone`

* Functions for writing and clearing range tombstones:
  * `Engine.ExperimentalClearMVCCRangeTombstone()`
  * `Engine.ExperimentalDeleteMVCCRange()`
  * `storage.ExperimentalMVCCDeleteRangeUsingTombstone()`

* Iterator and function for reading range tombstones:
  * `Engine.NewMVCCRangeTombstoneIterator()`
  * `storage.MVCCRangeTombstoneIterator`
  * `storage.ScanMVCCRangeTombstones()`

Range tombstones do not have a distinct identity, and should instead be
considered a tombstone continuum: they will merge with abutting
tombstones, can be partially cleared, can split or merge along with
ranges, and so on. Bounded scans will truncate them to the scan bounds.

Range tombstones are not yet handled in the rest of the MVCC API, nor
are they exposed via KV APIs. They are not persisted to disk either, due
to Pebble range key limitations. Subsequent pull requests will extend
their functionality and integrate them with other components.

Touches #70412.

Release note: None

---

For high-level summary, see internal [draft tech note](https://docs.google.com/document/d/1jd0rAo-c9OIwJcPTUJ2Kt2mcG0XtqA3Exv67ekcC5bg/edit#).