### PR TITLE
sql: support version numbers on descriptor validation

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1885,7 +1885,8 @@ func (r *restoreResumer) publishDescriptors(
 				return err
 			}
 		}
-		if err := mutTable.AllocateIDs(ctx); err != nil {
+		version := r.settings.Version.ActiveVersion(ctx)
+		if err := mutTable.AllocateIDs(ctx, version); err != nil {
 			return err
 		}
 		allMutDescs = append(allMutDescs, mutTable)

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//pkg/ccl/utilccl",
         "//pkg/cloud",
         "//pkg/cloud/impl:cloudimpl",
+        "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -76,7 +77,7 @@ func parseTableDesc(createTableStmt string) (catalog.TableDescriptor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mutDesc, descbuilder.ValidateSelf(mutDesc)
+	return mutDesc, descbuilder.ValidateSelf(mutDesc, clusterversion.TestingClusterVersion)
 }
 
 func parseValues(tableDesc catalog.TableDescriptor, values string) ([]rowenc.EncDatumRow, error) {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -894,7 +894,7 @@ func (b *changefeedResumer) OnPauseRequest(
 func getQualifiedTableName(
 	ctx context.Context, execCfg *sql.ExecutorConfig, txn *kv.Txn, desc catalog.TableDescriptor,
 ) (string, error) {
-	col := execCfg.CollectionFactory.MakeCollection(nil /* temporarySchemaProvider */)
+	col := execCfg.CollectionFactory.MakeCollection(ctx, nil /* TemporarySchemaProvider */)
 	dbDesc, err := col.Direct().MustGetDatabaseDescByID(ctx, txn, desc.GetParentID())
 	if err != nil {
 		return "", err

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -71,7 +71,7 @@ func newRowFetcherCache(
 	return &rowFetcherCache{
 		codec:      codec,
 		leaseMgr:   leaseMgr,
-		collection: cf.NewCollection(nil /* TemporarySchemaProvider */),
+		collection: cf.NewCollection(ctx, nil /* TemporarySchemaProvider */),
 		db:         db,
 		fetchers:   cache.NewUnorderedCache(rfCacheConfig),
 	}

--- a/pkg/ccl/importccl/read_import_mysql.go
+++ b/pkg/ccl/importccl/read_import_mysql.go
@@ -431,6 +431,7 @@ func mysqlTableToCockroach(
 		seqDesc, err = sql.NewSequenceTableDesc(
 			ctx,
 			nil, /* planner */
+			evalCtx.Settings,
 			seqName,
 			opts,
 			parentDB.GetID(),
@@ -600,7 +601,8 @@ func addDelayedFKs(
 		if err := fixDescriptorFKState(def.tbl); err != nil {
 			return err
 		}
-		if err := def.tbl.AllocateIDs(ctx); err != nil {
+		version := evalCtx.Settings.Version.ActiveVersion(ctx)
+		if err := def.tbl.AllocateIDs(ctx, version); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/importccl/read_import_pgdump.go
+++ b/pkg/ccl/importccl/read_import_pgdump.go
@@ -322,6 +322,7 @@ func createPostgresSequences(
 		desc, err := sql.NewSequenceTableDesc(
 			ctx,
 			nil, /* planner */
+			execCfg.Settings,
 			schemaAndTableName.table,
 			seq.Options,
 			parentID,

--- a/pkg/ccl/importccl/testutils_test.go
+++ b/pkg/ccl/importccl/testutils_test.go
@@ -61,6 +61,7 @@ func descForTable(
 		desc, err := sql.NewSequenceTableDesc(
 			ctx,
 			nil, /* planner */
+			settings,
 			name,
 			tree.SequenceOptions{},
 			parent,

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/ccl/storageccl",
         "//pkg/ccl/testutilsccl",
         "//pkg/ccl/utilccl",
+        "//pkg/clusterversion",
         "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/jobs",

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/importccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -154,7 +155,7 @@ func (pt *partitioningTest) parse() error {
 			return err
 		}
 		pt.parsed.tableDesc = mutDesc
-		if err := descbuilder.ValidateSelf(pt.parsed.tableDesc); err != nil {
+		if err := descbuilder.ValidateSelf(pt.parsed.tableDesc, clusterversion.TestingClusterVersion); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/doctor.go
+++ b/pkg/cli/doctor.go
@@ -28,8 +28,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/doctor"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -74,6 +76,7 @@ tables are queried either from a live cluster or from an unzipped debug.zip.
 }
 
 type doctorFn = func(
+	version *clusterversion.ClusterVersion,
 	descTable doctor.DescriptorTable,
 	namespaceTable doctor.NamespaceTable,
 	jobsTable doctor.JobsTable,
@@ -82,19 +85,27 @@ type doctorFn = func(
 
 func makeZipDirCommand(fn doctorFn) *cobra.Command {
 	return &cobra.Command{
-		Use:   "zipdir <debug_zip_dir>",
+		Use:   "zipdir <debug_zip_dir> [version]",
 		Short: "run doctor tool on data from an unzipped debug.zip",
 		Long: `
 Run the doctor tool on system data from an unzipped debug.zip. This command
-requires the path of the unzipped 'debug' directory as its argument.
+requires the path of the unzipped 'debug' directory as its argument. A version
+can be optionally specified, which will be used enable / disable validation
+that may not exist on downlevel versions.
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			descs, ns, jobs, err := fromZipDir(args[0])
+			var version *clusterversion.ClusterVersion
+			if len(args) == 2 {
+				version = &clusterversion.ClusterVersion{
+					Version: roachpb.MustParseVersion(args[1]),
+				}
+			}
 			if err != nil {
 				return err
 			}
-			return fn(descs, ns, jobs, os.Stdout)
+			return fn(version, descs, ns, jobs, os.Stdout)
 		},
 	}
 }
@@ -118,7 +129,7 @@ Run the doctor tool system data from a live cluster specified by --url.
 				if err != nil {
 					return err
 				}
-				return fn(descs, ns, jobs, os.Stdout)
+				return fn(nil, descs, ns, jobs, os.Stdout)
 			}),
 	}
 }
@@ -137,6 +148,7 @@ var doctorRecreateClusterCmd = makeClusterCommand(runDoctorRecreate)
 var doctorRecreateZipDirCmd = makeZipDirCommand(runDoctorRecreate)
 
 func runDoctorRecreate(
+	_ *clusterversion.ClusterVersion,
 	descTable doctor.DescriptorTable,
 	namespaceTable doctor.NamespaceTable,
 	jobsTable doctor.JobsTable,
@@ -146,14 +158,26 @@ func runDoctorRecreate(
 }
 
 func runDoctorExamine(
+	version *clusterversion.ClusterVersion,
 	descTable doctor.DescriptorTable,
 	namespaceTable doctor.NamespaceTable,
 	jobsTable doctor.JobsTable,
 	out io.Writer,
 ) (err error) {
+	if version == nil {
+		version = &clusterversion.ClusterVersion{
+			Version: clusterversion.DoctorBinaryVersion,
+		}
+	}
 	var valid bool
 	valid, err = doctor.Examine(
-		context.Background(), descTable, namespaceTable, jobsTable, debugCtx.verbose, out)
+		context.Background(),
+		*version,
+		descTable,
+		namespaceTable,
+		jobsTable,
+		debugCtx.verbose,
+		out)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/doctor_test.go
+++ b/pkg/cli/doctor_test.go
@@ -57,7 +57,7 @@ func TestDoctorZipDir(t *testing.T) {
 	defer c.Cleanup()
 
 	t.Run("examine", func(t *testing.T) {
-		out, err := c.RunWithCapture("debug doctor examine zipdir testdata/doctor/debugzip")
+		out, err := c.RunWithCapture("debug doctor examine zipdir testdata/doctor/debugzip 21.1")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cli/testdata/doctor/test_examine_zipdir
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir
@@ -1,6 +1,6 @@
 debug doctor examine zipdir testdata/doctor/debugzip
 ----
-debug doctor examine zipdir testdata/doctor/debugzip
+debug doctor examine zipdir testdata/doctor/debugzip 21.1
 WARNING: errors occurred during the production of system.jobs.txt, contents may be missing or incomplete.
 Examining 37 descriptors and 42 namespace entries...
   ParentID  52, ParentSchemaID 29: relation "users" (53): referenced database ID 52: referenced descriptor not found

--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "keyed_versions.go",
         "setting.go",
         "testutils.go",
+        "utilversions.go",
         ":gen-key-stringer",  # keep
     ],
     embed = [":clusterversion_go_proto"],

--- a/pkg/clusterversion/utilversions.go
+++ b/pkg/clusterversion/utilversions.go
@@ -1,0 +1,14 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package clusterversion
+
+// DoctorBinaryVersion level used by the debug doctor when validating any files.
+var DoctorBinaryVersion = binaryVersion

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -81,7 +82,7 @@ func writeMutation(
 ) {
 	tableDesc.Mutations = append(tableDesc.Mutations, m)
 	tableDesc.Version++
-	if err := descbuilder.ValidateSelf(tableDesc); err != nil {
+	if err := descbuilder.ValidateSelf(tableDesc, clusterversion.TestingClusterVersion); err != nil {
 		t.Fatal(err)
 	}
 	if err := kvDB.Put(

--- a/pkg/migration/migrations/ensure_no_draining_names_external_test.go
+++ b/pkg/migration/migrations/ensure_no_draining_names_external_test.go
@@ -88,7 +88,9 @@ func TestEnsureNoDrainingNames(t *testing.T) {
 	// Check that the draining name persists in the descriptor and in the db's
 	// schema mapping.
 	{
-		db := desctestutils.TestingGetDatabaseDescriptor(s.DB(), c, "t")
+		version := tc.Server(0).ClusterSettings().Version.ActiveVersion(ctx)
+		db := desctestutils.TestingGetDatabaseDescriptorWitVersion(
+			s.DB(), c, version, "t")
 		_ = db.ForEachSchemaInfo(func(id descpb.ID, name string, isDropped bool) error {
 			switch name {
 			case "foo":
@@ -98,7 +100,8 @@ func TestEnsureNoDrainingNames(t *testing.T) {
 			}
 			return nil
 		})
-		foo := desctestutils.TestingGetSchemaDescriptor(s.DB(), c, db.GetID(), "foo")
+		foo := desctestutils.TestingGetSchemaDescriptorWithVersion(
+			s.DB(), c, version, db.GetID(), "foo")
 		require.NotEmpty(t, foo.GetDrainingNames())
 	}
 
@@ -120,15 +123,16 @@ func TestEnsureNoDrainingNames(t *testing.T) {
 	// Check that there are no draining names and that the database schema mapping
 	// is correct.
 	{
-		db := desctestutils.TestingGetDatabaseDescriptor(s.DB(), c, "t")
+		version := tc.Server(0).ClusterSettings().Version.ActiveVersion(ctx)
+		db := desctestutils.TestingGetDatabaseDescriptorWitVersion(s.DB(), c, version, "t")
 		_ = db.ForEachSchemaInfo(func(id descpb.ID, name string, isDropped bool) error {
 			require.False(t, isDropped)
 			require.True(t, name == "foo" || name == "bar")
 			return nil
 		})
-		foo := desctestutils.TestingGetSchemaDescriptor(s.DB(), c, db.GetID(), "foo")
+		foo := desctestutils.TestingGetSchemaDescriptorWithVersion(s.DB(), c, version, db.GetID(), "foo")
 		require.Empty(t, foo.GetDrainingNames())
-		bar := desctestutils.TestingGetSchemaDescriptor(s.DB(), c, db.GetID(), "bar")
+		bar := desctestutils.TestingGetSchemaDescriptorWithVersion(s.DB(), c, version, db.GetID(), "bar")
 		require.Empty(t, bar.GetDrainingNames())
 	}
 }

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -161,7 +161,8 @@ func (p *planner) addColumnImpl(
 
 	// We need to allocate new ID for the created column in order to correctly
 	// assign sequence ownership.
-	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+	version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+	if err := n.tableDesc.AllocateIDs(params.ctx, version); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -415,7 +415,8 @@ func alterColumnTypeGeneral(
 		tableDesc.SetPrimaryIndex(primaryIndex)
 	}
 
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	version := params.ExecCfg().Settings.Version.ActiveVersion(ctx)
+	if err := tableDesc.AllocateIDs(ctx, version); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -136,7 +136,8 @@ func (n *alterIndexNode) startExec(params runParams) error {
 
 	}
 
-	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+	version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+	if err := n.tableDesc.AllocateIDs(params.ctx, version); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -237,7 +237,8 @@ func (p *planner) AlterPrimaryKey(
 	if err := tableDesc.AddIndexMutation(newPrimaryIndexDesc, descpb.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
+	if err := tableDesc.AllocateIDs(ctx, version); err != nil {
 		return err
 	}
 
@@ -521,7 +522,7 @@ func (p *planner) AlterPrimaryKey(
 	}
 	tableDesc.AddPrimaryKeySwapMutation(swapArgs)
 
-	if err := descbuilder.ValidateSelf(tableDesc); err != nil {
+	if err := descbuilder.ValidateSelf(tableDesc, version); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -307,7 +307,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 				// We need to allocate IDs upfront in the event we need to update the zone config
 				// in the same transaction.
-				if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+				version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+				if err := n.tableDesc.AllocateIDs(params.ctx, version); err != nil {
 					return err
 				}
 				if err := params.p.configureZoneConfigForNewIndexPartitioning(
@@ -1055,7 +1056,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 		}
 
 		// Allocate IDs now, so new IDs are available to subsequent commands
-		if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+		version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+		if err := n.tableDesc.AllocateIDs(params.ctx, version); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -345,7 +345,8 @@ func (n *alterTableSetLocalityNode) alterTableLocalityToRegionalByRow(
 		mutationIdxAllowedInSameTxn = &mutationIdx
 		newColumnName = &partColName
 
-		if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+		version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+		if err := n.tableDesc.AllocateIDs(params.ctx, version); err != nil {
 			return err
 		}
 

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/geo/geoindex",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/catalog/dbdesc/BUILD.bazel
+++ b/pkg/sql/catalog/dbdesc/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     srcs = ["database_test.go"],
     embed = [":dbdesc"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/security",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -116,7 +117,7 @@ func TestValidateDatabaseDesc(t *testing.T) {
 		t.Run(d.err, func(t *testing.T) {
 			desc := NewBuilder(&d.desc).BuildImmutable()
 			expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), d.err)
-			if err := validate.Self(desc); err == nil {
+			if err := validate.Self(clusterversion.TestingClusterVersion, desc); err == nil {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, d.desc)
 			} else if expectedErr != err.Error() {
 				t.Errorf("%d: expected \"%s\", but found \"%+v\"", i, expectedErr, err)
@@ -287,7 +288,7 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			return nil
 		})
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		results := cb.Validate(ctx, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, desc)
+		results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, desc)
 		if err := results.CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/descbuilder/BUILD.bazel
+++ b/pkg/sql/catalog/descbuilder/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/catalog/descbuilder/desc_builder.go
+++ b/pkg/sql/catalog/descbuilder/desc_builder.go
@@ -11,6 +11,7 @@
 package descbuilder
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -53,6 +54,6 @@ func NewBuilder(desc *descpb.Descriptor) catalog.DescriptorBuilder {
 }
 
 // ValidateSelf validates that the descriptor is internally consistent.
-func ValidateSelf(desc catalog.Descriptor) error {
-	return validate.Self(desc)
+func ValidateSelf(desc catalog.Descriptor, version clusterversion.ClusterVersion) error {
+	return validate.Self(version, desc)
 }

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -39,6 +40,7 @@ import (
 
 // makeCollection constructs a Collection.
 func makeCollection(
+	ctx context.Context,
 	leaseMgr *lease.Manager,
 	settings *cluster.Settings,
 	codec keys.SQLCodec,
@@ -49,12 +51,13 @@ func makeCollection(
 ) Collection {
 	return Collection{
 		settings:       settings,
+		version:        settings.Version.ActiveVersion(ctx),
 		hydratedTables: hydratedTables,
 		virtual:        makeVirtualDescriptors(virtualSchemas),
 		leased:         makeLeasedDescriptors(leaseMgr),
 		kv:             makeKVDescriptors(codec, systemNamespace),
 		temporary:      makeTemporaryDescriptors(settings, codec, temporarySchemaProvider),
-		direct:         makeDirect(codec, settings),
+		direct:         makeDirect(ctx, codec, settings),
 	}
 }
 
@@ -67,6 +70,9 @@ type Collection struct {
 
 	// settings dictate whether we validate descriptors on write.
 	settings *cluster.Settings
+
+	// version used for validation
+	version clusterversion.ClusterVersion
 
 	// virtualSchemas optionally holds the virtual schemas.
 	virtual virtualDescriptors
@@ -220,7 +226,7 @@ func (tc *Collection) WriteDescToBatch(
 ) error {
 	desc.MaybeIncrementVersion()
 	if !tc.skipValidationOnWrite && ValidateOnWriteEnabled.Get(&tc.settings.SV) {
-		if err := validate.Self(desc); err != nil {
+		if err := validate.Self(tc.version, desc); err != nil {
 			return err
 		}
 	}
@@ -273,7 +279,7 @@ func newMutableSyntheticDescriptorAssertionError(id descpb.ID) error {
 // first checking the Collection's cached descriptors for validity if validate
 // is set to true before defaulting to a key-value scan, if necessary.
 func (tc *Collection) GetAllDescriptors(ctx context.Context, txn *kv.Txn) (nstree.Catalog, error) {
-	return tc.kv.getAllDescriptors(ctx, txn)
+	return tc.kv.getAllDescriptors(ctx, txn, tc.version)
 }
 
 // GetAllDatabaseDescriptors returns all database descriptors visible by the
@@ -285,7 +291,7 @@ func (tc *Collection) GetAllDescriptors(ctx context.Context, txn *kv.Txn) (nstre
 func (tc *Collection) GetAllDatabaseDescriptors(
 	ctx context.Context, txn *kv.Txn,
 ) ([]catalog.DatabaseDescriptor, error) {
-	return tc.kv.getAllDatabaseDescriptors(ctx, txn)
+	return tc.kv.getAllDatabaseDescriptors(ctx, txn, tc.version)
 }
 
 // GetAllTableDescriptorsInDatabase returns all the table descriptors visible to

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -58,7 +58,7 @@ func TestCollectionWriteDescToBatch(t *testing.T) {
 
 	db := s0.DB()
 	descriptors := s0.ExecutorConfig().(sql.ExecutorConfig).CollectionFactory.
-		NewCollection(nil /* TemporarySchemaProvider */)
+		NewCollection(ctx, nil /* TemporarySchemaProvider */)
 
 	// Note this transaction abuses the mechanisms normally required for updating
 	// tables and is just for testing what this test intends to exercise.

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -139,7 +139,7 @@ func (tc *Collection) getDescriptorsByID(
 		return descs, nil
 	}
 	kvDescs, err := tc.withReadFromStore(flags.RequireMutable, func() ([]catalog.MutableDescriptor, error) {
-		return tc.kv.getByIDs(ctx, txn, kvIDs)
+		return tc.kv.getByIDs(ctx, txn, tc.version, kvIDs)
 	})
 	if err != nil {
 		return nil, err
@@ -293,7 +293,15 @@ func (tc *Collection) getByName(
 	var descs []catalog.Descriptor
 	descs, err = tc.withReadFromStore(mutable, func() ([]catalog.MutableDescriptor, error) {
 		uncommittedDB, _ := tc.uncommitted.getByID(parentID).(catalog.DatabaseDescriptor)
-		desc, err := tc.kv.getByName(ctx, txn, uncommittedDB, parentID, parentSchemaID, name)
+		version := tc.settings.Version.ActiveVersion(ctx)
+		desc, err := tc.kv.getByName(
+			ctx,
+			txn,
+			version,
+			uncommittedDB,
+			parentID,
+			parentSchemaID,
+			name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -11,6 +11,8 @@
 package descs
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -59,18 +61,16 @@ func NewBareBonesCollectionFactory(
 
 // MakeCollection constructs a Collection for the purposes of embedding.
 func (cf *CollectionFactory) MakeCollection(
-	temporarySchemaProvider TemporarySchemaProvider,
+	ctx context.Context, temporarySchemaProvider TemporarySchemaProvider,
 ) Collection {
-	return makeCollection(
-		cf.leaseMgr, cf.settings, cf.codec, cf.hydratedTables, cf.systemDatabase,
-		cf.virtualSchemas, temporarySchemaProvider,
-	)
+	return makeCollection(ctx, cf.leaseMgr, cf.settings, cf.codec, cf.hydratedTables, cf.systemDatabase,
+		cf.virtualSchemas, temporarySchemaProvider)
 }
 
 // NewCollection constructs a new Collection.
 func (cf *CollectionFactory) NewCollection(
-	temporarySchemaProvider TemporarySchemaProvider,
+	ctx context.Context, temporarySchemaProvider TemporarySchemaProvider,
 ) *Collection {
-	c := cf.MakeCollection(temporarySchemaProvider)
+	c := cf.MakeCollection(ctx, temporarySchemaProvider)
 	return &c
 }

--- a/pkg/sql/catalog/descs/kv_descriptors.go
+++ b/pkg/sql/catalog/descs/kv_descriptors.go
@@ -13,6 +13,7 @@ package descs
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -177,6 +178,7 @@ func (kd *kvDescriptors) lookupName(
 func (kd *kvDescriptors) getByName(
 	ctx context.Context,
 	txn *kv.Txn,
+	version clusterversion.ClusterVersion,
 	maybeDB catalog.DatabaseDescriptor,
 	parentID descpb.ID,
 	parentSchemaID descpb.ID,
@@ -186,7 +188,7 @@ func (kd *kvDescriptors) getByName(
 	if err != nil || descID == descpb.InvalidID {
 		return nil, err
 	}
-	descs, err := kd.getByIDs(ctx, txn, []descpb.ID{descID})
+	descs, err := kd.getByIDs(ctx, txn, version, []descpb.ID{descID})
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			// Having done the namespace lookup, the descriptor must exist.
@@ -210,7 +212,7 @@ func (kd *kvDescriptors) getByName(
 
 // getByIDs actually reads a batch of descriptors from the storage layer.
 func (kd *kvDescriptors) getByIDs(
-	ctx context.Context, txn *kv.Txn, ids []descpb.ID,
+	ctx context.Context, txn *kv.Txn, version clusterversion.ClusterVersion, ids []descpb.ID,
 ) ([]catalog.MutableDescriptor, error) {
 	ret := make([]catalog.MutableDescriptor, len(ids))
 	kvIDs := make([]descpb.ID, 0, len(ids))
@@ -235,7 +237,7 @@ func (kd *kvDescriptors) getByIDs(
 	if len(kvIDs) == 0 {
 		return ret, nil
 	}
-	kvDescs, err := catkv.MustGetDescriptorsByID(ctx, txn, kd.codec, kvIDs, catalog.Any)
+	kvDescs, err := catkv.MustGetDescriptorsByID(ctx, txn, kd.codec, version, kvIDs, catalog.Any)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +248,7 @@ func (kd *kvDescriptors) getByIDs(
 }
 
 func (kd *kvDescriptors) getAllDescriptors(
-	ctx context.Context, txn *kv.Txn,
+	ctx context.Context, txn *kv.Txn, version clusterversion.ClusterVersion,
 ) (nstree.Catalog, error) {
 	if kd.allDescriptors.isUnset() {
 		c, err := catkv.GetCatalogUnvalidated(ctx, txn, kd.codec)
@@ -255,7 +257,7 @@ func (kd *kvDescriptors) getAllDescriptors(
 		}
 
 		descs := c.OrderedDescriptors()
-		ve := c.Validate(ctx, catalog.ValidationReadTelemetry, catalog.ValidationLevelCrossReferences, descs...)
+		ve := c.Validate(ctx, version, catalog.ValidationReadTelemetry, catalog.ValidationLevelCrossReferences, descs...)
 		if err := ve.CombinedError(); err != nil {
 			return nstree.Catalog{}, err
 		}
@@ -274,14 +276,14 @@ func (kd *kvDescriptors) getAllDescriptors(
 }
 
 func (kd *kvDescriptors) getAllDatabaseDescriptors(
-	ctx context.Context, txn *kv.Txn,
+	ctx context.Context, txn *kv.Txn, version clusterversion.ClusterVersion,
 ) ([]catalog.DatabaseDescriptor, error) {
 	if kd.allDatabaseDescriptors == nil {
 		c, err := catkv.GetAllDatabaseDescriptorIDs(ctx, txn, kd.codec)
 		if err != nil {
 			return nil, err
 		}
-		dbDescs, err := catkv.MustGetDescriptorsByID(ctx, txn, kd.codec, c.OrderedDescriptorIDs(), catalog.Database)
+		dbDescs, err := catkv.MustGetDescriptorsByID(ctx, txn, kd.codec, version, c.OrderedDescriptorIDs(), catalog.Database)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -92,7 +92,7 @@ func (cf *CollectionFactory) Txn(
 		if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			modifiedDescriptors = nil
 			deletedDescs = nil
-			descsCol = cf.MakeCollection(nil)
+			descsCol = cf.MakeCollection(ctx, nil)
 			defer descsCol.ReleaseAll(ctx)
 			if !UnsafeSkipSystemConfigTrigger.Get(&cf.settings.SV) {
 				if err := txn.SetSystemConfigTrigger(cf.leaseMgr.Codec().ForSystemTenant()); err != nil {

--- a/pkg/sql/catalog/descs/validate.go
+++ b/pkg/sql/catalog/descs/validate.go
@@ -13,6 +13,7 @@ package descs
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -37,7 +38,14 @@ func (tc *Collection) Validate(
 		tc:  tc,
 		txn: txn,
 	}
-	return validate.Validate(ctx, cbd, telemetry, targetLevel, descriptors...).CombinedError()
+	version := tc.settings.Version.ActiveVersion(ctx)
+	return validate.Validate(
+		ctx,
+		version,
+		cbd,
+		telemetry,
+		targetLevel,
+		descriptors...).CombinedError()
 }
 
 // ValidateUncommittedDescriptors validates all uncommitted descriptors.
@@ -69,7 +77,7 @@ var _ validate.ValidationDereferencer = &collectionBackedDereferencer{}
 // DereferenceDescriptors implements the validate.ValidationDereferencer
 // interface by leveraging the collection's uncommitted descriptors.
 func (c collectionBackedDereferencer) DereferenceDescriptors(
-	ctx context.Context, reqs []descpb.ID,
+	ctx context.Context, version clusterversion.ClusterVersion, reqs []descpb.ID,
 ) (ret []catalog.Descriptor, _ error) {
 	ret = make([]catalog.Descriptor, len(reqs))
 	fallbackReqs := make([]descpb.ID, 0, len(reqs))
@@ -90,7 +98,12 @@ func (c collectionBackedDereferencer) DereferenceDescriptors(
 		// TODO(postamar): actually use the Collection here instead,
 		// either by calling the Collection's methods or by caching the results
 		// of this call in the Collection.
-		fallbackRet, err := catkv.GetCrossReferencedDescriptorsForValidation(ctx, c.txn, c.tc.codec(), fallbackReqs)
+		fallbackRet, err := catkv.GetCrossReferencedDescriptorsForValidation(
+			ctx,
+			c.txn,
+			c.tc.codec(),
+			version,
+			fallbackReqs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/catalog/desctestutils/BUILD.bazel
+++ b/pkg/sql/catalog/desctestutils/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/sql/catalog",

--- a/pkg/sql/catalog/internal/catkv/BUILD.bazel
+++ b/pkg/sql/catalog/internal/catkv/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/catkv",
     visibility = ["//pkg/sql/catalog:__subpackages__"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/sql/catalog/internal/validate/BUILD.bazel
+++ b/pkg/sql/catalog/internal/validate/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate",
     visibility = ["//pkg/sql/catalog:__subpackages__"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog",

--- a/pkg/sql/catalog/internal/validate/validate.go
+++ b/pkg/sql/catalog/internal/validate/validate.go
@@ -14,6 +14,7 @@ package validate
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -23,8 +24,8 @@ import (
 
 // Self is a convenience function for Validate called at the
 // ValidationLevelSelfOnly level and combining the resulting errors.
-func Self(descriptors ...catalog.Descriptor) error {
-	results := Validate(context.TODO(), nil, catalog.NoValidationTelemetry, catalog.ValidationLevelSelfOnly, descriptors...)
+func Self(version clusterversion.ClusterVersion, descriptors ...catalog.Descriptor) error {
+	results := Validate(context.TODO(), version, nil, catalog.NoValidationTelemetry, catalog.ValidationLevelSelfOnly, descriptors...)
 	return results.CombinedError()
 }
 
@@ -38,6 +39,7 @@ func Self(descriptors ...catalog.Descriptor) error {
 // errors either as a slice or combined as one.
 func Validate(
 	ctx context.Context,
+	version clusterversion.ClusterVersion,
 	vd ValidationDereferencer,
 	telemetry catalog.ValidationTelemetry,
 	targetLevel catalog.ValidationLevel,
@@ -46,6 +48,7 @@ func Validate(
 	vea := validationErrorAccumulator{
 		ValidationTelemetry: telemetry,
 		targetLevel:         targetLevel,
+		activeVersion:       version,
 	}
 	// Internal descriptor consistency checks.
 	if !vea.validateDescriptorsAtLevel(
@@ -59,7 +62,7 @@ func Validate(
 	// Collect descriptors referenced by the validated descriptors.
 	// These are their immediate neighbors in the reference graph, and in some
 	// special cases those neighbors' immediate neighbors also.
-	vdg, descGetterErr := collectDescriptorsForValidation(ctx, vd, descriptors)
+	vdg, descGetterErr := collectDescriptorsForValidation(ctx, vd, version, descriptors)
 	if descGetterErr != nil {
 		vea.reportDescGetterError(collectingReferencedDescriptors, descGetterErr)
 		return vea.errors
@@ -109,7 +112,7 @@ func Validate(
 // Lookups are performed on a best-effort basis. When a descriptor or namespace
 // entry cannot be found, the zero-value is returned, with no error.
 type ValidationDereferencer interface {
-	DereferenceDescriptors(ctx context.Context, reqs []descpb.ID) ([]catalog.Descriptor, error)
+	DereferenceDescriptors(ctx context.Context, version clusterversion.ClusterVersion, reqs []descpb.ID) ([]catalog.Descriptor, error)
 	DereferenceDescriptorIDs(ctx context.Context, requests []descpb.NameInfo) ([]descpb.ID, error)
 }
 
@@ -121,6 +124,7 @@ type validationErrorAccumulator struct {
 	// Used to decorate errors with appropriate prefixes and telemetry keys.
 	catalog.ValidationTelemetry                         // set at initialization
 	targetLevel                 catalog.ValidationLevel // set at initialization
+	activeVersion               clusterversion.ClusterVersion
 	currentState                validationErrorAccumulatorState
 	currentLevel                catalog.ValidationLevel
 	currentDescriptor           catalog.Descriptor
@@ -171,6 +175,11 @@ func (vea *validationErrorAccumulator) validateDescriptorsAtLevel(
 		return false
 	}
 	return true
+}
+
+// IsActive implements the ValidationErrorAccumulator interface.
+func (vea *validationErrorAccumulator) IsActive(version clusterversion.Key) bool {
+	return vea.activeVersion.IsActive(version)
 }
 
 func (vea *validationErrorAccumulator) reportDescGetterError(
@@ -337,7 +346,7 @@ func (cs *collectorState) addDirectReferences(desc catalog.Descriptor) error {
 // getMissingDescs fetches the descriptors which have corresponding IDs in the
 // state but which are otherwise missing.
 func (cs *collectorState) getMissingDescs(
-	ctx context.Context, vd ValidationDereferencer,
+	ctx context.Context, vd ValidationDereferencer, version clusterversion.ClusterVersion,
 ) ([]catalog.Descriptor, error) {
 	reqs := make([]descpb.ID, 0, cs.referencedBy.Len())
 	for _, id := range cs.referencedBy.Ordered() {
@@ -348,7 +357,7 @@ func (cs *collectorState) getMissingDescs(
 	if len(reqs) == 0 {
 		return nil, nil
 	}
-	resps, err := vd.DereferenceDescriptors(ctx, reqs)
+	resps, err := vd.DereferenceDescriptors(ctx, version, reqs)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +372,10 @@ func (cs *collectorState) getMissingDescs(
 // collectDescriptorsForValidation is used by Validate to provide it with all
 // possible descriptors required for validation.
 func collectDescriptorsForValidation(
-	ctx context.Context, vd ValidationDereferencer, descriptors []catalog.Descriptor,
+	ctx context.Context,
+	vd ValidationDereferencer,
+	version clusterversion.ClusterVersion,
+	descriptors []catalog.Descriptor,
 ) (*validationDescGetterImpl, error) {
 	cs := collectorState{
 		vdg: validationDescGetterImpl{
@@ -380,7 +392,7 @@ func collectDescriptorsForValidation(
 			return nil, err
 		}
 	}
-	newDescs, err := cs.getMissingDescs(ctx, vd)
+	newDescs, err := cs.getMissingDescs(ctx, vd, version)
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +407,7 @@ func collectDescriptorsForValidation(
 			}
 		}
 	}
-	_, err = cs.getMissingDescs(ctx, vd)
+	_, err = cs.getMissingDescs(ctx, vd, version)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -174,7 +174,8 @@ func (m *Manager) PublishMultiple(
 			for _, id := range ids {
 				// Re-read the current versions of the descriptor, this time
 				// transactionally.
-				desc, err := catkv.MustGetDescriptorByID(ctx, txn, m.storage.codec, id, catalog.Any)
+				version := m.storage.settings.Version.ActiveVersion(ctx)
+				desc, err := catkv.MustGetDescriptorByID(ctx, txn, m.storage.codec, version, id, catalog.Any)
 				// Due to details in #51417, it is possible for a user to request a
 				// descriptor which no longer exists. In that case, just return an error.
 				if err != nil {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -123,7 +123,8 @@ func (m *Manager) WaitForOneVersion(
 ) (desc catalog.Descriptor, _ error) {
 	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
 		if err := m.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
-			desc, err = catkv.MustGetDescriptorByID(ctx, txn, m.Codec(), id, catalog.Any)
+			version := m.storage.settings.Version.ActiveVersion(ctx)
+			desc, err = catkv.MustGetDescriptorByID(ctx, txn, m.Codec(), version, id, catalog.Any)
 			return err
 		}); err != nil {
 			return nil, err

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -105,7 +105,8 @@ func (s storage) acquire(
 			expiration = minExpiration.Add(int64(time.Millisecond), 0)
 		}
 
-		desc, err = catkv.MustGetDescriptorByID(ctx, txn, s.codec, id, catalog.Any)
+		version := s.settings.Version.ActiveVersion(ctx)
+		desc, err = catkv.MustGetDescriptorByID(ctx, txn, s.codec, version, id, catalog.Any)
 		if err != nil {
 			return err
 		}
@@ -217,7 +218,8 @@ func (s storage) getForExpiration(
 		if err != nil {
 			return err
 		}
-		desc, err = catkv.MustGetDescriptorByID(ctx, txn, s.codec, id, catalog.Any)
+		version := s.settings.Version.ActiveVersion(ctx)
+		desc, err = catkv.MustGetDescriptorByID(ctx, txn, s.codec, version, id, catalog.Any)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/catalog/nstree/BUILD.bazel
+++ b/pkg/sql/catalog/nstree/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/internal/validate",

--- a/pkg/sql/catalog/schemadesc/BUILD.bazel
+++ b/pkg/sql/catalog/schemadesc/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     srcs = ["schema_desc_test.go"],
     deps = [
         ":schemadesc",
+        "//pkg/clusterversion",
         "//pkg/security",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/dbdesc",

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
@@ -173,7 +174,7 @@ func TestValidateCrossSchemaReferences(t *testing.T) {
 		cb.UpsertDescriptorEntry(dbdesc.NewBuilder(&test.dbDesc).BuildImmutable())
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
 		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
-		results := cb.Validate(ctx, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
+		results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
 		if err := results.CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/docs",
         "//pkg/geo/geoindex",
         "//pkg/keys",
@@ -67,6 +68,7 @@ go_test(
     embed = [":tabledesc"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/geo/geoindex",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -366,7 +367,7 @@ func TestIndexStrictColumnIDs(t *testing.T) {
 	idx.StoreColumnNames = append([]string{}, name, name, name, name)
 	idx.KeySuffixColumnIDs = append([]descpb.ColumnID{}, id, id, id, id)
 	mut.Version++
-	require.NoError(t, validate.Self(mut))
+	require.NoError(t, validate.Self(clusterversion.TestingClusterVersion, mut))
 
 	// Store the corrupted table descriptor.
 	err = db.Put(
@@ -399,7 +400,7 @@ func TestIndexStrictColumnIDs(t *testing.T) {
 	// considered invalid.
 	idx.Version = descpb.StrictIndexColumnIDGuaranteesVersion
 	expected = fmt.Sprintf(`relation "t" (%d): index "sec" has duplicates in KeySuffixColumnIDs: [2 2 2 2]`, mut.GetID())
-	require.EqualError(t, validate.Self(mut), expected)
+	require.EqualError(t, validate.Self(clusterversion.TestingClusterVersion, mut), expected)
 
 	_, err = conn.Exec(`ALTER TABLE d.t DROP COLUMN c2`)
 	require.NoError(t, err)

--- a/pkg/sql/catalog/tabledesc/safe_format_test.go
+++ b/pkg/sql/catalog/tabledesc/safe_format_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -275,7 +276,7 @@ func TestSafeMessage(t *testing.T) {
 				td = desc
 			}
 			redacted := string(redact.Sprint(td).Redact())
-			require.NoError(t, validate.Self(desc))
+			require.NoError(t, validate.Self(clusterversion.TestingClusterVersion, desc))
 			require.Equal(t, tc.exp, redacted)
 			var m map[string]interface{}
 			require.NoError(t, yaml.UnmarshalStrict([]byte(redacted), &m), redacted)

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -626,7 +627,7 @@ func (desc *Mutable) MaybeFillColumnID(
 // AllocateIDs allocates column, family, and index ids for any column, family,
 // or index which has an ID of 0. It's the same as AllocateIDsWithoutValidation,
 // but does validation on the table elements.
-func (desc *Mutable) AllocateIDs(ctx context.Context) error {
+func (desc *Mutable) AllocateIDs(ctx context.Context, version clusterversion.ClusterVersion) error {
 	if err := desc.AllocateIDsWithoutValidation(ctx); err != nil {
 		return err
 	}
@@ -638,7 +639,7 @@ func (desc *Mutable) AllocateIDs(ctx context.Context) error {
 	if desc.ID == 0 {
 		desc.ID = keys.SystemDatabaseID
 	}
-	err := validate.Self(desc)
+	err := validate.Self(version, desc)
 	desc.ID = savedID
 
 	return err

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -1857,7 +1858,7 @@ func TestValidateTableDesc(t *testing.T) {
 			d.desc.Privileges = descpb.NewBasePrivilegeDescriptor(security.RootUserName())
 			desc := NewBuilder(&d.desc).BuildImmutableTable()
 			expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), d.err)
-			err := validate.Self(desc)
+			err := validate.Self(clusterversion.TestingClusterVersion, desc)
 			if d.err == "" && err != nil {
 				t.Errorf("%d: expected success, but found error: \"%+v\"", i, err)
 			} else if d.err != "" && err == nil {
@@ -2233,7 +2234,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			desc := NewBuilder(&test.desc).BuildImmutable()
 			expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
 			const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
-			results := cb.Validate(ctx, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
+			results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
 			if err := results.CombinedError(); err == nil {
 				if test.err != "" {
 					t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/typedesc/BUILD.bazel
+++ b/pkg/sql/catalog/typedesc/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     ],
     deps = [
         ":typedesc",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -790,7 +791,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	for i, test := range testData {
 		desc := typedesc.NewBuilder(&test.desc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		ve := cb.Validate(ctx, catalog.NoValidationTelemetry, catalog.ValidationLevelCrossReferences, desc)
+		ve := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelCrossReferences, desc)
 		if err := ve.CombinedError(); err == nil {
 			t.Errorf("#%d expected err: %s but found nil: %v", i, expectedErr, test.desc)
 		} else if expectedErr != err.Error() {
@@ -836,6 +837,6 @@ func TestTableImplicitTypeDescCannotBeSerializedOrValidated(t *testing.T) {
 
 	desc := typedesc.NewBuilder(td).BuildImmutable()
 
-	err := validate.Self(desc)
+	err := validate.Self(clusterversion.TestingClusterVersion, desc)
 	require.Contains(t, err.Error(), "kind TABLE_IMPLICIT_RECORD_TYPE should never be serialized")
 }

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -13,6 +13,7 @@ package catalog
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/errors"
@@ -62,6 +63,11 @@ type ValidationErrorAccumulator interface {
 	// Report is called by the validation methods to report a possible error.
 	// No-ops when err is nil.
 	Report(err error)
+
+	// IsActive is used to confirm if a certain version of validation should
+	// be enabled, by comparing against the active version. If the active version
+	// is unknown the validation in question will always be enabled.
+	IsActive(version clusterversion.Key) bool
 }
 
 // ValidationErrors is the error container returned by Validate which contains

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -871,9 +871,7 @@ func (s *Server) newConnExecutor(
 		portals:   make(map[string]PreparedPortal),
 	}
 	ex.extraTxnState.prepStmtsNamespaceMemAcc = ex.sessionMon.MakeBoundAccount()
-	ex.extraTxnState.descCollection = s.cfg.CollectionFactory.MakeCollection(
-		descs.NewTemporarySchemaProvider(sdMutIterator.sds),
-	)
+	ex.extraTxnState.descCollection = s.cfg.CollectionFactory.MakeCollection(ctx, descs.NewTemporarySchemaProvider(sdMutIterator.sds))
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangeJobRecords = make(map[descpb.ID]*jobs.Record)
 	ex.mu.ActiveQueries = make(map[ClusterWideID]*queryMeta)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4548,7 +4548,11 @@ CREATE TABLE crdb_internal.invalid_objects (
 					)
 				}
 			}
-			ve := c.ValidateWithRecover(ctx, descriptor)
+			version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
+			ve := c.ValidateWithRecover(
+				ctx,
+				version,
+				descriptor)
 			for _, validationError := range ve {
 				addValidationErrorRow(validationError)
 			}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -97,7 +97,8 @@ func (p *planner) maybeSetupConstraintForShard(
 ) error {
 	// Assign an ID to the newly-added shard column, which is needed for the creation
 	// of a valid check constraint.
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
+	if err := tableDesc.AllocateIDs(ctx, version); err != nil {
 		return err
 	}
 
@@ -648,7 +649,8 @@ func (n *createIndexNode) startExec(params runParams) error {
 	if err := n.tableDesc.AddIndexMutation(indexDesc, descpb.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := n.tableDesc.AllocateIDs(params.ctx); err != nil {
+	version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+	if err := n.tableDesc.AllocateIDs(params.ctx, version); err != nil {
 		return err
 	}
 	if err := params.p.configureZoneConfigForNewIndexPartitioning(

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	clustersettings "github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
@@ -130,6 +131,7 @@ func doCreateSequence(
 	desc, err := NewSequenceTableDesc(
 		ctx,
 		p,
+		p.EvalContext().Settings,
 		name.Object(),
 		opts,
 		dbDesc.GetID(),
@@ -239,6 +241,7 @@ func (*createSequenceNode) Close(context.Context)        {}
 func NewSequenceTableDesc(
 	ctx context.Context,
 	p *planner,
+	settings *clustersettings.Settings,
 	sequenceName string,
 	sequenceOptions tree.SequenceOptions,
 	parentID descpb.ID,
@@ -312,7 +315,8 @@ func NewSequenceTableDesc(
 		desc.SetTableLocalityRegionalByTable(tree.PrimaryRegionNotSpecifiedName)
 	}
 
-	if err := descbuilder.ValidateSelf(&desc); err != nil {
+	version := settings.Version.ActiveVersion(ctx)
+	if err := descbuilder.ValidateSelf(&desc, version); err != nil {
 		return nil, err
 	}
 	return &desc, nil

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1989,8 +1989,8 @@ func NewTableDesc(
 			desc.AddFamily(fam)
 		}
 	}
-
-	if err := desc.AllocateIDs(ctx); err != nil {
+	version := st.Version.ActiveVersionOrEmpty(ctx)
+	if err := desc.AllocateIDs(ctx, version); err != nil {
 		return nil, err
 	}
 
@@ -2166,7 +2166,7 @@ func NewTableDesc(
 	// happens to work in gc, but does not work in gccgo.
 	//
 	// See https://github.com/golang/go/issues/23188.
-	if err := desc.AllocateIDs(ctx); err != nil {
+	if err := desc.AllocateIDs(ctx, version); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -208,7 +208,6 @@ func (n *createViewNode) startExec(params runParams) error {
 		var creationTime hlc.Timestamp
 		desc, err := makeViewTableDesc(
 			params.ctx,
-			params.p.ExecCfg().Settings,
 			viewName,
 			n.viewQuery,
 			n.dbDesc.GetID(),
@@ -219,10 +218,10 @@ func (n *createViewNode) startExec(params runParams) error {
 			privs,
 			&params.p.semaCtx,
 			params.p.EvalContext(),
+			params.p.EvalContext().Settings,
 			n.persistence,
 			n.dbDesc.IsMultiRegion(),
-			params.p,
-		)
+			params.p)
 		if err != nil {
 			return err
 		}
@@ -237,7 +236,8 @@ func (n *createViewNode) startExec(params runParams) error {
 			desc.IsMaterializedView = true
 			desc.State = descpb.DescriptorState_ADD
 			desc.CreateAsOfTime = params.p.Txn().ReadTimestamp()
-			if err := desc.AllocateIDs(params.ctx); err != nil {
+			version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+			if err := desc.AllocateIDs(params.ctx, version); err != nil {
 				return err
 			}
 			// For multi-region databases, we want this descriptor to be GLOBAL instead.
@@ -361,7 +361,6 @@ func (n *createViewNode) Close(ctx context.Context)  {}
 // include the back-references.
 func makeViewTableDesc(
 	ctx context.Context,
-	st *cluster.Settings,
 	viewName string,
 	viewQuery string,
 	parentID descpb.ID,
@@ -372,6 +371,7 @@ func makeViewTableDesc(
 	privileges *descpb.PrivilegeDescriptor,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
+	st *cluster.Settings,
 	persistence tree.Persistence,
 	isMultiRegion bool,
 	sc resolver.SchemaResolver,
@@ -404,7 +404,7 @@ func makeViewTableDesc(
 	}
 	desc.ViewQuery = typeReplacedQuery
 
-	if err := addResultColumns(ctx, semaCtx, evalCtx, &desc, resultColumns); err != nil {
+	if err := addResultColumns(ctx, semaCtx, evalCtx, st, &desc, resultColumns); err != nil {
 		return tabledesc.Mutable{}, err
 	}
 
@@ -514,7 +514,7 @@ func (p *planner) replaceViewDesc(
 	// Reset the columns to add the new result columns onto.
 	toReplace.Columns = make([]descpb.ColumnDescriptor, 0, len(n.columns))
 	toReplace.NextColumnID = 0
-	if err := addResultColumns(ctx, &p.semaCtx, p.EvalContext(), toReplace, n.columns); err != nil {
+	if err := addResultColumns(ctx, &p.semaCtx, p.EvalContext(), p.EvalContext().Settings, toReplace, n.columns); err != nil {
 		return nil, err
 	}
 
@@ -596,6 +596,7 @@ func addResultColumns(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
+	st *cluster.Settings,
 	desc *tabledesc.Mutable,
 	resultColumns colinfo.ResultColumns,
 ) error {
@@ -612,7 +613,8 @@ func addResultColumns(
 		}
 		desc.AddColumn(cdd.ColumnDescriptor)
 	}
-	if err := desc.AllocateIDs(ctx); err != nil {
+	version := st.Version.ActiveVersionOrEmpty(ctx)
+	if err := desc.AllocateIDs(ctx, version); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -86,7 +87,7 @@ func (mt mutationTest) makeMutationsActive(ctx context.Context) {
 	}
 	mt.tableDesc.Mutations = nil
 	mt.tableDesc.Version++
-	if err := descbuilder.ValidateSelf(mt.tableDesc); err != nil {
+	if err := descbuilder.ValidateSelf(mt.tableDesc, clusterversion.TestingClusterVersion); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -146,7 +147,7 @@ func (mt mutationTest) writeMutation(ctx context.Context, m descpb.DescriptorMut
 	}
 	mt.tableDesc.Mutations = append(mt.tableDesc.Mutations, m)
 	mt.tableDesc.Version++
-	if err := descbuilder.ValidateSelf(mt.tableDesc); err != nil {
+	if err := descbuilder.ValidateSelf(mt.tableDesc, clusterversion.TestingClusterVersion); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -456,21 +457,21 @@ CREATE INDEX allidx ON t.test (k, v);
 	// Check that a mutation can only be inserted with an explicit mutation state, and direction.
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []descpb.DescriptorMutation{{}}
-	if err := descbuilder.ValidateSelf(tableDesc); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
+	if err := descbuilder.ValidateSelf(tableDesc, clusterversion.TestingClusterVersion); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations = []descpb.DescriptorMutation{{Descriptor_: &descpb.DescriptorMutation_Column{Column: &tableDesc.Columns[len(tableDesc.Columns)-1]}}}
 	tableDesc.Columns = tableDesc.Columns[:len(tableDesc.Columns)-1]
-	if err := descbuilder.ValidateSelf(tableDesc); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
+	if err := descbuilder.ValidateSelf(tableDesc, clusterversion.TestingClusterVersion); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = descpb.DescriptorMutation_DELETE_ONLY
-	if err := descbuilder.ValidateSelf(tableDesc); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
+	if err := descbuilder.ValidateSelf(tableDesc, clusterversion.TestingClusterVersion); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = descpb.DescriptorMutation_UNKNOWN
 	tableDesc.Mutations[0].Direction = descpb.DescriptorMutation_DROP
-	if err := descbuilder.ValidateSelf(tableDesc); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
+	if err := descbuilder.ValidateSelf(tableDesc, clusterversion.TestingClusterVersion); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
 		t.Fatal(err)
 	}
 }
@@ -666,7 +667,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));
 	index := tableDesc.PublicNonPrimaryIndexes()[len(tableDesc.PublicNonPrimaryIndexes())-1]
 	tableDesc.Mutations = []descpb.DescriptorMutation{{Descriptor_: &descpb.DescriptorMutation_Index{Index: index.IndexDesc()}}}
 	tableDesc.RemovePublicNonPrimaryIndex(index.Ordinal())
-	if err := descbuilder.ValidateSelf(tableDesc); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
+	if err := descbuilder.ValidateSelf(tableDesc, clusterversion.TestingClusterVersion); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -485,7 +485,7 @@ func (ds *ServerImpl) newFlowContext(
 		// If we weren't passed a descs.Collection, then make a new one. We are
 		// responsible for cleaning it up and releasing any accessed descriptors
 		// on flow cleanup.
-		flowCtx.Descriptors = ds.CollectionFactory.NewCollection(descs.NewTemporarySchemaProvider(evalCtx.SessionDataStack))
+		flowCtx.Descriptors = ds.CollectionFactory.NewCollection(ctx, descs.NewTemporarySchemaProvider(evalCtx.SessionDataStack))
 		flowCtx.IsDescriptorsCleanupRequired = true
 	}
 	return flowCtx

--- a/pkg/sql/doctor/BUILD.bazel
+++ b/pkg/sql/doctor/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/doctor",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
@@ -29,6 +30,7 @@ go_test(
     srcs = ["doctor_test.go"],
     deps = [
         ":doctor",
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -545,7 +546,13 @@ func TestExamineDescriptors(t *testing.T) {
 	for i, test := range tests {
 		var buf bytes.Buffer
 		valid, err := doctor.ExamineDescriptors(
-			context.Background(), test.descTable, test.namespaceTable, test.jobsTable, false, &buf)
+			context.Background(),
+			clusterversion.TestingClusterVersion,
+			test.descTable,
+			test.namespaceTable,
+			test.jobsTable,
+			false,
+			&buf)
 		msg := fmt.Sprintf("Test %d failed!", i+1)
 		if test.errStr != "" {
 			require.Containsf(t, err.Error(), test.errStr, msg)

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -246,7 +246,8 @@ func (n *dropIndexNode) dropShardColumnAndConstraint(
 // finalizeDropColumn finalizes the dropping of one or more columns. It should
 // only be called if queueDropColumn has been called at least once.
 func (n *dropIndexNode) finalizeDropColumn(params runParams, tableDesc *tabledesc.Mutable) error {
-	if err := tableDesc.AllocateIDs(params.ctx); err != nil {
+	version := params.ExecCfg().Settings.Version.ActiveVersion(params.ctx)
+	if err := tableDesc.AllocateIDs(params.ctx, version); err != nil {
 		return err
 	}
 	mutationID := tableDesc.ClusterVersion.NextMutationID

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":545,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":546,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -325,7 +325,7 @@ func newInternalPlanner(
 	sds := sessiondata.NewStack(sd)
 
 	if params.collection == nil {
-		params.collection = execCfg.CollectionFactory.NewCollection(descs.NewTemporarySchemaProvider(sds))
+		params.collection = execCfg.CollectionFactory.NewCollection(ctx, descs.NewTemporarySchemaProvider(sds))
 	}
 
 	var ts time.Time

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -267,7 +267,7 @@ func (c *DatumRowConverter) getSequenceAnnotation(
 	// TODO(postamar): give the tree.EvalContext a useful interface
 	// instead of cobbling a descs.Collection in this way.
 	cf := descs.NewBareBonesCollectionFactory(evalCtx.Settings, evalCtx.Codec)
-	descsCol := cf.MakeCollection(descs.NewTemporarySchemaProvider(evalCtx.SessionDataStack))
+	descsCol := cf.MakeCollection(evalCtx.Context, descs.NewTemporarySchemaProvider(evalCtx.SessionDataStack))
 	err := evalCtx.DB.Txn(evalCtx.Context, func(ctx context.Context, txn *kv.Txn) error {
 		seqNameToMetadata = make(map[string]*SequenceMetadata)
 		seqIDToMetadata = make(map[descpb.ID]*SequenceMetadata)

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps/sctestdeps",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -621,7 +622,7 @@ func (b *testCatalogChangeBatcher) ValidateAndRun(ctx context.Context) error {
 		b.s.LogSideEffectf("delete descriptor #%d", deletedID)
 		b.s.catalog.DeleteDescriptorEntry(deletedID)
 	}
-	ve := b.s.catalog.Validate(ctx, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, b.descs...)
+	ve := b.s.catalog.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, b.descs...)
 	return ve.CombinedError()
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5362,7 +5362,7 @@ value if you rely on the HLC for accuracy.`,
 				// TODO(postamar): give the tree.EvalContext a useful interface
 				// instead of cobbling a descs.Collection in this way.
 				cf := descs.NewBareBonesCollectionFactory(ctx.Settings, ctx.Codec)
-				descsCol := cf.MakeCollection(descs.NewTemporarySchemaProvider(ctx.SessionDataStack))
+				descsCol := cf.MakeCollection(ctx.Context, descs.NewTemporarySchemaProvider(ctx.SessionDataStack))
 				tableDesc, err := descsCol.Direct().MustGetTableDescByID(ctx.Ctx(), ctx.Txn, descpb.ID(tableID))
 				if err != nil {
 					return nil, err
@@ -5400,7 +5400,7 @@ value if you rely on the HLC for accuracy.`,
 				// TODO(postamar): give the tree.EvalContext a useful interface
 				// instead of cobbling a descs.Collection in this way.
 				cf := descs.NewBareBonesCollectionFactory(ctx.Settings, ctx.Codec)
-				descsCol := cf.MakeCollection(descs.NewTemporarySchemaProvider(ctx.SessionDataStack))
+				descsCol := cf.MakeCollection(ctx.Context, descs.NewTemporarySchemaProvider(ctx.SessionDataStack))
 				tableDesc, err := descsCol.Direct().MustGetTableDescByID(ctx.Ctx(), ctx.Txn, descpb.ID(tableID))
 				if err != nil {
 					return nil, err

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -294,7 +294,8 @@ func (p *planner) writeTableDescToBatch(
 		}
 	}
 
-	if err := descbuilder.ValidateSelf(tableDesc); err != nil {
+	version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
+	if err := descbuilder.ValidateSelf(tableDesc, version); err != nil {
 		return errors.NewAssertionErrorWithWrappedErrf(err, "table descriptor is not valid\n%v\n", tableDesc)
 	}
 

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -404,7 +405,7 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	}
 	desc.SetPrimaryIndex(descpb.IndexDescriptor{})
 
-	err = descbuilder.ValidateSelf(desc)
+	err = descbuilder.ValidateSelf(desc, clusterversion.TestingClusterVersion)
 	if !testutils.IsError(err, tabledesc.ErrMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -521,7 +521,7 @@ func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(
 	waitTimeForCreation := TempObjectWaitInterval.Get(&c.settings.SV)
 	// Build a set of all databases with temporary objects.
 	var allDbDescs []catalog.DatabaseDescriptor
-	descsCol := c.collectionFactory.NewCollection(nil /* temporarySchemaProvider */)
+	descsCol := c.collectionFactory.NewCollection(ctx, nil /* TemporarySchemaProvider */)
 	if err := retryFunc(ctx, func() error {
 		var err error
 		allDbDescs, err = descsCol.GetAllDatabaseDescriptors(ctx, txn)

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/bench",
         "//pkg/ccl",
         "//pkg/ccl/utilccl",
+        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/internal/rsg",
         "//pkg/internal/sqlsmith",

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -190,7 +191,7 @@ func TestSystemTableLiterals(t *testing.T) {
 			if err != nil {
 				t.Fatalf("test: %+v, err: %v", test, err)
 			}
-			require.NoError(t, descbuilder.ValidateSelf(gen))
+			require.NoError(t, descbuilder.ValidateSelf(gen, clusterversion.TestingClusterVersion))
 
 			if test.pkg.TableDesc().Equal(gen.TableDesc()) {
 				return

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -75,6 +75,7 @@ func CreateTestTableDescriptor(
 		desc, err := NewSequenceTableDesc(
 			ctx,
 			nil, /* planner */
+			st,
 			n.Name.Table(),
 			n.Options,
 			parentID, keys.PublicSchemaID, id,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -209,7 +209,8 @@ func (p *planner) truncateTable(ctx context.Context, id descpb.ID, jobDesc strin
 	}
 
 	// Create new ID's for all of the indexes in the table.
-	if err := tableDesc.AllocateIDs(ctx); err != nil {
+	version := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
+	if err := tableDesc.AllocateIDs(ctx, version); err != nil {
 		return err
 	}
 

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -248,21 +248,20 @@ func (v virtualSchemaView) initVirtualTableDesc(
 	}
 	mutDesc, err := makeViewTableDesc(
 		ctx,
-		st,
 		create.Name.Table(),
 		tree.AsStringWithFlags(create.AsSource, tree.FmtParsable),
-		0, /* parentID */
+		0,
 		sc.GetID(),
 		id,
 		columns,
-		startTime, /* creationTime */
+		startTime,
 		descpb.NewVirtualTablePrivilegeDescriptor(),
-		nil, /* semaCtx */
-		nil, /* evalCtx */
+		nil,
+		nil,
+		st,
 		tree.PersistencePermanent,
-		false, /* isMultiRegion */
-		nil,   /* sc */
-	)
+		false,
+		nil)
 	return mutDesc.TableDescriptor, err
 }
 
@@ -696,7 +695,8 @@ func NewVirtualSchemaHolder(
 				}
 			}
 			td := tabledesc.NewBuilder(&tableDesc).BuildImmutableTable()
-			if err := descbuilder.ValidateSelf(td); err != nil {
+			version := st.Version.ActiveVersionOrEmpty(ctx)
+			if err := descbuilder.ValidateSelf(td, version); err != nil {
 				return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 					"failed to validate virtual table %s: programmer error", errors.Safe(td.GetName()))
 			}


### PR DESCRIPTION
Previously, the descriptor validation code did not
take a version number, so it was not possible to version
gate new validation logic. This was inadequate  because
when new fields are introduced we don't want their validation
to kick in for certain cases like the debug doctor, such as any
new fields with non-zero defaults. To address this, this patch add supports
for version numbers inside the validation, and updates unit tests
to pass this in as well. It also adds a new option on debug doctor
to run a version of validation.

Release note (cli change): Add new optional version argument
to the doctor examine command. This can be used to enable /
disable validation when examining older zip directories.