### PR TITLE
sql: fix a span use-after-finish in generator cleanup

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -751,7 +751,7 @@ CREATE TABLE crdb_internal.jobs (
 			return nil, nil, err
 		}
 
-		cleanup := func() {
+		cleanup := func(ctx context.Context) {
 			if err := it.Close(); err != nil {
 				// TODO(yuzefovich): this error should be propagated further up
 				// and not simply being logged. Fix it (#61123).

--- a/pkg/sql/virtual_table_test.go
+++ b/pkg/sql/virtual_table_test.go
@@ -48,7 +48,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 		require.Equal(t, tree.Datums{tree.NewDInt(1)}, d)
 
 		// Check that we can safely cleanup in the middle of execution.
-		cleanup()
+		cleanup(ctx)
 	})
 
 	t.Run("test worker error", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 		require.NoError(t, err)
 		_, err = next()
 		require.Error(t, err)
-		cleanup()
+		cleanup(ctx)
 	})
 
 	t.Run("test no next", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 		}
 		_, cleanup, setupError := setupGenerator(ctx, worker, stopper)
 		require.NoError(t, setupError)
-		cleanup()
+		cleanup(ctx)
 	})
 
 	t.Run("test context cancellation", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 		if err != nil {
 			require.Equal(t, cancelchecker.QueryCanceledError, err)
 		}
-		cleanup()
+		cleanup(ctx)
 
 		// Test cancellation after asking for a row.
 		ctx, cancel = context.WithCancel(context.Background())
@@ -117,7 +117,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 		cancel()
 		_, err = next()
 		require.Equal(t, cancelchecker.QueryCanceledError, err)
-		cleanup()
+		cleanup(ctx)
 
 		// Test cancellation after asking for all the rows.
 		ctx, cancel = context.WithCancel(context.Background())
@@ -128,7 +128,7 @@ func TestVirtualTableGenerators(t *testing.T) {
 		_, err = next()
 		require.NoError(t, err)
 		cancel()
-		cleanup()
+		cleanup(ctx)
 	})
 }
 
@@ -153,6 +153,6 @@ func BenchmarkVirtualTableGenerators(b *testing.B) {
 			_, err := next()
 			require.NoError(b, err)
 		}
-		cleanup()
+		cleanup(ctx)
 	})
 }


### PR DESCRIPTION
A virtual table cleanup closure (the one for crdb_internal.jobs) was
capturing a context and using it after the tracing span in that context
had already been finished. This patch fixes it by plumbing a proper
context to the generator cleanup functions.

Release note: None