### PR TITLE
colexec: change Close to take in a context

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1152,7 +1152,7 @@ func benchmarkAggregateFunction(
 						break
 					}
 				}
-				if err = a.(colexecop.Closer).Close(); err != nil {
+				if err = a.(colexecop.Closer).Close(ctx); err != nil {
 					b.Fatal(err)
 				}
 				source.Reset(ctx)

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -201,9 +201,9 @@ func (a *default_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
-func (a *default_AGGKINDAggAlloc) Close() error {
+func (a *default_AGGKINDAggAlloc) Close(ctx context.Context) error {
 	for _, fn := range a.returnedFns {
-		fn.fn.Close(fn.ctx)
+		fn.fn.Close(ctx)
 	}
 	a.returnedFns = nil
 	return nil

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -172,9 +172,9 @@ func (a *defaultHashAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
-func (a *defaultHashAggAlloc) Close() error {
+func (a *defaultHashAggAlloc) Close(ctx context.Context) error {
 	for _, fn := range a.returnedFns {
-		fn.fn.Close(fn.ctx)
+		fn.fn.Close(ctx)
 	}
 	a.returnedFns = nil
 	return nil

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -237,9 +237,9 @@ func (a *defaultOrderedAggAlloc) newAggFunc() AggregateFunc {
 	return f
 }
 
-func (a *defaultOrderedAggAlloc) Close() error {
+func (a *defaultOrderedAggAlloc) Close(ctx context.Context) error {
 	for _, fn := range a.returnedFns {
-		fn.fn.Close(fn.ctx)
+		fn.fn.Close(ctx)
 	}
 	a.returnedFns = nil
 	return nil

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -106,7 +106,7 @@ var _ execinfra.Releasable = &NewColOperatorResult{}
 // TestCleanupNoError releases the resources associated with this result and
 // asserts that no error is returned. It should only be used in tests.
 func (r *NewColOperatorResult) TestCleanupNoError(t testing.TB) {
-	require.NoError(t, r.ToClose.Close())
+	require.NoError(t, r.ToClose.Close(context.Background()))
 }
 
 var newColOperatorResultPool = sync.Pool{

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -99,7 +99,7 @@ func (c *crossJoiner) Next() coldata.Batch {
 	}
 	willEmit := c.willEmit()
 	if willEmit == 0 {
-		if err := c.Close(); err != nil {
+		if err := c.Close(c.Ctx); err != nil {
 			colexecerror.InternalError(err)
 		}
 		c.done = true
@@ -462,8 +462,7 @@ func (b *crossJoinerBase) Reset(ctx context.Context) {
 	b.builderState.numEmittedTotal = 0
 }
 
-func (b *crossJoinerBase) Close() error {
-	ctx := b.initHelper.EnsureCtx()
+func (b *crossJoinerBase) Close(ctx context.Context) error {
 	if b.rightTuples != nil {
 		return b.rightTuples.Close(ctx)
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -889,20 +889,20 @@ func (o *mergeJoinBase) completeRightBufferedGroup() {
 	o.finishRightBufferedGroup()
 }
 
-func (o *mergeJoinBase) Close() error {
+func (o *mergeJoinBase) Close(ctx context.Context) error {
 	if !o.CloserHelper.Close() {
 		return nil
 	}
 	var lastErr error
 	for _, op := range []colexecop.Operator{o.left.source, o.right.source} {
 		if c, ok := op.(colexecop.Closer); ok {
-			if err := c.Close(); err != nil {
+			if err := c.Close(ctx); err != nil {
 				lastErr = err
 			}
 		}
 	}
 	if h := o.bufferedGroup.helper; h != nil {
-		if err := h.Close(); err != nil {
+		if err := h.Close(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -440,7 +440,7 @@ func RunTestsWithOrderedCols(
 // setting, the closing happens at the end of the query execution.
 func closeIfCloser(t *testing.T, op colexecop.Operator) {
 	if c, ok := op.(colexecop.Closer); ok {
-		if err := c.Close(); err != nil {
+		if err := c.Close(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
+++ b/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
@@ -76,12 +76,12 @@ func (a *countRowsWindowAggregator) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (a *countRowsWindowAggregator) Close() {
+func (a *countRowsWindowAggregator) Close(ctx context.Context) {
 	if !a.CloserHelper.Close() {
 		return
 	}
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 }
 
 // processBatch implements the bufferedWindower interface.

--- a/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
@@ -201,9 +201,9 @@ func (b *_OP_NAMEBase) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (b *_OP_NAMEBase) Close() {
+func (b *_OP_NAMEBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }

--- a/pkg/sql/colexec/colexecwindow/first_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/first_value.eg.go
@@ -567,9 +567,9 @@ func (b *firstValueBase) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (b *firstValueBase) Close() {
+func (b *firstValueBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -1595,9 +1595,9 @@ func (b *lagBase) Init(ctx context.Context) {
 	}
 }
 
-func (b *lagBase) Close() {
+func (b *lagBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }

--- a/pkg/sql/colexec/colexecwindow/last_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/last_value.eg.go
@@ -567,9 +567,9 @@ func (b *lastValueBase) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (b *lastValueBase) Close() {
+func (b *lastValueBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }

--- a/pkg/sql/colexec/colexecwindow/lead.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lead.eg.go
@@ -1595,9 +1595,9 @@ func (b *leadBase) Init(ctx context.Context) {
 	}
 }
 
-func (b *leadBase) Close() {
+func (b *leadBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -174,11 +174,11 @@ func (b *_OP_NAMEBase) Init(ctx context.Context) {
 	}
 }
 
-func (b *_OP_NAMEBase) Close() {
+func (b *_OP_NAMEBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }
 
 // {{/*

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
@@ -341,10 +341,10 @@ func (a *minBoolAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	}
 }
 
-func (a *minBoolAggregator) Close() {
+func (a *minBoolAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minBoolAggregator{}
 }
 
@@ -494,10 +494,10 @@ func (a *minBytesAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *minBytesAggregator) Close() {
+func (a *minBytesAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minBytesAggregator{}
 }
 
@@ -649,10 +649,10 @@ func (a *minDecimalAggregator) aggregateOverIntervals(intervals []windowInterval
 	}
 }
 
-func (a *minDecimalAggregator) Close() {
+func (a *minDecimalAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minDecimalAggregator{}
 }
 
@@ -826,10 +826,10 @@ func (a *minInt16Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *minInt16Aggregator) Close() {
+func (a *minInt16Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minInt16Aggregator{}
 }
 
@@ -1003,10 +1003,10 @@ func (a *minInt32Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *minInt32Aggregator) Close() {
+func (a *minInt32Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minInt32Aggregator{}
 }
 
@@ -1180,10 +1180,10 @@ func (a *minInt64Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *minInt64Aggregator) Close() {
+func (a *minInt64Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minInt64Aggregator{}
 }
 
@@ -1373,10 +1373,10 @@ func (a *minFloat64Aggregator) aggregateOverIntervals(intervals []windowInterval
 	}
 }
 
-func (a *minFloat64Aggregator) Close() {
+func (a *minFloat64Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minFloat64Aggregator{}
 }
 
@@ -1542,10 +1542,10 @@ func (a *minTimestampAggregator) aggregateOverIntervals(intervals []windowInterv
 	}
 }
 
-func (a *minTimestampAggregator) Close() {
+func (a *minTimestampAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minTimestampAggregator{}
 }
 
@@ -1697,10 +1697,10 @@ func (a *minIntervalAggregator) aggregateOverIntervals(intervals []windowInterva
 	}
 }
 
-func (a *minIntervalAggregator) Close() {
+func (a *minIntervalAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minIntervalAggregator{}
 }
 
@@ -1895,10 +1895,10 @@ func (a *minJSONAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	}
 }
 
-func (a *minJSONAggregator) Close() {
+func (a *minJSONAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minJSONAggregator{}
 }
 
@@ -2054,10 +2054,10 @@ func (a *minDatumAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *minDatumAggregator) Close() {
+func (a *minDatumAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = minDatumAggregator{}
 }
 
@@ -2308,10 +2308,10 @@ func (a *maxBoolAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	}
 }
 
-func (a *maxBoolAggregator) Close() {
+func (a *maxBoolAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxBoolAggregator{}
 }
 
@@ -2461,10 +2461,10 @@ func (a *maxBytesAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *maxBytesAggregator) Close() {
+func (a *maxBytesAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxBytesAggregator{}
 }
 
@@ -2616,10 +2616,10 @@ func (a *maxDecimalAggregator) aggregateOverIntervals(intervals []windowInterval
 	}
 }
 
-func (a *maxDecimalAggregator) Close() {
+func (a *maxDecimalAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxDecimalAggregator{}
 }
 
@@ -2793,10 +2793,10 @@ func (a *maxInt16Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *maxInt16Aggregator) Close() {
+func (a *maxInt16Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxInt16Aggregator{}
 }
 
@@ -2970,10 +2970,10 @@ func (a *maxInt32Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *maxInt32Aggregator) Close() {
+func (a *maxInt32Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxInt32Aggregator{}
 }
 
@@ -3147,10 +3147,10 @@ func (a *maxInt64Aggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *maxInt64Aggregator) Close() {
+func (a *maxInt64Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxInt64Aggregator{}
 }
 
@@ -3340,10 +3340,10 @@ func (a *maxFloat64Aggregator) aggregateOverIntervals(intervals []windowInterval
 	}
 }
 
-func (a *maxFloat64Aggregator) Close() {
+func (a *maxFloat64Aggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxFloat64Aggregator{}
 }
 
@@ -3509,10 +3509,10 @@ func (a *maxTimestampAggregator) aggregateOverIntervals(intervals []windowInterv
 	}
 }
 
-func (a *maxTimestampAggregator) Close() {
+func (a *maxTimestampAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxTimestampAggregator{}
 }
 
@@ -3664,10 +3664,10 @@ func (a *maxIntervalAggregator) aggregateOverIntervals(intervals []windowInterva
 	}
 }
 
-func (a *maxIntervalAggregator) Close() {
+func (a *maxIntervalAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxIntervalAggregator{}
 }
 
@@ -3862,10 +3862,10 @@ func (a *maxJSONAggregator) aggregateOverIntervals(intervals []windowInterval) {
 	}
 }
 
-func (a *maxJSONAggregator) Close() {
+func (a *maxJSONAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxJSONAggregator{}
 }
 
@@ -4021,10 +4021,10 @@ func (a *maxDatumAggregator) aggregateOverIntervals(intervals []windowInterval) 
 	}
 }
 
-func (a *maxDatumAggregator) Close() {
+func (a *maxDatumAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = maxDatumAggregator{}
 }
 

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
@@ -296,10 +296,10 @@ func (a *_AGG_TYPEAggregator) aggregateOverIntervals(intervals []windowInterval)
 	}
 }
 
-func (a *_AGG_TYPEAggregator) Close() {
+func (a *_AGG_TYPEAggregator) Close(ctx context.Context) {
 	a.queue.close()
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 	*a = _AGG_TYPEAggregator{}
 }
 

--- a/pkg/sql/colexec/colexecwindow/nth_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/nth_value.eg.go
@@ -767,9 +767,9 @@ func (b *nthValueBase) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (b *nthValueBase) Close() {
+func (b *nthValueBase) Close(ctx context.Context) {
 	if !b.CloserHelper.Close() {
 		return
 	}
-	b.buffer.Close(b.EnsureCtx())
+	b.buffer.Close(ctx)
 }

--- a/pkg/sql/colexec/colexecwindow/ntile.eg.go
+++ b/pkg/sql/colexec/colexecwindow/ntile.eg.go
@@ -276,4 +276,4 @@ func (b *nTileBase) startNewPartition() {
 
 func (b *nTileBase) Init(ctx context.Context) {}
 
-func (b *nTileBase) Close() {}
+func (b *nTileBase) Close(context.Context) {}

--- a/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/ntile_tmpl.go
@@ -256,4 +256,4 @@ func (b *nTileBase) startNewPartition() {
 
 func (b *nTileBase) Init(ctx context.Context) {}
 
-func (b *nTileBase) Close() {}
+func (b *nTileBase) Close(context.Context) {}

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -310,7 +310,7 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -323,14 +323,14 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *percentRankNoPartitionOp) Close() error {
+func (r *percentRankNoPartitionOp) Close(ctx context.Context) error {
 	if !r.CloserHelper.Close() || r.Ctx == nil {
 		// Either Close() has already been called or Init() was never called. In
 		// both cases there is nothing to do.
 		return nil
 	}
 	var lastErr error
-	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
+	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr
@@ -589,7 +589,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -602,17 +602,17 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *percentRankWithPartitionOp) Close() error {
+func (r *percentRankWithPartitionOp) Close(ctx context.Context) error {
 	if !r.CloserHelper.Close() || r.Ctx == nil {
 		// Either Close() has already been called or Init() was never called. In
 		// both cases there is nothing to do.
 		return nil
 	}
 	var lastErr error
-	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
+	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.partitionsState.Close(r.Ctx); err != nil {
+	if err := r.partitionsState.Close(ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr
@@ -856,7 +856,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -869,17 +869,17 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *cumeDistNoPartitionOp) Close() error {
+func (r *cumeDistNoPartitionOp) Close(ctx context.Context) error {
 	if !r.CloserHelper.Close() || r.Ctx == nil {
 		// Either Close() has already been called or Init() was never called. In
 		// both cases there is nothing to do.
 		return nil
 	}
 	var lastErr error
-	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
+	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.peerGroupsState.Close(r.Ctx); err != nil {
+	if err := r.peerGroupsState.Close(ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr
@@ -1217,7 +1217,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -1230,20 +1230,20 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 	}
 }
 
-func (r *cumeDistWithPartitionOp) Close() error {
+func (r *cumeDistWithPartitionOp) Close(ctx context.Context) error {
 	if !r.CloserHelper.Close() || r.Ctx == nil {
 		// Either Close() has already been called or Init() was never called. In
 		// both cases there is nothing to do.
 		return nil
 	}
 	var lastErr error
-	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
+	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.partitionsState.Close(r.Ctx); err != nil {
+	if err := r.partitionsState.Close(ctx); err != nil {
 		lastErr = err
 	}
-	if err := r.peerGroupsState.Close(r.Ctx); err != nil {
+	if err := r.peerGroupsState.Close(ctx); err != nil {
 		lastErr = err
 	}
 	return lastErr

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -576,7 +576,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			return r.output
 
 		case relativeRankFinished:
-			if err := r.Close(); err != nil {
+			if err := r.Close(r.Ctx); err != nil {
 				colexecerror.InternalError(err)
 			}
 			return coldata.ZeroBatch
@@ -589,23 +589,23 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 	}
 }
 
-func (r *_RELATIVE_RANK_STRINGOp) Close() error {
+func (r *_RELATIVE_RANK_STRINGOp) Close(ctx context.Context) error {
 	if !r.CloserHelper.Close() || r.Ctx == nil {
 		// Either Close() has already been called or Init() was never called. In
 		// both cases there is nothing to do.
 		return nil
 	}
 	var lastErr error
-	if err := r.bufferedTuples.Close(r.Ctx); err != nil {
+	if err := r.bufferedTuples.Close(ctx); err != nil {
 		lastErr = err
 	}
 	// {{if .HasPartition}}
-	if err := r.partitionsState.Close(r.Ctx); err != nil {
+	if err := r.partitionsState.Close(ctx); err != nil {
 		lastErr = err
 	}
 	// {{end}}
 	// {{if .IsCumeDist}}
-	if err := r.peerGroupsState.Close(r.Ctx); err != nil {
+	if err := r.peerGroupsState.Close(ctx); err != nil {
 		lastErr = err
 	}
 	// {{end}}

--- a/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
@@ -174,15 +174,15 @@ func (a *windowAggregatorBase) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (a *windowAggregatorBase) Close() {
+func (a *windowAggregatorBase) Close(ctx context.Context) {
 	if !a.CloserHelper.Close() {
 		return
 	}
-	if err := a.closers.Close(); err != nil {
+	if err := a.closers.Close(ctx); err != nil {
 		colexecerror.InternalError(err)
 	}
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 }
 
 func (a *windowAggregator) startNewPartition() {
@@ -190,8 +190,8 @@ func (a *windowAggregator) startNewPartition() {
 	a.agg.Reset()
 }
 
-func (a *windowAggregator) Close() {
-	a.windowAggregatorBase.Close()
+func (a *windowAggregator) Close(ctx context.Context) {
+	a.windowAggregatorBase.Close(ctx)
 	a.agg.Reset()
 	*a = windowAggregator{}
 }
@@ -236,8 +236,8 @@ func (a *slidingWindowAggregator) startNewPartition() {
 	a.agg.Reset()
 }
 
-func (a *slidingWindowAggregator) Close() {
-	a.windowAggregatorBase.Close()
+func (a *slidingWindowAggregator) Close(ctx context.Context) {
+	a.windowAggregatorBase.Close(ctx)
 	a.agg.Reset()
 	*a = slidingWindowAggregator{}
 }

--- a/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
@@ -179,15 +179,15 @@ func (a *windowAggregatorBase) Init(ctx context.Context) {
 }
 
 // Close implements the bufferedWindower interface.
-func (a *windowAggregatorBase) Close() {
+func (a *windowAggregatorBase) Close(ctx context.Context) {
 	if !a.CloserHelper.Close() {
 		return
 	}
-	if err := a.closers.Close(); err != nil {
+	if err := a.closers.Close(ctx); err != nil {
 		colexecerror.InternalError(err)
 	}
 	a.framer.close()
-	a.buffer.Close(a.EnsureCtx())
+	a.buffer.Close(ctx)
 }
 
 func (a *windowAggregator) startNewPartition() {
@@ -195,8 +195,8 @@ func (a *windowAggregator) startNewPartition() {
 	a.agg.Reset()
 }
 
-func (a *windowAggregator) Close() {
-	a.windowAggregatorBase.Close()
+func (a *windowAggregator) Close(ctx context.Context) {
+	a.windowAggregatorBase.Close(ctx)
 	a.agg.Reset()
 	*a = windowAggregator{}
 }
@@ -220,8 +220,8 @@ func (a *slidingWindowAggregator) startNewPartition() {
 	a.agg.Reset()
 }
 
-func (a *slidingWindowAggregator) Close() {
-	a.windowAggregatorBase.Close()
+func (a *slidingWindowAggregator) Close(ctx context.Context) {
+	a.windowAggregatorBase.Close(ctx)
 	a.agg.Reset()
 	*a = slidingWindowAggregator{}
 }

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1083,7 +1083,7 @@ func TestWindowFunctions(t *testing.T) {
 			// Close all closers manually (in production this is done on the
 			// flow cleanup).
 			for _, c := range toClose {
-				require.NoError(t, c.Close())
+				require.NoError(t, c.Close(ctx))
 			}
 			for i, sem := range semsToCheck {
 				require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -133,7 +133,7 @@ func newColumnarizer(
 				// Close will call InternalClose(). Note that we don't return
 				// any trailing metadata here because the columnarizers
 				// propagate it in DrainMeta.
-				if err := c.Close(); buildutil.CrdbTestBuild && err != nil {
+				if err := c.Close(c.Ctx); buildutil.CrdbTestBuild && err != nil {
 					// Close never returns an error.
 					colexecerror.InternalError(errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error from Columnarizer.Close"))
 				}
@@ -289,7 +289,7 @@ func (c *Columnarizer) DrainMeta() []execinfrapb.ProducerMetadata {
 }
 
 // Close is part of the colexecop.ClosableOperator interface.
-func (c *Columnarizer) Close() error {
+func (c *Columnarizer) Close(context.Context) error {
 	if c.removedFromFlow {
 		return nil
 	}

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -109,7 +109,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 
 			if tc.consumerClosed {
 				// Closing the Columnarizer should call ConsumerClosed on the processor.
-				require.NoError(t, c.Close())
+				require.NoError(t, c.Close(ctx))
 				require.Equal(t, execinfra.ConsumerClosed, rb.ConsumerStatus, "unexpected consumer status %d", rb.ConsumerStatus)
 			} else {
 				// Calling DrainMeta from the vectorized execution engine should propagate to

--- a/pkg/sql/colexec/disk_spiller.go
+++ b/pkg/sql/colexec/disk_spiller.go
@@ -234,16 +234,16 @@ func (d *diskSpillerBase) Reset(ctx context.Context) {
 }
 
 // Close implements the Closer interface.
-func (d *diskSpillerBase) Close() error {
+func (d *diskSpillerBase) Close(ctx context.Context) error {
 	if !d.CloserHelper.Close() {
 		return nil
 	}
 	var retErr error
 	if c, ok := d.inMemoryOp.(colexecop.Closer); ok {
-		retErr = c.Close()
+		retErr = c.Close(ctx)
 	}
 	if c, ok := d.diskBackedOp.(colexecop.Closer); ok {
-		if err := c.Close(); err != nil {
+		if err := c.Close(ctx); err != nil {
 			retErr = err
 		}
 	}

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -298,7 +298,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	for b := sorter.Next(); b.Length() > 0; b = sorter.Next() {
 	}
 	for _, c := range closers {
-		require.NoError(t, c.Close())
+		require.NoError(t, c.Close(ctx))
 	}
 
 	require.True(t, spilled)

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -469,16 +469,16 @@ func (op *hashAggregator) resetBucketsAndTrackingState(ctx context.Context) {
 	op.curOutputBucketIdx = 0
 }
 
-func (op *hashAggregator) Close() error {
+func (op *hashAggregator) Close(ctx context.Context) error {
 	if !op.CloserHelper.Close() {
 		return nil
 	}
 	op.accountingHelper.Release()
 	var retErr error
 	if op.inputTrackingState.tuples != nil {
-		retErr = op.inputTrackingState.tuples.Close(op.EnsureCtx())
+		retErr = op.inputTrackingState.tuples.Close(ctx)
 	}
-	if err := op.toClose.Close(); err != nil {
+	if err := op.toClose.Close(ctx); err != nil {
 		retErr = err
 	}
 	return retErr

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -127,10 +127,10 @@ func (i *invariantsChecker) DrainMeta() []execinfrapb.ProducerMetadata {
 }
 
 // Close is part of the colexecop.ClosableOperator interface.
-func (i *invariantsChecker) Close() error {
+func (i *invariantsChecker) Close(ctx context.Context) error {
 	c, ok := i.Input.(colexecop.Closer)
 	if !ok {
 		return nil
 	}
-	return c.Close()
+	return c.Close(ctx)
 }

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -399,6 +399,6 @@ func (a *orderedAggregator) Reset(ctx context.Context) {
 	}
 }
 
-func (a *orderedAggregator) Close() error {
-	return a.toClose.Close()
+func (a *orderedAggregator) Close(ctx context.Context) error {
+	return a.toClose.Close(ctx)
 }

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -299,11 +299,15 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	return bufferedMeta
 }
 
-func (o *OrderedSynchronizer) Close() error {
+func (o *OrderedSynchronizer) Close(context.Context) error {
+	// Note that we're using the context of the synchronizer rather than the
+	// argument of Close() because the synchronizer derives its own tracing
+	// span.
+	ctx := o.EnsureCtx()
 	o.accountingHelper.Release()
 	var lastErr error
 	for _, input := range o.inputs {
-		if err := input.ToClose.Close(); err != nil {
+		if err := input.ToClose.Close(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -243,11 +243,15 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 	return bufferedMeta
 }
 
-func (o *OrderedSynchronizer) Close() error {
+func (o *OrderedSynchronizer) Close(context.Context) error {
+	// Note that we're using the context of the synchronizer rather than the
+	// argument of Close() because the synchronizer derives its own tracing
+	// span.
+	ctx := o.EnsureCtx()
 	o.accountingHelper.Release()
 	var lastErr error
 	for _, input := range o.inputs {
-		if err := input.ToClose.Close(); err != nil {
+		if err := input.ToClose.Close(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -63,7 +63,8 @@ const (
 type ParallelUnorderedSynchronizer struct {
 	colexecop.InitHelper
 
-	inputs []colexecargs.OpWithMetaInfo
+	inputs    []colexecargs.OpWithMetaInfo
+	inputCtxs []context.Context
 	// cancelLocalInput stores context cancellation functions for each of the
 	// inputs. The functions are populated only if LocalPlan is true.
 	cancelLocalInput []context.CancelFunc
@@ -139,6 +140,7 @@ func NewParallelUnorderedSynchronizer(
 	}
 	return &ParallelUnorderedSynchronizer{
 		inputs:            inputs,
+		inputCtxs:         make([]context.Context, len(inputs)),
 		cancelLocalInput:  make([]context.CancelFunc, len(inputs)),
 		tracingSpans:      make([]*tracing.Span, len(inputs)),
 		readNextBatch:     readNextBatch,
@@ -165,8 +167,7 @@ func (s *ParallelUnorderedSynchronizer) Init(ctx context.Context) {
 		return
 	}
 	for i, input := range s.inputs {
-		var inputCtx context.Context
-		inputCtx, s.tracingSpans[i] = execinfra.ProcessorSpan(s.Ctx, fmt.Sprintf("parallel unordered sync input %d", i))
+		s.inputCtxs[i], s.tracingSpans[i] = execinfra.ProcessorSpan(s.Ctx, fmt.Sprintf("parallel unordered sync input %d", i))
 		if s.LocalPlan {
 			// If there plan is local, there are no colrpc.Inboxes in this input
 			// tree, and the synchronizer can cancel the current work eagerly
@@ -177,9 +178,9 @@ func (s *ParallelUnorderedSynchronizer) Init(ctx context.Context) {
 			// because canceling the context would break the gRPC stream and
 			// make it impossible to fetch the remote metadata. Furthermore, it
 			// will result in the remote flow cancellation.
-			inputCtx, s.cancelLocalInput[i] = context.WithCancel(inputCtx)
+			s.inputCtxs[i], s.cancelLocalInput[i] = context.WithCancel(s.inputCtxs[i])
 		}
-		input.Root.Init(inputCtx)
+		input.Root.Init(s.inputCtxs[i])
 		s.nextBatch[i] = func(inputOp colexecop.Operator, inputIdx int) func() {
 			return func() {
 				s.batches[inputIdx] = inputOp.Next()
@@ -222,7 +223,7 @@ func (s *ParallelUnorderedSynchronizer) init() {
 				}
 				// We need to close all of the closers of this input before we
 				// notify the wait groups.
-				input.ToClose.CloseAndLogOnErr(s.Ctx, "parallel unordered synchronizer input")
+				input.ToClose.CloseAndLogOnErr(s.inputCtxs[inputIdx], "parallel unordered synchronizer input")
 				s.internalWaitGroup.Done()
 				s.externalWaitGroup.Done()
 			}()
@@ -460,7 +461,7 @@ func (s *ParallelUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetada
 }
 
 // Close is part of the colexecop.ClosableOperator interface.
-func (s *ParallelUnorderedSynchronizer) Close() error {
+func (s *ParallelUnorderedSynchronizer) Close(ctx context.Context) error {
 	if state := s.getState(); state != parallelUnorderedSynchronizerStateUninitialized {
 		// Input goroutines have been started and will take care of closing the
 		// closers from the corresponding input trees, so we don't need to do
@@ -483,7 +484,7 @@ func (s *ParallelUnorderedSynchronizer) Close() error {
 	}
 	var lastErr error
 	for _, input := range s.inputs {
-		if err := input.ToClose.Close(); err != nil {
+		if err := input.ToClose.Close(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -248,7 +248,7 @@ func TestParallelUnorderedSyncClosesInputs(t *testing.T) {
 	// closure occurred as expected.
 	closed := false
 	firstInput := &colexecop.CallbackOperator{
-		CloseCb: func() error {
+		CloseCb: func(context.Context) error {
 			closed = true
 			return nil
 		},
@@ -273,7 +273,7 @@ func TestParallelUnorderedSyncClosesInputs(t *testing.T) {
 	// In the production setting, the user of the synchronizer is still expected
 	// to close it, even if a panic is encountered in Init, so we do the same
 	// thing here and verify that the first input is properly closed.
-	require.NoError(t, s.Close())
+	require.NoError(t, s.Close(ctx))
 	require.True(t, closed)
 }
 

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -107,10 +107,14 @@ func (s *SerialUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata
 }
 
 // Close is part of the colexecop.ClosableOperator interface.
-func (s *SerialUnorderedSynchronizer) Close() error {
+func (s *SerialUnorderedSynchronizer) Close(context.Context) error {
+	// Note that we're using the context of the synchronizer rather than the
+	// argument of Close() because the synchronizer derives its own tracing
+	// span.
+	ctx := s.EnsureCtx()
 	var lastErr error
 	for _, input := range s.inputs {
-		if err := input.ToClose.Close(); err != nil {
+		if err := input.ToClose.Close(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colexecop/testutils.go
+++ b/pkg/sql/colexecop/testutils.go
@@ -141,7 +141,7 @@ type CallbackOperator struct {
 	ZeroInputNode
 	InitCb  func(context.Context)
 	NextCb  func() coldata.Batch
-	CloseCb func() error
+	CloseCb func(ctx context.Context) error
 }
 
 var _ ClosableOperator = &CallbackOperator{}
@@ -163,11 +163,11 @@ func (o *CallbackOperator) Next() coldata.Batch {
 }
 
 // Close is part of the ClosableOperator interface.
-func (o *CallbackOperator) Close() error {
+func (o *CallbackOperator) Close(ctx context.Context) error {
 	if o.CloseCb == nil {
 		return nil
 	}
-	return o.CloseCb()
+	return o.CloseCb(ctx)
 }
 
 // TestingSemaphore is a semaphore.Semaphore that never blocks and is always

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -281,8 +281,12 @@ func (s *ColBatchScan) Release() {
 }
 
 // Close implements the colexecop.Closer interface.
-func (s *ColBatchScan) Close() error {
-	s.cf.Close(s.EnsureCtx())
+func (s *ColBatchScan) Close(context.Context) error {
+	// Note that we're using the context of the ColBatchScan rather than the
+	// argument of Close() because the ColBatchScan derives its own tracing
+	// span.
+	ctx := s.EnsureCtx()
+	s.cf.Close(ctx)
 	if s.tracingSpan != nil {
 		s.tracingSpan.Finish()
 		s.tracingSpan = nil

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -589,7 +589,7 @@ func (s *ColIndexJoin) Release() {
 }
 
 // Close implements the colexecop.Closer interface.
-func (s *ColIndexJoin) Close() error {
+func (s *ColIndexJoin) Close(context.Context) error {
 	s.closeInternal()
 	if s.tracingSpan != nil {
 		s.tracingSpan.Finish()
@@ -601,7 +601,11 @@ func (s *ColIndexJoin) Close() error {
 // closeInternal is a subset of Close() which doesn't finish the operator's
 // span.
 func (s *ColIndexJoin) closeInternal() {
-	s.cf.Close(s.EnsureCtx())
+	// Note that we're using the context of the ColIndexJoin rather than the
+	// argument of Close() because the ColIndexJoin derives its own tracing
+	// span.
+	ctx := s.EnsureCtx()
+	s.cf.Close(ctx)
 	if s.spanAssembler != nil {
 		// spanAssembler can be nil if Release() has already been called.
 		s.spanAssembler.Close()

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -266,7 +266,7 @@ func (f *BatchFlowCoordinator) Run(ctx context.Context) {
 	// Make sure that we close the coordinator and notify the batch receiver in
 	// all cases.
 	defer func() {
-		if err := f.close(); err != nil && status != execinfra.ConsumerClosed {
+		if err := f.close(ctx); err != nil && status != execinfra.ConsumerClosed {
 			f.pushError(err)
 		}
 		f.output.ProducerDone()
@@ -332,11 +332,11 @@ func (f *BatchFlowCoordinator) Run(ctx context.Context) {
 
 // close cancels the flow and closes all colexecop.Closers the coordinator is
 // responsible for.
-func (f *BatchFlowCoordinator) close() error {
+func (f *BatchFlowCoordinator) close(ctx context.Context) error {
 	f.cancelFlow()
 	var lastErr error
 	for _, toClose := range f.input.ToClose {
-		if err := toClose.Close(); err != nil {
+		if err := toClose.Close(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1037,14 +1037,14 @@ func (s *vectorizedFlowCreator) setupOutput(
 // callbackCloser is a utility struct that implements the Closer interface by
 // calling the provided callback.
 type callbackCloser struct {
-	closeCb func() error
+	closeCb func(context.Context) error
 }
 
 var _ colexecop.Closer = &callbackCloser{}
 
 // Close implements the Closer interface.
-func (c *callbackCloser) Close() error {
-	return c.closeCb()
+func (c *callbackCloser) Close(ctx context.Context) error {
+	return c.closeCb(ctx)
 }
 
 func (s *vectorizedFlowCreator) setupFlow(
@@ -1131,12 +1131,12 @@ func (s *vectorizedFlowCreator) setupFlow(
 				for i := range toCloseCopy {
 					func(idx int) {
 						closed := false
-						result.ToClose[idx] = &callbackCloser{closeCb: func() error {
+						result.ToClose[idx] = &callbackCloser{closeCb: func(ctx context.Context) error {
 							if !closed {
 								closed = true
 								atomic.AddInt32(&s.numClosed, 1)
 							}
-							return toCloseCopy[idx].Close()
+							return toCloseCopy[idx].Close(ctx)
 						}}
 					}(i)
 				}

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -59,13 +59,13 @@ var (
 )
 
 type callbackCloser struct {
-	closeCb func() error
+	closeCb func(context.Context) error
 }
 
 var _ colexecop.Closer = callbackCloser{}
 
-func (c callbackCloser) Close() error {
-	return c.closeCb()
+func (c callbackCloser) Close(ctx context.Context) error {
+	return c.closeCb(ctx)
 }
 
 // TestVectorizedFlowShutdown tests that closing the FlowCoordinator correctly
@@ -257,7 +257,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						colexecargs.OpWithMetaInfo{
 							Root:            outboxInput,
 							MetadataSources: outboxMetadataSources,
-							ToClose: []colexecop.Closer{callbackCloser{closeCb: func() error {
+							ToClose: []colexecop.Closer{callbackCloser{closeCb: func(context.Context) error {
 								idToClosed.Lock()
 								idToClosed.mapping[id] = true
 								idToClosed.Unlock()
@@ -358,7 +358,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				inputInfo := colexecargs.OpWithMetaInfo{
 					Root:            input,
 					MetadataSources: colexecop.MetadataSources{inputMetadataSource},
-					ToClose: colexecop.Closers{callbackCloser{closeCb: func() error {
+					ToClose: colexecop.Closers{callbackCloser{closeCb: func(context.Context) error {
 						closeCalled = true
 						return nil
 					}}},


### PR DESCRIPTION
Previously, all `Closer`s would use their own context (either captured
in `Init` or derived from the one in `Init`) in the implementation of
`Close` (for example, when they wanted to log something). However, due
to the way the draining of the wrapped row-by-row processors and
closing of `Closer`s is structured (the draining happens first), it was
possible for the captured context to have a tracing span which was
already `Finish`ed. This is so because the row-by-row processors derive
separate tracing spans and finish them automatically during draining
whereas the closure of `Closer`s happens later.

This commit fixes this issue by passing a context as an argument to
`Close` function, and most of the implementations now use that. Only
components that derive their own tracing span are allowed to use their
own context since they control when the span is finished.

Fixes: #76096.

Release note: None