### PR TITLE
scripts: add `gceworker reset` to hard reset VM

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -83,6 +83,16 @@ case "${cmd}" in
     fi
     gcloud compute instances stop "${NAME}"
     ;;
+    reset)
+    read -r -p "This will hard reset (\"powercycle\") the VM. Are you sure? [yes] " response
+    # Convert to lowercase.
+    response=$(echo "$response" | tr '[:upper:]' '[:lower:]')
+    if [[ $response != "yes" ]]; then
+      echo Aborting
+      exit 1
+    fi
+    gcloud compute instances reset "${NAME}"
+    ;;
     delete|destroy)
     read -r -p "This will delete the VM! Are you sure? [yes] " response
     # Convert to lowercase.


### PR DESCRIPTION
This patch adds a command `gceworker reset` which will do a hard reset
("powercycle") of the VM. This is useful e.g. if some runaway process
(read: gopls) eats up all the memory and essentially freezes the VM.

Release note: None