### PR TITLE
bazel, ui: embed `tracing_ui` JS packages with `with_ui` config only

### DIFF
--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -7,11 +7,17 @@ go_library(
         "tracing_ui.go",
         "ui.go",
     ],
-    embedsrcs = [
-        "dist_vendor/list.min.js",
-        "templates/tracing/html_template.html",
-        "dist_vendor/.gitkeep",
-    ],
+    embedsrcs = select({
+        "//pkg/ui:cockroach_with_ui": [
+            "dist_vendor/list.min.js",
+            "templates/tracing/html_template.html",
+            "dist_vendor/.gitkeep",
+        ],
+        "//conditions:default": [
+            "templates/tracing/html_template.html",
+            "dist_vendor/.gitkeep",
+        ],
+    }),
     importpath = "github.com/cockroachdb/cockroach/pkg/ui",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
Recently, `tracing_ui` page was added that embeds additional JS packages,
and it wasn't guarded by `cockroach_with_ui` config to avoid NPM packages
installation with any build.

With this change, `dist_vendor/list.min.js` is embedded conditionally for
UI specific builds.

Release note: None