### PR TITLE
ci: make sure metamorphic nightly uses proper formatter for issues

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -51,6 +51,9 @@ _tc_release_branch() {
 #   `GO_TEST_JSON_OUTPUT_FILE`.
 # create_tarball: whether to create a tarball with full logs. If the test's
 #   exit code is passed, the tarball is generated on failures.
+#
+# The variable BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS can be set to add extra
+# arguments to $github_post.
 process_test_json() {
   local testfilter=$1
   local github_post=$2
@@ -79,7 +82,7 @@ process_test_json() {
       echo "GITHUB_API_TOKEN must be set"
       exit 1
     else
-      $github_post < "$test_json"
+      $github_post ${BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS:+$BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS} < "$test_json"
     fi
   fi
 

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -26,7 +26,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci test \
                                       --test_arg -ops --test_arg "uniform:5000-25000" \
     || exit_status=$?
 
-process_test_json \
+BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS=--formatter=pebble-metamorphic process_test_json \
     $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
     $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
     /artifacts $GO_TEST_JSON_OUTPUT_FILE $exit_status


### PR DESCRIPTION
The `--formatter=pebble-metamorphic` option got lost in #75585.

Release note: None