### PR TITLE
server: reduce allocations in setupSpanForIncomingRPC

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -297,6 +297,7 @@ go_test(
         "api_v2_test.go",
         "authentication_test.go",
         "auto_tls_init_test.go",
+        "bench_test.go",
         "config_test.go",
         "connectivity_test.go",
         "drain_test.go",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2707,9 +2707,9 @@ func (s *adminServer) SendKVBatch(
 	}
 	log.StructuredEvent(ctx, event)
 
-	ctx, finishSpan := s.server.node.setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba)
+	ctx, sp := s.server.node.setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba)
 	var br *roachpb.BatchResponse
-	defer func() { finishSpan(ctx, br) }()
+	defer func() { sp.finish(ctx, br) }()
 	br, pErr := s.server.db.NonTransactionalSender().Send(ctx, *ba)
 	br.Error = pErr
 	return br, nil

--- a/pkg/server/bench_test.go
+++ b/pkg/server/bench_test.go
@@ -1,0 +1,41 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
+)
+
+func BenchmarkSetupSpanForIncomingRPC(b *testing.B) {
+	skip.UnderDeadlock(b, "span reuse triggers false-positives in the deadlock detector")
+	defer leaktest.AfterTest(b)()
+	ctx := context.Background()
+	ba := &roachpb.BatchRequest{Header: roachpb.Header{TraceInfo: tracingpb.TraceInfo{
+		TraceID:       1,
+		ParentSpanID:  2,
+		RecordingMode: tracingpb.TraceInfo_NONE,
+	}}}
+	b.ReportAllocs()
+	tr := tracing.NewTracerWithOpt(ctx,
+		tracing.WithTracingMode(tracing.TracingModeActiveSpansRegistry),
+		tracing.WithSpanReusePercent(100))
+	for i := 0; i < b.N; i++ {
+		_, finish := setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba, tr)
+		finish(ctx, nil /* br */)
+	}
+}

--- a/pkg/server/bench_test.go
+++ b/pkg/server/bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkSetupSpanForIncomingRPC(b *testing.B) {
 		tracing.WithTracingMode(tracing.TracingModeActiveSpansRegistry),
 		tracing.WithSpanReusePercent(100))
 	for i := 0; i < b.N; i++ {
-		_, finish := setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba, tr)
-		finish(ctx, nil /* br */)
+		_, sp := setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba, tr)
+		sp.finish(ctx, nil /* br */)
 	}
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1048,7 +1048,12 @@ func (n *Node) Batch(
 func (n *Node) setupSpanForIncomingRPC(
 	ctx context.Context, tenID roachpb.TenantID, ba *roachpb.BatchRequest,
 ) (context.Context, func(context.Context, *roachpb.BatchResponse)) {
-	tr := n.storeCfg.AmbientCtx.Tracer
+	return setupSpanForIncomingRPC(ctx, tenID, ba, n.storeCfg.AmbientCtx.Tracer)
+}
+
+func setupSpanForIncomingRPC(
+	ctx context.Context, tenID roachpb.TenantID, ba *roachpb.BatchRequest, tr *tracing.Tracer,
+) (context.Context, func(context.Context, *roachpb.BatchResponse)) {
 	var newSpan *tracing.Span
 	parentSpan := tracing.SpanFromContext(ctx)
 	localRequest := grpcutil.IsLocalRequestContext(ctx)


### PR DESCRIPTION
A couple of variables were independently escaping because they were
captured by a closure. This patch groups them into a single allocation,
saving two allocations per call.

name                        old time/op    new time/op    delta
SetupSpanForIncomingRPC-32     508ns ± 2%     442ns ± 0%  -12.91%  (p=0.008 n=5+5)
name                        old alloc/op   new alloc/op   delta
SetupSpanForIncomingRPC-32      178B ± 0%      145B ± 0%  -18.54%  (p=0.008 n=5+5)
name                        old allocs/op  new allocs/op  delta
SetupSpanForIncomingRPC-32      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.008 n=5+5)

Release note: None