### PR TITLE
kv: enforce minimum Raft snapshot rate limit

### DIFF
--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -57,7 +57,7 @@ func TestSettingWatcherOnTenant(t *testing.T) {
 		"cluster.organization":                                   {"foobar", "bazbax"},
 		// Include a system-only setting to verify that we don't try to change its
 		// value (which would cause a panic in test builds).
-		systemOnlySetting: {1024, 2048},
+		systemOnlySetting: {2 << 20, 4 << 20},
 	}
 	fakeTenant := roachpb.MakeTenantID(2)
 	systemTable := keys.SystemSQLCodec.TablePrefix(keys.SettingsTableID)


### PR DESCRIPTION
Related to #75728.

This commit enforces a minimum Raft snapshot rate limit of 1mb/s. We've seen
recent problems (#75728) related to mis-configured cluster settings, so it's
best to protect ourselves from this kind of misconfiguration.

```
root@127.0.0.1:26257/movr> set cluster setting kv.snapshot_rebalance.max_rate = '8';
ERROR: invalid value for kv.snapshot_rebalance.max_rate: snapshot rate cannot be set to a value below 1.0 MiB: 8 B

root@127.0.0.1:26257/movr> set cluster setting kv.snapshot_rebalance.max_rate = '8Kib';
ERROR: invalid value for kv.snapshot_rebalance.max_rate: snapshot rate cannot be set to a value below 1.0 MiB: 8.0 KiB

root@127.0.0.1:26257/movr> set cluster setting kv.snapshot_rebalance.max_rate = '8Mib';
SET CLUSTER SETTING
```