### PR TITLE
sql: Replace `WITH BUCKET_COUNT` with new `bucket_count` storage param.

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -2622,7 +2622,7 @@ SET experimental_enable_hash_sharded_indexes = true
 
 statement ok
 CREATE TABLE hash_sharded_idx_table (
-  pk INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+  pk INT PRIMARY KEY USING HASH WITH (bucket_count=8)
 )
 
 statement error cannot convert hash_sharded_idx_table to REGIONAL BY ROW as the table contains hash sharded indexes

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -48,21 +48,21 @@ SET experimental_enable_hash_sharded_indexes = true
 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
 CREATE TABLE regional_by_row_table (
-  pk INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+  pk INT PRIMARY KEY USING HASH WITH (bucket_count=8)
 ) LOCALITY REGIONAL BY ROW
 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
 CREATE TABLE regional_by_row_table (
   pk INT NOT NULL,
   a INT,
-  PRIMARY KEY(pk) USING HASH WITH BUCKET_COUNT = 8
+  PRIMARY KEY(pk) USING HASH WITH (bucket_count=8)
 ) LOCALITY REGIONAL BY ROW
 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
 CREATE TABLE regional_by_row_table (
   pk INT NOT NULL,
   a INT,
-  INDEX(a) USING HASH WITH BUCKET_COUNT = 8
+  INDEX(a) USING HASH WITH (bucket_count=8)
 ) LOCALITY REGIONAL BY ROW
 
 statement error multi-region tables with an INDEX containing PARTITION BY are not supported
@@ -333,10 +333,10 @@ CREATE INDEX bad_idx ON regional_by_row_table(a) PARTITION BY LIST (a) (
 )
 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-CREATE INDEX bad_idx ON regional_by_row_table(a) USING HASH WITH BUCKET_COUNT = 8
+CREATE INDEX bad_idx ON regional_by_row_table(a) USING HASH WITH (bucket_count=8)
 
 statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HASH WITH BUCKET_COUNT = 8
+ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HASH WITH (bucket_count=8)
 
 # Try add a new unique column.
 statement ok

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -256,16 +256,16 @@ func TestIndexForDisplay(t *testing.T) {
 			tableName:   descpb.AnonymousTable,
 			partition:   "",
 			displayMode: IndexDisplayDefOnly,
-			expected:    "INDEX baz (a DESC) USING HASH WITH BUCKET_COUNT = 8",
-			pgExpected:  "INDEX baz USING btree (a DESC) USING HASH WITH BUCKET_COUNT = 8",
+			expected:    "INDEX baz (a DESC) USING HASH WITH (bucket_count=8)",
+			pgExpected:  "INDEX baz USING btree (a DESC) USING HASH WITH (bucket_count=8)",
 		},
 		{
 			index:       shardedIndex,
 			tableName:   tableName,
 			partition:   "",
 			displayMode: IndexDisplayShowCreate,
-			expected:    "CREATE INDEX baz ON foo.public.bar (a DESC) USING HASH WITH BUCKET_COUNT = 8",
-			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH WITH BUCKET_COUNT = 8",
+			expected:    "CREATE INDEX baz ON foo.public.bar (a DESC) USING HASH WITH (bucket_count=8)",
+			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH WITH (bucket_count=8)",
 		},
 	}
 

--- a/pkg/sql/catalog/catpb/catalog.proto
+++ b/pkg/sql/catalog/catpb/catalog.proto
@@ -99,7 +99,7 @@ enum GeneratedAsIdentityType {
 // As as example, sample field values for the following table:
 //
 // CREATE TABLE abc (
-//   a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=10,  // column id: 1
+//   a INT PRIMARY KEY USING HASH WITH (bucket_count=10),  // column id: 1
 //   b BYTES
 // );
 //

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -505,7 +505,7 @@ CREATE TABLE system.statement_statistics (
     ) STORED,
 
     CONSTRAINT "primary" PRIMARY KEY (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
-      USING HASH WITH BUCKET_COUNT = 8,
+      USING HASH WITH (bucket_count=8),
     INDEX "fingerprint_stats_idx" (fingerprint_id, transaction_fingerprint_id),
 		FAMILY "primary" (
 			crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,
@@ -539,7 +539,7 @@ CREATE TABLE system.transaction_statistics (
     )) STORED,
 
     CONSTRAINT "primary" PRIMARY KEY (aggregated_ts, fingerprint_id, app_name, node_id)
-      USING HASH WITH BUCKET_COUNT = 8,
+      USING HASH WITH (bucket_count=8),
     INDEX "fingerprint_stats_idx" (fingerprint_id),
 		FAMILY "primary" (
 			crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8,

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -63,7 +63,7 @@ func TestIndexInterface(t *testing.T) {
 			INDEX s1 (c4 DESC, c5 DESC),
 			INVERTED INDEX s2 (c6),
 			INDEX s3 (c2, c3) STORING (c5, c6),
-			INDEX s4 (c5) USING HASH WITH BUCKET_COUNT=8,
+			INDEX s4 (c5) USING HASH WITH (bucket_count=8),
 			UNIQUE INDEX s5 (c1, c4) WHERE c4 = 'x',
 			INVERTED INDEX s6 (c7) WITH (s2_level_mod=2)
 		);

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -595,7 +595,7 @@ func PrimaryKeyString(desc catalog.TableDescriptor) string {
 	f.WriteByte(')')
 	if primaryIdx.IsSharded() {
 		f.WriteString(
-			fmt.Sprintf(" USING HASH WITH BUCKET_COUNT = %v", primaryIdx.GetSharded().ShardBuckets),
+			fmt.Sprintf(" USING HASH WITH (bucket_count=%v)", primaryIdx.GetSharded().ShardBuckets),
 		)
 	}
 	return f.CloseAndGetString()

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -193,7 +193,7 @@ CREATE TABLE t (
   UNIQUE INDEX i4 (z), -- will be rewritten.
   UNIQUE INDEX i5 (w) STORING (y), -- will be rewritten.
   INVERTED INDEX i6 (v), -- will be rewritten.
-  INDEX i7 (z) USING HASH WITH BUCKET_COUNT = 4, -- will be rewritten.
+  INDEX i7 (z) USING HASH WITH (bucket_count=4), -- will be rewritten.
   FAMILY (x, y, z, w, v)
 );
 INSERT INTO t VALUES (1, 2, 3, 4, '{}');
@@ -217,7 +217,7 @@ t  CREATE TABLE public.t (
    UNIQUE INDEX i4 (z ASC),
    UNIQUE INDEX i5 (w ASC) STORING (y),
    INVERTED INDEX i6 (v),
-   INDEX i7 (z ASC) USING HASH WITH BUCKET_COUNT = 4,
+   INDEX i7 (z ASC) USING HASH WITH (bucket_count=4),
    FAMILY fam_0_x_y_z_w_v (x, y, z, w, v)
 )
 
@@ -349,11 +349,11 @@ CREATE TABLE t (
   x INT PRIMARY KEY,
   y INT NOT NULL,
   z INT,
-  INDEX i1 (z) USING HASH WITH BUCKET_COUNT = 5,
+  INDEX i1 (z) USING HASH WITH (bucket_count=5),
   FAMILY (x, y, z)
 );
 INSERT INTO t VALUES (1, 2, 3);
-ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y) USING HASH WITH BUCKET_COUNT = 10
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y) USING HASH WITH (bucket_count=10)
 
 query TT
 SHOW CREATE t
@@ -364,9 +364,9 @@ t  CREATE TABLE public.t (
    z INT8 NULL,
    crdb_internal_z_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(z)), 5:::INT8)) VIRTUAL,
    crdb_internal_y_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(y)), 10:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 10,
+   CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=10),
    UNIQUE INDEX t_x_key (x ASC),
-   INDEX i1 (z ASC) USING HASH WITH BUCKET_COUNT = 5,
+   INDEX i1 (z ASC) USING HASH WITH (bucket_count=5),
    FAMILY fam_0_x_y_z (x, y, z)
 )
 
@@ -406,7 +406,7 @@ SELECT * FROM t@i1
 statement ok
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (
-  x INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=5,
+  x INT PRIMARY KEY USING HASH WITH (bucket_count=5),
   y INT NOT NULL,
   z INT,
   INDEX i (z),
@@ -424,7 +424,7 @@ t  CREATE TABLE public.t (
    y INT8 NOT NULL,
    z INT8 NULL,
    CONSTRAINT t_pkey PRIMARY KEY (y ASC),
-   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 5,
+   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=5),
    INDEX i (z ASC),
    FAMILY fam_0_x_y_z (x, y, z)
 )
@@ -542,7 +542,7 @@ t  CREATE TABLE public.t (
 statement ok
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (x INT NOT NULL);
-ALTER TABLE t ADD PRIMARY KEY (x) USING HASH WITH BUCKET_COUNT=4
+ALTER TABLE t ADD PRIMARY KEY (x) USING HASH WITH (bucket_count=4)
 
 query TT
 SHOW CREATE t
@@ -551,7 +551,7 @@ t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
    crdb_internal_x_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 4:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 4,
+   CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=4),
    FAMILY "primary" (x, rowid)
 )
 
@@ -934,8 +934,8 @@ SELECT index_id, index_name FROM crdb_internal.table_indexes WHERE descriptor_na
 # count shouldn't cause the old primary key to be copied.
 statement ok
 DROP TABLE IF EXISTS t CASCADE;
-CREATE TABLE t (x INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 2);
-ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (x) USING HASH WITH BUCKET_COUNT=3
+CREATE TABLE t (x INT PRIMARY KEY USING HASH WITH (bucket_count=2));
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (x) USING HASH WITH (bucket_count=3)
 
 query TT
 SHOW CREATE t
@@ -944,7 +944,7 @@ t  CREATE TABLE public.t (
    crdb_internal_x_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 2:::INT8)) VIRTUAL,
    x INT8 NOT NULL,
    crdb_internal_x_shard_3 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 3:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH BUCKET_COUNT = 3,
+   CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=3),
    FAMILY "primary" (x)
 )
 
@@ -952,8 +952,8 @@ t  CREATE TABLE public.t (
 # primary key to be copied.
 statement ok
 DROP TABLE t;
-CREATE TABLE t (x INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 2, y INT NOT NULL, FAMILY (x, y));
-ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y) USING HASH WITH BUCKET_COUNT=2
+CREATE TABLE t (x INT PRIMARY KEY USING HASH WITH (bucket_count=2), y INT NOT NULL, FAMILY (x, y));
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y) USING HASH WITH (bucket_count=2)
 
 query TT
 SHOW CREATE t
@@ -963,8 +963,8 @@ t  CREATE TABLE public.t (
    x INT8 NOT NULL,
    y INT8 NOT NULL,
    crdb_internal_y_shard_2 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(y)), 2:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH BUCKET_COUNT = 2,
-   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH BUCKET_COUNT = 2,
+   CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=2),
+   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=2),
    FAMILY fam_0_x_y (x, y)
 )
 
@@ -1096,7 +1096,7 @@ t1_id_id2_key  id2    ASC
 t1_id_key      id     ASC
 
 statement ok
-alter table t1 alter primary key using columns(id) USING HASH WITH BUCKET_COUNT = 10
+alter table t1 alter primary key using columns(id) USING HASH WITH (bucket_count=10)
 
 query TTT
 select index_name,column_name,direction from [show indexes from t1];
@@ -1149,7 +1149,7 @@ SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
 t_pkey  i  ASC
 
 statement ok
-ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (i) USING HASH WITH BUCKET_COUNT = 2
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (i) USING HASH WITH (bucket_count=2)
 
 query TTT
 SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
@@ -1385,8 +1385,9 @@ ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) WITH (bucket_count=
 statement error pq: "bucket_count" storage parameter and "BUCKET_COUNT" cannot be set at the same time
 ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5);
 
+# Make sure old BUCKET_COUNT syntax still works
 statement ok
-ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH (bucket_count=5);
+ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH BUCKET_COUNT = 5;
 
 query T
 SELECT @2 FROM [SHOW CREATE TABLE t_test_param]
@@ -1395,7 +1396,7 @@ CREATE TABLE public.t_test_param (
    a INT8 NOT NULL,
    b INT8 NOT NULL,
    crdb_internal_b_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
-   CONSTRAINT t_test_param_pkey PRIMARY KEY (b ASC) USING HASH WITH BUCKET_COUNT = 5,
+   CONSTRAINT t_test_param_pkey PRIMARY KEY (b ASC) USING HASH WITH (bucket_count=5),
    UNIQUE INDEX t_test_param_a_key (a ASC),
    FAMILY fam_0_a_b (a, b)
 )

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -137,7 +137,7 @@ CREATE TABLE telemetry (
 
 statement ok
 CREATE INVERTED INDEX ON telemetry (z);
-CREATE INDEX ON telemetry (y) USING HASH WITH BUCKET_COUNT = 4
+CREATE INDEX ON telemetry (y) USING HASH WITH (bucket_count=4)
 
 query T rowsort
 SELECT feature_name FROM crdb_internal.feature_usage
@@ -363,7 +363,7 @@ SET CLUSTER SETTING jobs.registry.interval.cancel = DEFAULT;
 statement ok
 SET experimental_use_new_schema_changer = $schema_changer_state
 
-subtest test_bucket_count_storage_param
+subtest test_old_bucket_count_syntax
 
 statement ok
 CREATE TABLE t_hash (
@@ -374,10 +374,10 @@ CREATE TABLE t_hash (
 );
 
 statement ok
-CREATE INDEX idx_t_hash_a ON t_hash (a) USING HASH WITH (bucket_count=5);
+CREATE INDEX idx_t_hash_a ON t_hash (a) USING HASH WITH BUCKET_COUNT = 5;
 
 statement ok
-CREATE UNIQUE INDEX idx_t_hash_b ON t_hash (b) USING HASH WITH (bucket_count=5);
+CREATE UNIQUE INDEX idx_t_hash_b ON t_hash (b) USING HASH WITH BUCKET_COUNT = 5;
 
 query T
 SELECT @2 FROM [SHOW CREATE TABLE t_hash]
@@ -389,7 +389,7 @@ CREATE TABLE public.t_hash (
    crdb_internal_a_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
    crdb_internal_b_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
    CONSTRAINT t_hash_pkey PRIMARY KEY (pk ASC),
-   INDEX idx_t_hash_a (a ASC) USING HASH WITH BUCKET_COUNT = 5,
-   UNIQUE INDEX idx_t_hash_b (b ASC) USING HASH WITH BUCKET_COUNT = 5,
+   INDEX idx_t_hash_a (a ASC) USING HASH WITH (bucket_count=5),
+   UNIQUE INDEX idx_t_hash_b (b ASC) USING HASH WITH (bucket_count=5),
    FAMILY fam_0_pk_a_b (pk, a, b)
 )

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -102,7 +102,7 @@ CREATE TABLE telemetry (
   y INT,
   z JSONB,
   INVERTED INDEX (z),
-  INDEX (y) USING HASH WITH BUCKET_COUNT = 4
+  INDEX (y) USING HASH WITH (bucket_count=4)
 )
 
 query T rowsort
@@ -340,7 +340,7 @@ like_more_specifiers  CREATE TABLE public.like_more_specifiers (
 )
 
 statement ok
-CREATE TABLE like_hash_base (a INT, INDEX (a) USING HASH WITH BUCKET_COUNT=4)
+CREATE TABLE like_hash_base (a INT, INDEX (a) USING HASH WITH (bucket_count=4))
 
 statement ok
 CREATE TABLE like_hash (LIKE like_hash_base INCLUDING INDEXES)
@@ -353,7 +353,7 @@ like_hash  CREATE TABLE public.like_hash (
            crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL,
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
            CONSTRAINT like_hash_base_pkey PRIMARY KEY (rowid ASC),
-           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4),
            FAMILY "primary" (a, crdb_internal_a_shard_4, rowid)
 )
 
@@ -368,7 +368,7 @@ like_hash  CREATE TABLE public.like_hash (
            crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
            CONSTRAINT like_hash_base_pkey PRIMARY KEY (rowid ASC),
-           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4),
            FAMILY "primary" (a, rowid)
 )
 
@@ -842,12 +842,14 @@ CREATE TABLE t_bad_param (
   PRIMARY KEY (a) WITH (s2_max_level=20)
 ) AS SELECT * FROM t_source;
 
+subtest test_old_bucket_count_syntax
+
 statement ok
 CREATE TABLE t_good_hash_indexes_1 (
- a INT PRIMARY KEY USING HASH WITH (bucket_count=5),
+ a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 5,
  b INT,
  c INT,
- INDEX (b) USING HASH WITH (bucket_count=5),
+ INDEX (b) USING HASH WITH BUCKET_COUNT = 5,
  FAMILY "primary" (a, b, c)
 );
 
@@ -860,15 +862,15 @@ CREATE TABLE public.t_good_hash_indexes_1 (
   b INT8 NULL,
   c INT8 NULL,
   crdb_internal_b_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
-  CONSTRAINT t_good_hash_indexes_1_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 5,
-  INDEX t_good_hash_indexes_1_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 5,
+  CONSTRAINT t_good_hash_indexes_1_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=5),
+  INDEX t_good_hash_indexes_1_b_idx (b ASC) USING HASH WITH (bucket_count=5),
   FAMILY "primary" (a, b, c)
 )
 
 statement ok
 CREATE TABLE t_good_hash_indexes_2 (
  a INT,
- PRIMARY KEY (a) USING HASH WITH (bucket_count=5)
+ PRIMARY KEY (a) USING HASH WITH BUCKET_COUNT = 5
 );
 
 query T
@@ -877,6 +879,6 @@ SELECT @2 FROM [SHOW CREATE TABLE t_good_hash_indexes_2];
 CREATE TABLE public.t_good_hash_indexes_2 (
     a INT8 NOT NULL,
     crdb_internal_a_shard_5 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
-    CONSTRAINT t_good_hash_indexes_2_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 5,
+    CONSTRAINT t_good_hash_indexes_2_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=5),
     FAMILY "primary" (a)
 )

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -2,8 +2,8 @@ statement ok
 SET experimental_enable_hash_sharded_indexes = true
 
 # Tests for creating a hash sharded primary key
-statement ok
-CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 10)
+statement ok 
+CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH (bucket_count=10))
 
 query TT
 SHOW CREATE TABLE sharded_primary
@@ -11,24 +11,24 @@ SHOW CREATE TABLE sharded_primary
 sharded_primary  CREATE TABLE public.sharded_primary (
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
                  a INT8 NOT NULL,
-                 CONSTRAINT sharded_primary_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 CONSTRAINT sharded_primary_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
                  FAMILY "primary" (a)
 )
 
 statement error pgcode 22023 BUCKET_COUNT must be a 32-bit integer greater than 1, got -1
-CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=-1)
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=-1))
 
 statement error pgcode 22023 BUCKET_COUNT must be a 32-bit integer greater than 1, got 1099511627776
-CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=1099511627776)
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=1099511627776))
 
 statement error pgcode 22023 BUCKET_COUNT must be a 32-bit integer greater than 1, got 1
-CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=1)
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=1))
 
 statement error expected BUCKET_COUNT expression to have type int, but '2.32' has type decimal
-CREATE TABLE fractional_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=2.32)
+CREATE TABLE fractional_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=2.32))
 
 statement error variable sub-expressions are not allowed in BUCKET_COUNT
-CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=(SELECT 1))
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=(SELECT 1)))
 
 # Ensure that this is round-tripable
 statement ok
@@ -37,7 +37,7 @@ DROP TABLE sharded_primary
 statement ok
 CREATE TABLE sharded_primary (
                 a INT8 NOT NULL,
-                CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
                 FAMILY "primary" (a)
 )
 
@@ -47,7 +47,7 @@ SHOW CREATE TABLE sharded_primary
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
                  FAMILY "primary" (a)
 )
 
@@ -59,7 +59,7 @@ WHERE tablename = 'sharded_primary'
 ORDER BY 1, 2, 3
 ----
 tablename        indexname  indexdef
-sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC) USING HASH WITH BUCKET_COUNT = 10
+sharded_primary  primary    CREATE UNIQUE INDEX "primary" ON test.public.sharded_primary USING btree (a ASC) USING HASH WITH (bucket_count=10)
 
 query TTB
 SELECT index_name, column_name, implicit FROM [SHOW INDEXES FROM sharded_primary]
@@ -89,7 +89,7 @@ statement ok
 CREATE TABLE specific_family (
     a INT,
     b INT,
-    INDEX (b) USING HASH WITH BUCKET_COUNT=10,
+    INDEX (b) USING HASH WITH (bucket_count=10),
     FAMILY "a_family" (a),
     FAMILY "b_family" (b)
 )
@@ -103,14 +103,14 @@ specific_family  CREATE TABLE public.specific_family (
                  crdb_internal_b_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 10:::INT8)) VIRTUAL,
                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                  CONSTRAINT specific_family_pkey PRIMARY KEY (rowid ASC),
-                 INDEX specific_family_b_idx (b ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 INDEX specific_family_b_idx (b ASC) USING HASH WITH (bucket_count=10),
                  FAMILY a_family (a, rowid),
                  FAMILY b_family (b)
 )
 
 # Tests for secondary sharded indexes
 statement ok
-CREATE TABLE sharded_secondary (a INT, INDEX (a) USING HASH WITH BUCKET_COUNT=4)
+CREATE TABLE sharded_secondary (a INT, INDEX (a) USING HASH WITH (bucket_count=4))
 
 query TT
 SHOW CREATE TABLE sharded_secondary
@@ -120,7 +120,7 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=4),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -130,7 +130,7 @@ DROP TABLE sharded_secondary
 statement ok
 CREATE TABLE sharded_secondary (
                         a INT8 NULL,
-                        INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                        INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH (bucket_count=4),
                         FAMILY "primary" (a, rowid)
 )
 
@@ -142,7 +142,7 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH (bucket_count=4),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -158,7 +158,7 @@ CREATE TABLE sharded_secondary (
 )
 
 statement ok
-CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT = 10
+CREATE INDEX ON sharded_secondary (a) USING HASH WITH (bucket_count=10)
 
 statement ok
 INSERT INTO sharded_secondary values (1), (2), (1)
@@ -171,7 +171,7 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
                    CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -180,7 +180,7 @@ INSERT INTO sharded_secondary values (3), (2), (1)
 
 # Test multiple indexes on the same column set
 statement ok
-CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT = 4
+CREATE INDEX ON sharded_secondary (a) USING HASH WITH (bucket_count=4)
 
 query TT
 SHOW CREATE TABLE sharded_secondary
@@ -191,8 +191,8 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
                    crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
                    CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
+                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=4),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -208,7 +208,7 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
                    CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=4),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -229,7 +229,7 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
 # Ensure that the shard column cannot be used in the same txn if its dropped along with
 # the sharded index.
 statement ok
-CREATE INDEX idx on sharded_secondary (a) USING HASH WITH BUCKET_COUNT = 3
+CREATE INDEX idx on sharded_secondary (a) USING HASH WITH (bucket_count=3)
 
 statement ok
 BEGIN
@@ -251,13 +251,13 @@ DROP INDEX sharded_secondary@idx
 
 # Ensure that multiple (> 2) identical indexes can be created.
 statement ok
-CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT=10
+CREATE INDEX ON sharded_secondary (a) USING HASH WITH (bucket_count=10)
 
 statement ok
-CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT=10
+CREATE INDEX ON sharded_secondary (a) USING HASH WITH (bucket_count=10)
 
 statement ok
-CREATE INDEX ON sharded_secondary (a) USING HASH WITH BUCKET_COUNT=10
+CREATE INDEX ON sharded_secondary (a) USING HASH WITH (bucket_count=10)
 
 query TT
 SHOW CREATE TABLE sharded_secondary
@@ -267,9 +267,9 @@ sharded_secondary  CREATE TABLE public.sharded_secondary (
                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                    crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
                    CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                   INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
+                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=10),
+                   INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH (bucket_count=10),
                    FAMILY "primary" (a, rowid)
 )
 
@@ -281,7 +281,7 @@ SELECT count(*) FROM sharded_secondary
 6
 
 statement ok
-CREATE INDEX ON sharded_primary (a) USING HASH WITH BUCKET_COUNT = 4;
+CREATE INDEX ON sharded_primary (a) USING HASH WITH (bucket_count=4);
 
 query TT
 SHOW CREATE TABLE sharded_primary
@@ -290,8 +290,8 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
                  crdb_internal_a_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 4,
+                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
+                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH (bucket_count=4),
                  FAMILY "primary" (a)
 )
 
@@ -307,12 +307,12 @@ SHOW CREATE TABLE sharded_primary
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
                  FAMILY "primary" (a)
 )
 
 statement ok
-CREATE INDEX on sharded_primary (a) USING HASH WITH BUCKET_COUNT=10;
+CREATE INDEX on sharded_primary (a) USING HASH WITH (bucket_count=10);
 
 query TT
 SHOW CREATE TABLE sharded_primary
@@ -320,8 +320,8 @@ SHOW CREATE TABLE sharded_primary
 sharded_primary  CREATE TABLE public.sharded_primary (
                  a INT8 NOT NULL,
                  crdb_internal_a_shard_10 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 10,
-                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 10,
+                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
+                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
                  FAMILY "primary" (a)
 )
 
@@ -336,7 +336,7 @@ statement ok
 DROP TABLE sharded_secondary
 
 statement ok
-CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH BUCKET_COUNT=12)
+CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH (bucket_count=12))
 
 # Ensure that hash sharded indexes can be created on columns that are added in the same
 # statement, just like non-sharded indexes.
@@ -347,7 +347,7 @@ statement ok
 ALTER TABLE sharded_secondary ADD COLUMN b INT
 
 statement ok
-CREATE INDEX ON sharded_secondary (a, b) USING HASH WITH BUCKET_COUNT=12
+CREATE INDEX ON sharded_secondary (a, b) USING HASH WITH (bucket_count=12)
 
 statement ok
 COMMIT TRANSACTION
@@ -357,7 +357,7 @@ statement ok
 ALTER TABLE sharded_secondary ADD COLUMN c INT AS (mod(a, 100)) STORED
 
 statement error cannot create a sharded index on a computed column
-CREATE INDEX ON sharded_secondary (a, c) USING HASH WITH BUCKET_COUNT=12;
+CREATE INDEX ON sharded_secondary (a, c) USING HASH WITH (bucket_count=12);
 
 # Ensure that sharded indexes cannot be created on computed columns
 # in the same txn
@@ -365,7 +365,7 @@ statement error cannot create a sharded index on a computed column
 CREATE TABLE shard_on_computed_column (
     a INT,
     b INT AS (a % 5) STORED,
-    INDEX (b) USING HASH WITH BUCKET_COUNT=10
+    INDEX (b) USING HASH WITH (bucket_count=10)
 )
 
 statement ok
@@ -375,7 +375,7 @@ statement ok
 ALTER TABLE sharded_secondary ADD COLUMN d INT AS (mod(a, 100)) STORED
 
 statement error cannot create a sharded index on a computed column
-CREATE INDEX ON sharded_secondary (a, d) USING HASH WITH BUCKET_COUNT=12;
+CREATE INDEX ON sharded_secondary (a, d) USING HASH WITH (bucket_count=12);
 
 statement ok
 ROLLBACK TRANSACTION
@@ -384,7 +384,7 @@ ROLLBACK TRANSACTION
 statement ok
 CREATE TABLE column_used_on_unsharded (
     a INT,
-    INDEX foo (a) USING HASH WITH BUCKET_COUNT=10
+    INDEX foo (a) USING HASH WITH (bucket_count=10)
 )
 
 statement ok
@@ -411,7 +411,7 @@ DROP INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx
 statement ok
 CREATE TABLE column_used_on_unsharded_create_table (
     a INT,
-    INDEX foo (a) USING HASH WITH BUCKET_COUNT=10,
+    INDEX foo (a) USING HASH WITH (bucket_count=10),
     INDEX (crdb_internal_a_shard_10)
 )
 
@@ -440,16 +440,16 @@ statement ok
 SET experimental_enable_hash_sharded_indexes = false
 
 statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable
-CREATE TABLE disabled (k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 10)
+CREATE TABLE disabled (k INT PRIMARY KEY USING HASH WITH (bucket_count=10))
 
 statement ok
 CREATE TABLE disabled_secondary (k INT, v BYTES)
 
 statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable
-CREATE INDEX failure on disabled_secondary (k) USING HASH WITH BUCKET_COUNT = 12
+CREATE INDEX failure on disabled_secondary (k) USING HASH WITH (bucket_count=12)
 
 statement error pq: hash sharded indexes require the experimental_enable_hash_sharded_indexes session variable
-CREATE TABLE disabled (k INT, INDEX (k) USING HASH WITH BUCKET_COUNT = 10)
+CREATE TABLE disabled (k INT, INDEX (k) USING HASH WITH (bucket_count=10))
 
 # Ensure everything works with weird column names
 statement ok
@@ -457,13 +457,13 @@ SET experimental_enable_hash_sharded_indexes = true
 
 statement ok
 CREATE TABLE weird_names (
-    "I am a column with spaces" INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 12,
+    "I am a column with spaces" INT PRIMARY KEY USING HASH WITH (bucket_count=12),
     "'quotes' in the column's name" INT,
     FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name")
     )
 
 statement ok
-CREATE INDEX foo on weird_names ("'quotes' in the column's name") USING HASH WITH BUCKET_COUNT = 4
+CREATE INDEX foo on weird_names ("'quotes' in the column's name") USING HASH WITH (bucket_count=4)
 
 statement ok
 INSERT INTO weird_names VALUES (1, 2)
@@ -481,8 +481,8 @@ weird_names  CREATE TABLE public.weird_names (
              "I am a column with spaces" INT8 NOT NULL,
              "'quotes' in the column's name" INT8 NULL,
              "crdb_internal_'quotes' in the column's name_shard_4" INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes("'quotes' in the column's name")), 4:::INT8)) VIRTUAL,
-             CONSTRAINT weird_names_pkey PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH BUCKET_COUNT = 12,
-             INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH BUCKET_COUNT = 4,
+             CONSTRAINT weird_names_pkey PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH (bucket_count=12),
+             INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH (bucket_count=4),
              FAMILY "primary" ("I am a column with spaces", "'quotes' in the column's name")
 )
 
@@ -492,7 +492,7 @@ statement ok
 CREATE TABLE t0();
 
 statement error column "c0" does not exist
-CREATE INDEX ON t0 (c0) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX ON t0 (c0) USING HASH WITH (bucket_count=8);
 
 statement ok
 DROP TABLE t0;
@@ -508,7 +508,7 @@ statement ok
 begin; ALTER TABLE create_idx_drop_column DROP COLUMN c1;
 
 statement error column "c1" does not exist
-CREATE INDEX idx_create_idx_drop_column ON create_idx_drop_column (c1) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX idx_create_idx_drop_column ON create_idx_drop_column (c1) USING HASH WITH (bucket_count=8);
 
 statement ok
 ROLLBACK;
@@ -523,7 +523,7 @@ statement ok
 CREATE TABLE sharded_index_with_nulls (
      a INT8 PRIMARY KEY,
      b INT8,
-     INDEX (b) USING HASH WITH BUCKET_COUNT = 8
+     INDEX (b) USING HASH WITH (bucket_count=8)
 )
 
 statement ok
@@ -540,8 +540,8 @@ CREATE TABLE rename_column (
     c0 INT,
     c1 INT,
     c2 INT,
-    PRIMARY KEY (c0, c1) USING HASH WITH BUCKET_COUNT = 8,
-    INDEX (c2) USING HASH WITH BUCKET_COUNT = 8,
+    PRIMARY KEY (c0, c1) USING HASH WITH (bucket_count=8),
+    INDEX (c2) USING HASH WITH (bucket_count=8),
     FAMILY "primary" (c0, c1, c2)
 );
 
@@ -557,8 +557,8 @@ rename_column  CREATE TABLE public.rename_column (
                c2 INT8 NULL,
                crdb_internal_c0_c1_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c0, c1)), 8:::INT8)) VIRTUAL,
                crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c2)), 8:::INT8)) VIRTUAL,
-               CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH (bucket_count=8),
+               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH (bucket_count=8),
                FAMILY "primary" (c0, c1, c2)
 )
 
@@ -581,8 +581,8 @@ rename_column  CREATE TABLE public.rename_column (
                c3 INT8 NULL,
                crdb_internal_c1_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c1, c2)), 8:::INT8)) VIRTUAL,
                crdb_internal_c3_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c3)), 8:::INT8)) VIRTUAL,
-               CONSTRAINT rename_column_pkey PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               CONSTRAINT rename_column_pkey PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8),
+               INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH (bucket_count=8),
                FAMILY "primary" (c1, c2, c3)
 )
 
@@ -604,8 +604,8 @@ rename_column  CREATE TABLE public.rename_column (
                c2 INT8 NULL,
                crdb_internal_c0_c1_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c0, c1)), 8:::INT8)) VIRTUAL,
                crdb_internal_c2_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c2)), 8:::INT8)) VIRTUAL,
-               CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH BUCKET_COUNT = 8,
-               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH BUCKET_COUNT = 8,
+               CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH (bucket_count=8),
+               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH (bucket_count=8),
                FAMILY "primary" (c0, c1, c2)
 )
 
@@ -634,10 +634,10 @@ CREATE TABLE IF NOT EXISTS drop_earlier_hash_column (
 );
 
 statement ok
-CREATE INDEX h1 ON drop_earlier_hash_column(j) USING HASH WITH BUCKET_COUNT = 8
+CREATE INDEX h1 ON drop_earlier_hash_column(j) USING HASH WITH (bucket_count=8)
 
 statement ok
-CREATE INDEX h2 ON drop_earlier_hash_column(k) USING HASH WITH BUCKET_COUNT = 8
+CREATE INDEX h2 ON drop_earlier_hash_column(k) USING HASH WITH (bucket_count=8)
 
 statement ok
 DROP INDEX h1
@@ -645,7 +645,7 @@ DROP INDEX h1
 subtest test_table_indexes
 
 statement ok
-CREATE TABLE poor_t (a INT PRIMARY KEY, b INT, INDEX t_idx_b (b) USING HASH WITH BUCKET_COUNT = 8)
+CREATE TABLE poor_t (a INT PRIMARY KEY, b INT, INDEX t_idx_b (b) USING HASH WITH (bucket_count=8))
 
 query ITITTBBB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = 'poor_t'
@@ -667,7 +667,7 @@ DROP TABLE IF EXISTS parent
 
 statement ok
 CREATE TABLE parent (
-    id INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+    id INT PRIMARY KEY USING HASH WITH (bucket_count=8)
 );
 
 statement ok
@@ -701,7 +701,7 @@ CREATE TABLE parent (
 );
 
 statement ok
-CREATE UNIQUE INDEX t_idx_oid ON parent(oid) USING HASH WITH BUCKET_COUNT = 8
+CREATE UNIQUE INDEX t_idx_oid ON parent(oid) USING HASH WITH (bucket_count=8)
 
 statement ok
 CREATE TABLE child (
@@ -731,7 +731,7 @@ statement ok
 CREATE TABLE parent (
     a INT NOT NULL,
     b INT NOT NULL,
-    PRIMARY KEY (a, b) USING HASH WITH BUCKET_COUNT = 8
+    PRIMARY KEY (a, b) USING HASH WITH (bucket_count=8)
 );
 
 statement ok
@@ -765,7 +765,7 @@ CREATE TABLE parent (
 );
 
 statement ok
-CREATE UNIQUE INDEX t_idx_a_b ON parent(a, b) USING HASH WITH BUCKET_COUNT = 8
+CREATE UNIQUE INDEX t_idx_a_b ON parent(a, b) USING HASH WITH (bucket_count=8)
 
 
 statement ok
@@ -793,7 +793,7 @@ DROP TABLE IF EXISTS t
 
 statement ok
 CREATE TABLE t (
-    a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+    a INT PRIMARY KEY USING HASH WITH (bucket_count=8)
 );
 
 let $create_statement
@@ -811,7 +811,7 @@ SELECT @2 FROM [SHOW CREATE TABLE t]
 CREATE TABLE public.t (
     crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
     a INT8 NOT NULL,
-    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 8,
+    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
     FAMILY "primary" (a)
 )
 
@@ -824,7 +824,7 @@ statement ok
 CREATE TABLE public.t (
     crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
     a INT8 NOT NULL,
-    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 8,
+    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
     FAMILY "primary" (a),
     CONSTRAINT check_crdb_internal_a_shard_8 CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
@@ -835,7 +835,7 @@ SELECT @2 FROM [SHOW CREATE TABLE t]
 CREATE TABLE public.t (
     crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
     a INT8 NOT NULL,
-    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 8,
+    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
     FAMILY "primary" (a),
     CONSTRAINT check_crdb_internal_a_shard_8 CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
@@ -860,7 +860,7 @@ AND r.split_enforced_until IS NOT NULL;
 ----
 
 statement ok
-CREATE INDEX t_hash_pre_split_idx_b ON t_hash_pre_split (b) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX t_hash_pre_split_idx_b ON t_hash_pre_split (b) USING HASH WITH (bucket_count=8);
 
 skipif config 3node-tenant
 query TITTT colnames,retry
@@ -890,7 +890,7 @@ CREATE TABLE t_default_bucket_8 (
   b INT,
   c INT,
   INDEX idx_t_default_bucket_8_b (b) USING HASH,
-  INDEX idx_t_default_bucket_8_c (c) USING HASH WITH BUCKET_COUNT = 4,
+  INDEX idx_t_default_bucket_8_c (c) USING HASH WITH (bucket_count=4),
   FAMILY fam_0_a (a),
   FAMILY fam_1_c_b (c, b)
 );
@@ -905,9 +905,9 @@ CREATE TABLE public.t_default_bucket_8 (
    c INT8 NULL,
    crdb_internal_b_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 8:::INT8)) VIRTUAL,
    crdb_internal_c_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 4:::INT8)) VIRTUAL,
-   CONSTRAINT t_default_bucket_8_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 8,
-   INDEX idx_t_default_bucket_8_b (b ASC) USING HASH WITH BUCKET_COUNT = 8,
-   INDEX idx_t_default_bucket_8_c (c ASC) USING HASH WITH BUCKET_COUNT = 4,
+   CONSTRAINT t_default_bucket_8_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
+   INDEX idx_t_default_bucket_8_b (b ASC) USING HASH WITH (bucket_count=8),
+   INDEX idx_t_default_bucket_8_c (c ASC) USING HASH WITH (bucket_count=4),
    FAMILY fam_0_a (a),
    FAMILY fam_1_c_b (c, b)
 )
@@ -924,7 +924,7 @@ SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_16]
 CREATE TABLE public.t_default_bucket_16 (
    crdb_internal_a_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
    a INT8 NOT NULL,
-   CONSTRAINT t_default_bucket_16_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 16,
+   CONSTRAINT t_default_bucket_16_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
    FAMILY "primary" (a)
 )
 
@@ -943,7 +943,7 @@ CREATE TABLE t (
 )
 
 statement ok
-CREATE UNIQUE INDEX t_uniq_idx_y_z ON t(y, z) USING HASH WITH BUCKET_COUNT = 8
+CREATE UNIQUE INDEX t_uniq_idx_y_z ON t(y, z) USING HASH WITH (bucket_count=8)
 
 statement ok
 INSERT INTO t (x, y, z) VALUES (1, 11, 111) ON CONFLICT (y, z) DO UPDATE SET duped = true
@@ -999,7 +999,7 @@ DROP TABLE IF EXISTS t
 
 statement ok
 CREATE TABLE t (
-    x INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8,
+    x INT PRIMARY KEY USING HASH WITH (bucket_count=8),
     duped BOOL DEFAULT false
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5204,7 +5204,7 @@ SET experimental_enable_hash_sharded_indexes = true
 statement ok
 CREATE TABLE t_hash (
   a INT,
-  INDEX t_hash_a_idx (a DESC) USING HASH WITH BUCKET_COUNT=8
+  INDEX t_hash_a_idx (a DESC) USING HASH WITH (bucket_count=8)
 );
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/record
+++ b/pkg/sql/logictest/testdata/logic_test/record
@@ -41,7 +41,7 @@ SET experimental_enable_hash_sharded_indexes=true
 
 # The tuple type doesn't contain implicit columns like rowid or hash columns.
 statement ok
-CREATE TABLE implicit_col(d INT, e TEXT, INDEX (e) USING HASH WITH BUCKET_COUNT = 8)
+CREATE TABLE implicit_col(d INT, e TEXT, INDEX (e) USING HASH WITH (bucket_count=8))
 
 query T
 SELECT (1, 'foo')::implicit_col

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -4,7 +4,7 @@ statement ok
 SET experimental_enable_hash_sharded_indexes = true;
 
 statement ok
-CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=11)
+CREATE TABLE sharded_primary (a INT PRIMARY KEY USING HASH WITH (bucket_count=11))
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO sharded_primary (a) VALUES (1), (2)
@@ -38,7 +38,7 @@ vectorized: true
               row 1, expr 0: 2
 
 statement ok
-CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH BUCKET_COUNT=12)
+CREATE TABLE sharded_secondary (a INT8, INDEX (a) USING HASH WITH (bucket_count=12))
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO sharded_secondary (a) VALUES (1), (2)
@@ -93,7 +93,7 @@ CREATE TABLE sharded_primary_with_many_column_types  (
     inet  INET,
     vb    VARBIT,
     FAMILY (i2, i4, i8, f4, f8, s, c, b, dc, ival, oid, tstz, ts, da, inet, vb),
-    PRIMARY KEY (i2, i4, i8, f4, f8, s, c, b, dc, ival, oid, tstz, ts, da, inet, vb) USING HASH WITH BUCKET_COUNT = 7
+    PRIMARY KEY (i2, i4, i8, f4, f8, s, c, b, dc, ival, oid, tstz, ts, da, inet, vb) USING HASH WITH (bucket_count=7)
 );
 
 query T
@@ -129,7 +129,7 @@ subtest create_with_show_create_keeps_shard_col_constraint
 
 statement ok
 CREATE TABLE t (
-    a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8
+    a INT PRIMARY KEY USING HASH WITH (bucket_count=8)
 );
 
 query T
@@ -167,7 +167,7 @@ SELECT @2 FROM [SHOW CREATE TABLE t]
 CREATE TABLE public.t (
     crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
     a INT8 NOT NULL,
-    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH BUCKET_COUNT = 8,
+    CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
     FAMILY "primary" (a)
 )
 
@@ -198,7 +198,7 @@ subtest test_hash_index_unique_constraint_pkey
 
 statement ok
 CREATE TABLE t_hash_indexed (
-  a INT8 PRIMARY KEY USING HASH WITH BUCKET_COUNT = 8,
+  a INT8 PRIMARY KEY USING HASH WITH (bucket_count=8),
   b INT8 NOT NULL,
   FAMILY (a, b)
 );
@@ -434,7 +434,7 @@ CREATE TABLE t_hash_indexed (
 );
 
 statement ok
-CREATE UNIQUE INDEX idx_t_hash_indexed ON t_hash_indexed (b) USING HASH WITH BUCKET_COUNT = 8;
+CREATE UNIQUE INDEX idx_t_hash_indexed ON t_hash_indexed (b) USING HASH WITH (bucket_count=8);
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765)

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -358,8 +358,8 @@ CREATE TABLE IF NOT EXISTS user_checklist_items (
     create_date TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (tenant_id, location_id, checklist_item_id, user_id)
 );
-CREATE INDEX IF NOT EXISTS userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem ON user_checklist_items (tenant_id, user_id, date_should_be_completed, location_name, title, order_item, checklist_item_id) USING HASH WITH BUCKET_COUNT = 8;
-CREATE INDEX IF NOT EXISTS userchecklistitems_tenantid_locationid_configurationmaintenanceid_configurationmaintenanceitemid_dateshouldbecompleted ON user_checklist_items (tenant_id, location_id, configuration_maintenance_id, configuration_maintenance_item_id, date_should_be_completed) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX IF NOT EXISTS userchecklistitems_tenantid_userid_dateshouldbecompleted_locationname_orderitem ON user_checklist_items (tenant_id, user_id, date_should_be_completed, location_name, title, order_item, checklist_item_id) USING HASH WITH (bucket_count=8);
+CREATE INDEX IF NOT EXISTS userchecklistitems_tenantid_locationid_configurationmaintenanceid_configurationmaintenanceitemid_dateshouldbecompleted ON user_checklist_items (tenant_id, location_id, configuration_maintenance_id, configuration_maintenance_item_id, date_should_be_completed) USING HASH WITH (bucket_count=8);
 
 statement ok
 ALTER TABLE user_checklist_items INJECT STATISTICS

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7408,7 +7408,7 @@ INSERT INTO t.test VALUES (1, 2);
 	// Make sure shard column constraint is not validated.
 	tdb.Exec(t, `
 SET experimental_enable_hash_sharded_indexes = ON;
-CREATE INDEX ON t.test (b) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX ON t.test (b) USING HASH WITH (bucket_count=8);
 `,
 	)
 	require.Len(t, constraintsToValidate, 0)
@@ -7482,6 +7482,6 @@ CREATE TABLE t.test_split(a INT PRIMARY KEY, b INT NOT NULL);
 
 	tdb.Exec(t, `
 SET experimental_enable_hash_sharded_indexes = on;
-CREATE INDEX idx_test_split_b ON t.test_split (b) USING HASH WITH BUCKET_COUNT = 8;
+CREATE INDEX idx_test_split_b ON t.test_split (b) USING HASH WITH (bucket_count=8);
 `)
 }

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -87,7 +87,7 @@ CREATE INDEX id3
 
 build
 CREATE INDEX id4
-	ON defaultdb.t1 (id, name) USING HASH WITH BUCKET_COUNT =  8 STORING (money)
+	ON defaultdb.t1 (id, name) USING HASH STORING (money) WITH (bucket_count=8)
 ----
 - [[Column:{DescID: 104, ColumnID: 4}, PUBLIC], ABSENT]
   details:

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1579,8 +1579,11 @@ func (node *RangePartition) doc(p *PrettyCfg) pretty.Doc {
 func (node *ShardedIndexDef) doc(p *PrettyCfg) pretty.Doc {
 	// Final layout:
 	//
-	// USING HASH WITH BUCKET_COUNT = bucket_count
+	// USING HASH [WITH BUCKET_COUNT = bucket_count]
 	//
+	if _, ok := node.ShardBuckets.(DefaultVal); ok {
+		return pretty.Keyword("USING HASH")
+	}
 	parts := []pretty.Doc{
 		pretty.Keyword("USING HASH WITH BUCKET_COUNT = "),
 		p.Doc(node.ShardBuckets),
@@ -1956,10 +1959,28 @@ func (node *ColumnTableDef) docRow(p *PrettyCfg) pretty.TableRow {
 		clauses = append(clauses, p.maybePrependConstraintName(&node.Unique.ConstraintName, pkConstraint))
 	}
 
+	// Always prefer to output hash sharding bucket count as a storage param.
+	pkStorageParams := node.PrimaryKey.StorageParams
 	if node.PrimaryKey.Sharded {
-		clauses = append(clauses, pretty.Keyword("USING HASH WITH BUCKET_COUNT = "))
-		clauses = append(clauses, p.Doc(node.PrimaryKey.ShardBuckets))
+		clauses = append(clauses, pretty.Keyword("USING HASH"))
+		bcStorageParam := node.PrimaryKey.StorageParams.GetVal(`bucket_count`)
+		if _, ok := node.PrimaryKey.ShardBuckets.(DefaultVal); !ok && bcStorageParam == nil {
+			pkStorageParams = append(
+				pkStorageParams, StorageParam{
+					Key:   `bucket_count`,
+					Value: node.PrimaryKey.ShardBuckets,
+				},
+			)
+		}
 	}
+	if len(pkStorageParams) > 0 {
+		clauses = append(clauses, p.bracketKeyword(
+			"WITH", " (",
+			p.Doc(&pkStorageParams),
+			")", "",
+		))
+	}
+
 	// CHECK expressions/constraints.
 	for _, checkExpr := range node.CheckExprs {
 		clauses = append(clauses, p.maybePrependConstraintName(&checkExpr.ConstraintName,

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -274,14 +274,14 @@ func TestShowCreateTable(t *testing.T) {
 		{
 			CreateStatement: `CREATE TABLE %s (
 				a INT,
-				INDEX (a) USING HASH WITH BUCKET_COUNT = 8
+				INDEX (a) USING HASH WITH (bucket_count=8)
 			)`,
 			Expect: `CREATE TABLE public.%[1]s (
 	a INT8 NULL,
 	crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
 	rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
 	CONSTRAINT %[1]s_pkey PRIMARY KEY (rowid ASC),
-	INDEX %[1]s_a_idx (a ASC) USING HASH WITH BUCKET_COUNT = 8,
+	INDEX %[1]s_a_idx (a ASC) USING HASH WITH (bucket_count=8),
 	FAMILY "primary" (a, rowid)
 )`,
 		},

--- a/pkg/sql/tests/hash_sharded_test.go
+++ b/pkg/sql/tests/hash_sharded_test.go
@@ -97,7 +97,7 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 	t.Run("primary", func(t *testing.T) {
 		if _, err := db.Exec(`
 			CREATE TABLE kv_primary (
-				k INT PRIMARY KEY USING HASH WITH BUCKET_COUNT=5,
+				k INT PRIMARY KEY USING HASH WITH (bucket_count=5),
 				v BYTES
 			)
 		`); err != nil {
@@ -135,7 +135,7 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 			CREATE TABLE kv_secondary (
 				k INT,
 				v BYTES,
-				INDEX sharded_secondary (k) USING HASH WITH BUCKET_COUNT = 12
+				INDEX sharded_secondary (k) USING HASH WITH (bucket_count=12)
 			)
 		`); err != nil {
 			t.Fatal(err)
@@ -155,7 +155,7 @@ func TestBasicHashShardedIndexes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := db.Exec(`CREATE INDEX sharded_secondary2 ON kv_secondary2 (k) USING HASH WITH BUCKET_COUNT = 12`); err != nil {
+		if _, err := db.Exec(`CREATE INDEX sharded_secondary2 ON kv_secondary2 (k) USING HASH WITH (bucket_count=12)`); err != nil {
 			t.Fatal(err)
 		}
 		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, `d`, `kv_secondary2`)


### PR DESCRIPTION
a follow up of pr #76068

Release note (sql change): We have add support for the new `bucket_count`
storage param syntax. We prefer it over the old `WITH BUCKET_COUNT=xxx`
syntax. With this change, crdb outputs the new syntax for `SHOW CREATE`.
Though for the AST tree formatting, we still respect the old syntax if
user used it.