### PR TITLE
ui,server: Table stats collection details added to Database pages

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4603,6 +4603,7 @@ a table.
 | zone_config_level | [ZoneConfigurationLevel](#cockroach.server.serverpb.TableDetailsResponse-cockroach.server.serverpb.ZoneConfigurationLevel) |  | The level at which this object's zone configuration is set. | [reserved](#support-status) |
 | descriptor_id | [int64](#cockroach.server.serverpb.TableDetailsResponse-int64) |  | descriptor_id is an identifier used to uniquely identify this table. It can be used to find events pertaining to this table by filtering on the 'target_id' field of events. | [reserved](#support-status) |
 | configure_zone_statement | [string](#cockroach.server.serverpb.TableDetailsResponse-string) |  | configure_zone_statement is the output of "SHOW ZONE CONFIGURATION FOR TABLE" for this table. It is a SQL statement that would re-configure the table's current zone if executed. | [reserved](#support-status) |
+| stats_last_created_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableDetailsResponse-google.protobuf.Timestamp) |  | stats_last_created_at is the time at which statistics were last created. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1279,6 +1279,12 @@
           "format": "int64",
           "x-go-name": "RangeCount"
         },
+        "stats_last_created_at": {
+          "description": "stats_last_created_at is the time at which statistics were last created.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "StatsLastCreatedAt"
+        },
         "zone_config": {
           "$ref": "#/definitions/ZoneConfig"
         },

--- a/pkg/gen/excluded.bzl
+++ b/pkg/gen/excluded.bzl
@@ -346,6 +346,8 @@ EXCLUDED_SRCS = [
   "//pkg/ui/workspaces/cluster-ui:dist/types/sessions/sessionsTableContent.d.ts",
   "//pkg/ui/workspaces/cluster-ui:dist/types/sessions/terminateQueryModal.d.ts",
   "//pkg/ui/workspaces/cluster-ui:dist/types/sessions/terminateSessionModal.d.ts",
+  "//pkg/ui/workspaces/cluster-ui:dist/types/settings/booleanSetting.d.ts",
+  "//pkg/ui/workspaces/cluster-ui:dist/types/settings/index.d.ts",
   "//pkg/ui/workspaces/cluster-ui:dist/types/sortedtable/index.d.ts",
   "//pkg/ui/workspaces/cluster-ui:dist/types/sortedtable/sortedtable.d.ts",
   "//pkg/ui/workspaces/cluster-ui:dist/types/sortedtable/tableHead/index.d.ts",

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -673,6 +673,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 				"CREATE USER app",
 				fmt.Sprintf("GRANT SELECT ON %s.%s TO readonly", escDBName, tblName),
 				fmt.Sprintf("GRANT SELECT,UPDATE,DELETE ON %s.%s TO app", escDBName, tblName),
+				fmt.Sprintf("CREATE STATISTICS test_stats FROM %s.%s", escDBName, tblName),
 			}
 			pgURL, cleanupGoDB := sqlutils.PGUrl(
 				t, s.ServingSQLAddr(), "StartServer" /* prefix */, url.User(security.RootUser))
@@ -776,6 +777,22 @@ func TestAdminAPITableDetails(t *testing.T) {
 
 				if a, e := resp.CreateTableStatement, createStmt; a != e {
 					t.Fatalf("mismatched create table statement; expected %s, got %s", e, a)
+				}
+			}
+
+			// Verify statistics last updated.
+			{
+
+				showStatisticsForTableQuery := fmt.Sprintf("SELECT max(created) AS created FROM [SHOW STATISTICS FOR TABLE %s.%s]", escDBName, tblName)
+
+				row := db.QueryRow(showStatisticsForTableQuery)
+				var createdTs time.Time
+				if err := row.Scan(&createdTs); err != nil {
+					t.Fatal(err)
+				}
+
+				if a, e := resp.StatsLastCreatedAt, createdTs; reflect.DeepEqual(a, e) {
+					t.Fatalf("mismatched statistics creation timestamp; expected %s, got %s", e, a)
 				}
 			}
 

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -210,6 +210,8 @@ message TableDetailsResponse {
   // for this table. It is a SQL statement that would re-configure the table's current
   // zone if executed.
   string configure_zone_statement = 9;
+  // stats_last_created_at is the time at which statistics were last created.
+  google.protobuf.Timestamp stats_last_created_at = 10 [(gogoproto.stdtime) = true];
 }
 
 // TableStatsRequest is a request for detailed, computationally expensive

--- a/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
@@ -59,6 +59,7 @@ $colors--functional-orange-5: #764205;
 $colors--title: $colors--neutral-8;
 $colors--primary-text: $colors--neutral-7;
 $colors--secondary-text: $colors--neutral-6;
+$colors--success: $colors--primary-green-3;
 $colors--disabled: $colors--neutral-5;
 $colors--link: $colors--primary-blue-3;
 $colors--white: $colors--neutral-0;

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -25,6 +25,7 @@ import {
 } from "./databaseDetailsPage";
 
 import * as H from "history";
+import moment from "moment";
 const history = H.createHashHistory();
 
 const withLoadingIndicator: DatabaseDetailsPageProps = {
@@ -107,6 +108,7 @@ const withData: DatabaseDetailsPageProps = {
         userCount: roles.length,
         roles: roles,
         grants: grants,
+        statsLastUpdated: moment("0001-01-01T00:00:00Z"),
       },
       showNodeRegionsColumn: true,
       stats: {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -36,6 +36,8 @@ import {
   baseHeadingClasses,
   statisticsClasses,
 } from "src/transactionsPage/transactionsPageClasses";
+import { Moment } from "moment";
+import { formatDate } from "antd/es/date-picker/utils";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -101,6 +103,7 @@ export interface DatabaseDetailsPageDataTableDetails {
   userCount: number;
   roles: string[];
   grants: string[];
+  statsLastUpdated?: Moment;
 }
 
 export interface DatabaseDetailsPageDataTableStats {
@@ -350,6 +353,26 @@ export class DatabaseDetailsPage extends React.Component<
         name: "regions",
         showByDefault: this.props.showNodeRegionsColumn,
         hideIfTenant: true,
+      },
+      {
+        title: (
+          <Tooltip
+            placement="bottom"
+            title="The last time table statistics were created or updated."
+          >
+            Table Stats Last Updated (UTC)
+          </Tooltip>
+        ),
+        cell: table =>
+          !table.details.statsLastUpdated
+            ? "No table statistics found"
+            : formatDate(
+                table.details.statsLastUpdated,
+                "MMM DD, YYYY [at] h:mm A",
+              ),
+        sort: table => table.details.statsLastUpdated,
+        className: cx("database-table__col--table-stats"),
+        name: "tableStatsUpdated",
       },
     ];
   }

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -26,6 +26,7 @@ const history = H.createHashHistory();
 const withLoadingIndicator: DatabaseTablePageProps = {
   databaseName: randomName(),
   name: randomName(),
+  automaticStatsCollectionEnabled: true,
   details: {
     loading: true,
     loaded: false,
@@ -33,6 +34,7 @@ const withLoadingIndicator: DatabaseTablePageProps = {
     replicaCount: 0,
     indexNames: [],
     grants: [],
+    statsLastUpdated: moment("0001-01-01T00:00:00Z"),
   },
   stats: {
     loading: true,
@@ -58,6 +60,7 @@ const withLoadingIndicator: DatabaseTablePageProps = {
   refreshTableStats: () => {},
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
+  refreshSettings: () => {},
 };
 
 const name = randomName();
@@ -65,6 +68,7 @@ const name = randomName();
 const withData: DatabaseTablePageProps = {
   databaseName: randomName(),
   name: name,
+  automaticStatsCollectionEnabled: true,
   details: {
     loading: false,
     loaded: true,
@@ -89,6 +93,7 @@ const withData: DatabaseTablePageProps = {
         };
       }),
     ),
+    statsLastUpdated: moment("0001-01-01T00:00:00Z"),
   },
   showNodeRegionsSection: true,
   stats: {
@@ -136,6 +141,7 @@ const withData: DatabaseTablePageProps = {
   refreshTableStats: () => {},
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
+  refreshSettings: () => {},
 };
 
 storiesOf("Database Table Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
@@ -22,6 +22,7 @@ const history = H.createHashHistory();
 const withLoadingIndicator: DatabasesPageProps = {
   loading: true,
   loaded: false,
+  automaticStatsCollectionEnabled: true,
   databases: [],
   sortSetting: {
     ascending: false,
@@ -29,6 +30,7 @@ const withLoadingIndicator: DatabasesPageProps = {
   },
   onSortingChange: () => {},
   refreshDatabases: () => {},
+  refreshSettings: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
   location: history.location,
@@ -44,6 +46,7 @@ const withLoadingIndicator: DatabasesPageProps = {
 const withoutData: DatabasesPageProps = {
   loading: false,
   loaded: true,
+  automaticStatsCollectionEnabled: true,
   databases: [],
   sortSetting: {
     ascending: false,
@@ -51,6 +54,7 @@ const withoutData: DatabasesPageProps = {
   },
   onSortingChange: () => {},
   refreshDatabases: () => {},
+  refreshSettings: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
   location: history.location,
@@ -67,6 +71,7 @@ const withData: DatabasesPageProps = {
   loading: false,
   loaded: true,
   showNodeRegionsColumn: true,
+  automaticStatsCollectionEnabled: true,
   sortSetting: {
     ascending: false,
     columnTitle: "name",
@@ -86,6 +91,7 @@ const withData: DatabasesPageProps = {
   }),
   onSortingChange: () => {},
   refreshDatabases: () => {},
+  refreshSettings: () => {},
   refreshDatabaseDetails: () => {},
   refreshTableStats: () => {},
   location: history.location,

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -14,8 +14,10 @@ import { Tooltip } from "antd";
 import classNames from "classnames/bind";
 import _ from "lodash";
 
+import { Anchor } from "src/anchor";
 import { StackIcon } from "src/icon/stackIcon";
 import { Pagination, ResultsPerPageLabel } from "src/pagination";
+import { BooleanSetting } from "src/settings/booleanSetting";
 import {
   ColumnDescriptor,
   ISortedTablePagination,
@@ -30,10 +32,13 @@ import {
   baseHeadingClasses,
   statisticsClasses,
 } from "src/transactionsPage/transactionsPageClasses";
-import { syncHistory } from "../util";
+import { syncHistory, tableStatsClusterSetting } from "src/util";
+import classnames from "classnames/bind";
+import booleanSettingStyles from "../settings/booleanSetting.module.scss";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
+const booleanSettingCx = classnames.bind(booleanSettingStyles);
 
 // We break out separate interfaces for some of the nested objects in our data
 // both so that they can be available as SortedTable rows and for making
@@ -67,6 +72,7 @@ export interface DatabasesPageData {
   loaded: boolean;
   databases: DatabasesPageDataDatabase[];
   sortSetting: SortSetting;
+  automaticStatsCollectionEnabled: boolean;
   showNodeRegionsColumn?: boolean;
 }
 
@@ -99,6 +105,7 @@ export interface DatabasesPageActions {
   refreshDatabases: () => void;
   refreshDatabaseDetails: (database: string) => void;
   refreshTableStats: (database: string, table: string) => void;
+  refreshSettings: () => void;
   refreshNodes?: () => void;
   onSortingChange?: (
     name: string,
@@ -158,6 +165,10 @@ export class DatabasesPage extends React.Component<
   private refresh(): void {
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
+    }
+
+    if (this.props.refreshSettings != null) {
+      this.props.refreshSettings();
     }
 
     if (!this.props.loaded && !this.props.loading) {
@@ -282,7 +293,28 @@ export class DatabasesPage extends React.Component<
     );
     return (
       <div>
-        <h3 className={baseHeadingClasses.tableName}>Databases</h3>
+        <div className={baseHeadingClasses.wrapper}>
+          <h3 className={baseHeadingClasses.tableName}>Databases</h3>
+          <BooleanSetting
+            text={"Auto stats collection"}
+            enabled={this.props.automaticStatsCollectionEnabled}
+            tooltipText={
+              <span>
+                {" "}
+                Automatic statistics can help improve query performance. Learn
+                how to{" "}
+                <Anchor
+                  href={tableStatsClusterSetting}
+                  target="_blank"
+                  className={booleanSettingCx("crl-hover-text__link-text")}
+                >
+                  manage statistics collection
+                </Anchor>
+                .
+              </span>
+            }
+          />
+        </div>
         <section className={sortableTableCx("cl-table-container")}>
           <div className={statisticsClasses.statistic}>
             <h4 className={statisticsClasses.countTitle}>

--- a/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.module.scss
@@ -1,0 +1,36 @@
+@import "src/core/index.module";
+
+.crl-hover-text {
+  font-size: 12px;
+
+  &__dashed-underline {
+    color: inherit;
+    border-bottom-width: 1px;
+    border-bottom-style: dashed;
+    border-bottom-color: inherit;
+    cursor: default;
+  }
+
+  &__link-text {
+  color: inherit;
+  font-size: inherit;
+  }
+}
+
+.bool-setting-icon {
+
+  &__enabled {
+    fill: $colors--success;
+    margin-right: 8px;
+    height: 8px;
+    width: 8px;
+  }
+
+  &__disabled {
+    fill: $colors--disabled;
+    margin-right: 8px;
+    height: 8px;
+    width: 8px;
+  }
+}
+

--- a/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.tsx
@@ -1,0 +1,43 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as React from "react";
+import { CircleFilled } from "src/icon";
+import { Tooltip } from "antd";
+import classNames from "classnames/bind";
+import styles from "./booleanSetting.module.scss";
+
+const cx = classNames.bind(styles);
+
+export interface BooleanSettingProps {
+  text: string;
+  enabled: boolean;
+  tooltipText: JSX.Element;
+}
+
+export function BooleanSetting(props: BooleanSettingProps) {
+  const { text, enabled, tooltipText } = props;
+  const label = enabled ? "enabled" : "disabled";
+  const boolClass = enabled
+    ? "bool-setting-icon__enabled"
+    : "bool-setting-icon__disabled";
+  return (
+    <div>
+      <CircleFilled className={cx(boolClass)} />
+      <Tooltip
+        placement="bottom"
+        title={tooltipText}
+        className={cx("crl-hover-text__dashed-underline")}
+      >
+        {text} - {label}
+      </Tooltip>
+    </div>
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/settings/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/settings/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,5 +8,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./connectedMount";
-export * from "./assertDeepStrictEqual";
+export * from "./booleanSetting";

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
@@ -11,6 +11,9 @@
 import React from "react";
 import classnames from "classnames/bind";
 import styles from "./summaryCard.module.scss";
+import booleanSettingStyles from "../settings/booleanSetting.module.scss";
+import { CircleFilled } from "src/icon";
+import { Tooltip } from "antd";
 
 interface ISummaryCardProps {
   children: React.ReactNode;
@@ -18,6 +21,7 @@ interface ISummaryCardProps {
 }
 
 const cx = classnames.bind(styles);
+const booleanSettingCx = classnames.bind(booleanSettingStyles);
 
 // tslint:disable-next-line: variable-name
 export const SummaryCard: React.FC<ISummaryCardProps> = ({
@@ -31,6 +35,10 @@ interface ISummaryCardItemProps {
   className?: string;
 }
 
+interface ISummaryCardItemBoolSettingProps extends ISummaryCardItemProps {
+  toolTipText: JSX.Element;
+}
+
 export const SummaryCardItem: React.FC<ISummaryCardItemProps> = ({
   label,
   value,
@@ -41,3 +49,31 @@ export const SummaryCardItem: React.FC<ISummaryCardItemProps> = ({
     <p className={cx("summary--card__item--value")}>{value}</p>
   </div>
 );
+
+export const SummaryCardItemBoolSetting: React.FC<ISummaryCardItemBoolSettingProps> = ({
+  label,
+  value,
+  toolTipText,
+  className,
+}) => {
+  const boolValue = value ? "Enabled" : "Disabled";
+  const boolClass = value
+    ? "bool-setting-icon__enabled"
+    : "bool-setting-icon__disabled";
+
+  return (
+    <div className={cx("summary--card__item", className)}>
+      <h4 className={cx("summary--card__item--label")}>{label}</h4>
+      <p className={cx("summary--card__item--value")}>
+        <CircleFilled className={booleanSettingCx(boolClass)} />
+        <Tooltip
+          placement="bottom"
+          title={toolTipText}
+          className={cx("crl-hover-text__dashed-underline")}
+        >
+          {boolValue}
+        </Tooltip>
+      </p>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -84,6 +84,9 @@ export const reviewOfCockroachTerminology = docsURL(
   "ui-replication-dashboard.html#review-of-cockroachdb-terminology",
 );
 export const sessionsTable = docsURL("ui-sessions-page.html");
+export const tableStatsClusterSetting = docsURL(
+  "cost-based-optimizer.html#control-automatic-statistics",
+);
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion =

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -41,3 +41,14 @@ export const selectResolution30mStorageTTL = createSelector(
     return util.durationFromISO8601String(value);
   },
 );
+
+export const selectAutomaticStatsCollectionEnabled = createSelector(
+  selectClusterSettings,
+  (settings): boolean | undefined => {
+    if (!settings) {
+      return undefined;
+    }
+    const value = settings["sql.stats.automatic_collection.enabled"]?.value;
+    return value === "true";
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/test-utils/assertDeepStrictEqual.ts
+++ b/pkg/ui/workspaces/db-console/src/test-utils/assertDeepStrictEqual.ts
@@ -1,0 +1,21 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import assert from "assert";
+
+export function assertDeepStrictEqual<T>(expected: T, actual: T) {
+  assert.deepStrictEqual(actual, expected, errorMessage(expected, actual));
+}
+
+function errorMessage(expected: any, actual: any): string {
+  return `expected: ${JSON.stringify(expected)} but was ${JSON.stringify(
+    actual,
+  )}`;
+}

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -17,6 +17,7 @@ import fetchMock from "src/util/fetch-mock";
 const {
   DatabasesResponse,
   DatabaseDetailsResponse,
+  SettingsResponse,
   TableDetailsResponse,
   TableStatsResponse,
   TableIndexStatsResponse,
@@ -52,6 +53,16 @@ const {
 
 export function restore() {
   fetchMock.restore();
+}
+
+export function stubClusterSettings(
+  response: cockroach.server.serverpb.ISettingsResponse,
+) {
+  stubGet(
+    "/settings?unredacted_values=true",
+    SettingsResponse.encode(response),
+    API_PREFIX,
+  );
 }
 
 export function stubDatabases(

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -12,7 +12,11 @@ import { RouteComponentProps } from "react-router";
 import { createSelector } from "reselect";
 import { LocalSetting } from "src/redux/localsettings";
 import _ from "lodash";
-import { DatabaseDetailsPageData, ViewMode } from "@cockroachlabs/cluster-ui";
+import {
+  DatabaseDetailsPageData,
+  util,
+  ViewMode,
+} from "@cockroachlabs/cluster-ui";
 
 import { cockroach } from "src/js/protos";
 import {
@@ -30,6 +34,7 @@ import {
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
 import { getNodesByRegionString } from "../utils";
+
 const {
   DatabaseDetailsRequest,
   TableDetailsRequest,
@@ -132,7 +137,6 @@ export const mapStateToProps = createSelector(
         const numIndexes = _.uniq(
           _.map(details?.data?.indexes, index => index.name),
         ).length;
-
         return {
           name: table,
           details: {
@@ -143,6 +147,9 @@ export const mapStateToProps = createSelector(
             userCount: roles.length,
             roles: roles,
             grants: grants,
+            statsLastUpdated: details?.data?.stats_last_created_at
+              ? util.TimestampToMoment(details?.data?.stats_last_created_at)
+              : null,
           },
           stats: {
             loading: !!stats?.inFlight,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -20,6 +20,7 @@ import {
   refreshTableStats,
   refreshNodes,
   refreshIndexStats,
+  refreshSettings,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { databaseNameAttr, tableNameAttr } from "src/util/constants";
@@ -31,6 +32,7 @@ import {
 } from "src/redux/nodes";
 import { getNodesByRegionString } from "../utils";
 import { resetIndexUsageStatsAction } from "src/redux/indexUsageStats";
+import { selectAutomaticStatsCollectionEnabled } from "src/redux/clusterSettings";
 
 const {
   TableDetailsRequest,
@@ -49,6 +51,7 @@ export const mapStateToProps = createSelector(
   state => state.cachedData.indexStats,
   state => nodeRegionsByIDSelector(state),
   state => selectIsMoreThanOneNode(state),
+  state => selectAutomaticStatsCollectionEnabled(state),
 
   (
     database,
@@ -58,6 +61,7 @@ export const mapStateToProps = createSelector(
     indexUsageStats,
     nodeRegions,
     showNodeRegionsSection,
+    automaticStatsCollectionEnabled,
   ): DatabaseTablePageData => {
     const details = tableDetails[generateTableID(database, table)];
     const stats = tableStats[generateTableID(database, table)];
@@ -102,8 +106,12 @@ export const mapStateToProps = createSelector(
         replicaCount: details?.data?.zone_config?.num_replicas || 0,
         indexNames: _.uniq(_.map(details?.data?.indexes, index => index.name)),
         grants: grants,
+        statsLastUpdated: details?.data?.stats_last_created_at
+          ? util.TimestampToMoment(details?.data?.stats_last_created_at)
+          : null,
       },
       showNodeRegionsSection,
+      automaticStatsCollectionEnabled,
       stats: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -139,4 +147,6 @@ export const mapDispatchToProps = {
   resetIndexUsageStats: resetIndexUsageStatsAction,
 
   refreshNodes,
+
+  refreshSettings,
 };

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -23,6 +23,7 @@ import {
   refreshDatabaseDetails,
   refreshTableStats,
   refreshNodes,
+  refreshSettings,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { FixLong } from "src/util/fixLong";
@@ -31,6 +32,7 @@ import {
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
 import { getNodesByRegionString } from "../utils";
+import { selectAutomaticStatsCollectionEnabled } from "src/redux/clusterSettings";
 
 const { DatabaseDetailsRequest, TableStatsRequest } = cockroach.server.serverpb;
 
@@ -123,10 +125,12 @@ export const mapStateToProps = (state: AdminUIState): DatabasesPageData => ({
   loaded: selectLoaded(state),
   databases: selectDatabases(state),
   sortSetting: sortSettingLocalSetting.selector(state),
+  automaticStatsCollectionEnabled: selectAutomaticStatsCollectionEnabled(state),
   showNodeRegionsColumn: selectIsMoreThanOneNode(state),
 });
 
 export const mapDispatchToProps = {
+  refreshSettings,
   refreshDatabases,
   refreshDatabaseDetails: (database: string) => {
     return refreshDatabaseDetails(


### PR DESCRIPTION
Closes: #67510

Release note (ui change):
- Added status of automatic statistics collection to the Database
and Database table pages on the DB Console.
- Added timestamp of last statistics collection to the Database
details and Database table pages on the DB Console.

Here's a video of the changes in the UI:

https://user-images.githubusercontent.com/27286675/153521703-9ed19ed0-5fe9-4cb6-a537-1d227aeb0a0b.mov


