### PR TITLE
sql: use 16 as default bucket count for hash index

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -85,7 +85,7 @@ sql.cross_db_views.enabled	boolean	false	if true, creating views that refer to o
 sql.defaults.cost_scans_with_default_col_size.enabled	boolean	false	setting to true uses the same size for all columns to compute scan cost
 sql.defaults.datestyle	enumeration	iso, mdy	default value for DateStyle session setting [iso, mdy = 0, iso, dmy = 1, iso, ymd = 2]
 sql.defaults.datestyle.enabled	boolean	false	default value for datestyle_enabled session setting
-sql.defaults.default_hash_sharded_index_bucket_count	integer	8	used as bucket count if bucket count is not specified in hash sharded index definition
+sql.defaults.default_hash_sharded_index_bucket_count	integer	16	used as bucket count if bucket count is not specified in hash sharded index definition
 sql.defaults.default_int_size	integer	8	the size, in bytes, of an INT type
 sql.defaults.disallow_full_table_scans.enabled	boolean	false	setting to true rejects queries that have planned a full table scan
 sql.defaults.distsql	enumeration	auto	default distributed SQL execution mode [off = 0, auto = 1, on = 2, always = 3]

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -96,7 +96,7 @@
 <tr><td><code>sql.defaults.cost_scans_with_default_col_size.enabled</code></td><td>boolean</td><td><code>false</code></td><td>setting to true uses the same size for all columns to compute scan cost</td></tr>
 <tr><td><code>sql.defaults.datestyle</code></td><td>enumeration</td><td><code>iso, mdy</code></td><td>default value for DateStyle session setting [iso, mdy = 0, iso, dmy = 1, iso, ymd = 2]</td></tr>
 <tr><td><code>sql.defaults.datestyle.enabled</code></td><td>boolean</td><td><code>false</code></td><td>default value for datestyle_enabled session setting</td></tr>
-<tr><td><code>sql.defaults.default_hash_sharded_index_bucket_count</code></td><td>integer</td><td><code>8</code></td><td>used as bucket count if bucket count is not specified in hash sharded index definition</td></tr>
+<tr><td><code>sql.defaults.default_hash_sharded_index_bucket_count</code></td><td>integer</td><td><code>16</code></td><td>used as bucket count if bucket count is not specified in hash sharded index definition</td></tr>
 <tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
 <tr><td><code>sql.defaults.disallow_full_table_scans.enabled</code></td><td>boolean</td><td><code>false</code></td><td>setting to true rejects queries that have planned a full table scan</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>auto</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, always = 3]</td></tr>

--- a/pkg/sql/catalog/catconstants/constants.go
+++ b/pkg/sql/catalog/catconstants/constants.go
@@ -385,6 +385,6 @@ var DefaultHashShardedIndexBucketCount = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"sql.defaults.default_hash_sharded_index_bucket_count",
 	"used as bucket count if bucket count is not specified in hash sharded index definition",
-	8,
+	16,
 	settings.NonNegativeInt,
 ).WithPublic()

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -885,38 +885,15 @@ t_hash_pre_split  142       t_hash_pre_split_idx_b  /Table/142/2/7  /Max
 subtest test_default_bucket_count
 
 statement ok
-CREATE TABLE t_default_bucket_8 (
+CREATE TABLE t_default_bucket_16 (
   a INT PRIMARY KEY USING HASH,
   b INT,
   c INT,
-  INDEX idx_t_default_bucket_8_b (b) USING HASH,
-  INDEX idx_t_default_bucket_8_c (c) USING HASH WITH (bucket_count=4),
+  INDEX idx_t_default_bucket_16_b (b) USING HASH,
+  INDEX idx_t_default_bucket_16_c (c) USING HASH WITH (bucket_count=4),
   FAMILY fam_0_a (a),
   FAMILY fam_1_c_b (c, b)
 );
-
-query T
-SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_8]
-----
-CREATE TABLE public.t_default_bucket_8 (
-   crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
-   a INT8 NOT NULL,
-   b INT8 NULL,
-   c INT8 NULL,
-   crdb_internal_b_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 8:::INT8)) VIRTUAL,
-   crdb_internal_c_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 4:::INT8)) VIRTUAL,
-   CONSTRAINT t_default_bucket_8_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
-   INDEX idx_t_default_bucket_8_b (b ASC) USING HASH WITH (bucket_count=8),
-   INDEX idx_t_default_bucket_8_c (c ASC) USING HASH WITH (bucket_count=4),
-   FAMILY fam_0_a (a),
-   FAMILY fam_1_c_b (c, b)
-)
-
-statement ok
-SET CLUSTER SETTING sql.defaults.default_hash_sharded_index_bucket_count = 16
-
-statement ok
-CREATE TABLE t_default_bucket_16 (a INT PRIMARY KEY USING HASH);
 
 query T
 SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_16]
@@ -924,7 +901,30 @@ SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_16]
 CREATE TABLE public.t_default_bucket_16 (
    crdb_internal_a_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
    a INT8 NOT NULL,
+   b INT8 NULL,
+   c INT8 NULL,
+   crdb_internal_b_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+   crdb_internal_c_shard_4 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 4:::INT8)) VIRTUAL,
    CONSTRAINT t_default_bucket_16_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
+   INDEX idx_t_default_bucket_16_b (b ASC) USING HASH WITH (bucket_count=16),
+   INDEX idx_t_default_bucket_16_c (c ASC) USING HASH WITH (bucket_count=4),
+   FAMILY fam_0_a (a),
+   FAMILY fam_1_c_b (c, b)
+)
+
+statement ok
+SET CLUSTER SETTING sql.defaults.default_hash_sharded_index_bucket_count = 8
+
+statement ok
+CREATE TABLE t_default_bucket_8 (a INT PRIMARY KEY USING HASH);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_8]
+----
+CREATE TABLE public.t_default_bucket_8 (
+   crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
+   a INT8 NOT NULL,
+   CONSTRAINT t_default_bucket_8_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
    FAMILY "primary" (a)
 )
 


### PR DESCRIPTION
for some reason I forgot to modify it in my previous pr :(

Release note (sql change): 16 is used as the default bucket count
for hash sharded index.