### PR TITLE
migrations: remove unused testing knobs

### DIFF
--- a/pkg/migration/BUILD.bazel
+++ b/pkg/migration/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/jobs",
-        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",

--- a/pkg/migration/testing_knobs.go
+++ b/pkg/migration/testing_knobs.go
@@ -13,7 +13,6 @@ package migration
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 )
 
 // TestingKnobs are knobs to inject behavior into the migration manager which
@@ -27,23 +26,6 @@ type TestingKnobs struct {
 
 	// RegistryOverride is used to inject migrations for specific cluster versions.
 	RegistryOverride func(cv clusterversion.ClusterVersion) (Migration, bool)
-
-	// BeforeWaitInRetryJobsWithExponentialBackoffMigration is called before
-	// waiting for a mutation job to complete in retryJobsWithExponentialBackoff
-	// migration.
-	// TODO(sajjad): Remove this knob when the related migration code is removed.
-	// This knob is used only in exponential backoff migration and related tests. See
-	// pkg/migration/retry_jobs_with_exponential_backoff.go and
-	// pkg/migration/retry_jobs_with_exponential_backoff_external_test.go
-	BeforeWaitInRetryJobsWithExponentialBackoffMigration func(jobspb.JobID)
-
-	// SkippedMutation is called if a mutation job is skipped as part of the
-	// retryJobsWithExponentialBackoff migration.
-	// TODO(sajjad): Remove this knob when the related migration code is removed.
-	// This knob is used only in exponential backoff migration and related tests. See
-	// pkg/migration/retry_jobs_with_exponential_backoff.go and
-	// pkg/migration/retry_jobs_with_exponential_backoff_external_test.go
-	SkippedMutation func()
 }
 
 // ModuleTestingKnobs makes TestingKnobs a base.ModuleTestingKnobs.


### PR DESCRIPTION
These testing knobs are currently unused.

Release note: None