### PR TITLE
server: don't return both TestTenant and error 

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -392,14 +392,14 @@ func (c *transientCluster) Start(
 			for i := 0; i < c.demoCtx.NumNodes; i++ {
 				latencyMap := c.servers[i].Cfg.TestingKnobs.Server.(*server.TestingKnobs).ContextTestingKnobs.ArtificialLatencyMap
 				c.infoLog(ctx, "starting tenant node %d", i)
-				stopper := stop.NewStopper()
+				tenantStopper := stop.NewStopper()
 				ts, err := c.servers[i].StartTenant(ctx, base.TestTenantArgs{
 					// We set the tenant ID to i+2, since tenant 0 is not a tenant, and
 					// tenant 1 is the system tenant. We also subtract 2 for the "starting"
 					// SQL/HTTP ports so the first tenant ends up with the desired default
 					// ports.
 					TenantID:         roachpb.MakeTenantID(uint64(i + 2)),
-					Stopper:          stopper,
+					Stopper:          tenantStopper,
 					ForceInsecure:    c.demoCtx.Insecure,
 					SSLCertsDir:      c.demoDir,
 					StartingSQLPort:  c.demoCtx.SQLPort - 2,
@@ -418,7 +418,7 @@ func (c *transientCluster) Start(
 					if ts != nil {
 						stopCtx = ts.AnnotateCtx(stopCtx)
 					}
-					stopper.Stop(stopCtx)
+					tenantStopper.Stop(stopCtx)
 				}))
 				if err != nil {
 					return err

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -725,7 +725,10 @@ func (ts *TestServer) StartTenant(
 		baseCfg,
 		sqlCfg,
 	)
-	return &TestTenant{SQLServer: sqlServer, Cfg: &baseCfg, sqlAddr: addr, httpAddr: httpAddr}, err
+	if err != nil {
+		return nil, err
+	}
+	return &TestTenant{SQLServer: sqlServer, Cfg: &baseCfg, sqlAddr: addr, httpAddr: httpAddr}, nil
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should


### PR DESCRIPTION
StartTenant could return both an error and a non-nil,
partially-initialized result, which is unusual and was confusing the
caller.

Fixes https://github.com/cockroachdb/cockroach/issues/76128

Release note: None