### PR TITLE
sql: introduce the random cost fuzzer test

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -371,7 +371,7 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 	if class == tree.WindowClass && s.d6() != 1 {
 		class = tree.NormalClass
 	}
-	fns := functions[class][typ.Oid()]
+	fns := s.functions[class][typ.Oid()]
 	if len(fns) == 0 {
 		return nil, false
 	}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/lib/pq/oid"
 )
 
 // sqlsmith-go
@@ -68,6 +69,7 @@ type Smither struct {
 	nameCounts       map[string]int
 	activeSavepoints []string
 	types            *typeInfo
+	functions        map[tree.FunctionClass]map[oid.Oid][]function
 
 	stmtWeights, alterWeights          []statementWeight
 	stmtSampler, alterSampler          *statementSampler
@@ -82,6 +84,7 @@ type Smither struct {
 	disableImpureFns   bool
 	disableLimits      bool
 	disableWindowFuncs bool
+	disableImpureFuncs bool
 	simpleDatums       bool
 	avoidConsts        bool
 	outputSort         bool
@@ -122,6 +125,7 @@ func NewSmither(db *gosql.DB, rnd *rand.Rand, opts ...SmitherOption) (*Smither, 
 	for _, opt := range opts {
 		opt.Apply(s)
 	}
+	s.functions = functions(s)
 	s.stmtSampler = newWeightedStatementSampler(s.stmtWeights, rnd.Int63())
 	s.alterSampler = newWeightedStatementSampler(s.alterWeights, rnd.Int63())
 	s.tableExprSampler = newWeightedTableExprSampler(s.tableExprWeights, rnd.Int63())
@@ -238,6 +242,24 @@ var DisableMutations = simpleOption("disable mutations", func(s *Smither) {
 	s.stmtWeights = nonMutatingStatements
 	s.tableExprWeights = nonMutatingTableExprs
 })
+
+// DisableImpureFuncs causes the Smither to not emit statements that contain
+// impure builtins (aka builtins that don't always return the same result).
+var DisableImpureFuncs = simpleOption("disable impure funcs", func(s *Smither) {
+	s.disableImpureFuncs = true
+})
+
+// SetComplexity configures the Smither's complexity, in other words the
+// likelihood that at any given node the Smither will recurse and create a
+// deeper query true. The default is .2.
+func SetComplexity(complexity float64) SmitherOption {
+	return option{
+		name: "set complexity (likelihood of making a deeper random tree",
+		apply: func(s *Smither) {
+			s.complexity = complexity
+		},
+	}
+}
 
 // DisableDDLs causes the Smither to not emit statements that change table
 // schema (CREATE, DROP, ALTER, etc.)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2894,6 +2894,10 @@ func (m *sessionDataMutator) SetTestingVectorizeInjectPanics(val bool) {
 	m.data.TestingVectorizeInjectPanics = val
 }
 
+func (m *sessionDataMutator) SetTestingOptimizerRandomCostSeed(val int64) {
+	m.data.LocalOnlySessionData.TestingOptimizerRandomCostSeed = val
+}
+
 func (m *sessionDataMutator) SetOptimizerFKCascadesLimit(val int) {
 	m.data.OptimizerFKCascadesLimit = int64(val)
 }

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/tools/container/intsets"
 )
@@ -83,6 +84,8 @@ type coster struct {
 	// 0.5, and the estimated cost of an expression is c, the cost returned by
 	// ComputeCost will be in the range [c - 0.5 * c, c + 0.5 * c).
 	perturbation float64
+
+	rng *rand.Rand
 }
 
 var _ Coster = &coster{}
@@ -439,14 +442,26 @@ var fnCost = map[string]memo.Cost{
 }
 
 // Init initializes a new coster structure with the given memo.
-func (c *coster) Init(evalCtx *tree.EvalContext, mem *memo.Memo, perturbation float64) {
+func (c *coster) Init(evalCtx *tree.EvalContext, mem *memo.Memo, perturbation float64, seed int64) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
+	var rng *rand.Rand
+	if perturbation != 0 || seed != 0 {
+		rng, _ = randutil.NewPseudoRand()
+		rng.Seed(seed)
+		if perturbation == 0 {
+			// If we've been initialized with a random seed but not an explicit
+			// perturbation value, use the max perturbation. This is used for tests
+			// that set the seed with testing_optimizer_random_cost_seed.
+			perturbation = 1.0
+		}
+	}
 	*c = coster{
 		evalCtx:      evalCtx,
 		mem:          mem,
 		locality:     evalCtx.Locality,
 		perturbation: perturbation,
+		rng:          rng,
 	}
 }
 
@@ -555,7 +570,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		// Don't perturb the cost if we are forcing an index.
 		if cost < hugeCost {
 			// Get a random value in the range [-1.0, 1.0)
-			multiplier := 2*rand.Float64() - 1
+			multiplier := 2*c.rng.Float64() - 1
 
 			// If perturbation is p, and the estimated cost of an expression is c,
 			// the new cost is in the range [max(0, c - pc), c + pc). For example,

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -113,7 +113,8 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	o.f.Init(evalCtx, catalog)
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
-	o.defaultCoster.Init(evalCtx, o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation)
+	o.defaultCoster.Init(evalCtx, o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation,
+		evalCtx.SessionData().LocalOnlySessionData.TestingOptimizerRandomCostSeed)
 	o.coster = &o.defaultCoster
 	if evalCtx.TestingKnobs.DisableOptimizerRuleProbability > 0 {
 		o.disableRules(evalCtx.TestingKnobs.DisableOptimizerRuleProbability)
@@ -951,7 +952,7 @@ func (o *Optimizer) FormatMemo(flags FmtFlags) string {
 // the real computed cost, not the perturbed cost.
 func (o *Optimizer) RecomputeCost() {
 	var c coster
-	c.Init(o.evalCtx, o.mem, 0 /* perturbation */)
+	c.Init(o.evalCtx, o.mem, 0 /* perturbation */, 0 /* seed */)
 
 	root := o.mem.RootExpr()
 	rootProps := o.mem.RootProps()

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -226,6 +226,10 @@ message LocalOnlySessionData {
   // and joins using the same default number of bytes per column instead of
   // column sizes from the AvgSize table statistic.
   bool cost_scans_with_default_col_size = 61;
+  // TestingOptimizerRandomCostSeed is non-zero when the coster should randomly
+  // perturb costs with an rng seeded to the given integer. This should only be
+  // used in test scenarios and is very much a non-production setting.
+  int64 testing_optimizer_random_cost_seed = 62;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/tests/cost_fuzzer_test.go
+++ b/pkg/sql/tests/cost_fuzzer_test.go
@@ -1,0 +1,153 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestCostFuzzer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	scope := log.Scope(t)
+	outDir := scope.GetDirectory()
+	defer scope.Close(t)
+	ctx := context.Background()
+	cluster := testcluster.NewTestCluster(t, 1, base.TestClusterArgs{})
+	cluster.Start(t)
+	defer cluster.Stopper().Stop(ctx)
+
+	conn := cluster.Conns[0]
+	rng, _ := randutil.NewTestRand()
+
+	setup := sqlsmith.Setups[sqlsmith.RandTableSetupName](rng)
+	if _, err := conn.Exec(setup); err != nil {
+		t.Fatal(err)
+	}
+	setupLog := []string{setup}
+
+	// Initialize a smither that generates only INSERT, UPDATE, and DELETE
+	// statements with the MutationsOnly option.
+	mutatingSmither, err := sqlsmith.NewSmither(conn, rng, sqlsmith.MutationsOnly())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mutatingSmither.Close()
+	smither, err := sqlsmith.NewSmither(conn, rng,
+		sqlsmith.DisableMutations(), sqlsmith.DisableImpureFuncs(), sqlsmith.DisableLimits(),
+		sqlsmith.SetComplexity(.3),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer smither.Close()
+
+	runner := sqlutils.MakeSQLRunner(conn)
+	for i := 0; i < 100000; i++ {
+		_, err = conn.Exec("SET testing_optimizer_random_cost_seed = 0")
+		if err != nil {
+			t.Fatalf("failed to perturb costs %s", err)
+		}
+		// Run 1000 mutations first so that the tables have rows. Run a mutation
+		// for a tenth of the iterations after that to continually change the
+		// state of the database.
+		if i < 1000 || i%10 == 0 {
+			stmt := mutatingSmither.Generate()
+			setupLog = append(setupLog, stmt)
+			if _, err := conn.Exec(stmt); err != nil {
+				// Ignore generation errors.
+				continue
+			}
+		}
+
+		stmt := smither.Generate()
+
+		// First, run the statement without cost perturbation.
+		rows, err := conn.Query(stmt)
+		if err != nil {
+			// Ignore errors.
+			continue
+		}
+		defer rows.Close()
+		unperturbedRows, err := sqlutils.RowsToStrMatrix(rows)
+		if err != nil {
+			// Ignore errors.
+			continue
+		}
+		seed := rng.Int63()
+		_, err = conn.Exec(fmt.Sprintf("SET testing_optimizer_random_cost_seed = %d", seed))
+		if err != nil {
+			t.Fatalf("failed to perturb costs %s", err)
+		}
+
+		// Then, run the query with cost perturbation.
+		rows2, err := conn.Query(stmt)
+		if err != nil {
+			// Ignore errors.
+			continue
+		}
+		defer rows2.Close()
+		perturbedRows, err := sqlutils.RowsToStrMatrix(rows2)
+		if err != nil {
+			// Ignore errors.
+			continue
+		}
+		if diff := UnsortedMatricesDiff(unperturbedRows, perturbedRows); diff != "" {
+			// We have a mismatch in the perturbed vs non-perturbed query outputs.
+			// Output the real plan and the perturbed plan, along with the seed, so
+			// that the perturbed query is reproducible.
+			perturbedExplain := sqlutils.MatrixToStr(runner.QueryStr(t, "EXPLAIN "+stmt))
+			runner.Exec(t, "SET testing_optimizer_random_cost_seed = 0")
+			unperturbedExplain := sqlutils.MatrixToStr(runner.QueryStr(t, "EXPLAIN "+stmt))
+
+			logfile := filepath.Join(outDir, "setup.log")
+			if err := os.WriteFile(logfile, []byte(strings.Join(setupLog, ";\n\n")+";"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Fatalf(
+				`expected unperturbed and perturbed results to be equal:
+%s
+
+sql:
+%s
+
+testing_optimizer_random_cost_seed = %d
+non-perturbed explain:
+%s
+
+perturbed explain:
+%s
+
+schema:
+%s
+
+%s
+%s
+
+setup logs written to %s
+`,
+				diff, stmt, seed, unperturbedExplain, perturbedExplain, setup, unperturbedRows, perturbedRows, logfile)
+		}
+	}
+}

--- a/pkg/sql/tests/unsorted_matrices_diff.go
+++ b/pkg/sql/tests/unsorted_matrices_diff.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// UnsortedMatricesDiff returns a diff of the two input string matrices. The
+// inputs do not have to be in the same sorted order to be compared as equal.
+// If the input matrices are identical, the result is the empty string.
+func UnsortedMatricesDiff(rowMatrix1, rowMatrix2 [][]string) string {
+	var rows1 []string
+	for _, row := range rowMatrix1 {
+		rows1 = append(rows1, strings.Join(row[:], ","))
+	}
+	var rows2 []string
+	for _, row := range rowMatrix2 {
+		rows2 = append(rows2, strings.Join(row[:], ","))
+	}
+	sort.Strings(rows1)
+	sort.Strings(rows2)
+	return cmp.Diff(rows1, rows2)
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -692,6 +692,24 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: globalFalse,
 	},
 
+	`testing_optimizer_random_cost_seed`: {
+		GetStringVal: makeIntGetStringValFn(`testing_optimizer_random_cost_seed`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			i, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			m.SetTestingOptimizerRandomCostSeed(i)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return strconv.FormatInt(evalCtx.SessionData().LocalOnlySessionData.TestingOptimizerRandomCostSeed, 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(0, 10)
+		},
+	},
+
 	// CockroachDB extension.
 	// This is deprecated; the only allowable setting is "on".
 	`optimizer`: {


### PR DESCRIPTION
This is a new test that leverages the optimizer cost perturbation test
mode and SQLSmith statemente generation. The test runs in a loop, by
creating a random statement, running it as normal, then running it with
perturbed costs, and comparing the results. If the results are not
identical with and without cost perturbation, there should be a bug
somewhere in either the execution engine (one of the operators doing the
wrong thing) or the optimizer (one of the transformation rules doing the
wrong thing).

Release note: None