### PR TITLE
coldata: change Bytes vector implementation

### DIFF
--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -18,13 +18,11 @@ go_library(
     deps = [
         "//pkg/col/typeconv",
         "//pkg/sql/colexecerror",
-        "//pkg/sql/memsize",
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/json",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -348,8 +348,8 @@ func (b *Bytes) ensureLengthForAppend(destIdx, newLen int) {
 // AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive []byte
 // values from src into the receiver starting at destIdx.
 func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
-	if b == src && srcStartIdx != srcEndIdx {
-		panic("AppendSlice when b == src is only supported when srcStartIdx == srcEndIdx")
+	if b == src {
+		panic("AppendSlice when b == src is not supported")
 	}
 	if b.isWindow {
 		panic("AppendSlice is called on a window into Bytes")
@@ -378,8 +378,8 @@ func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 // appendSliceWithSel appends all values specified in sel from the source into
 // the receiver starting at position destIdx.
 func (b *Bytes) appendSliceWithSel(src *Bytes, destIdx int, sel []int) {
-	if b == src && len(sel) != 0 {
-		panic("appendSliceWithSel when b == src is only supported when len(sel) == 0")
+	if b == src {
+		panic("appendSliceWithSel when b == src is not supported")
 	}
 	if b.isWindow {
 		panic("appendSliceWithSel is called on a window into Bytes")

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -97,6 +97,11 @@ func (e *element) get(b *Bytes) []byte {
 	if e.inlined {
 		return e.inlinedSlice()[:e.inlinedLength:BytesMaxInlineLength]
 	}
+	return e.getNonInlined(b)
+}
+
+//gcassert:inline
+func (e *element) getNonInlined(b *Bytes) []byte {
 	return b.buffer[e.header.bufferOffset : e.header.bufferOffset+e.header.len : e.header.bufferOffset+e.header.cap]
 }
 
@@ -117,11 +122,20 @@ func (e *element) set(v []byte, b *Bytes) {
 	}
 }
 
+// copy copies the value contained in other into the receiver.
+func (e *element) copy(other element, dest, src *Bytes) {
+	if other.inlined {
+		*e = other
+		return
+	}
+	e.setNonInlined(other.getNonInlined(src), dest)
+}
+
 func (e *element) setNonInlined(v []byte, b *Bytes) {
 	// Check if we there was an old non-inlined value we can overwrite.
 	if !e.inlined && e.header.cap >= len(v) {
 		e.header.len = len(v)
-		copy(e.get(b), v)
+		copy(e.getNonInlined(b), v)
 	} else {
 		*e = element{
 			header: sliceHeader{
@@ -197,6 +211,57 @@ func (b *Bytes) Window(start, end int) *Bytes {
 	}
 }
 
+// copy copies a single value from src at position srcIdx into position destIdx
+// of the receiver. It is faster than b.Set(destIdx, src.Get(srcIdx)).
+func (b *Bytes) copy(src *Bytes, destIdx, srcIdx int) {
+	if buildutil.CrdbTestBuild {
+		if b.isWindow {
+			panic("copy is called on a window into Bytes")
+		}
+	}
+	b.elements[destIdx].copy(src.elements[srcIdx], b, src)
+}
+
+// copyElements copies the provided elements into the receiver starting at
+// position destIdx. The method assumes that there are enough elements in the
+// receiver in [destIdx:] range to fit all the source elements.
+func (b *Bytes) copyElements(srcElementsToCopy []element, src *Bytes, destIdx int) {
+	if len(srcElementsToCopy) == 0 {
+		return
+	}
+	destElements := b.elements[destIdx:]
+	if buildutil.CrdbTestBuild {
+		if len(destElements) < len(srcElementsToCopy) {
+			panic(errors.AssertionFailedf("unexpectedly not enough destination elements"))
+		}
+	}
+	// Optimize copying of the elements by copying all of them directly into the
+	// destination. This way all inlined values become correctly set, and we
+	// only need to set the non-inlined values separately.
+	copy(destElements, srcElementsToCopy)
+	// Early bounds checks.
+	_ = destElements[len(srcElementsToCopy)-1]
+	for i := 0; i < len(srcElementsToCopy); i++ {
+		//gcassert:bce
+		if e := &destElements[i]; !e.inlined {
+			// This value is non-inlined, so at the moment it is pointing
+			// into the buffer of the source - we have to explicitly set it
+			// in order to copy the actual value's data into the buffer of
+			// b.
+			//
+			// First, unset the element so that we don't try to reuse the old
+			// non-inlined value to write the new value into - we do want to
+			// append the new value to b.buffer.
+			*e = element{}
+			//gcassert:bce
+			e.setNonInlined(srcElementsToCopy[i].getNonInlined(src), b)
+		}
+	}
+}
+
+// TODO(yuzefovich): unexport some of the methods (like CopySlice and
+// AppendSlice).
+
 // CopySlice copies srcStartIdx inclusive and srcEndIdx exclusive []byte values
 // from src into the receiver starting at destIdx. Similar to the copy builtin,
 // min(dest.Len(), src.Len()) values will be copied.
@@ -235,18 +300,48 @@ func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 		return
 	}
 
-	// If we're copying from the vector into itself and from the earlier part
-	// into the later part, we need to reverse the order (otherwise we would
-	// overwrite the later values before copying them, thus corrupting the
-	// vector).
-	if b == src && destIdx > srcStartIdx {
+	if b != src {
+		srcElementsToCopy := src.elements[srcStartIdx : srcStartIdx+toCopy]
+		b.copyElements(srcElementsToCopy, src, destIdx)
+	} else if destIdx > srcStartIdx {
+		// If we're copying from the vector into itself and from the earlier
+		// part into the later part, we need to reverse the order (otherwise we
+		// would overwrite the later values before copying them, thus corrupting
+		// the vector).
 		for i := toCopy - 1; i >= 0; i-- {
-			b.Set(destIdx+i, src.Get(srcStartIdx+i))
+			b.elements[destIdx+i].copy(src.elements[srcStartIdx+i], b, src)
 		}
 	} else {
 		for i := 0; i < toCopy; i++ {
-			b.Set(destIdx+i, src.Get(srcStartIdx+i))
+			b.elements[destIdx+i].copy(src.elements[srcStartIdx+i], b, src)
 		}
+	}
+}
+
+// ensureLengthForAppend makes sure that b has enough elements to support newLen
+// as the new length of the vector for an append operation.
+func (b *Bytes) ensureLengthForAppend(destIdx, newLen int) {
+	if cap(b.elements) < newLen {
+		// If the elements slice doesn't have enough capacity, then it must be
+		// reallocated.
+		oldElements := b.elements
+		// Figure out the new capacity of the elements slice. We will be
+		// doubling the existing capacity until newLen elements can fit, unless
+		// currently elements slice is nil, in which case we use newLen as the
+		// new capacity.
+		newCap := cap(b.elements)
+		if newCap > 0 {
+			for newCap < newLen {
+				newCap *= 2
+			}
+		} else {
+			newCap = newLen
+		}
+		b.elements = make([]element, newLen, newCap)
+		copy(b.elements[:destIdx], oldElements)
+	} else {
+		// We don't have to reallocate, so we can just reuse the old elements.
+		b.elements = b.elements[:newLen]
 	}
 }
 
@@ -276,35 +371,36 @@ func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 	}
 	srcElementsToCopy := src.elements[srcStartIdx:srcEndIdx]
 	newLen := destIdx + srcEndIdx - srcStartIdx
-	if cap(b.elements) < newLen {
-		// If the elements slice doesn't have enough capacity, then it must be
-		// reallocated.
-		oldElements := b.elements
-		// Figure out the new capacity of the elements slice. We will be
-		// doubling the existing capacity until newLen elements can fit, unless
-		// currently elements slice is nil, in which case we use newLen as the
-		// new capacity.
-		newCap := cap(b.elements)
-		if newCap > 0 {
-			for newCap < newLen {
-				newCap *= 2
-			}
-		} else {
-			newCap = newLen
-		}
-		b.elements = make([]element, newLen, newCap)
-		copy(b.elements[:destIdx], oldElements)
-	} else {
-		// We don't have to reallocate, so we can just reuse the old elements.
-		b.elements = b.elements[:newLen]
+	b.ensureLengthForAppend(destIdx, newLen)
+	b.copyElements(srcElementsToCopy, src, destIdx)
+}
+
+// appendSliceWithSel appends all values specified in sel from the source into
+// the receiver starting at position destIdx.
+func (b *Bytes) appendSliceWithSel(src *Bytes, destIdx int, sel []int) {
+	if b == src && len(sel) != 0 {
+		panic("appendSliceWithSel when b == src is only supported when len(sel) == 0")
 	}
-	for i := 0; i < len(srcElementsToCopy); i++ {
-		b.elements[destIdx+i].set(srcElementsToCopy[i].get(src), b)
+	if b.isWindow {
+		panic("appendSliceWithSel is called on a window into Bytes")
+	}
+	if destIdx < 0 || destIdx > b.Len() {
+		panic(
+			fmt.Sprintf(
+				"dest index %d out of range (len=%d)", destIdx, b.Len(),
+			),
+		)
+	}
+	newLen := destIdx + len(sel)
+	b.ensureLengthForAppend(destIdx, newLen)
+	for i, srcIdx := range sel {
+		b.elements[destIdx+i].copy(src.elements[srcIdx], b, src)
 	}
 }
 
 // AppendVal appends the given []byte value to the end of the receiver. A nil
 // value will be "converted" into an empty byte slice.
+// TODO(yuzefovich): remove this method.
 func (b *Bytes) AppendVal(v []byte) {
 	if b.isWindow {
 		panic("AppendVal is called on a window into Bytes")

--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -17,161 +17,170 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
 
-// Bytes is a wrapper type for a two-dimensional byte slice ([][]byte).
+// element describes a single []byte value. If a value doesn't exceed
+// BytesMaxInlineLength (30 bytes on 64 bit systems), then the whole value is
+// stored within the element; otherwise, the element "points" at a region in
+// Bytes.buffer where the non-inlined value is stored.
+//
+// If the value is inlined, then the layout of element is used as follows:
+//
+//            24-byte header | 6-byte padding
+//   element: .............................. | length | true
+//   Bytes.buffer: N/A
+//
+// where 30 dots describe the inlinable space followed by a single byte for the
+// length followed by a boolean 'true' indicating an inlined value.
+//
+// If the value is non-inlined, then the layout of element is used as follows:
+//
+//                                             padding
+//   element: .offset. | ..len... | ..cap... | xxxxxx | x | false
+//   Bytes.buffer: xxxxxxxx | offset .... | xxxxxxxx
+//
+// where first 24 bytes contain our custom "header" of a byte slice that is
+// backed by Bytes.buffer. The following 7 bytes (the padding and the
+// inlinedLength byte) are not used, and then we have a boolean 'false'
+// indicating a non-inlined value.
+type element struct {
+	header sliceHeader
+	_      [6]byte
+	// inlinedLength contains the length of the []byte value if it is inlined.
+	// Since the length of that value is at most BytesMaxInlineLength (30), it
+	// can definitely fit into a single byte.
+	inlinedLength byte
+	// inlined indicates whether the byte value is inlined in the element.
+	inlined bool
+}
+
+// sliceHeader describes a non-inlined byte value that is backed by
+// Bytes.buffer.
+//
+// We do not just use []byte for two reasons:
+// 1. we can easily overwrite the whole struct when a value is inlined without
+// causing any issues with the GC (because our sliceHeader doesn't contain an
+// actual slice, GC doesn't have to track whether the backing array is live or
+// not);
+// 2. our slice header remains valid even when Bytes.buffer is reallocated. If
+// we were to use []byte, then whenever that reallocation occurred, we would
+// have to iterate over all non-inlined values and update the byte slices to
+// point to the new Bytes.buffer.
+type sliceHeader struct {
+	// bufferOffset stores the offset into Bytes.buffer where the corresponding
+	// bytes value begins.
+	bufferOffset int
+	len          int
+	cap          int
+}
+
+// ElementSize is the size of element object. It is expected to be 32 on a 64
+// bit system.
+const ElementSize = int64(unsafe.Sizeof(element{}))
+
+// BytesMaxInlineLength is the maximum length of a []byte that can be inlined
+// within element.
+const BytesMaxInlineLength = int(unsafe.Offsetof(element{}.inlinedLength))
+
+// inlinedSlice returns 30 bytes of space within e that can be used for storing
+// a value inlined, as a slice.
+//gcassert:inline
+func (e *element) inlinedSlice() []byte {
+	return (*(*[BytesMaxInlineLength]byte)(unsafe.Pointer(&e.header)))[:]
+}
+
+//gcassert:inline
+func (e *element) get(b *Bytes) []byte {
+	if e.inlined {
+		return e.inlinedSlice()[:e.inlinedLength:BytesMaxInlineLength]
+	}
+	return b.buffer[e.header.bufferOffset : e.header.bufferOffset+e.header.len : e.header.bufferOffset+e.header.cap]
+}
+
+//gcassert:inline
+func (e *element) len() int {
+	if e.inlined {
+		return int(e.inlinedLength)
+	}
+	return e.header.len
+}
+
+func (e *element) set(v []byte, b *Bytes) {
+	if len(v) <= BytesMaxInlineLength {
+		*e = element{inlinedLength: byte(len(v)), inlined: true}
+		copy(e.inlinedSlice(), v)
+	} else {
+		e.setNonInlined(v, b)
+	}
+}
+
+func (e *element) setNonInlined(v []byte, b *Bytes) {
+	// Check if we there was an old non-inlined value we can overwrite.
+	if !e.inlined && e.header.cap >= len(v) {
+		e.header.len = len(v)
+		copy(e.get(b), v)
+	} else {
+		*e = element{
+			header: sliceHeader{
+				bufferOffset: len(b.buffer),
+				len:          len(v),
+				cap:          len(v),
+			},
+			inlined: false,
+		}
+		b.buffer = append(b.buffer, v...)
+	}
+}
+
+// Bytes is a vector that stores []byte values.
 type Bytes struct {
-	// data is the slice of all bytes.
-	data []byte
-	// offsets contains the offsets for each []byte slice in data. Note that the
-	// last offset (similarly to Arrow format) will contain the full length of
-	// data. Note that we assume that offsets are non-decreasing, and with every
-	// access of this Bytes we will try to maintain this assumption.
-	offsets []int32
-
-	// maxSetLength specifies the number of elements set by the user of this
-	// struct. This enables us to disallow unordered sets (which would require
-	// data movement). Also, this helps us maintain the assumption of
-	// non-decreasing offsets.
-	maxSetLength int
-
+	// elements contains all values stored in this Bytes vector.
+	elements []element
+	// buffer contains all values that couldn't be inlined within the
+	// corresponding elements.
+	buffer []byte
 	// isWindow indicates whether this Bytes is a "window" into another Bytes.
 	// If it is, no modifications are allowed (all of them will panic).
 	isWindow bool
 }
 
-// BytesInitialAllocationFactor is an estimate of how many bytes each []byte
-// slice takes up. It is used during the initialization of Bytes.
-const BytesInitialAllocationFactor = 64
-
-// NewBytes returns a Bytes struct with enough capacity for n zero-length
-// []byte values. It is legal to call Set on the returned Bytes at this point,
-// but Get is undefined until at least one element is Set.
-// BytesInitialAllocationFactor number of bytes are allocated initially for each
-// []byte element.
+// NewBytes returns a Bytes struct with enough capacity to store n []byte
+// values.
 func NewBytes(n int) *Bytes {
-	return NewBytesWithAvgLength(n, BytesInitialAllocationFactor)
-}
-
-// NewBytesWithAvgLength returns a Bytes struct with enough capacity for n
-// []byte values with the average length of avgElementLength. It is legal to
-// call Set on the returned Bytes at this point, but Get is undefined until at
-// least one element is Set.
-// - avgElementLength determines the average length of a single []byte element
-// that will be added to this Bytes.
-func NewBytesWithAvgLength(n int, avgElementLength int) *Bytes {
-	return &Bytes{
-		// Given that the []byte slices are of variable length, we multiply the
-		// number of elements by some constant factor.
-		// TODO(asubiotto): Make this tunable.
-		data:    make([]byte, 0, n*avgElementLength),
-		offsets: make([]int32, n+1),
-	}
-}
-
-// AssertOffsetsAreNonDecreasing asserts that all b.offsets[:n+1] are
-// non-decreasing.
-func (b *Bytes) AssertOffsetsAreNonDecreasing(n int) {
-	for j := 1; j <= n; j++ {
-		if b.offsets[j] < b.offsets[j-1] {
-			panic(errors.AssertionFailedf("unexpectedly found decreasing offsets: %v", b.offsets))
-		}
-	}
-}
-
-// UpdateOffsetsToBeNonDecreasing makes sure that b.offsets[:n+1] are
-// non-decreasing which is an invariant that we need to maintain. It must be
-// called by the colexecop.Operator that is modifying this Bytes before
-// returning it as an output. A convenient place for this is Batch.SetLength()
-// method - we assume that *always*, before returning a batch, the length is
-// set on it. UpdateOffsetsToBeNonDecreasing assumes that all offsets up to
-// b.maxSetLength are non-decreasing. Note that this method is a noop when
-// n <= b.maxSetLength.
-//gcassert:inline
-func (b *Bytes) UpdateOffsetsToBeNonDecreasing(n int) {
-	// Note that we're not checking whether this Bytes is a window because
-	// although this function might modify the "window" Bytes, it maintains the
-	// invariant that we need to have.
-	//
-	// Note that the offsets slice always has one more value than there are
-	// elements stored in data, because the index of the start of the first
-	// element must be stored (usually zero). The following is an example of what
-	// the offsets might look like for different values of maxSetLength (and a
-	// maximum length of 2 elements):
-	//   maxSetLength | offsets
-	//    0           | [0, 0, 0] // No elements.
-	//    1           | [0, 4, 0] // Set a 4-byte element at index 0 (1 element).
-	//    2           | [0, 4, 8] // Set a 4-byte element at index 1 (2 elements).
-	//
-	// This means that maxSetLength is also the index into offsets at which the
-	// end index for the max set element is stored. Therefore, the value at
-	// offsets[maxSetLength] should be used to back-fill offsets.
-	if n > b.maxSetLength {
-		offsets := b.offsets
-		prev := offsets[b.maxSetLength]
-		_ = offsets[b.maxSetLength+1]
-		_ = offsets[n]
-		for i := b.maxSetLength + 1; i <= n; i++ {
-			//gcassert:bce
-			offsets[i] = prev
-		}
-	}
+	return &Bytes{elements: make([]element, n)}
 }
 
 // Get returns the ith []byte in Bytes. Note that the returned byte slice is
 // unsafe for reuse if any write operation happens.
-// NOTE: if ith element was never set in any way, the behavior of Get is
-// undefined.
-//gcassert:inline
+//
+// Note this function call is mostly inlined except in a handful of very large
+// generated functions, so we can't add the gcassert directive for it.
 func (b *Bytes) Get(i int) []byte {
-	return b.data[b.offsets[i]:b.offsets[i+1]]
+	return b.elements[i].get(b)
 }
 
-// getAppendTo returns a byte slice that ith []byte value should be appended to.
-// This method will panic if i is less than maximum previously Set index.
-//gcassert:inline
-func (b *Bytes) getAppendTo(i int) []byte {
+// Set sets the ith []byte in Bytes.
+//
+// Note this function call is mostly inlined except in a handful of very large
+// generated functions, so we can't add the gcassert directive for it.
+func (b *Bytes) Set(i int, v []byte) {
 	if buildutil.CrdbTestBuild {
 		if b.isWindow {
-			panic("getAppendTo is called on a window into Bytes")
-		}
-		if i < b.maxSetLength-1 {
-			panic(
-				fmt.Sprintf(
-					"cannot overwrite value on flat Bytes: maxSetLength=%d, setIndex=%d, consider using Reset",
-					b.maxSetLength,
-					i,
-				),
-			)
+			panic("Set is called on a window into Bytes")
 		}
 	}
-	// We're maybe setting an element not right after the last already present
-	// element (i.e. there might be gaps in b.offsets). This is probably due to
-	// NULL values that are stored separately. In order to maintain the
-	// assumption of non-decreasing offsets, we need to backfill them.
-	b.UpdateOffsetsToBeNonDecreasing(i)
-	return b.data[:b.offsets[i]]
+	b.elements[i].set(v, b)
 }
 
-// Set sets the ith []byte in Bytes. Overwriting a value that is not at the end
-// of the Bytes is not allowed since it complicates memory movement to make/take
-// away necessary space in the flat buffer. Note that a nil value will be
-// "converted" into an empty byte slice.
-func (b *Bytes) Set(i int, v []byte) {
-	appendTo := b.getAppendTo(i)
-	b.data = append(appendTo, v...)
-	b.offsets[i+1] = int32(len(b.data))
-	b.maxSetLength = i + 1
-}
-
-// Window creates a "window" into the receiver. It behaves similarly to
-// Golang's slice, but the returned object is *not* allowed to be modified - it
-// is read-only. Window is a lightweight operation that doesn't involve copying
-// the underlying data.
+// Window creates a "window" into the receiver. It behaves similarly to Golang's
+// slice, but the returned object is *not* allowed to be modified - it is
+// read-only. If b is modified, then the returned object becomes invalid.
+//
+// Window is a lightweight operation that doesn't involve copying the underlying
+// data.
 func (b *Bytes) Window(start, end int) *Bytes {
 	if start < 0 || start > end || end > b.Len() {
 		panic(
@@ -181,34 +190,16 @@ func (b *Bytes) Window(start, end int) *Bytes {
 			),
 		)
 	}
-	b.UpdateOffsetsToBeNonDecreasing(end)
-	data := b.data[:b.offsets[end]]
-	if end == 0 {
-		data = b.data[:0]
-	}
 	return &Bytes{
-		data: data,
-		// We use 'end+1' because of the extra offset to know the length of the
-		// last element of the newly created window.
-		offsets: b.offsets[start : end+1],
-		// maxSetLength is set only for pretty printing the Bytes.
-		maxSetLength: end - start,
-		isWindow:     true,
+		elements: b.elements[start:end],
+		buffer:   b.buffer,
+		isWindow: true,
 	}
 }
 
 // CopySlice copies srcStartIdx inclusive and srcEndIdx exclusive []byte values
 // from src into the receiver starting at destIdx. Similar to the copy builtin,
-// min(dest.Len(), src.Len()) values will be copied. Note that if the length of
-// the receiver is greater than the length of the source, bytes will have to be
-// physically moved. Consider the following example:
-// dest Bytes: "helloworld", offsets: []int32{0, 5}, lengths: []int32{5, 5}
-// src Bytes: "a", offsets: []int32{0}, lengths: []int32{1}
-// If we copy src into the beginning of dest, we will have to move "world" so
-// that the result is:
-// result Bytes: "aworld", offsets: []int32{0, 1}, lengths: []int32{1, 5}
-// Similarly, if "a", is instead "alongerstring", "world" would have to be
-// shifted right.
+// min(dest.Len(), src.Len()) values will be copied.
 func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 	if b.isWindow {
 		panic("CopySlice is called on a window into Bytes")
@@ -232,78 +223,31 @@ func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 	if toCopy == 0 || b.Len() == 0 || destIdx == b.Len() {
 		return
 	}
-	b.UpdateOffsetsToBeNonDecreasing(destIdx)
 
 	if destIdx+toCopy > b.Len() {
 		// Reduce the number of elements to copy to what can fit into the
 		// destination.
 		toCopy = b.Len() - destIdx
-		srcEndIdx = srcStartIdx + toCopy
 	}
 
-	// It is possible that the last couple of elements to be copied from the
-	// source are actually NULL values in which case the corresponding offsets
-	// might remain zeroes. We want to be on the safe side, so we backfill the
-	// source offsets as well.
-	src.UpdateOffsetsToBeNonDecreasing(srcEndIdx)
-	srcDataToCopy := src.data[src.offsets[srcStartIdx]:src.offsets[srcEndIdx]]
-
-	var leftoverDestBytes []byte
-	if destIdx+toCopy < b.maxSetLength {
-		// There will still be elements left over after the last element to copy. We
-		// copy those elements into leftoverDestBytes to append after all elements
-		// have been copied.
-		leftoverDestBytesToCopy := b.data[b.offsets[destIdx+toCopy]:]
-		leftoverDestBytes = make([]byte, len(leftoverDestBytesToCopy))
-		copy(leftoverDestBytes, leftoverDestBytesToCopy)
+	if b == src && destIdx == srcStartIdx {
+		// No need to do anything.
+		return
 	}
 
-	newLength := destIdx + toCopy
-	if newLength > b.maxSetLength {
-		b.maxSetLength = newLength
-	}
-
-	destDataIdx := int32(0)
-	if destIdx != 0 {
-		// Note that due to our implementation of slicing, b.offsets[0] is not
-		// always 0, so we need this 'if'.
-		destDataIdx = b.offsets[destIdx]
-	}
-	translateBy := destDataIdx - src.offsets[srcStartIdx]
-
-	// Append the actual bytes, we use an append instead of a copy to ensure that
-	// b.data has enough capacity. Note that the "capacity" was checked
-	// beforehand, but the number of elements to copy does not correlate with the
-	// number of bytes.
-	if destIdx != 0 {
-		b.data = append(b.data[:b.offsets[destIdx]], srcDataToCopy...)
+	// If we're copying from the vector into itself and from the earlier part
+	// into the later part, we need to reverse the order (otherwise we would
+	// overwrite the later values before copying them, thus corrupting the
+	// vector).
+	if b == src && destIdx > srcStartIdx {
+		for i := toCopy - 1; i >= 0; i-- {
+			b.Set(destIdx+i, src.Get(srcStartIdx+i))
+		}
 	} else {
-		b.data = append(b.data[:0], srcDataToCopy...)
-	}
-	copy(b.offsets[destIdx:], src.offsets[srcStartIdx:srcEndIdx])
-
-	if translateBy != 0 {
-		destOffsets := b.offsets[destIdx : destIdx+toCopy]
-		for i := range destOffsets {
-			destOffsets[i] += translateBy
+		for i := 0; i < toCopy; i++ {
+			b.Set(destIdx+i, src.Get(srcStartIdx+i))
 		}
 	}
-
-	oldPrefixAndCopiedDataLen := b.offsets[destIdx] + int32(len(srcDataToCopy))
-	if leftoverDestBytes != nil {
-		dataToAppendTo := b.data[:oldPrefixAndCopiedDataLen]
-		// Append (to make sure we have the capacity for) the leftoverDestBytes to
-		// the end of the data we just copied.
-		b.data = append(dataToAppendTo, leftoverDestBytes...)
-		// The lengths for these elements are correct (they weren't overwritten),
-		// but the offsets need updating.
-		destOffsets := b.offsets[destIdx+toCopy+1:]
-		translateBy := int32(len(dataToAppendTo)) - b.offsets[destIdx+toCopy]
-		for i := range destOffsets {
-			destOffsets[i] += translateBy
-		}
-	}
-	b.offsets[destIdx+toCopy] = oldPrefixAndCopiedDataLen
 }
 
 // AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive []byte
@@ -330,48 +274,32 @@ func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 			),
 		)
 	}
-	// NOTE: it is important that we do not update b.maxSetLength before we update
-	// the tail offsets. Also, since it is possible to have a self referencing
-	// source, we can update b.maxSetLength only after updating the offsets for
-	// the source below.
-	b.UpdateOffsetsToBeNonDecreasing(destIdx)
-	toAppend := srcEndIdx - srcStartIdx
-	if toAppend == 0 {
-		b.maxSetLength = destIdx
-		// We're simply slicing up to destIdx (exclusive).
-		if destIdx == b.Len() {
-			return
+	srcElementsToCopy := src.elements[srcStartIdx:srcEndIdx]
+	newLen := destIdx + srcEndIdx - srcStartIdx
+	if cap(b.elements) < newLen {
+		// If the elements slice doesn't have enough capacity, then it must be
+		// reallocated.
+		oldElements := b.elements
+		// Figure out the new capacity of the elements slice. We will be
+		// doubling the existing capacity until newLen elements can fit, unless
+		// currently elements slice is nil, in which case we use newLen as the
+		// new capacity.
+		newCap := cap(b.elements)
+		if newCap > 0 {
+			for newCap < newLen {
+				newCap *= 2
+			}
+		} else {
+			newCap = newLen
 		}
-		b.data = b.data[:b.offsets[destIdx]]
-		b.offsets = b.offsets[:destIdx+1]
-		return
+		b.elements = make([]element, newLen, newCap)
+		copy(b.elements[:destIdx], oldElements)
+	} else {
+		// We don't have to reallocate, so we can just reuse the old elements.
+		b.elements = b.elements[:newLen]
 	}
-
-	// It is possible that the last couple of elements to be copied from the
-	// source are actually NULL values in which case the corresponding offsets
-	// might remain zeroes. We want to be on the safe side, so we backfill the
-	// source offsets as well.
-	src.UpdateOffsetsToBeNonDecreasing(srcEndIdx)
-	srcDataToAppend := src.data[src.offsets[srcStartIdx]:src.offsets[srcEndIdx]]
-	destDataIdx := b.offsets[destIdx]
-	b.maxSetLength = destIdx + toAppend
-
-	// Calculate the amount to translate offsets by before modifying any
-	// destination offsets since we might be appending from the same Bytes (and
-	// might be overwriting information).
-	translateBy := destDataIdx - src.offsets[srcStartIdx]
-	b.data = append(b.data[:destDataIdx], srcDataToAppend...)
-	b.offsets = append(b.offsets[:destIdx], src.offsets[srcStartIdx:srcEndIdx+1]...)
-	if translateBy == 0 {
-		// No offset translation needed.
-		return
-	}
-	// destOffsets is used to avoid having to recompute the target index on every
-	// iteration.
-	destOffsets := b.offsets[destIdx:]
-	// The lengths for these elements are correct, but the offsets need updating.
-	for i := range destOffsets {
-		destOffsets[i] += translateBy
+	for i := 0; i < len(srcElementsToCopy); i++ {
+		b.elements[destIdx+i].set(srcElementsToCopy[i].get(src), b)
 	}
 }
 
@@ -381,16 +309,14 @@ func (b *Bytes) AppendVal(v []byte) {
 	if b.isWindow {
 		panic("AppendVal is called on a window into Bytes")
 	}
-	b.UpdateOffsetsToBeNonDecreasing(b.Len())
-	b.data = append(b.data[:b.offsets[b.Len()]], v...)
-	b.offsets = append(b.offsets, int32(len(b.data)))
-	b.maxSetLength = b.Len()
+	b.elements = append(b.elements, element{})
+	b.elements[len(b.elements)-1].set(v, b)
 }
 
 // Len returns how many []byte values the receiver contains.
 //gcassert:inline
 func (b *Bytes) Len() int {
-	return len(b.offsets) - 1
+	return len(b.elements)
 }
 
 // FlatBytesOverhead is the overhead of Bytes in bytes.
@@ -401,27 +327,30 @@ func (b *Bytes) Size() int64 {
 	if b == nil {
 		return 0
 	}
-	return FlatBytesOverhead +
-		int64(cap(b.data)) +
-		int64(cap(b.offsets))*memsize.Int32
+	return FlatBytesOverhead + int64(cap(b.elements))*ElementSize + int64(cap(b.buffer))
 }
 
-// ProportionalSize returns the size of the receiver in bytes that is
-// attributed to only first n out of Len() elements.
+// ProportionalSize returns the size of the receiver in bytes that is attributed
+// to only first n out of Len() elements.
 func (b *Bytes) ProportionalSize(n int64) int64 {
 	if n == 0 {
 		return 0
 	}
-	// It is possible that we have a "window" into the vector that doesn't start
-	// from the offset of 0, so we have to look at the first actual offset.
-	return FlatBytesOverhead + int64(len(b.data[b.offsets[0]:b.offsets[n]])) + n*memsize.Int32
+	s := FlatBytesOverhead
+	for i := 0; i < int(n); i++ {
+		s += b.ElemSize(i)
+	}
+	return s
 }
 
 // ElemSize returns the size in bytes of the []byte elem at the given index.
 // Panics if passed an invalid element.
 //gcassert:inline
 func (b *Bytes) ElemSize(idx int) int64 {
-	return int64(b.offsets[idx+1] - b.offsets[idx])
+	if b.elements[idx].inlined {
+		return ElementSize
+	}
+	return ElementSize + int64(b.elements[idx].header.cap)
 }
 
 // Abbreviated returns a uint64 slice where each uint64 represents the first
@@ -469,53 +398,37 @@ func abbreviate(bs []byte) uint64 {
 	return v << uint(8*(8-len(bs)))
 }
 
-// Reset resets the underlying Bytes for reuse.
-// TODO(asubiotto): Move towards removing Set in favor of AppendVal. At that
-// point we can truncate the offsets slice.
+var zeroElements = make([]element, MaxBatchSize)
+
+// Reset resets the underlying Bytes for reuse. It is a noop if b is a window
+// into another Bytes.
+//
+// Calling it is not required for correctness and is only an optimization.
+// Namely, this allows us to remove all "holes" (unused space) in b.buffer which
+// can occur when an old non-inlined element is overwritten by a new element
+// that is either fully-inlined or non-inlined but larger.
+//gcassert:inline
 func (b *Bytes) Reset() {
 	if b.isWindow {
-		panic("Reset is called on a window into Bytes")
-	}
-	b.data = b.data[:0]
-	b.maxSetLength = 0
-}
-
-// ResetForAppend is similar to Reset, but it also resets the offsets slice so
-// that future calls to AppendSlice or AppendVal will append starting from index
-// zero. TODO(drewk): once Set is removed, this can just be Reset.
-func (b *Bytes) ResetForAppend() {
-	b.Reset()
-	// The first offset indicates where the first element will start.
-	b.offsets = b.offsets[:1]
-}
-
-// Truncate truncates the underlying bytes to the given length. This allows Set
-// to be called at or beyond the given length. If the length of the bytes is
-// already less than or equal to the given length, Truncate is a no-op.
-func (b *Bytes) Truncate(length int) {
-	if b.isWindow {
-		panic("Truncate is called on a window into Bytes")
-	}
-	if length < 0 {
-		panic(fmt.Sprintf("length out of range: %d", length))
-	}
-	if length > b.Len() {
-		// This is a no-op.
 		return
 	}
-	// Ensure that calling Truncate with a length greater than maxSetLength does
-	// not invalidate the non-decreasing invariant.
-	b.UpdateOffsetsToBeNonDecreasing(length)
-	b.data = b.data[:b.offsets[length]]
-	b.maxSetLength = length
+	// Zero out all elements, up to the capacity, and then restore the length of
+	// the vector.
+	l := len(b.elements)
+	b.elements = b.elements[:cap(b.elements)]
+	for n := 0; n < len(b.elements); {
+		n += copy(b.elements[n:], zeroElements)
+	}
+	b.elements = b.elements[:l]
+	b.buffer = b.buffer[:0]
 }
 
 // String is used for debugging purposes.
 func (b *Bytes) String() string {
 	var builder strings.Builder
-	for i := range b.offsets[:b.maxSetLength] {
+	for i := range b.elements {
 		builder.WriteString(
-			fmt.Sprintf("%d: %v\n", i, b.data[b.offsets[i]:b.offsets[i+1]]),
+			fmt.Sprintf("%d: %v\n", i, b.Get(i)),
 		)
 	}
 	return builder.String()
@@ -524,64 +437,38 @@ func (b *Bytes) String() string {
 // BytesFromArrowSerializationFormat takes an Arrow byte slice and accompanying
 // offsets and populates b.
 func BytesFromArrowSerializationFormat(b *Bytes, data []byte, offsets []int32) {
-	b.data = data
-	b.offsets = offsets
-	b.maxSetLength = len(offsets) - 1
+	numElements := len(offsets) - 1
+	if cap(b.elements) < numElements {
+		b.elements = make([]element, numElements)
+		b.buffer = b.buffer[:0]
+	} else {
+		b.Reset()
+		b.elements = b.elements[:numElements]
+	}
+	for i := 0; i < numElements; i++ {
+		b.Set(i, data[offsets[i]:offsets[i+1]])
+	}
 }
 
 // ToArrowSerializationFormat returns a bytes slice and offsets that are
 // Arrow-compatible. n is the number of elements to serialize.
 func (b *Bytes) ToArrowSerializationFormat(n int) ([]byte, []int32) {
-	if n == 0 {
-		return []byte{}, []int32{0}
+	// Calculate the size of the flat byte slice that will contain all elements.
+	var dataSize int
+	for _, e := range b.elements[:n] {
+		dataSize += e.len()
 	}
-	serializeStart := b.offsets[0]
-	serializeLength := b.offsets[n]
-	data := b.data[serializeStart:serializeLength]
-	offsets := b.offsets[:n+1]
-	if serializeStart > 0 {
-		// This can happen when the receiver is a window. We will have to ensure
-		// that offsets starts at index zero into the truncated version of b.data.
-		offsets = make([]int32, len(offsets))
-		for i := range offsets {
-			// This works because of the non-decreasing invariant imposed on the
-			// offsets.
-			offsets[i] = b.offsets[i] - serializeStart
-		}
+	data := make([]byte, 0, dataSize)
+	offsets := make([]int32, 1, n+1)
+	for _, e := range b.elements[:n] {
+		data = append(data, e.get(b)...)
+		offsets = append(offsets, int32(len(data)))
 	}
 	return data, offsets
 }
 
-// AssertOffsetsAreNonDecreasing calls the method of the same name on bytes-like
-// vectors, panicking if not bytes-like.
-func AssertOffsetsAreNonDecreasing(v Vec, n int) {
-	family := v.CanonicalTypeFamily()
-	switch family {
-	case types.BytesFamily:
-		v.Bytes().AssertOffsetsAreNonDecreasing(n)
-	case types.JsonFamily:
-		v.JSON().AssertOffsetsAreNonDecreasing(n)
-	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", family))
-	}
-}
-
-// UpdateOffsetsToBeNonDecreasing calls the method of the same name on bytes-like
-// vectors, panicking if not bytes-like.
-func UpdateOffsetsToBeNonDecreasing(v Vec, n int) {
-	family := v.CanonicalTypeFamily()
-	switch family {
-	case types.BytesFamily:
-		v.Bytes().UpdateOffsetsToBeNonDecreasing(n)
-	case types.JsonFamily:
-		v.JSON().UpdateOffsetsToBeNonDecreasing(n)
-	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", family))
-	}
-}
-
-// ProportionalSize calls the method of the same name on bytes-like
-// vectors, panicking if not bytes-like.
+// ProportionalSize calls the method of the same name on bytes-like vectors,
+// panicking if not bytes-like.
 func ProportionalSize(v Vec, length int64) int64 {
 	family := v.CanonicalTypeFamily()
 	switch family {
@@ -595,16 +482,12 @@ func ProportionalSize(v Vec, length int64) int64 {
 	return 0
 }
 
-// Reset calls the method of the same name on bytes-like
-// vectors, panicking if not bytes-like.
-func Reset(v Vec) {
-	family := v.CanonicalTypeFamily()
-	switch family {
+// ResetIfBytesLike calls Reset on v if it is bytes-like, noop otherwise.
+func ResetIfBytesLike(v Vec) {
+	switch v.CanonicalTypeFamily() {
 	case types.BytesFamily:
 		v.Bytes().Reset()
 	case types.JsonFamily:
 		v.JSON().Reset()
-	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", family))
 	}
 }

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Use double of the max inline length so that we get a mix of inlinable and
+// non-inlinable values.
+const testMaxElementLength = BytesMaxInlineLength * 2
+
 type bytesMethod int
 
 const (
@@ -86,13 +90,8 @@ func applyMethodsAndVerify(
 		debugString += m.String()
 		switch m {
 		case set:
-			// Can only Set starting from maxSetLength - 1 (or zero if maxSetLength is
-			// zero).
-			i := b1.maxSetLength - 1 + rng.Intn(b1.Len()-(b1.maxSetLength-1))
-			if i < 0 {
-				i = 0
-			}
-			new := make([]byte, rng.Intn(16))
+			i := rng.Intn(n)
+			new := make([]byte, rng.Intn(testMaxElementLength))
 			rng.Read(new)
 			debugString += fmt.Sprintf("(%d, %v)", i, new)
 			b1.Set(i, new)
@@ -106,9 +105,6 @@ func applyMethodsAndVerify(
 			debugString += fmt.Sprintf("(%d, %d)", start, end)
 			b1Window := b1.Window(start, end)
 			b2Window := b2[start:end]
-			// b1Window is not allowed to be modified, so we check explicitly whether
-			// it equals the reference, and we do not update b1 and b2.
-			b1Window.AssertOffsetsAreNonDecreasing(b1Window.Len())
 			debugString += fmt.Sprintf("\n%s\n", b1Window)
 			if err := verifyEqual(b1Window, b2Window); err != nil {
 				return errors.Wrapf(err,
@@ -150,7 +146,7 @@ func applyMethodsAndVerify(
 				b2Slice[i] = append([]byte(nil), b2Slice[i]...)
 			}
 		case appendVal:
-			v := make([]byte, 16)
+			v := make([]byte, rng.Intn(testMaxElementLength))
 			rng.Read(v)
 			debugString += fmt.Sprintf("(%v)", v)
 			b1.AppendVal(v)
@@ -162,12 +158,11 @@ func applyMethodsAndVerify(
 		default:
 			return errors.Errorf("unknown method name: %s", m)
 		}
-		b1.AssertOffsetsAreNonDecreasing(b1.Len())
 		debugString += fmt.Sprintf("\n%s\n", b1)
 		if err := verifyEqual(b1, b2); err != nil {
 			return errors.Wrapf(err,
-				"\ndebugString:\n%s\nflat (maxSetLength=%d):\n%s\nreference:\n%s",
-				debugString, b1.maxSetLength, b1.String(), prettyByteSlice(b2))
+				"\ndebugString:\n%s\nflat:\n%s\nreference:\n%s",
+				debugString, b1.String(), prettyByteSlice(b2))
 		}
 	}
 	return nil
@@ -205,16 +200,24 @@ func TestBytesRefImpl(t *testing.T) {
 		maxLength        = 16
 		nRuns            = 100
 	)
+	v := make([]byte, testMaxElementLength)
+	var flat *Bytes
 
 	for nRun := 0; nRun < nRuns; nRun++ {
 		n := 1 + rng.Intn(maxLength)
 
-		flat := NewBytes(n)
+		if flat != nil && cap(flat.elements) >= n && rng.Float64() < 0.5 {
+			// If the flat vector is large enough, reuse it with 50% chance.
+			flat.Reset()
+			flat.elements = flat.elements[:n]
+		} else {
+			flat = NewBytes(n)
+		}
 		reference := make([][]byte, n)
 		for i := 0; i < n; i++ {
-			v := make([]byte, rng.Intn(16))
+			v = v[:rng.Intn(testMaxElementLength)]
 			rng.Read(v)
-			flat.Set(i, append([]byte(nil), v...))
+			flat.Set(i, v)
 			reference[i] = append([]byte(nil), v...)
 		}
 
@@ -225,13 +228,13 @@ func TestBytesRefImpl(t *testing.T) {
 		selfReferencingSources := true
 		if rng.Float64() < 0.5 {
 			selfReferencingSources = false
-			sourceN := 1 + rng.Intn(maxLength)
+			sourceN := 1 + rng.Intn(testMaxElementLength)
 			flatSource = NewBytes(sourceN)
 			referenceSource = make([][]byte, sourceN)
 			for i := 0; i < sourceN; i++ {
-				v := make([]byte, rng.Intn(16))
+				v = v[:rng.Intn(testMaxElementLength)]
 				rng.Read(v)
-				flatSource.Set(i, append([]byte(nil), v...))
+				flatSource.Set(i, v)
 				referenceSource[i] = append([]byte(nil), v...)
 			}
 		}
@@ -262,29 +265,6 @@ func TestBytes(t *testing.T) {
 		b1.AppendVal(nil)
 		require.Equal(t, []byte{}, b1.Get(1))
 		require.Equal(t, 2, b1.Len())
-		// Verify that we cannot overwrite a value.
-		require.Panics(
-			t,
-			func() { b1.Set(0, []byte("not allowed")) },
-			"should be unable to overwrite value",
-		)
-
-		// However, it is legal to overwrite the last value.
-		b1.Set(1, []byte("ok"))
-
-		// If we Reset the Bytes, we can Set any index.
-		b1.Reset()
-		b1.Set(1, []byte("new usage"))
-		// But not an index before that.
-		require.Panics(
-			t,
-			func() { b1.Set(0, []byte("still not allowed")) },
-			"should be unable to overwrite value",
-		)
-
-		// Same with Reset.
-		b1.Reset()
-		b1.Set(1, []byte("reset new usage"))
 	})
 
 	t.Run("Append", func(t *testing.T) {
@@ -337,7 +317,6 @@ func TestBytes(t *testing.T) {
 		require.Equal(t, 4, b.Len())
 		require.Equal(t, "zero", string(b.Get(0)))
 		require.Equal(t, "three", string(b.Get(3)))
-		b.AssertOffsetsAreNonDecreasing(b.Len())
 	})
 
 	t.Run("Copy", func(t *testing.T) {
@@ -368,8 +347,7 @@ func TestBytes(t *testing.T) {
 
 		// Set the length to 1 and follow it with testing a full overwrite of
 		// only one element.
-		b1.offsets = b1.offsets[:2]
-		b1.maxSetLength = 1
+		b1.elements = b1.elements[:1]
 		require.Equal(t, 1, b1.Len())
 		b1.CopySlice(b2, 0, 0, b2.Len())
 		require.Equal(t, 1, b1.Len())
@@ -428,33 +406,6 @@ func TestBytes(t *testing.T) {
 		)
 	})
 
-	t.Run("InvariantSimple", func(t *testing.T) {
-		b1 := NewBytes(8)
-		b1.Set(0, []byte("zero"))
-		other := b1.Window(0, 2)
-		other.AssertOffsetsAreNonDecreasing(2)
-
-		b2 := NewBytes(8)
-		b2.Set(0, []byte("zero"))
-		b2.Set(2, []byte("two"))
-		other = b2.Window(0, 4)
-		other.AssertOffsetsAreNonDecreasing(4)
-	})
-
-	t.Run("Truncate", func(t *testing.T) {
-		b := NewBytes(8)
-		b.Set(4, []byte("foo"))
-		require.Equal(t, 5, b.maxSetLength)
-		require.Panics(t, func() { b.Set(1, []byte("bar")) })
-		b.Truncate(1)
-		require.Equal(t, 1, b.maxSetLength)
-		require.NotPanics(t, func() { b.Set(1, []byte("baz")) })
-		require.Equal(t, 2, b.maxSetLength)
-		b.Truncate(0)
-		require.Equal(t, 0, b.maxSetLength)
-		require.NotPanics(t, func() { b.Set(4, []byte("deadbeef")) })
-	})
-
 	t.Run("Abbreviated", func(t *testing.T) {
 		rng, _ := randutil.NewTestRand()
 
@@ -483,13 +434,48 @@ func TestBytes(t *testing.T) {
 			}
 		}
 	})
+
+	// AppendSliceWithReset verifies that reusing the old non-inlined value
+	// (that is past the length of the elements slice) doesn't lead to a
+	// corruption.
+	t.Run("AppendSliceWithReset", func(t *testing.T) {
+		// Operate only with large values that are not inlined.
+		v0 := make([]byte, 2*BytesMaxInlineLength)
+		shortV0 := v0[:BytesMaxInlineLength+1]
+		v1 := make([]byte, 2*BytesMaxInlineLength)
+		for i := range v1 {
+			v1[i] = 1
+		}
+
+		b := NewBytes(2)
+		b2 := NewBytes(1)
+		b.Set(0, shortV0)
+		b.Set(1, v1)
+		b.Set(0, v0)
+
+		// Now b.buffer = shortV0 | v1 | v0.
+
+		// Truncate b to length 1.
+		b.AppendSlice(b2, 1, 0, 0)
+
+		b.Reset()
+		b.Set(0, v0)
+		b2.Set(0, v1)
+
+		// Here is the meat of the test - if b.elements[1] has not been properly
+		// reset, then it could reuse the old non-inlined value in the buffer
+		// corrupting the value of v0.
+		b.AppendSlice(b2, 1 /* destIdx */, 0 /* srcStartIdx */, 1 /* srcEndIdx */)
+		require.Equal(t, v0, b.Get(0))
+		require.Equal(t, v1, b.Get(1))
+	})
 }
 
 func TestProportionalSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Use a large value so that the bytes vector needs to expand.
-	value := make([]byte, 3*BytesInitialAllocationFactor)
+	// Use a large value so that elements are not inlined.
+	value := make([]byte, 3*BytesMaxInlineLength)
 
 	rng, _ := randutil.NewTestRand()
 	// We need a number divisible by 4.
@@ -531,8 +517,6 @@ func TestToArrowSerializationFormat(t *testing.T) {
 		element := []byte(randgen.RandString(rng, 1+rng.Intn(maxStringLength), letters))
 		b.Set(i, element)
 	}
-	// We have to call this in case there are trailing nulls.
-	b.UpdateOffsetsToBeNonDecreasing(numElements)
 
 	startIdx := rng.Intn(numElements)
 	endIdx := startIdx + rng.Intn(numElements-startIdx)
@@ -555,36 +539,12 @@ func TestToArrowSerializationFormat(t *testing.T) {
 	// Verify that the data contains the correct values.
 	for i := 0; i < len(offsets)-1; i++ {
 		element := data[offsets[i]:offsets[i+1]]
+		if len(element) == 0 {
+			// Bytes.Get returns a nil []byte value for NULL values whereas the
+			// slicing above will make it a zero-length []byte value. Override
+			// the latter to the former.
+			element = nil
+		}
 		require.Equal(t, wind.Get(i), element)
 	}
-}
-
-func TestForRegressions(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	t.Run("Regression test for #42054", func(t *testing.T) {
-		b := NewBytes(4)
-		b.Set(0, []byte("zero"))
-		b.Set(1, []byte("one"))
-		b.Set(2, []byte("two"))
-
-		// Emulate copying when the first two values are null and the last is
-		// non-null.
-		b.Reset()
-		b.Set(2, []byte("three"))
-		b.AssertOffsetsAreNonDecreasing(2)
-
-		b.Reset()
-		b.Set(0, []byte("zero"))
-		b.Set(1, []byte("one"))
-		b.Set(2, []byte("two"))
-		b.Set(3, []byte("three"))
-
-		// Emulate copying when the first and last values are non-null, and the
-		// middle two are null.
-		b.Reset()
-		b.Set(0, []byte("zero"))
-		b.Set(3, []byte("four"))
-		b.AssertOffsetsAreNonDecreasing(3)
-	})
 }

--- a/pkg/col/coldata/json.go
+++ b/pkg/col/coldata/json.go
@@ -70,6 +70,12 @@ func (js *JSONs) Window(start, end int) *JSONs {
 	}
 }
 
+// copy copies a single value from src at position srcIdx into position destIdx
+// of the receiver.
+func (js *JSONs) copy(src *JSONs, destIdx, srcIdx int) {
+	js.Bytes.copy(&src.Bytes, destIdx, srcIdx)
+}
+
 // CopySlice copies srcStartIdx inclusive and srcEndIdx exclusive []byte values
 // from src into the receiver starting at destIdx. See Bytes.CopySlice.
 func (js *JSONs) CopySlice(src *JSONs, destIdx, srcStartIdx, srcEndIdx int) {
@@ -82,20 +88,10 @@ func (js *JSONs) AppendSlice(src *JSONs, destIdx, srcStartIdx, srcEndIdx int) {
 	js.Bytes.AppendSlice(&src.Bytes, destIdx, srcStartIdx, srcEndIdx)
 }
 
-// AppendVal appends the given JSON value to the end of the receiver.
-func (js *JSONs) AppendVal(j json.JSON) {
-	if j == nil {
-		// A nil JSON indicates a NULL value in the column. We've got to insert a
-		// "zero value" which in this case means an empty byte slice.
-		js.Bytes.AppendVal(nil)
-		return
-	}
-	var err error
-	js.scratch, err = json.EncodeJSON(js.scratch[:0], j)
-	if err != nil {
-		colexecerror.ExpectedError(err)
-	}
-	js.Bytes.AppendVal(js.scratch)
+// appendSliceWithSel appends all values specified in sel from the source into
+// the receiver starting at position destIdx.
+func (js *JSONs) appendSliceWithSel(src *JSONs, destIdx int, sel []int) {
+	js.Bytes.appendSliceWithSel(&src.Bytes, destIdx, sel)
 }
 
 // String is used for debugging purposes.

--- a/pkg/col/coldata/vec.eg.go
+++ b/pkg/col/coldata/vec.eg.go
@@ -249,13 +249,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol.AppendSlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				// We need to truncate toCol before appending to it, so in case of
-				// bytes-like columns, we append an empty slice.
-				toCol.AppendSlice(toCol, args.DestIdx, 0, 0)
-				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx)
-					toCol.AppendVal(val)
-				}
+				toCol.appendSliceWithSel(fromCol, args.DestIdx, sel)
 			}
 			m.nulls.set(args)
 			m.col = toCol
@@ -449,13 +443,7 @@ func (m *memColumn) Append(args SliceArgs) {
 				toCol.AppendSlice(fromCol, args.DestIdx, args.SrcStartIdx, args.SrcEndIdx)
 			} else {
 				sel := args.Sel[args.SrcStartIdx:args.SrcEndIdx]
-				// We need to truncate toCol before appending to it, so in case of
-				// bytes-like columns, we append an empty slice.
-				toCol.AppendSlice(toCol, args.DestIdx, 0, 0)
-				for _, selIdx := range sel {
-					val := fromCol.Get(selIdx)
-					toCol.AppendVal(val)
-				}
+				toCol.appendSliceWithSel(fromCol, args.DestIdx, sel)
 			}
 			m.nulls.set(args)
 			m.col = toCol
@@ -556,8 +544,7 @@ func (m *memColumn) Copy(args SliceArgs) {
 						if nulls.NullAt(selIdx) {
 							m.nulls.SetNull(i + args.DestIdx)
 						} else {
-							v := fromCol.Get(selIdx)
-							toCol.Set(i+args.DestIdx, v)
+							toCol.copy(fromCol, i+args.DestIdx, selIdx)
 						}
 					}
 					return
@@ -566,8 +553,7 @@ func (m *memColumn) Copy(args SliceArgs) {
 				for i := 0; i < n; i++ {
 					//gcassert:bce
 					selIdx := sel[i]
-					v := fromCol.Get(selIdx)
-					toCol.Set(i+args.DestIdx, v)
+					toCol.copy(fromCol, i+args.DestIdx, selIdx)
 				}
 				return
 			}
@@ -864,8 +850,7 @@ func (m *memColumn) Copy(args SliceArgs) {
 						if nulls.NullAt(selIdx) {
 							m.nulls.SetNull(i + args.DestIdx)
 						} else {
-							v := fromCol.Get(selIdx)
-							toCol.Set(i+args.DestIdx, v)
+							toCol.copy(fromCol, i+args.DestIdx, selIdx)
 						}
 					}
 					return
@@ -874,8 +859,7 @@ func (m *memColumn) Copy(args SliceArgs) {
 				for i := 0; i < n; i++ {
 					//gcassert:bce
 					selIdx := sel[i]
-					v := fromCol.Get(selIdx)
-					toCol.Set(i+args.DestIdx, v)
+					toCol.copy(fromCol, i+args.DestIdx, selIdx)
 				}
 				return
 			}

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // Column is an interface that represents a raw array of a Go native type.
@@ -51,9 +50,6 @@ type Vec interface {
 	// CanonicalTypeFamily returns the canonical type family of data stored in
 	// this Vec.
 	CanonicalTypeFamily() types.Family
-	// IsBytesLike returns true if this data is stored with a flat bytes
-	// representation.
-	IsBytesLike() bool
 
 	// Bool returns a bool list.
 	Bool() Bools
@@ -165,9 +161,6 @@ func (cf *defaultColumnFactory) MakeColumn(t *types.T, length int) Column {
 	case types.BoolFamily:
 		return make(Bools, length)
 	case types.BytesFamily:
-		if t.Family() == types.UuidFamily {
-			return NewBytesWithAvgLength(length, uuid.Size)
-		}
 		return NewBytes(length)
 	case types.IntFamily:
 		switch t.Width() {
@@ -219,14 +212,6 @@ func (m *memColumn) Type() *types.T {
 
 func (m *memColumn) CanonicalTypeFamily() types.Family {
 	return m.canonicalTypeFamily
-}
-
-func (m *memColumn) IsBytesLike() bool {
-	switch m.canonicalTypeFamily {
-	case types.BytesFamily, types.JsonFamily:
-		return true
-	}
-	return false
 }
 
 func (m *memColumn) SetCol(col Column) {

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -91,8 +91,7 @@ type Vec interface {
 	// Vec.
 	// Refer to the SliceArgs comment for specifics and TestAppend for examples.
 	//
-	// Note: Append()'ing from a Vector into itself is only supported when
-	// args.SrcStartIdx == args.SrcEndIdx.
+	// Note: Append()'ing from a Vector into itself is not supported.
 	Append(SliceArgs)
 
 	// Copy uses SliceArgs to copy elements of a source Vec into this Vec. It is

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -321,7 +321,7 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 	src := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	dest := testAllocator.NewMemBatchWithMaxCapacity(typs)
 	bytesVec := src.ColVec(0).Bytes()
-	maxValueLen := coldata.BytesInitialAllocationFactor * 8
+	maxValueLen := coldata.BytesMaxInlineLength * 8
 	value := make([]byte, maxValueLen)
 	for i := 0; i < coldata.BatchSize(); i++ {
 		value = value[:rng.Intn(maxValueLen)]

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -98,9 +98,6 @@ func (b *defaultBuiltinFuncOperator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -212,8 +212,8 @@ func (c *caseOp) Next() coldata.Batch {
 
 	if c.scratch.output == nil || c.scratch.output.Capacity() < origLen {
 		c.scratch.output = c.allocator.NewMemColumn(c.typ, origLen)
-	} else if c.scratch.output.IsBytesLike() {
-		coldata.Reset(c.scratch.output)
+	} else {
+		coldata.ResetIfBytesLike(c.scratch.output)
 	}
 	orderCapacity := origLen
 	if origHasSel {

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1158,7 +1158,6 @@ func (c *castBoolFloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -1294,7 +1293,6 @@ func (c *castBoolInt2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -1430,7 +1428,6 @@ func (c *castBoolInt4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -1566,7 +1563,6 @@ func (c *castBoolIntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -1682,7 +1678,6 @@ func (c *castDecimalBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -1874,7 +1869,6 @@ func (c *castDecimalInt2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2066,7 +2060,6 @@ func (c *castDecimalInt4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2234,7 +2227,6 @@ func (c *castDecimalIntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2382,7 +2374,6 @@ func (c *castDecimalFloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2518,7 +2509,6 @@ func (c *castDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2634,7 +2624,6 @@ func (c *castInt2Int4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2750,7 +2739,6 @@ func (c *castInt2IntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -2874,7 +2862,6 @@ func (c *castInt2BoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3014,7 +3001,6 @@ func (c *castInt2DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3138,7 +3124,6 @@ func (c *castInt2FloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3278,7 +3263,6 @@ func (c *castInt4Int2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3394,7 +3378,6 @@ func (c *castInt4IntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3518,7 +3501,6 @@ func (c *castInt4BoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3658,7 +3640,6 @@ func (c *castInt4DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3782,7 +3763,6 @@ func (c *castInt4FloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -3922,7 +3902,6 @@ func (c *castIntInt2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4062,7 +4041,6 @@ func (c *castIntInt4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4186,7 +4164,6 @@ func (c *castIntBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4326,7 +4303,6 @@ func (c *castIntDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4450,7 +4426,6 @@ func (c *castIntFloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4574,7 +4549,6 @@ func (c *castFloatBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4722,7 +4696,6 @@ func (c *castFloatDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4858,7 +4831,6 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -4994,7 +4966,6 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5130,7 +5101,6 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5270,7 +5240,6 @@ func (c *castDateInt2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5410,7 +5379,6 @@ func (c *castDateInt4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5526,7 +5494,6 @@ func (c *castDateIntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5650,7 +5617,6 @@ func (c *castDateFloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5790,7 +5756,6 @@ func (c *castDateDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -5922,7 +5887,6 @@ func (c *castBytesUuidOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6058,7 +6022,6 @@ func (c *castStringBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6190,7 +6153,6 @@ func (c *castStringBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6402,7 +6364,6 @@ func (c *castStringStringOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6534,7 +6495,6 @@ func (c *castStringUuidOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6686,7 +6646,6 @@ func (c *castJsonbStringOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6831,7 +6790,6 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -6976,7 +6934,6 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7121,7 +7078,6 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7266,7 +7222,6 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7411,7 +7366,6 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7556,7 +7510,6 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7701,7 +7654,6 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7846,7 +7798,6 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -7991,7 +7942,6 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -8132,7 +8082,6 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -8273,7 +8222,6 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -8418,7 +8366,6 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -8559,7 +8506,6 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -8700,7 +8646,6 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch
@@ -8864,7 +8809,6 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			batch.SetLength(n)
 		},
 	)
 	return batch

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -460,12 +460,6 @@ func (c *cast_NAMEOp) Next() coldata.Batch {
 					castTuples(inputCol, inputNulls, outputCol, outputNulls, toType, n, sel, c.evalCtx, false, false)
 				}
 			}
-			// {{/*
-			// Although we didn't change the length of the batch, it is
-			// necessary to set the length anyway (this helps maintaining the
-			// invariant of flat bytes).
-			// */}}
-			batch.SetLength(n)
 		},
 	)
 	return batch

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops.eg.go
@@ -70,9 +70,6 @@ func (d *defaultCmpProjOp) Next() coldata.Batch {
 			}
 		}
 	})
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -130,9 +127,6 @@ func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
 			}
 		}
 	})
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -99,9 +99,6 @@ func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 			}
 		}
 	})
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -134,9 +134,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -230,9 +227,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -326,9 +320,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -422,9 +413,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -518,9 +506,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -614,9 +599,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -710,9 +692,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -806,9 +785,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -902,9 +878,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1026,9 +999,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1122,9 +1092,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1218,9 +1185,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1314,9 +1278,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1410,9 +1371,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1506,9 +1464,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1602,9 +1557,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1698,9 +1650,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1794,9 +1743,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1890,9 +1836,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2014,9 +1957,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2110,9 +2050,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2206,9 +2143,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2302,9 +2236,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2398,9 +2329,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2494,9 +2422,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2590,9 +2515,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2686,9 +2608,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2782,9 +2701,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2878,9 +2794,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3002,9 +2915,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3126,9 +3036,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3250,9 +3157,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3374,9 +3278,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3494,9 +3395,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3614,9 +3512,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3734,9 +3629,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3854,9 +3746,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3982,9 +3871,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4124,9 +4010,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4244,9 +4127,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4364,9 +4244,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4484,9 +4361,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4612,9 +4486,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4754,9 +4625,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4874,9 +4742,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4994,9 +4859,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5114,9 +4976,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5242,9 +5101,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5384,9 +5240,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5492,9 +5345,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5600,9 +5450,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5708,9 +5555,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5796,9 +5640,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5938,9 +5779,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6078,9 +5916,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6218,9 +6053,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6358,9 +6190,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6498,9 +6327,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6622,9 +6448,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6746,9 +6569,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6870,9 +6690,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6990,9 +6807,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7110,9 +6924,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7230,9 +7041,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7350,9 +7158,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7478,9 +7283,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7620,9 +7422,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7740,9 +7539,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7860,9 +7656,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7980,9 +7773,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8108,9 +7898,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8250,9 +8037,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8370,9 +8154,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8490,9 +8271,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8610,9 +8388,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8738,9 +8513,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8880,9 +8652,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8988,9 +8757,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9088,9 +8854,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9196,9 +8959,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9284,9 +9044,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9426,9 +9183,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9548,9 +9302,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9654,9 +9405,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9760,9 +9508,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9866,9 +9611,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9990,9 +9732,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10130,9 +9869,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10270,9 +10006,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10410,9 +10143,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10550,9 +10280,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10690,9 +10417,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10814,9 +10538,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10938,9 +10659,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11062,9 +10780,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11182,9 +10897,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11290,9 +11002,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11442,9 +11151,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11594,9 +11300,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11746,9 +11449,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11874,9 +11574,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11962,9 +11659,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12114,9 +11808,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12266,9 +11957,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12418,9 +12106,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12546,9 +12231,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12634,9 +12316,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12786,9 +12465,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12938,9 +12614,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13090,9 +12763,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13218,9 +12888,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13306,9 +12973,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13414,9 +13078,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13502,9 +13163,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13590,9 +13248,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13678,9 +13333,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13766,9 +13418,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13854,9 +13503,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13962,9 +13608,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14102,9 +13745,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14242,9 +13882,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14382,9 +14019,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14518,9 +14152,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14654,9 +14285,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14790,9 +14418,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14926,9 +14551,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15070,9 +14692,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15206,9 +14825,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15342,9 +14958,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15478,9 +15091,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15622,9 +15232,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15758,9 +15365,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15894,9 +15498,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16030,9 +15631,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16174,9 +15772,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16298,9 +15893,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16402,9 +15994,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16506,9 +16095,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16610,9 +16196,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16714,9 +16297,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16854,9 +16434,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16994,9 +16571,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17134,9 +16708,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17270,9 +16841,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17386,9 +16954,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17502,9 +17067,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17618,9 +17180,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17762,9 +17321,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17878,9 +17434,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17994,9 +17547,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18110,9 +17660,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18254,9 +17801,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18370,9 +17914,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18486,9 +18027,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18602,9 +18140,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18746,9 +18281,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18870,9 +18402,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19010,9 +18539,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19150,9 +18676,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19290,9 +18813,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19426,9 +18946,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19542,9 +19059,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19658,9 +19172,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19774,9 +19285,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19918,9 +19426,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20034,9 +19539,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20150,9 +19652,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20266,9 +19765,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20410,9 +19906,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20526,9 +20019,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20642,9 +20132,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20758,9 +20245,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20902,9 +20386,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21026,9 +20507,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21150,9 +20628,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21274,9 +20749,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21398,9 +20870,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21518,9 +20987,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21662,9 +21128,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21806,9 +21269,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21950,9 +21410,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22078,9 +21535,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22222,9 +21676,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22366,9 +21817,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22510,9 +21958,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22638,9 +22083,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22782,9 +22224,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22926,9 +22365,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23070,9 +22506,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23198,9 +22631,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23306,9 +22736,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23420,9 +22847,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23530,9 +22954,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23654,9 +23075,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23774,9 +23192,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23894,9 +23309,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24014,9 +23426,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24134,9 +23543,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24254,9 +23660,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24374,9 +23777,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24494,9 +23894,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24614,9 +24011,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24734,9 +24128,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24874,9 +24265,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25014,9 +24402,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25154,9 +24539,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25274,9 +24656,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25394,9 +24773,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25514,9 +24890,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25634,9 +25007,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25754,9 +25124,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25874,9 +25241,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25994,9 +25358,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26114,9 +25475,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26234,9 +25592,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26374,9 +25729,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26514,9 +25866,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26654,9 +26003,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26788,9 +26134,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26910,9 +26253,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27032,9 +26372,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27154,9 +26491,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27324,9 +26658,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27482,9 +26813,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27640,9 +26968,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27798,9 +27123,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27920,9 +27242,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28082,9 +27401,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -137,9 +137,6 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 		} else {
 			_SET_PROJECTION(false)
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -137,9 +137,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -233,9 +230,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -329,9 +323,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -425,9 +416,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -521,9 +509,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -617,9 +602,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -713,9 +695,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -809,9 +788,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -905,9 +881,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1029,9 +1002,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1125,9 +1095,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1221,9 +1188,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1317,9 +1281,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1413,9 +1374,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1509,9 +1467,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1605,9 +1560,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1701,9 +1653,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1797,9 +1746,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1893,9 +1839,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2017,9 +1960,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2113,9 +2053,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2209,9 +2146,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2305,9 +2239,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2401,9 +2332,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2497,9 +2425,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2593,9 +2518,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2689,9 +2611,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2785,9 +2704,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2881,9 +2797,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3005,9 +2918,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3129,9 +3039,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3253,9 +3160,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3377,9 +3281,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3497,9 +3398,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3617,9 +3515,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3737,9 +3632,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3857,9 +3749,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3985,9 +3874,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4125,9 +4011,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4245,9 +4128,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4365,9 +4245,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4485,9 +4362,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4613,9 +4487,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4753,9 +4624,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4873,9 +4741,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4993,9 +4858,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5113,9 +4975,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5241,9 +5100,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5381,9 +5237,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5489,9 +5342,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5597,9 +5447,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5705,9 +5552,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5793,9 +5637,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5933,9 +5774,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6075,9 +5913,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6217,9 +6052,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6359,9 +6191,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6501,9 +6330,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6625,9 +6451,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6749,9 +6572,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6873,9 +6693,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6993,9 +6810,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7113,9 +6927,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7233,9 +7044,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7353,9 +7161,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7481,9 +7286,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7621,9 +7423,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7741,9 +7540,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7861,9 +7657,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7981,9 +7774,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8109,9 +7899,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8249,9 +8036,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8369,9 +8153,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8489,9 +8270,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8609,9 +8387,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8737,9 +8512,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8877,9 +8649,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8985,9 +8754,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9085,9 +8851,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9193,9 +8956,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9281,9 +9041,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9421,9 +9178,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9543,9 +9297,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9651,9 +9402,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9759,9 +9507,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9867,9 +9612,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9991,9 +9733,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10133,9 +9872,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10273,9 +10009,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10415,9 +10148,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10557,9 +10287,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10699,9 +10426,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10823,9 +10547,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10947,9 +10668,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11071,9 +10789,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11191,9 +10906,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11299,9 +11011,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11451,9 +11160,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11603,9 +11309,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11755,9 +11458,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11883,9 +11583,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11971,9 +11668,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12123,9 +11817,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12275,9 +11966,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12427,9 +12115,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12555,9 +12240,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12643,9 +12325,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12795,9 +12474,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12947,9 +12623,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13099,9 +12772,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13227,9 +12897,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13315,9 +12982,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13423,9 +13087,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13511,9 +13172,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13599,9 +13257,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13687,9 +13342,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13775,9 +13427,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13863,9 +13512,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13971,9 +13617,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14111,9 +13754,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14251,9 +13891,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14391,9 +14028,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14527,9 +14161,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14663,9 +14294,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14799,9 +14427,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14935,9 +14560,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15079,9 +14701,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15215,9 +14834,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15351,9 +14967,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15487,9 +15100,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15631,9 +15241,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15767,9 +15374,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15903,9 +15507,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16039,9 +15640,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16183,9 +15781,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16307,9 +15902,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16411,9 +16003,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16515,9 +16104,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16619,9 +16205,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16723,9 +16306,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16863,9 +16443,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17003,9 +16580,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17143,9 +16717,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17279,9 +16850,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17395,9 +16963,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17511,9 +17076,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17627,9 +17189,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17771,9 +17330,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17887,9 +17443,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18003,9 +17556,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18119,9 +17669,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18263,9 +17810,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18379,9 +17923,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18495,9 +18036,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18611,9 +18149,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18755,9 +18290,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18879,9 +18411,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19019,9 +18548,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19159,9 +18685,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19299,9 +18822,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19435,9 +18955,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19551,9 +19068,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19667,9 +19181,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19783,9 +19294,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19927,9 +19435,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20043,9 +19548,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20159,9 +19661,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20275,9 +19774,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20419,9 +19915,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20535,9 +20028,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20651,9 +20141,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20767,9 +20254,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20911,9 +20395,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21035,9 +20516,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21159,9 +20637,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21283,9 +20758,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21407,9 +20879,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21527,9 +20996,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21671,9 +21137,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21815,9 +21278,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21959,9 +21419,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22087,9 +21544,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22231,9 +21685,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22375,9 +21826,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22519,9 +21967,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22647,9 +22092,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22791,9 +22233,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22935,9 +22374,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23079,9 +22515,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23207,9 +22640,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23315,9 +22745,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23429,9 +22856,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23539,9 +22963,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23663,9 +23084,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23783,9 +23201,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23903,9 +23318,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24023,9 +23435,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24143,9 +23552,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24263,9 +23669,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24383,9 +23786,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24503,9 +23903,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24623,9 +24020,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24743,9 +24137,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24885,9 +24276,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25027,9 +24415,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25169,9 +24554,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25289,9 +24671,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25409,9 +24788,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25529,9 +24905,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25649,9 +25022,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25769,9 +25139,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25889,9 +25256,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26009,9 +25373,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26129,9 +25490,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26249,9 +25607,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26391,9 +25746,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26533,9 +25885,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26675,9 +26024,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26809,9 +26155,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26933,9 +26276,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27057,9 +26397,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27181,9 +26518,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27351,9 +26685,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27511,9 +26842,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27671,9 +26999,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27831,9 +27156,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27953,9 +27275,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28115,9 +27434,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28259,9 +27575,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28369,9 +27682,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28505,9 +27815,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28641,9 +27948,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28777,9 +28081,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28921,9 +28222,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29033,9 +28331,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29189,9 +28484,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29345,9 +28637,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29501,9 +28790,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29689,9 +28975,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29825,9 +29108,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29981,9 +29261,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30137,9 +29414,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30293,9 +29567,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30481,9 +29752,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30617,9 +29885,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30773,9 +30038,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30929,9 +30191,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31085,9 +30344,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31273,9 +30529,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31409,9 +30662,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31597,9 +30847,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31785,9 +31032,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31973,9 +31217,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32161,9 +31402,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32305,9 +31543,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32445,9 +31680,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32557,9 +31789,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32691,9 +31920,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32809,9 +32035,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32953,9 +32176,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33063,9 +32283,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33199,9 +32416,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33335,9 +32549,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33471,9 +32682,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33615,9 +32823,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33727,9 +32932,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33883,9 +33085,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34039,9 +33238,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34195,9 +33391,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34383,9 +33576,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34519,9 +33709,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34675,9 +33862,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34831,9 +34015,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34987,9 +34168,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35175,9 +34353,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35311,9 +34486,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35467,9 +34639,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35623,9 +34792,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35779,9 +34945,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35967,9 +35130,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36103,9 +35263,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36291,9 +35448,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36479,9 +35633,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36667,9 +35818,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36855,9 +36003,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36999,9 +36144,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37139,9 +36281,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37251,9 +36390,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37385,9 +36521,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37503,9 +36636,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37647,9 +36777,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37757,9 +36884,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37893,9 +37017,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38029,9 +37150,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38165,9 +37283,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38309,9 +37424,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38421,9 +37533,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38577,9 +37686,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38733,9 +37839,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38889,9 +37992,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39077,9 +38177,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39213,9 +38310,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39369,9 +38463,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39525,9 +38616,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39681,9 +38769,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39869,9 +38954,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40005,9 +39087,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40161,9 +39240,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40317,9 +39393,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40473,9 +39546,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40661,9 +39731,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40797,9 +39864,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40985,9 +40049,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41173,9 +40234,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41361,9 +40419,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41549,9 +40604,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41693,9 +40745,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41833,9 +40882,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41945,9 +40991,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42079,9 +41122,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42197,9 +41237,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42341,9 +41378,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42451,9 +41485,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42587,9 +41618,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42723,9 +41751,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42859,9 +41884,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43003,9 +42025,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43115,9 +42134,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43271,9 +42287,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43427,9 +42440,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43583,9 +42593,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43771,9 +42778,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43907,9 +42911,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44063,9 +43064,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44219,9 +43217,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44375,9 +43370,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44563,9 +43555,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44699,9 +43688,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44855,9 +43841,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45011,9 +43994,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45167,9 +44147,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45355,9 +44332,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45491,9 +44465,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45679,9 +44650,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45867,9 +44835,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46055,9 +45020,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46243,9 +45205,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46387,9 +45346,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46527,9 +45483,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46639,9 +45592,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46773,9 +45723,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46891,9 +45838,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47035,9 +45979,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47145,9 +46086,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47281,9 +46219,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47417,9 +46352,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47553,9 +46485,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47697,9 +46626,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47809,9 +46735,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47965,9 +46888,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48121,9 +47041,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48277,9 +47194,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48465,9 +47379,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48601,9 +47512,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48757,9 +47665,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48913,9 +47818,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49069,9 +47971,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49257,9 +48156,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49393,9 +48289,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49549,9 +48442,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49705,9 +48595,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49861,9 +48748,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50049,9 +48933,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50185,9 +49066,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50373,9 +49251,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50561,9 +49436,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50749,9 +49621,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50937,9 +49806,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51081,9 +49947,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51221,9 +50084,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51333,9 +50193,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51467,9 +50324,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51585,9 +50439,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51729,9 +50580,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51839,9 +50687,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51975,9 +50820,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52111,9 +50953,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52247,9 +51086,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52391,9 +51227,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52503,9 +51336,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52659,9 +51489,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52815,9 +51642,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52971,9 +51795,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53159,9 +51980,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53295,9 +52113,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53451,9 +52266,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53607,9 +52419,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53763,9 +52572,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53951,9 +52757,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54087,9 +52890,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54243,9 +53043,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54399,9 +53196,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54555,9 +53349,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54743,9 +53534,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54879,9 +53667,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55067,9 +53852,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55255,9 +54037,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55443,9 +54222,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55631,9 +54407,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55775,9 +54548,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55915,9 +54685,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56027,9 +54794,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56161,9 +54925,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56279,9 +55040,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }

--- a/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
@@ -96,9 +96,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -182,9 +179,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -268,9 +262,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -354,9 +345,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -440,9 +428,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -526,9 +511,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -612,9 +594,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -698,9 +677,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -164,9 +164,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -268,9 +265,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -372,9 +366,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -476,9 +467,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -580,9 +568,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -684,9 +669,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -788,9 +770,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -892,9 +871,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -996,9 +972,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1126,9 +1099,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1230,9 +1200,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1334,9 +1301,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1438,9 +1402,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1542,9 +1503,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1646,9 +1604,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1750,9 +1705,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1854,9 +1806,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -1958,9 +1907,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2062,9 +2008,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2192,9 +2135,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2296,9 +2236,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2400,9 +2337,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2504,9 +2438,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2608,9 +2539,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2712,9 +2640,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2816,9 +2741,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -2920,9 +2842,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3024,9 +2943,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3128,9 +3044,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3258,9 +3171,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3390,9 +3300,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3522,9 +3429,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3654,9 +3558,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3782,9 +3683,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -3910,9 +3808,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4038,9 +3933,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4166,9 +4058,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4302,9 +4191,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4450,9 +4336,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4578,9 +4461,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4706,9 +4586,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4834,9 +4711,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -4970,9 +4844,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5118,9 +4989,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5246,9 +5114,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5374,9 +5239,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5502,9 +5364,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5638,9 +5497,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5786,9 +5642,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -5902,9 +5755,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6018,9 +5868,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6134,9 +5981,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6230,9 +6074,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6378,9 +6219,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6526,9 +6364,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6674,9 +6509,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6822,9 +6654,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -6970,9 +6799,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7102,9 +6928,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7234,9 +7057,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7366,9 +7186,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7494,9 +7311,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7622,9 +7436,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7750,9 +7561,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -7878,9 +7686,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8014,9 +7819,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8162,9 +7964,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8290,9 +8089,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8418,9 +8214,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8546,9 +8339,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8682,9 +8472,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8830,9 +8617,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -8958,9 +8742,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9086,9 +8867,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9214,9 +8992,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9350,9 +9125,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9498,9 +9270,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9614,9 +9383,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9722,9 +9488,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9838,9 +9601,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -9934,9 +9694,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10082,9 +9839,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10210,9 +9964,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10324,9 +10075,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10438,9 +10186,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10552,9 +10297,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10682,9 +10424,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10830,9 +10569,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -10976,9 +10712,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11124,9 +10857,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11272,9 +11002,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11420,9 +11147,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11552,9 +11276,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11684,9 +11405,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11816,9 +11534,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -11944,9 +11659,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12060,9 +11772,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12220,9 +11929,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12380,9 +12086,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12540,9 +12243,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12676,9 +12376,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12772,9 +12469,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -12932,9 +12626,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13092,9 +12783,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13252,9 +12940,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13388,9 +13073,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13484,9 +13166,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13644,9 +13323,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13804,9 +13480,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -13964,9 +13637,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14100,9 +13770,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14196,9 +13863,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14312,9 +13976,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14408,9 +14069,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14504,9 +14162,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14600,9 +14255,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14696,9 +14348,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14792,9 +14441,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -14908,9 +14554,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15056,9 +14699,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15204,9 +14844,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15352,9 +14989,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15496,9 +15130,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15640,9 +15271,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15784,9 +15412,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -15928,9 +15553,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16080,9 +15702,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16224,9 +15843,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16368,9 +15984,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16512,9 +16125,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16664,9 +16274,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16808,9 +16415,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -16952,9 +16556,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17096,9 +16697,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17248,9 +16846,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17380,9 +16975,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17492,9 +17084,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17604,9 +17193,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17716,9 +17302,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17828,9 +17411,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -17976,9 +17556,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18124,9 +17701,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18272,9 +17846,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18416,9 +17987,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18540,9 +18108,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18664,9 +18229,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18788,9 +18350,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -18940,9 +18499,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19064,9 +18620,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19188,9 +18741,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19312,9 +18862,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19464,9 +19011,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19588,9 +19132,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19712,9 +19253,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19836,9 +19374,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -19988,9 +19523,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20120,9 +19652,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20268,9 +19797,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20416,9 +19942,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20564,9 +20087,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20708,9 +20228,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20832,9 +20349,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -20956,9 +20470,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21080,9 +20591,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21232,9 +20740,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21356,9 +20861,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21480,9 +20982,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21604,9 +21103,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21756,9 +21252,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -21880,9 +21373,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22004,9 +21494,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22128,9 +21615,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22280,9 +21764,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22412,9 +21893,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22544,9 +22022,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22676,9 +22151,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22808,9 +22280,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -22936,9 +22405,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23088,9 +22554,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23240,9 +22703,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23392,9 +22852,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23528,9 +22985,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23680,9 +23134,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23832,9 +23283,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -23984,9 +23432,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24120,9 +23565,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24272,9 +23714,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24424,9 +23863,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24576,9 +24012,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24712,9 +24145,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24828,9 +24258,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -24948,9 +24375,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25064,9 +24488,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25194,9 +24615,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25322,9 +24740,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25450,9 +24865,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25578,9 +24990,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25706,9 +25115,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25834,9 +25240,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -25962,9 +25365,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26090,9 +25490,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26218,9 +25615,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26346,9 +25740,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26494,9 +25885,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26642,9 +26030,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26790,9 +26175,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -26918,9 +26300,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27046,9 +26425,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27174,9 +26550,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27302,9 +26675,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27430,9 +26800,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27558,9 +26925,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27686,9 +27050,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27814,9 +27175,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -27942,9 +27300,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28090,9 +27445,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28238,9 +27590,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28386,9 +27735,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28526,9 +27872,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28656,9 +27999,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28786,9 +28126,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -28916,9 +28253,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29092,9 +28426,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29258,9 +28589,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29424,9 +28752,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29590,9 +28915,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29718,9 +29040,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -29886,9 +29205,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30038,9 +29354,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30154,9 +29467,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30298,9 +29608,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30442,9 +29749,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30586,9 +29890,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30738,9 +30039,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -30858,9 +30156,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31022,9 +30317,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31186,9 +30478,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31350,9 +30639,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31546,9 +30832,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31690,9 +30973,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -31854,9 +31134,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32018,9 +31295,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32182,9 +31456,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32378,9 +31649,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32522,9 +31790,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32686,9 +31951,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -32850,9 +32112,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33014,9 +32273,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33210,9 +32466,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33354,9 +32607,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33550,9 +32800,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33746,9 +32993,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -33942,9 +33186,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34138,9 +33379,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34290,9 +33528,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34438,9 +33673,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34558,9 +33790,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34698,9 +33927,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34822,9 +34048,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -34974,9 +34197,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35090,9 +34310,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35234,9 +34451,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35378,9 +34592,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35522,9 +34733,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35674,9 +34882,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35794,9 +34999,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -35958,9 +35160,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36122,9 +35321,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36286,9 +35482,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36482,9 +35675,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36626,9 +35816,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36790,9 +35977,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -36954,9 +36138,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37118,9 +36299,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37314,9 +36492,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37458,9 +36633,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37622,9 +36794,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37786,9 +36955,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -37950,9 +37116,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38146,9 +37309,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38290,9 +37450,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38486,9 +37643,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38682,9 +37836,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -38878,9 +38029,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39074,9 +38222,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39226,9 +38371,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39374,9 +38516,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39494,9 +38633,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39634,9 +38770,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39758,9 +38891,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -39910,9 +39040,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40026,9 +39153,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40170,9 +39294,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40314,9 +39435,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40458,9 +39576,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40610,9 +39725,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40730,9 +39842,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -40894,9 +40003,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41058,9 +40164,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41222,9 +40325,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41418,9 +40518,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41562,9 +40659,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41726,9 +40820,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -41890,9 +40981,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42054,9 +41142,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42250,9 +41335,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42394,9 +41476,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42558,9 +41637,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42722,9 +41798,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -42886,9 +41959,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43082,9 +42152,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43226,9 +42293,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43422,9 +42486,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43618,9 +42679,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -43814,9 +42872,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44010,9 +43065,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44162,9 +43214,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44310,9 +43359,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44430,9 +43476,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44570,9 +43613,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44694,9 +43734,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44846,9 +43883,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -44962,9 +43996,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45106,9 +44137,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45250,9 +44278,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45394,9 +44419,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45546,9 +44568,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45666,9 +44685,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45830,9 +44846,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -45994,9 +45007,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46158,9 +45168,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46354,9 +45361,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46498,9 +45502,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46662,9 +45663,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46826,9 +45824,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -46990,9 +45985,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47186,9 +46178,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47330,9 +46319,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47494,9 +46480,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47658,9 +46641,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -47822,9 +46802,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48018,9 +46995,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48162,9 +47136,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48358,9 +47329,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48554,9 +47522,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48750,9 +47715,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -48946,9 +47908,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49098,9 +48057,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49246,9 +48202,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49366,9 +48319,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49506,9 +48456,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49630,9 +48577,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49782,9 +48726,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -49898,9 +48839,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50042,9 +48980,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50186,9 +49121,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50330,9 +49262,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50482,9 +49411,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50602,9 +49528,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50766,9 +49689,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -50930,9 +49850,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51094,9 +50011,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51290,9 +50204,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51434,9 +50345,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51598,9 +50506,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51762,9 +50667,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -51926,9 +50828,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52122,9 +51021,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52266,9 +51162,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52430,9 +51323,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52594,9 +51484,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52758,9 +51645,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -52954,9 +51838,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53098,9 +51979,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53294,9 +52172,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53490,9 +52365,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53686,9 +52558,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -53882,9 +52751,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54034,9 +52900,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54182,9 +53045,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54302,9 +53162,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54442,9 +53299,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54566,9 +53420,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54718,9 +53569,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54834,9 +53682,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -54978,9 +53823,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55122,9 +53964,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55266,9 +54105,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55418,9 +54254,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55538,9 +54371,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55702,9 +54532,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -55866,9 +54693,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56030,9 +54854,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56226,9 +55047,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56370,9 +55188,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56534,9 +55349,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56698,9 +55510,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -56862,9 +55671,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -57058,9 +55864,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -57202,9 +56005,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -57366,9 +56166,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -57530,9 +56327,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -57694,9 +56488,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -57890,9 +56681,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -58034,9 +56822,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -58230,9 +57015,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -58426,9 +57208,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -58622,9 +57401,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -58818,9 +57594,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -58970,9 +57743,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -59118,9 +57888,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -59238,9 +58005,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -59378,9 +58142,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }
@@ -59502,9 +58263,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 			// If $hasNulls is false, then there are no input Nulls. _outNulls is
 			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -142,9 +142,6 @@ func (p _OP_NAME) Next() coldata.Batch {
 		} else {
 			_SET_PROJECTION(false)
 		}
-		// Although we didn't change the length of the batch, it is necessary to set
-		// the length anyway (this helps maintaining the invariant of flat bytes).
-		batch.SetLength(n)
 	})
 	return batch
 }

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -305,9 +305,6 @@ func UpdateBatchState(batch coldata.Batch, length int, usesSel bool, sel []int) 
 	if usesSel {
 		copy(batch.Selection()[:length], sel[:length])
 	}
-	// Note: when usesSel is true, we have to set the length on the batch
-	// **after** setting the selection vector because we might use the values
-	// in the selection vector to maintain invariants (like for flat bytes).
 	batch.SetLength(length)
 }
 

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -15,7 +15,6 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -51,7 +50,6 @@ func newBufferedWindowOperator(
 			outputTypes:  outputTypes,
 			diskAcc:      args.DiskAcc,
 			outputColIdx: args.OutputColIdx,
-			outputColFam: typeconv.TypeFamilyToCanonicalTypeFamily(outputColType.Family()),
 		},
 		windower: windower,
 	}
@@ -153,7 +151,6 @@ type windowInitFields struct {
 	outputTypes  []*types.T
 	diskAcc      *mon.BoundAccount
 	outputColIdx int
-	outputColFam types.Family
 }
 
 // bufferedWindowOp extracts common fields for the various window operators
@@ -239,18 +236,8 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 			// Load the next batch into currentBatch. If currentBatch still has data,
 			// move it into the queue.
 			if b.currentBatch != nil && b.currentBatch.Length() > 0 {
-				// We might have already set some values on the output vector
-				// within the current batch. If that vector is bytes-like, we
-				// have to explicitly maintain the invariant of the vector by
-				// updating the offsets.
 				// TODO(yuzefovich): it is quite unfortunate that the output
 				// vector is being spilled to disk. Consider refactoring this.
-				switch b.outputColFam {
-				case types.BytesFamily:
-					b.currentBatch.ColVec(b.outputColIdx).Bytes().UpdateOffsetsToBeNonDecreasing(b.currentBatch.Length())
-				case types.JsonFamily:
-					b.currentBatch.ColVec(b.outputColIdx).JSON().UpdateOffsetsToBeNonDecreasing(b.currentBatch.Length())
-				}
 				b.bufferQueue.Enqueue(b.Ctx, b.currentBatch)
 			}
 			// We have to copy the input batch data because calling Next on the input
@@ -310,14 +297,6 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 				var output coldata.Batch
 				if output, err = b.bufferQueue.Dequeue(b.Ctx); err != nil {
 					colexecerror.InternalError(err)
-				}
-				// The spilling queue sets 'maxSetLength' to the length of the batch for
-				// bytes-like types, so we have to reset it so that `Set` can be used.
-				switch b.outputColFam {
-				case types.BytesFamily:
-					output.ColVec(b.outputColIdx).Bytes().Truncate(b.processingIdx)
-				case types.JsonFamily:
-					output.ColVec(b.outputColIdx).JSON().Truncate(b.processingIdx)
 				}
 				// Set all the window output values that remain unset, then emit this
 				// batch. Note that because the beginning of the next partition will

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -310,18 +310,12 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 					// first of the tuples yet to be processed was somewhere in the batch.
 					b.processingIdx = 0
 				}
-				// Although we didn't change the length of the batch, it is necessary to
-				// set the length anyway (to maintain the invariant of flat bytes).
-				output.SetLength(output.Length())
 				return output
 			}
 			if b.currentBatch.Length() > 0 {
 				b.windower.processBatch(b.currentBatch, b.processingIdx, b.nextPartitionIdx)
 				if b.nextPartitionIdx >= b.currentBatch.Length() {
-					// This was the last batch and it has been entirely filled. Although
-					// we didn't change the length of the batch, it is necessary to set
-					// the length anyway (to maintain the invariant of flat bytes).
-					b.currentBatch.SetLength(b.currentBatch.Length())
+					// This was the last batch and it has been entirely filled.
 					b.state = windowFinished
 					return b.currentBatch
 				}

--- a/pkg/sql/colexec/invariants_checker.go
+++ b/pkg/sql/colexec/invariants_checker.go
@@ -96,12 +96,6 @@ func (i *invariantsChecker) Next() coldata.Batch {
 	if n == 0 {
 		return b
 	}
-	for colIdx := 0; colIdx < b.Width(); colIdx++ {
-		v := b.ColVec(colIdx)
-		if v.IsBytesLike() {
-			coldata.AssertOffsetsAreNonDecreasing(v, n)
-		}
-	}
 	if sel := b.Selection(); sel != nil {
 		for i := 1; i < n; i++ {
 			if sel[i] <= sel[i-1] {

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -160,9 +160,6 @@ func (s *substringInt64Int16Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -242,9 +239,6 @@ func (s *substringInt64Int32Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -324,9 +318,6 @@ func (s *substringInt64Int64Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -406,9 +397,6 @@ func (s *substringInt16Int16Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -488,9 +476,6 @@ func (s *substringInt16Int32Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -570,9 +555,6 @@ func (s *substringInt16Int64Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -652,9 +634,6 @@ func (s *substringInt32Int16Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -734,9 +713,6 @@ func (s *substringInt32Int32Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 
@@ -816,8 +792,5 @@ func (s *substringInt32Int64Operator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -163,9 +163,6 @@ func (s *substring_StartType_LengthTypeOperator) Next() coldata.Batch {
 			}
 		},
 	)
-	// Although we didn't change the length of the batch, it is necessary to set
-	// the length anyway (this helps maintaining the invariant of flat bytes).
-	batch.SetLength(n)
 	return batch
 }
 

--- a/pkg/sql/colexec/vec_comparators.eg.go
+++ b/pkg/sql/colexec/vec_comparators.eg.go
@@ -125,13 +125,8 @@ func (c *BytesVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		// Since flat Bytes cannot be set at arbitrary indices (data needs to be
-		// moved around), we use CopySlice to accept the performance hit.
-		// Specifically, this is a performance hit because we are overwriting the
-		// variable number of bytes in `dstVecIdx`, so we will have to either shift
-		// the bytes after that element left or right, depending on how long the
-		// source bytes slice is. Refer to the CopySlice comment for an example.
-		c.vecs[dstVecIdx].CopySlice(c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
+		v := c.vecs[srcVecIdx].Get(srcIdx)
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 
@@ -491,13 +486,8 @@ func (c *JSONVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		// Since flat Bytes cannot be set at arbitrary indices (data needs to be
-		// moved around), we use CopySlice to accept the performance hit.
-		// Specifically, this is a performance hit because we are overwriting the
-		// variable number of bytes in `dstVecIdx`, so we will have to either shift
-		// the bytes after that element left or right, depending on how long the
-		// source bytes slice is. Refer to the CopySlice comment for an example.
-		c.vecs[dstVecIdx].CopySlice(c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
+		v := c.vecs[srcVecIdx].Get(srcIdx)
+		c.vecs[dstVecIdx].Set(dstIdx, v)
 	}
 }
 

--- a/pkg/sql/colexec/vec_comparators_tmpl.go
+++ b/pkg/sql/colexec/vec_comparators_tmpl.go
@@ -112,18 +112,8 @@ func (c *_TYPEVecComparator) set(srcVecIdx, dstVecIdx int, srcIdx, dstIdx int) {
 		c.nulls[dstVecIdx].SetNull(dstIdx)
 	} else {
 		c.nulls[dstVecIdx].UnsetNull(dstIdx)
-		// {{if .IsBytesLike}}
-		// Since flat Bytes cannot be set at arbitrary indices (data needs to be
-		// moved around), we use CopySlice to accept the performance hit.
-		// Specifically, this is a performance hit because we are overwriting the
-		// variable number of bytes in `dstVecIdx`, so we will have to either shift
-		// the bytes after that element left or right, depending on how long the
-		// source bytes slice is. Refer to the CopySlice comment for an example.
-		c.vecs[dstVecIdx].CopySlice(c.vecs[srcVecIdx], dstIdx, srcIdx, srcIdx+1)
-		// {{else}}
 		v := c.vecs[srcVecIdx].Get(srcIdx)
 		c.vecs[dstVecIdx].Set(dstIdx, v)
-		// {{end}}
 	}
 }
 

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/mon",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -306,7 +306,7 @@ func TestSetAccountingHelper(t *testing.T) {
 				switch typ.Family() {
 				case types.BytesFamily:
 					// For Bytes, insert pretty large values.
-					v := make([]byte, rng.Intn(8*coldata.BytesInitialAllocationFactor))
+					v := make([]byte, rng.Intn(8*coldata.BytesMaxInlineLength))
 					_, _ = rng.Read(v)
 					batch.ColVec(vecIdx).Bytes().Set(rowIdx, v)
 				default:


### PR DESCRIPTION
**coldata: change Bytes vector implementation**

This commit changes the way `Bytes` vector is implemented in order to
support `Set` operation at arbitrary positions. Now, a `Bytes` vector is
a slice of `element`s.

`element` describes a single `[]byte` value. If a value doesn't exceed
30 bytes, then the whole value is stored within the `element`; otherwise,
the `element` "points" at a region in a common `Bytes.buffer` where the
non-inlined value is stored.

If the value is inlined, then the layout of `element` is used as follows:
```
           24-byte header | 6-byte padding
  element: .............................. | length | true
  Bytes.buffer: N/A
```
where 30 dots describe the inlinable space followed by a single byte for the
length followed by a boolean `true` indicating an inlined value.

If the value is non-inlined, then the layout of `element` is used as follows:
```
                                            padding
  element: .offset. | ..len... | ..cap... | xxxxxx | x | false
  Bytes.buffer: xxxxxxxx | offset .... | xxxxxxxx
```
where first 24 bytes contain our custom "header" of a byte slice that is
backed by `Bytes.buffer`. The following 7 bytes (the padding and the
`inlinedLength` byte) are not used, and then we have a boolean `false`
indicating a non-inlined value.

We have a custom "slice header" for the non-inlined values and don't
just use `[]byte` for two reasons:
1. we can easily overwrite the whole struct when a value is inlined without
causing any issues with the GC (because our slice header doesn't contain an
actual slice, GC doesn't have to track whether the backing array is live or
not);
2. our slice header remains valid even when `Bytes.buffer` is reallocated.
If we were to use `[]byte`, then whenever that reallocation occurred, we
would have to iterate over all non-inlined values and update the byte
slices to point to the new `Bytes.buffer`.

This new implementation was inspired by Velox library from Facebook
(https://facebookincubator.github.io/velox/develop/vectors.html#flat-vectors-scalar-types).

Our original implementation was based on the Arrow format, so we were
getting extremely cheap serialization/deserialization. With this change
some of the benchmarks have regressed significantly:
```
Append/bytes/AppendSimple/NullProbability=0.0-24    356MB/s ± 5%   221MB/s ± 1%    -37.81%  (p=0.000 n=9+8)
Append/bytes/AppendWithSel/NullProbability=0.0-24   241MB/s ± 2%   105MB/s ± 4%    -56.49%  (p=0.000 n=9+10)
Append/bytes/AppendSimple/NullProbability=0.2-24    354MB/s ± 6%   219MB/s ± 4%    -38.11%  (p=0.000 n=8+9)
Append/bytes/AppendWithSel/NullProbability=0.2-24   229MB/s ± 3%    98MB/s ± 4%    -57.20%  (p=0.000 n=9+10)
Copy/bytes/CopySimple/NullProbability=0.0-24       39.7GB/s ± 1%   0.5GB/s ± 0%    -98.67%  (p=0.000 n=10+10)
Copy/bytes/CopyWithSel/NullProbability=0.0-24       753MB/s ± 1%   544MB/s ± 0%    -27.83%  (p=0.000 n=10+8)
Copy/bytes/CopySimple/NullProbability=0.2-24       28.9GB/s ± 1%   0.5GB/s ± 0%    -98.19%  (p=0.000 n=8+10)
Copy/bytes/CopyWithSel/NullProbability=0.2-24       634MB/s ± 0%   575MB/s ± 0%     -9.37%  (p=0.000 n=9+9)
```
```
ArrowBatchConverter/bytes/nullFraction=0.00/BatchToArrow-24   248GB/s ± 2%      3GB/s ± 3%     -98.90%  (p=0.000 n=10+10)
ArrowBatchConverter/bytes/nullFraction=0.25/BatchToArrow-24   240GB/s ± 2%      3GB/s ± 2%     -98.87%  (p=0.000 n=10+10)
ArrowBatchConverter/bytes/nullFraction=0.50/BatchToArrow-24   242GB/s ± 1%      3GB/s ± 2%     -98.86%  (p=0.000 n=10+10)
ArrowBatchConverter/bytes/nullFraction=0.00/ArrowToBatch-24   830GB/s ± 2%      3GB/s ± 2%     -99.59%  (p=0.000 n=10+10)
ArrowBatchConverter/bytes/nullFraction=0.25/ArrowToBatch-24   893GB/s ± 1%      3GB/s ± 1%     -99.62%  (p=0.000 n=10+8)
ArrowBatchConverter/bytes/nullFraction=0.50/ArrowToBatch-24   910GB/s ± 1%      3GB/s ± 1%     -99.62%  (p=0.000 n=10+9)
```
I'm not particularly worried about the regression in the serialization
(since the absolute speeds are still very high for this to not be
a bottle neck), but the slowdown in `Append/Copy` benchmark is
worrisome. I do have some ideas of how to improve those operations to
reduce the regressions to acceptable levels, and I'll add those
optimizations in a follow-up commit.

As a proxy for change of performance of `Bytes` vector overall, I ran
`BenchmarkSortUUID` with results [here](https://gist.github.com/yuzefovich/baaf6b4096cb3e2f1504ad2b38431cc6)
and the unordered distinct benchmarks with results [here](https://gist.github.com/yuzefovich/d8b9166977ec56780cb1749e848f5935).
They show that the number of allocations has decreased in all cases
although the total allocated space increased in some cases with small
number of rows. As a result, there are some regressions in performance
on a small number of rows. Overall, results seem satisfactory.

Notably, as a result of this change the performance of top K sort has
improved drastically when bytes-like types are present in the input
columns (because `CopySlice` used in top K sorter no longer has to move
the data around).

It's worth calling out that we still use the same Arrow format for
serialization, so there is no need to bump the DistSQL version because
the change of this commit is purely to the in-memory representation.

An additional nice result of this change is that we no longer have to
maintain the non-decreasing offsets, which will allow us to remove calls
to `SetLength` in many places where the length of the batch is not
changed. This will be done in the follow-up commit.

Fixes: #75536.

Release note: None

Release justification: low risk, high benefit changes to existing
functionality.

**coldata: optimize Append and Copy for Bytes vectors**

This commit optimizes `Append/Copy` operations for `Bytes` vectors. The
main idea is that a new primitive `copy` is introduced which allows for
copying one `element` from one vector into another `element` of another
vector which removes the allocations when copying inlined values.

An additional improvement is preallocating enough `element`s to
copy/append into many values.
```
name                                               old speed      new speed       delta
Append/bytes/AppendSimple/NullProbability=0.0-24    226MB/s ± 7%    221MB/s ± 8%      ~     (p=0.143 n=10+10)
Append/bytes/AppendWithSel/NullProbability=0.0-24   104MB/s ± 5%    189MB/s ± 1%   +81.57%  (p=0.000 n=10+8)
Append/bytes/AppendSimple/NullProbability=0.2-24    220MB/s ± 2%    229MB/s ± 7%    +4.23%  (p=0.004 n=8+10)
Append/bytes/AppendWithSel/NullProbability=0.2-24  98.4MB/s ± 5%  197.7MB/s ± 4%  +100.98%  (p=0.000 n=10+10)
Copy/bytes/CopySimple/NullProbability=0.0-24        521MB/s ± 0%   2981MB/s ± 1%  +471.63%  (p=0.000 n=10+10)
Copy/bytes/CopyWithSel/NullProbability=0.0-24       539MB/s ± 0%   1020MB/s ± 0%   +89.32%  (p=0.000 n=10+10)
Copy/bytes/CopySimple/NullProbability=0.2-24        518MB/s ± 0%   2913MB/s ± 0%  +462.62%  (p=0.000 n=10+8)
Copy/bytes/CopyWithSel/NullProbability=0.2-24       560MB/s ± 0%    875MB/s ± 0%   +56.12%  (p=0.000 n=10+8)

name                                               old alloc/op   new alloc/op    delta
Append/bytes/AppendSimple/NullProbability=0.0-24     76.1kB ± 8%    118.9kB ± 7%   +56.23%  (p=0.000 n=10+10)
Append/bytes/AppendWithSel/NullProbability=0.0-24     192kB ± 2%      131kB ± 1%   -32.15%  (p=0.000 n=10+8)
Append/bytes/AppendSimple/NullProbability=0.2-24     78.0kB ± 0%    117.2kB ± 3%   +50.27%  (p=0.000 n=8+9)
Append/bytes/AppendWithSel/NullProbability=0.2-24     198kB ± 1%      105kB ± 3%   -47.21%  (p=0.000 n=10+9)
Copy/bytes/CopySimple/NullProbability=0.0-24          0.00B           0.00B           ~     (all equal)
Copy/bytes/CopyWithSel/NullProbability=0.0-24         0.00B           0.00B           ~     (all equal)
Copy/bytes/CopySimple/NullProbability=0.2-24          0.00B           0.00B           ~     (all equal)
Copy/bytes/CopyWithSel/NullProbability=0.2-24         0.00B           0.00B           ~     (all equal)
```
I'm not sure what's up with some of the increase in allocations since
I don't see them locally on mac.

Release note: None

Release justification: low risk, high benefit changes to existing
functionality.

**colexec: cleanup top K with bytes-like types**

Since the previous commit made it so that `Bytes` vectors support Sets
at arbitrary positions, we no longer have to use `CopySlice` in the top
K sort implementation.

Release note: None

Release justification: low risk, high benefit changes to existing
functionality.

**coldata: prohibit Append from the vector into itself**

Previously, `Append`ing from the vector into itself was allowed when
`srcStartIdx == srcEndIdx` in order to be able to truncate the vector.
One of the previous commits removed the only place where this was
actually used (when implementing `Append` for Bytes-like types when
selection vector is present), so this commit removes this no-longer-used
feature.

Release note: None

Release justification: low risk cleanup.

**colexec: remove no longer needed calls to SetLength**

Previously, we required that operators that might populate a `Bytes`
vector set the length on the output batch (which was needed in order to
maintain the invariant of non-decreasing offsets in the old
implementation of the `Bytes` vector) even if the length of the batch
didn't change. This is no longer needed given the updated
implementation, so this commit removes those redundant calls to
`SetLength`.

Release note: None

Release justification: low risk cleanup.