### PR TITLE
dev: correct --remote_cache suggestion

### DIFF
--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -219,7 +219,7 @@ port: 9867
 	for _, line := range strings.Split(configFileContents, "\n") {
 		if strings.HasPrefix(line, "port:") {
 			port := strings.TrimSpace(strings.Split(line, ":")[1])
-			fmt.Printf("Add the string `--remote_cache=localhost:%s` to your ~/.bazelrc\n", port)
+			fmt.Printf("Add the string `--remote_cache=http://localhost:%s` to your ~/.bazelrc\n", port)
 			break
 		}
 	}


### PR DESCRIPTION
On macOS (I haven't checked linux), the default configuration we write
out for bazel-remote sets up a non-TLS HTTP listener. But, Bazel (4.2.1)
assumes an HTTPS scheme if one is given.  Thus, if a user follows
exactly these directions they will get:

```
ERROR: Failed to query remote execution capabilities: not an SSL/TLS
record:
485454502f312e31203430302042616420526571756573740d0a436f6e74656e742d547970653a20746578742f706c61696e3b20636861727365743d7574662d380d0a436f6e6e656374696f6e3a20636c6f73650d0a0d0a343030204261642052657175657374
```

I'll also note in case it helps others that using `localhost` as the
hostname can also be a problem on macOS since bazel-remote can end up
with an IPv4-only listener even when `localhost` resolves to an IPv6
address first:

```
$ ps | grep '[b]azel-remote'
45309 ttys004    0:04.78 /private/var/tmp/_bazel_ssd/a51ea94df2f483aee3088dde6a3dde4e/execroot/cockroach/bazel-out/darwin-fastbuild-ST-3891b650e255/bin/external/com_github_buchgr_bazel_remote/bazel-remote_/bazel-remote --config_file /Users/ssd/Library/Caches/dev-bazel-remote/config.yml

$ lsof -p 45309 | grep -i listen
bazel-rem 45309  ssd    6u    IPv4 0xe000f144d2b2f989      0t0                 TCP localhost:9867 (LISTEN)

$ dscacheutil -q host -a name localhost
name: localhost
ipv6_address: ::1

name: localhost
ip_address: 127.0.0.1
```

but, Bazel tries to connect to the IPv6 by default:

```
ERROR: Failed to query remote execution capabilities: Connection
refused: localhost/0:0:0:0:0:0:0:1:9867
```

My guess this isn't a problem on linux where I believe that Go will,
by default, create a listener that listens on both v4 and v6.

I haven't fixed this second problem in this PR. While it can be fixed
by using "127.0.0.1" or "0.0.0.0" explicitly as the address, that's a
bit of a bummer since it shouldn't really be necessary.

Release note: None