### PR TITLE
sql: fix nil pointer error in RunPostDeserializationChanges

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -96,6 +96,12 @@ func (ddb *databaseDescriptorBuilder) RunRestoreChanges(
 func maybeConvertIncompatibleDBPrivilegesToDefaultPrivileges(
 	privileges *descpb.PrivilegeDescriptor, defaultPrivileges *descpb.DefaultPrivilegeDescriptor,
 ) (hasChanged bool) {
+	// If privileges are nil, there is nothing to convert.
+	// This case can happen during restore where privileges are not yet created.
+	if privileges == nil {
+		return false
+	}
+
 	var pgIncompatibleDBPrivileges = privilege.List{
 		privilege.SELECT, privilege.INSERT, privilege.UPDATE, privilege.DELETE,
 	}


### PR DESCRIPTION
In some restore paths, the privilegeDescriptor would be nil in
RunPostDeserializationChanges, avoid doing work on a nil pointer.

Release note: None

Fixes https://github.com/cockroachdb/cockroach/issues/76063
Fixes https://github.com/cockroachdb/cockroach/issues/76062
Fixes https://github.com/cockroachdb/cockroach/issues/76042