### PR TITLE
util/tracing: optimize gprc span creation for Batch and DistSQL

### DIFF
--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -160,7 +160,7 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 					opName,
 					// NB: Nobody is collecting the recording of this span; we have no
 					// mechanism for it.
-					tracing.WithRemoteParent(spanMeta),
+					tracing.WithRemoteParentFromSpanMeta(spanMeta),
 					tracing.WithFollowsFrom(),
 				)
 			}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -926,6 +926,9 @@ func (r *Replica) getTraceData(ctx context.Context) map[string]string {
 	if sp == nil {
 		return nil
 	}
+	// TODO(andrei): We should propagate trace info even for non-verbose spans.
+	// We'd probably want to use a cheaper mechanism than `InjectMetaInto`,
+	// though.
 	if !sp.IsVerbose() {
 		return nil
 	}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -777,12 +777,12 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, func()) {
 	childDetachedChild := t1.StartSpan("root.child.detached_child", tracing.WithParent(child), tracing.WithDetachedRecording())
 
 	// Start a remote child span on "node 2".
-	childRemoteChild := t2.StartSpan("root.child.remotechild", tracing.WithRemoteParent(child.Meta()))
+	childRemoteChild := t2.StartSpan("root.child.remotechild", tracing.WithRemoteParentFromSpanMeta(child.Meta()))
 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start another remote child span on "node 2" that we finish.
-	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithRemoteParent(child.Meta()))
+	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithRemoteParentFromSpanMeta(child.Meta()))
 	child.ImportRemoteSpans(childRemoteChildFinished.FinishAndGetRecording(tracing.RecordingVerbose))
 
 	// Start another remote child span on "node 2" that we finish. This will have

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -591,20 +591,19 @@ func (ds *ServerImpl) setupSpanForIncomingRPC(
 			tracing.WithServerSpanKind)
 	}
 
-	var remoteParent tracing.SpanMeta
 	if !req.TraceInfo.Empty() {
-		remoteParent = tracing.SpanMetaFromProto(req.TraceInfo)
-	} else {
-		// For backwards compatibility with 21.2, if tracing info was passed as
-		// gRPC metadata, we use it.
-		var err error
-		remoteParent, err = tracing.ExtractSpanMetaFromGRPCCtx(ctx, tr)
-		if err != nil {
-			log.Warningf(ctx, "error extracting tracing info from gRPC: %s", err)
-		}
+		return tr.StartSpanCtx(ctx, tracing.SetupFlowMethodName,
+			tracing.WithRemoteParentFromTraceInfo(&req.TraceInfo),
+			tracing.WithServerSpanKind)
+	}
+	// For backwards compatibility with 21.2, if tracing info was passed as
+	// gRPC metadata, we use it.
+	remoteParent, err := tracing.ExtractSpanMetaFromGRPCCtx(ctx, tr)
+	if err != nil {
+		log.Warningf(ctx, "error extracting tracing info from gRPC: %s", err)
 	}
 	return tr.StartSpanCtx(ctx, tracing.SetupFlowMethodName,
-		tracing.WithRemoteParent(remoteParent),
+		tracing.WithRemoteParentFromSpanMeta(remoteParent),
 		tracing.WithServerSpanKind)
 }
 

--- a/pkg/util/tracing/collector/collector_test.go
+++ b/pkg/util/tracing/collector/collector_test.go
@@ -79,13 +79,13 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start a remote child span on "node 2".
-	childRemoteChild := t2.StartSpan("root.child.remotechild", tracing.WithRemoteParent(child.Meta()))
+	childRemoteChild := t2.StartSpan("root.child.remotechild", tracing.WithRemoteParentFromSpanMeta(child.Meta()))
 	childRemoteChild.RecordStructured(newTestStructured("root.child.remotechild"))
 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start another remote child span on "node 2" that we finish.
-	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithRemoteParent(child.Meta()))
+	childRemoteChildFinished := t2.StartSpan("root.child.remotechilddone", tracing.WithRemoteParentFromSpanMeta(child.Meta()))
 	child.ImportRemoteSpans(childRemoteChildFinished.FinishAndGetRecording(tracing.RecordingVerbose))
 
 	// Start a root span on "node 2".
@@ -95,12 +95,12 @@ func setupTraces(t1, t2 *tracing.Tracer) (tracingpb.TraceID, tracingpb.TraceID, 
 	// Start a child span on "node 2".
 	child2 := t2.StartSpan("root2.child", tracing.WithParent(root2))
 	// Start a remote child span on "node 1".
-	child2RemoteChild := t1.StartSpan("root2.child.remotechild", tracing.WithRemoteParent(child2.Meta()))
+	child2RemoteChild := t1.StartSpan("root2.child.remotechild", tracing.WithRemoteParentFromSpanMeta(child2.Meta()))
 
 	time.Sleep(10 * time.Millisecond)
 
 	// Start another remote child span on "node 1".
-	anotherChild2RemoteChild := t1.StartSpan("root2.child.remotechild2", tracing.WithRemoteParent(child2.Meta()))
+	anotherChild2RemoteChild := t1.StartSpan("root2.child.remotechild2", tracing.WithRemoteParentFromSpanMeta(child2.Meta()))
 	return root.TraceID(), root2.TraceID(), func() {
 		for _, span := range []*tracing.Span{root, child, childRemoteChild, root2, child2,
 			child2RemoteChild, anotherChild2RemoteChild} {

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -32,8 +32,12 @@ import (
 type crdbSpan struct {
 	tracer *Tracer
 
-	traceID      tracingpb.TraceID // probabilistically unique
-	spanID       tracingpb.SpanID  // probabilistically unique
+	traceID tracingpb.TraceID // probabilistically unique
+	spanID  tracingpb.SpanID  // probabilistically unique
+	// parentSpanID indicates the parent at the time when this span was created. 0
+	// if this span didn't have a parent. If crdbSpan.mu.parent is set,
+	// parentSpanID corresponds to it. However, if the parent finishes, or if the
+	// parent is a span from a remote node, crdbSpan.mu.parent will be nil.
 	parentSpanID tracingpb.SpanID
 	operation    string // name of operation associated with the span
 

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -331,6 +331,10 @@ func (s *crdbSpan) TraceID() tracingpb.TraceID {
 	return s.traceID
 }
 
+func (s *crdbSpan) SpanID() tracingpb.SpanID {
+	return s.spanID
+}
+
 // GetRecording returns the span's recording.
 //
 // finishing indicates whether s is in the process of finishing. If it isn't,

--- a/pkg/util/tracing/grpc_interceptor.go
+++ b/pkg/util/tracing/grpc_interceptor.go
@@ -147,7 +147,7 @@ func ServerInterceptor(tracer *Tracer) grpc.UnaryServerInterceptor {
 		ctx, serverSpan := tracer.StartSpanCtx(
 			ctx,
 			info.FullMethod,
-			WithRemoteParent(spanMeta),
+			WithRemoteParentFromSpanMeta(spanMeta),
 			WithServerSpanKind,
 		)
 		defer serverSpan.Finish()
@@ -193,7 +193,7 @@ func StreamServerInterceptor(tracer *Tracer) grpc.StreamServerInterceptor {
 		ctx, serverSpan := tracer.StartSpanCtx(
 			ss.Context(),
 			info.FullMethod,
-			WithRemoteParent(spanMeta),
+			WithRemoteParentFromSpanMeta(spanMeta),
 			WithServerSpanKind,
 		)
 		defer serverSpan.Finish()

--- a/pkg/util/tracing/service/service_test.go
+++ b/pkg/util/tracing/service/service_test.go
@@ -34,7 +34,7 @@ func TestTracingServiceGetSpanRecordings(t *testing.T) {
 		child2 := tracer1.StartSpan("root1.child.detached", tracing.WithParent(child1), tracing.WithDetachedRecording())
 		// Create a span that will be added to the tracers' active span map, but
 		// will share the same traceID as root.
-		child3 := tracer1.StartSpan("root1.remote_child", tracing.WithRemoteParent(child2.Meta()))
+		child3 := tracer1.StartSpan("root1.remote_child", tracing.WithRemoteParentFromSpanMeta(child2.Meta()))
 
 		time.Sleep(10 * time.Millisecond)
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -48,7 +48,7 @@ const (
 // rather than reporting to some external sink, the caller's "owner"
 // must propagate the trace data back across process boundaries towards
 // the root of the trace span tree; see WithParent
-// and WithRemoteParent, respectively.
+// and WithRemoteParentFromSpanMeta, respectively.
 //
 // Additionally, the internal span type also supports turning on, stopping,
 // and restarting its data collection (see Span.StartRecording), and this is
@@ -359,7 +359,7 @@ func (sp *Span) ImportRemoteSpans(remoteSpans []tracingpb.RecordedSpan) {
 
 // Meta returns the information which needs to be propagated across process
 // boundaries in order to derive child spans from this Span. This may return
-// nil, which is a valid input to WithRemoteParent, if the Span has been
+// nil, which is a valid input to WithRemoteParentFromSpanMeta, if the Span has been
 // optimized out.
 func (sp *Span) Meta() SpanMeta {
 	// It shouldn't be done in practice, but it is allowed to call Meta on
@@ -443,6 +443,11 @@ func (sp *Span) SetTag(key string, value attribute.Value) {
 // TraceID retrieves a span's trace ID.
 func (sp *Span) TraceID() tracingpb.TraceID {
 	return sp.i.TraceID()
+}
+
+// SpanID retrieves a span's ID.
+func (sp *Span) SpanID() tracingpb.SpanID {
+	return sp.i.SpanID()
 }
 
 // OperationName returns the name of this span assigned when the span was

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -50,6 +50,13 @@ func (s *spanInner) TraceID() tracingpb.TraceID {
 	return s.crdb.TraceID()
 }
 
+func (s *spanInner) SpanID() tracingpb.SpanID {
+	if s.isNoop() {
+		return 0
+	}
+	return s.crdb.SpanID()
+}
+
 func (s *spanInner) isNoop() bool {
 	return s.crdb == nil && s.netTr == nil && s.otelSpan == nil
 }

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -68,7 +68,7 @@ type spanOptions struct {
 	// collection of each processor span recording independently, without relying
 	// on collecting the recording of the flow's span.
 	ParentDoesNotCollectRecording bool
-	RemoteParent                  SpanMeta               // see WithRemoteParent
+	RemoteParent                  SpanMeta               // see WithRemoteParentFromSpanMeta
 	RefType                       spanReferenceType      // see WithFollowsFrom
 	LogTags                       *logtags.Buffer        // see WithLogTags
 	Tags                          map[string]interface{} // see WithTags
@@ -133,7 +133,7 @@ func (opts *spanOptions) otelContext() (oteltrace.Span, oteltrace.SpanContext) {
 // A synopsis of the options follows. For details, see their comments.
 //
 // - WithParent: create a child Span with a local parent.
-// - WithRemoteParent: create a child Span with a remote parent.
+// - WithRemoteParentFromSpanMeta: create a child Span with a remote parent.
 // - WithFollowsFrom: hint that child may outlive parent.
 // - WithLogTags: populates the Span tags from a `logtags.Buffer`.
 // - WithCtxLogTags: like WithLogTags, but takes a `context.Context`.
@@ -150,7 +150,7 @@ type parentOption spanRef
 // Span.
 //
 // In case when the parent span is created with a different Tracer (generally,
-// when the parent lives in a different process), WithRemoteParent should be
+// when the parent lives in a different process), WithRemoteParentFromSpanMeta should be
 // used.
 //
 // WithParent will be a no-op (i.e. the span resulting from
@@ -224,9 +224,9 @@ func (p parentOption) apply(opts spanOptions) spanOptions {
 
 type remoteParent SpanMeta
 
-// WithRemoteParent instructs StartSpan to create a child span descending from a
-// parent described via a SpanMeta. Generally this parent span lives in a
-// different process.
+// WithRemoteParentFromSpanMeta instructs StartSpan to create a child span
+// descending from a parent described via a SpanMeta. Generally this parent span
+// lives in a different process.
 //
 // For the purposes of trace recordings, there's no mechanism ensuring that the
 // child's recording will be passed to the parent span. When that's desired, it
@@ -240,7 +240,7 @@ type remoteParent SpanMeta
 // node 1                     (network)          node 2
 // --------------------------------------------------------------------------
 // Span.Meta()               ----------> sp2 := Tracer.StartSpan(
-//                                       		WithRemoteParent(.))
+//                                       		WithRemoteParentFromSpanMeta(.))
 //                                       doSomething(sp2)
 // Span.ImportRemoteSpans(.) <---------- sp2.FinishAndGetRecording()
 //
@@ -248,7 +248,12 @@ type remoteParent SpanMeta
 // corresponds to the expectation that the parent span will usually wait for the
 // child to Finish(). If this expectation does not hold, WithFollowsFrom should
 // be added to the StartSpan invocation.
-func WithRemoteParent(parent SpanMeta) SpanOption {
+//
+// If you're in possession of a TraceInfo instead of a SpanMeta, prefer using
+// WithRemoteParentFromTraceInfo instead. If the TraceInfo is heap-allocated,
+// WithRemoteParentFromTraceInfo will not allocate (whereas
+// WithRemoteParentFromSpanMeta allocates).
+func WithRemoteParentFromSpanMeta(parent SpanMeta) SpanOption {
 	if parent.sterile {
 		return remoteParent{}
 	}
@@ -257,6 +262,23 @@ func WithRemoteParent(parent SpanMeta) SpanOption {
 
 func (p remoteParent) apply(opts spanOptions) spanOptions {
 	opts.RemoteParent = (SpanMeta)(p)
+	return opts
+}
+
+type remoteParentFromTraceInfoOpt tracingpb.TraceInfo
+
+var _ SpanOption = &remoteParentFromTraceInfoOpt{}
+
+// WithRemoteParentFromTraceInfo is like WithRemoteParentFromSpanMeta, except the remote
+// parent info is passed in as *TraceInfo. This is equivalent to
+// WithRemoteParentFromSpanMeta(SpanMetaFromProto(ti)), but more efficient because it
+// doesn't allocate.
+func WithRemoteParentFromTraceInfo(ti *tracingpb.TraceInfo) SpanOption {
+	return (*remoteParentFromTraceInfoOpt)(ti)
+}
+
+func (r *remoteParentFromTraceInfoOpt) apply(opts spanOptions) spanOptions {
+	opts.RemoteParent = SpanMetaFromProto(*(*tracingpb.TraceInfo)(r))
 	return opts
 }
 
@@ -297,7 +319,7 @@ var followsFromSingleton = SpanOption(followsFromOpt{})
 // WithFollowsFrom instructs StartSpan to link the child span to its parent
 // using a different kind of relationship than the regular parent-child one,
 // should a child span be created (i.e. should WithParent or
-// WithRemoteParent be supplied as well). This relationship was
+// WithRemoteParentFromSpanMeta be supplied as well). This relationship was
 // called "follows-from" in the old OpenTracing API. This only matters if the
 // trace is sent to an OpenTelemetry tracer; CRDB itself ignores it (what
 // matters for CRDB is the WithDetachedTrace option).

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	otelsdk "go.opentelemetry.io/otel/sdk/trace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/metadata"
 )
@@ -66,7 +68,7 @@ func TestRecordingString(t *testing.T) {
 	wireSpanMeta, err := tr2.ExtractMetaFrom(carrier)
 	require.NoError(t, err)
 
-	remoteChild := tr2.StartSpan("remote child", WithRemoteParent(wireSpanMeta), WithDetachedRecording())
+	remoteChild := tr2.StartSpan("remote child", WithRemoteParentFromSpanMeta(wireSpanMeta), WithDetachedRecording())
 	root.Record("root 2")
 	remoteChild.Record("remote child 1")
 
@@ -596,4 +598,33 @@ func TestOpenChildIncludedRecording(t *testing.T) {
 			=== operation:child _unfinished:1 _verbose:1
 	`))
 	child.Finish()
+}
+
+func TestWithRemoteParentFromTraceInfo(t *testing.T) {
+	traceID := tracingpb.TraceID(1)
+	parentSpanID := tracingpb.SpanID(2)
+	otelTraceID := [16]byte{1, 2, 3, 4, 5}
+	otelSpanID := [8]byte{6, 7, 8, 9, 10}
+	ti := tracingpb.TraceInfo{
+		TraceID:       traceID,
+		ParentSpanID:  parentSpanID,
+		RecordingMode: tracingpb.TraceInfo_STRUCTURED,
+		Otel: &tracingpb.TraceInfo_OtelInfo{
+			TraceID: otelTraceID[:],
+			SpanID:  otelSpanID[:],
+		},
+	}
+
+	tr := NewTracer()
+	tr.SetOpenTelemetryTracer(otelsdk.NewTracerProvider().Tracer("test"))
+
+	sp := tr.StartSpan("test", WithRemoteParentFromTraceInfo(&ti))
+	defer sp.Finish()
+
+	require.Equal(t, traceID, sp.TraceID())
+	require.Equal(t, parentSpanID, sp.i.crdb.parentSpanID)
+	require.Equal(t, RecordingStructured, sp.RecordingType())
+	require.NotNil(t, sp.i.otelSpan)
+	otelCtx := sp.i.otelSpan.SpanContext()
+	require.Equal(t, oteltrace.TraceID(otelTraceID), otelCtx.TraceID())
 }

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1112,6 +1112,8 @@ child operation: %s, tracer created at:
 
 	s.i.crdb.enableRecording(opts.recordingType())
 
+	s.i.crdb.parentSpanID = opts.parentSpanID()
+
 	var localRoot bool
 	{
 		// If a parent is specified, link the newly created Span to the parent.
@@ -1139,7 +1141,6 @@ child operation: %s, tracer created at:
 				added := parent.addChildLocked(s, !opts.ParentDoesNotCollectRecording)
 				if added {
 					localRoot = false
-					s.i.crdb.parentSpanID = opts.parentSpanID()
 					// We take over the reference in opts.Parent. The child will release
 					// it once when it nils out s.i.crdb.mu.parent (i.e. when either the
 					// parent of the child finish). Note that some methods on opts cannot


### PR DESCRIPTION
The WithRemoteParent(SpanMeta) span creation option allocates.
This patch adds a flavor that doesn't allocate that takes in an
*tracingpb.TraceInfo, which is the structure passed in some RPC requests
(kv and DistSQL). The TraceInfo is already on the heap, so we can take
advantage of that. This saves one allocation in these RPCs.

```
name                        old time/op    new time/op    delta
SetupSpanForIncomingRPC-32     442ns ± 0%     308ns ± 1%  -30.24%  (p=0.008 n=5+5)
name                        old alloc/op   new alloc/op   delta
SetupSpanForIncomingRPC-32      145B ± 0%       49B ± 0%  -66.21%  (p=0.008 n=5+5)
name                        old allocs/op  new allocs/op  delta
SetupSpanForIncomingRPC-32      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
```

Release note: None