### PR TITLE
spanconfig: replace roachpb.SpanConfigEntry in package spanconfig 

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -456,11 +456,15 @@ func (c *Connector) TokenBucket(
 	return nil, ctx.Err()
 }
 
-// GetSpanConfigEntriesFor implements the spanconfig.KVAccessor interface.
-func (c *Connector) GetSpanConfigEntriesFor(
-	ctx context.Context, spans []roachpb.Span,
-) (entries []roachpb.SpanConfigEntry, _ error) {
+// GetSpanConfigRecords implements the spanconfig.KVAccessor interface.
+func (c *Connector) GetSpanConfigRecords(
+	ctx context.Context, targets []spanconfig.Target,
+) (records []spanconfig.Record, _ error) {
 	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
+		spans := make([]roachpb.Span, 0, len(targets))
+		for _, target := range targets {
+			spans = append(spans, *target.GetSpan())
+		}
 		resp, err := c.GetSpanConfigs(ctx, &roachpb.GetSpanConfigsRequest{
 			Spans: spans,
 		})
@@ -468,23 +472,31 @@ func (c *Connector) GetSpanConfigEntriesFor(
 			return err
 		}
 
-		entries = resp.SpanConfigEntries
+		records = spanconfig.EntriesToRecords(resp.SpanConfigEntries)
 		return nil
 	}); err != nil {
 		return nil, err
 	}
-	return entries, nil
+	return records, nil
 }
 
-// UpdateSpanConfigEntries implements the spanconfig.KVAccessor
+// UpdateSpanConfigRecords implements the spanconfig.KVAccessor
 // interface.
-func (c *Connector) UpdateSpanConfigEntries(
-	ctx context.Context, toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEntry,
+func (c *Connector) UpdateSpanConfigRecords(
+	ctx context.Context, toDelete []spanconfig.Target, toUpsert []spanconfig.Record,
 ) error {
+	spansToDelete := make([]roachpb.Span, 0, len(toDelete))
+	for _, toDel := range toDelete {
+		spansToDelete = append(spansToDelete, roachpb.Span(toDel))
+	}
+
+	entriesToUpsert := spanconfig.RecordsToSpanConfigEntries(toUpsert)
+
 	return c.withClient(ctx, func(ctx context.Context, c *client) error {
+
 		_, err := c.UpdateSpanConfigs(ctx, &roachpb.UpdateSpanConfigsRequest{
-			ToDelete: toDelete,
-			ToUpsert: toUpsert,
+			ToDelete: spansToDelete,
+			ToUpsert: entriesToUpsert,
 		})
 		return err
 	})

--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -495,39 +495,6 @@ func (c *Connector) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
 	panic("not applicable")
 }
 
-// GetSystemSpanConfigEntries implements the spanconfig.KVAccessor interface.
-func (c *Connector) GetSystemSpanConfigEntries(
-	ctx context.Context,
-) (entries []roachpb.SystemSpanConfigEntry, _ error) {
-	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
-		resp, err := c.GetSystemSpanConfigs(ctx, &roachpb.GetSystemSpanConfigsRequest{})
-		if err != nil {
-			return err
-		}
-
-		entries = resp.SystemSpanConfigEntries
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return entries, nil
-}
-
-// UpdateSystemSpanConfigEntries implements the spanconfig.KVAccessor interface.
-func (c *Connector) UpdateSystemSpanConfigEntries(
-	ctx context.Context,
-	toDelete []roachpb.SystemSpanConfigTarget,
-	toUpsert []roachpb.SystemSpanConfigEntry,
-) error {
-	return c.withClient(ctx, func(ctx context.Context, c *client) error {
-		_, err := c.UpdateSystemSpanConfigs(ctx, &roachpb.UpdateSystemSpanConfigsRequest{
-			ToDelete: toDelete,
-			ToUpsert: toUpsert,
-		})
-		return err
-	})
-}
-
 // withClient is a convenience wrapper that executes the given closure while
 // papering over InternalClient retrieval errors.
 func (c *Connector) withClient(

--- a/pkg/ccl/kvccl/kvtenantccl/connector_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector_test.go
@@ -114,18 +114,6 @@ func (m *mockServer) UpdateSpanConfigs(
 	panic("unimplemented")
 }
 
-func (m *mockServer) GetSystemSpanConfigs(
-	context.Context, *roachpb.GetSystemSpanConfigsRequest,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
-func (m *mockServer) UpdateSystemSpanConfigs(
-	context.Context, *roachpb.UpdateSystemSpanConfigsRequest,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
 func gossipEventForClusterID(clusterID uuid.UUID) *roachpb.GossipSubscriptionEvent {
 	return &roachpb.GossipSubscriptionEvent{
 		Key:            gossip.KeyClusterID,

--- a/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
@@ -70,12 +70,12 @@ func TestPreSeedSpanConfigsWrittenWhenActive(t *testing.T) {
 	tenantSeedSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.Next()}
 
 	{
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			tenantSpan,
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			spanconfig.MakeSpanTarget(tenantSpan),
 		})
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		require.Equal(t, entries[0].Span, tenantSeedSpan)
+		require.Len(t, records, 1)
+		require.Equal(t, *records[0].Target.GetSpan(), tenantSeedSpan)
 	}
 }
 
@@ -106,7 +106,9 @@ func TestSeedTenantSpanConfigs(t *testing.T) {
 
 	tenantID := roachpb.MakeTenantID(10)
 	tenantPrefix := keys.MakeTenantPrefix(tenantID)
-	tenantSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.PrefixEnd()}
+	tenantTarget := spanconfig.MakeSpanTarget(
+		roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.PrefixEnd()},
+	)
 	tenantSeedSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.Next()}
 	{
 		_, err := ts.StartTenant(ctx, base.TestTenantArgs{
@@ -123,12 +125,12 @@ func TestSeedTenantSpanConfigs(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	{ // Ensure that no span config entries are to be found
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			tenantSpan,
+	{ // Ensure that no span config records are to be found
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			tenantTarget,
 		})
 		require.NoError(t, err)
-		require.Empty(t, entries)
+		require.Empty(t, records)
 	}
 
 	tdb.Exec(t,
@@ -136,18 +138,18 @@ func TestSeedTenantSpanConfigs(t *testing.T) {
 		clusterversion.ByKey(clusterversion.SeedTenantSpanConfigs).String(),
 	)
 
-	{ // Ensure that the tenant now has a span config entry.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			tenantSpan,
+	{ // Ensure that the tenant now has a span config record.
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			tenantTarget,
 		})
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		require.Equal(t, entries[0].Span, tenantSeedSpan)
+		require.Len(t, records, 1)
+		require.Equal(t, *records[0].Target.GetSpan(), tenantSeedSpan)
 	}
 }
 
 // TestSeedTenantSpanConfigsWithExistingEntry tests that the migration ignores
-// tenants with existing span config entries.
+// tenants with existing span config records.
 func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -173,7 +175,9 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 
 	tenantID := roachpb.MakeTenantID(10)
 	tenantPrefix := keys.MakeTenantPrefix(tenantID)
-	tenantSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.PrefixEnd()}
+	tenantTarget := spanconfig.MakeSpanTarget(
+		roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.PrefixEnd()},
+	)
 	tenantSeedSpan := roachpb.Span{Key: tenantPrefix, EndKey: tenantPrefix.Next()}
 	{
 		_, err := ts.StartTenant(ctx, base.TestTenantArgs{
@@ -190,13 +194,13 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	{ // Ensure that the tenant already has a span config entry.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			tenantSpan,
+	{ // Ensure that the tenant already has a span config record.
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			tenantTarget,
 		})
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		require.Equal(t, entries[0].Span, tenantSeedSpan)
+		require.Len(t, records, 1)
+		require.Equal(t, *records[0].Target.GetSpan(), tenantSeedSpan)
 	}
 
 	// Ensure the cluster version bump goes through successfully.
@@ -205,12 +209,12 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 		clusterversion.ByKey(clusterversion.SeedTenantSpanConfigs).String(),
 	)
 
-	{ // Ensure that the tenant's span config entry stay as it was.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			tenantSpan,
+	{ // Ensure that the tenant's span config record stay as it was.
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			tenantTarget,
 		})
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		require.Equal(t, entries[0].Span, tenantSeedSpan)
+		require.Len(t, records, 1)
+		require.Equal(t, *records[0].Target.GetSpan(), tenantSeedSpan)
 	}
 }

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -191,16 +191,18 @@ func TestDataDriven(t *testing.T) {
 					}
 					return nil
 				})
-				entries, err := kvAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{keys.EverythingSpan})
+				records, err := kvAccessor.GetSpanConfigRecords(
+					ctx, []spanconfig.Target{spanconfig.MakeSpanTarget(keys.EverythingSpan)},
+				)
 				require.NoError(t, err)
-				sort.Slice(entries, func(i, j int) bool {
-					return entries[i].Span.Key.Compare(entries[j].Span.Key) < 0
+				sort.Slice(records, func(i, j int) bool {
+					return records[i].Target.Less(records[j].Target)
 				})
 
-				lines := make([]string, len(entries))
-				for i, entry := range entries {
-					lines[i] = fmt.Sprintf("%-42s %s", entry.Span,
-						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(entry.Config))
+				lines := make([]string, len(records))
+				for i, record := range records {
+					lines[i] = fmt.Sprintf("%-42s %s", record.Target.GetSpan().String(),
+						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.Config))
 				}
 				return spanconfigtestutils.MaybeLimitAndOffset(t, d, "...", lines)
 

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -159,31 +159,31 @@ func TestDataDriven(t *testing.T) {
 				}
 
 				sqlTranslator := tenant.SpanConfigSQLTranslator().(spanconfig.SQLTranslator)
-				entries, _, err := sqlTranslator.Translate(ctx, descpb.IDs{objID})
+				records, _, err := sqlTranslator.Translate(ctx, descpb.IDs{objID})
 				require.NoError(t, err)
-				sort.Slice(entries, func(i, j int) bool {
-					return entries[i].Span.Key.Compare(entries[j].Span.Key) < 0
+				sort.Slice(records, func(i, j int) bool {
+					return records[i].Target.Less(records[j].Target)
 				})
 
 				var output strings.Builder
-				for _, entry := range entries {
-					output.WriteString(fmt.Sprintf("%-42s %s\n", entry.Span,
-						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(entry.Config)))
+				for _, record := range records {
+					output.WriteString(fmt.Sprintf("%-42s %s\n", *record.Target.GetSpan(),
+						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.Config)))
 				}
 				return output.String()
 
 			case "full-translate":
 				sqlTranslator := tenant.SpanConfigSQLTranslator().(spanconfig.SQLTranslator)
-				entries, _, err := spanconfig.FullTranslate(ctx, sqlTranslator)
+				records, _, err := spanconfig.FullTranslate(ctx, sqlTranslator)
 				require.NoError(t, err)
 
-				sort.Slice(entries, func(i, j int) bool {
-					return entries[i].Span.Key.Compare(entries[j].Span.Key) < 0
+				sort.Slice(records, func(i, j int) bool {
+					return records[i].Target.Less(records[j].Target)
 				})
 				var output strings.Builder
-				for _, entry := range entries {
-					output.WriteString(fmt.Sprintf("%-42s %s\n", entry.Span,
-						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(entry.Config)))
+				for _, record := range records {
+					output.WriteString(fmt.Sprintf("%-42s %s\n", *record.Target.GetSpan(),
+						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.Config)))
 				}
 				return output.String()
 

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -91,18 +91,6 @@ func (n Node) UpdateSpanConfigs(
 	panic("unimplemented")
 }
 
-func (n Node) GetSystemSpanConfigs(
-	_ context.Context, _ *roachpb.GetSystemSpanConfigsRequest,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) UpdateSystemSpanConfigs(
-	_ context.Context, _ *roachpb.UpdateSystemSpanConfigsRequest,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
 func (n Node) TenantSettings(
 	*roachpb.TenantSettingsRequest, roachpb.Internal_TenantSettingsServer,
 ) error {

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -209,18 +209,6 @@ func (m *mockInternalClient) UpdateSpanConfigs(
 	return nil, fmt.Errorf("unsupported UpdateSpanConfigs call")
 }
 
-func (m *mockInternalClient) GetSystemSpanConfigs(
-	_ context.Context, _ *roachpb.GetSystemSpanConfigsRequest, _ ...grpc.CallOption,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	return nil, fmt.Errorf("unsupported GetSpanConfigs call")
-}
-
-func (m *mockInternalClient) UpdateSystemSpanConfigs(
-	_ context.Context, _ *roachpb.UpdateSystemSpanConfigsRequest, _ ...grpc.CallOption,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	return nil, fmt.Errorf("unsupported UpdateSpanConfigs call")
-}
-
 func (m *mockInternalClient) TenantSettings(
 	context.Context, *roachpb.TenantSettingsRequest, ...grpc.CallOption,
 ) (roachpb.Internal_TenantSettingsClient, error) {

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -69,10 +69,14 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	span := repl.Desc().RSpan().AsRawSpanWithNoLocals()
 	conf := roachpb.SpanConfig{NumReplicas: 5, NumVoters: 3}
 
-	deleted, added := spanConfigStore.Apply(ctx, false /* dryrun */, spanconfig.Addition(span, conf))
+	deleted, added := spanConfigStore.Apply(
+		ctx,
+		false, /* dryrun */
+		spanconfig.Addition(spanconfig.MakeSpanTarget(span), conf),
+	)
 	require.Empty(t, deleted)
 	require.Len(t, added, 1)
-	require.True(t, added[0].Span.Equal(span))
+	require.True(t, added[0].Target.GetSpan().Equal(span))
 	require.True(t, added[0].Config.Equal(conf))
 
 	require.NotNil(t, mockSubscriber.callback)

--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/server/serverpb",
+        "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",

--- a/pkg/migration/migrations/migrate_span_configs_test.go
+++ b/pkg/migration/migrations/migrate_span_configs_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -69,11 +68,11 @@ func TestEnsureSpanConfigReconciliation(t *testing.T) {
 	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'`)
 
 	{ // Ensure that no span config entries are found.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			keys.EverythingSpan,
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			spanconfig.MakeSpanTarget(keys.EverythingSpan),
 		})
 		require.NoError(t, err)
-		require.Empty(t, entries)
+		require.Empty(t, records)
 	}
 
 	// Ensure that upgrade attempts without having reconciled simply fail.
@@ -91,11 +90,11 @@ func TestEnsureSpanConfigReconciliation(t *testing.T) {
 	require.False(t, scReconciler.Checkpoint().IsEmpty())
 
 	{ // Ensure that the host tenant's span configs are installed.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			keys.EverythingSpan,
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			spanconfig.MakeSpanTarget(keys.EverythingSpan),
 		})
 		require.NoError(t, err)
-		require.NotEmpty(t, entries)
+		require.NotEmpty(t, records)
 	}
 }
 
@@ -154,11 +153,11 @@ func TestEnsureSpanConfigReconciliationMultiNode(t *testing.T) {
 	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'`)
 
 	{ // Ensure that no span config entries are to be found.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			keys.EverythingSpan,
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			spanconfig.MakeSpanTarget(keys.EverythingSpan),
 		})
 		require.NoError(t, err)
-		require.Empty(t, entries)
+		require.Empty(t, records)
 	}
 
 	// Ensure that upgrade attempts without having reconciled simply fail.
@@ -176,11 +175,11 @@ func TestEnsureSpanConfigReconciliationMultiNode(t *testing.T) {
 	require.False(t, scReconciler.Checkpoint().IsEmpty())
 
 	{ // Ensure that the host tenant's span configs are installed.
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			keys.EverythingSpan,
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			spanconfig.MakeSpanTarget(keys.EverythingSpan),
 		})
 		require.NoError(t, err)
-		require.NotEmpty(t, entries)
+		require.NotEmpty(t, records)
 	}
 }
 
@@ -220,11 +219,11 @@ func TestEnsureSpanConfigSubscription(t *testing.T) {
 	tdb.Exec(t, `SET CLUSTER SETTING spanconfig.reconciliation_job.enabled = true`)
 
 	testutils.SucceedsSoon(t, func() error {
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{
-			keys.EverythingSpan,
+		records, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{
+			spanconfig.MakeSpanTarget(keys.EverythingSpan),
 		})
 		require.NoError(t, err)
-		if len(entries) == 0 {
+		if len(records) == 0 {
 			return fmt.Errorf("empty global span configuration state")
 		}
 		return nil

--- a/pkg/migration/migrations/seed_tenant_span_configs.go
+++ b/pkg/migration/migrations/seed_tenant_span_configs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/migration"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/errors"
@@ -58,32 +59,32 @@ func seedTenantSpanConfigsMigration(
 			// boundary. Look towards CreateTenantRecord for more details.
 			tenantSpanConfig := d.SpanConfig.Default
 			tenantPrefix := keys.MakeTenantPrefix(tenantID)
-			tenantSpan := roachpb.Span{
+			tenantTarget := spanconfig.MakeSpanTarget(roachpb.Span{
 				Key:    tenantPrefix,
 				EndKey: tenantPrefix.PrefixEnd(),
-			}
+			})
 			tenantSeedSpan := roachpb.Span{
 				Key:    tenantPrefix,
 				EndKey: tenantPrefix.Next(),
 			}
-			toUpsert := []roachpb.SpanConfigEntry{
+			toUpsert := []spanconfig.Record{
 				{
-					Span:   tenantSeedSpan,
+					Target: spanconfig.MakeSpanTarget(tenantSeedSpan),
 					Config: tenantSpanConfig,
 				},
 			}
-			scEntries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{tenantSpan})
+			scRecords, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{tenantTarget})
 			if err != nil {
 				return err
 			}
-			if len(scEntries) != 0 {
+			if len(scRecords) != 0 {
 				// This tenant already has span config entries. It was either
 				// already migrated (migrations need to be idempotent) or it was
 				// created after PreSeedTenantSpanConfigs was activated. There's
 				// nothing left to do here.
 				continue
 			}
-			if err := scKVAccessor.UpdateSpanConfigEntries(
+			if err := scKVAccessor.UpdateSpanConfigRecords(
 				ctx, nil /* toDelete */, toUpsert,
 			); err != nil {
 				return errors.Wrapf(err, "failed to seed span config for tenant %d", tenantID)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2877,12 +2877,6 @@ service Internal {
   // keyspans.
   rpc UpdateSpanConfigs (UpdateSpanConfigsRequest) returns (UpdateSpanConfigsResponse) { }
 
-  //  GetSystemSpanConfigs is used to fetch system span configurations.
-  rpc GetSystemSpanConfigs(GetSystemSpanConfigsRequest) returns (GetSystemSpanConfigsResponse) { }
-
-  // UpdateSystemSpanConfigs is used to update system span configurations.
-  rpc UpdateSystemSpanConfigs (UpdateSystemSpanConfigsRequest) returns (UpdateSystemSpanConfigsResponse) {}
-
   // TenantSettings is used by tenants to obtain and stay up to date with tenant
   // setting overrides.
   rpc TenantSettings (TenantSettingsRequest) returns (stream TenantSettingsEvent) { }

--- a/pkg/roachpb/roachpbmock/mocks_generated.go
+++ b/pkg/roachpb/roachpbmock/mocks_generated.go
@@ -77,26 +77,6 @@ func (mr *MockInternalClientMockRecorder) GetSpanConfigs(arg0, arg1 interface{},
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpanConfigs", reflect.TypeOf((*MockInternalClient)(nil).GetSpanConfigs), varargs...)
 }
 
-// GetSystemSpanConfigs mocks base method.
-func (m *MockInternalClient) GetSystemSpanConfigs(arg0 context.Context, arg1 *roachpb.GetSystemSpanConfigsRequest, arg2 ...grpc.CallOption) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetSystemSpanConfigs", varargs...)
-	ret0, _ := ret[0].(*roachpb.GetSystemSpanConfigsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSystemSpanConfigs indicates an expected call of GetSystemSpanConfigs.
-func (mr *MockInternalClientMockRecorder) GetSystemSpanConfigs(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemSpanConfigs", reflect.TypeOf((*MockInternalClient)(nil).GetSystemSpanConfigs), varargs...)
-}
-
 // GossipSubscription mocks base method.
 func (m *MockInternalClient) GossipSubscription(arg0 context.Context, arg1 *roachpb.GossipSubscriptionRequest, arg2 ...grpc.CallOption) (roachpb.Internal_GossipSubscriptionClient, error) {
 	m.ctrl.T.Helper()
@@ -255,26 +235,6 @@ func (mr *MockInternalClientMockRecorder) UpdateSpanConfigs(arg0, arg1 interface
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSpanConfigs", reflect.TypeOf((*MockInternalClient)(nil).UpdateSpanConfigs), varargs...)
-}
-
-// UpdateSystemSpanConfigs mocks base method.
-func (m *MockInternalClient) UpdateSystemSpanConfigs(arg0 context.Context, arg1 *roachpb.UpdateSystemSpanConfigsRequest, arg2 ...grpc.CallOption) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "UpdateSystemSpanConfigs", varargs...)
-	ret0, _ := ret[0].(*roachpb.UpdateSystemSpanConfigsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateSystemSpanConfigs indicates an expected call of UpdateSystemSpanConfigs.
-func (mr *MockInternalClientMockRecorder) UpdateSystemSpanConfigs(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSystemSpanConfigs", reflect.TypeOf((*MockInternalClient)(nil).UpdateSystemSpanConfigs), varargs...)
 }
 
 // MockInternal_RangeFeedClient is a mock of Internal_RangeFeedClient interface.

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -175,39 +175,6 @@ message SpanConfigEntry {
   SpanConfig config = 2 [(gogoproto.nullable) = false];
 };
 
-// SystemSpanConfig is a system installed configuration that may apply to
-// multiple spans.
-message SystemSpanConfig {
-  option (gogoproto.equal) = true;
-
-  // ProtectionPolicies is a list of policies which protect data from being
-  // GC-ed.
-  repeated ProtectionPolicy protection_policies = 1 [(gogoproto.nullable) = false];
-}
-
-// SystemSpanConfigTarget is used to specify the target of a SystemSpanConfig.
-message SystemSpanConfigTarget {
-   // TenantID indicates the tenant ID of the logical cluster being targeted.
-   // For secondary tenants this field is left unset. For the host we can use
-   // this field to protect a specific secondary tenant.
-   //
-   // TODO(arul): Ensure that secondary tenants don't populate this field when
-   // we make use of these in the RPC.
-   roachpb.TenantID tenant_id = 1 [(gogoproto.customname) = "TenantID", (gogoproto.nullable) = true];
-}
-
-
-// SystemSpanConfigEntry is a SystemSpanConfigTarget and its corresponding
-// SystemSpanConfig.
-message SystemSpanConfigEntry {
-  // SystemSpanConfigTarget represents the target over which the config is said
-  // to apply.
-  SystemSpanConfigTarget system_span_config_target = 1 [(gogoproto.nullable) = false];
-
-  // SystemSpanConfig is the config that applies.
-  SystemSpanConfig system_span_config = 2 [(gogoproto.nullable) = false];
-}
-
 // GetSpanConfigsRequest is used to fetch the span configurations over the
 // specified keyspans.
 message GetSpanConfigsRequest {

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -190,6 +190,9 @@ message SystemSpanConfigTarget {
    // TenantID indicates the tenant ID of the logical cluster being targeted.
    // For secondary tenants this field is left unset. For the host we can use
    // this field to protect a specific secondary tenant.
+   //
+   // TODO(arul): Ensure that secondary tenants don't populate this field when
+   // we make use of these in the RPC.
    roachpb.TenantID tenant_id = 1 [(gogoproto.customname) = "TenantID", (gogoproto.nullable) = true];
 }
 
@@ -224,18 +227,6 @@ message GetSpanConfigsResponse {
   repeated SpanConfigEntry span_config_entries = 1 [(gogoproto.nullable) = false];
 };
 
-// GetSystemSpanConfigsRequest is used to fetch all system span configurations
-// installed by the requesting tenant.
-message GetSystemSpanConfigsRequest {};
-
-// GetSystemSpanConfigsResponse lists out all system span configurations that
-// are installed by the requesting tenant.
-message GetSystemSpanConfigsResponse {
-  // SystemSpanConfigEntries captures the system span configurations that have
-  // been set by the tenant.
-  repeated SystemSpanConfigEntry system_span_config_entries = 1 [(gogoproto.nullable) = false];
-};
-
 // UpdateSpanConfigsRequest is used to update the span configurations over the
 // given spans.
 //
@@ -262,20 +253,3 @@ message UpdateSpanConfigsRequest {
 
 message UpdateSpanConfigsResponse { };
 
-// UpdateSystemSpanConfigsRequest is used to update system span configurations.
-
-// System span config targets being deleted are expected to have been present.
-// Targets are not allowed to be duplicated in the same list or across lists;
-// existing span configs should be updated by including in the upsert list
-// without deleting their targets first.
-message UpdateSystemSpanConfigsRequest {
-  // SystemSpanConfigsToDelete captures the targets of the system span
-  // configurations to delete.
-  repeated SystemSpanConfigTarget to_delete = 1 [(gogoproto.nullable) = false];
-
-  // SystemSpanConfigsToUpsert captures the system span configurations we want
-  // to upsert with.
-  repeated SystemSpanConfigEntry to_upsert = 2 [(gogoproto.nullable) = false];
-};
-
-message UpdateSystemSpanConfigsResponse {};

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -112,12 +112,6 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.roachpb.Internal/UpdateSpanConfigs":
 		return a.authUpdateSpanConfigs(tenID, req.(*roachpb.UpdateSpanConfigsRequest))
 
-	case "/cockroach.roachpb.Internal/UpdateSystemSpanConfigs":
-		return a.authUpdateSystemSpanConfigs(tenID, req.(*roachpb.UpdateSystemSpanConfigsRequest))
-
-	case "/cockroach.roachpb.Internal/GetSystemSpanConfigs":
-		return a.authTenant(tenID)
-
 	default:
 		return authErrorf("unknown method %q", fullMethod)
 	}
@@ -316,40 +310,6 @@ func (a tenantAuthorizer) authUpdateSpanConfigs(
 		}
 	}
 
-	return nil
-}
-
-func (a tenantAuthorizer) authUpdateSystemSpanConfigs(
-	tenID roachpb.TenantID, args *roachpb.UpdateSystemSpanConfigsRequest,
-) error {
-	if err := a.authTenant(tenID); err != nil {
-		return err
-	}
-
-	// The host tenant is allowed to target other secondary tenants, so we can
-	// skip validation checks below.
-	if tenID == roachpb.SystemTenantID {
-		return nil
-	}
-
-	// Ensure a secondary tenant isn't being targeted.
-	validate := func(target roachpb.SystemSpanConfigTarget) error {
-		if target.TenantID != nil {
-			return authError("secondary tenants cannot target tenants for system span configurations")
-		}
-		return nil
-	}
-
-	for _, target := range args.ToDelete {
-		if err := validate(target); err != nil {
-			return err
-		}
-	}
-	for _, entry := range args.ToUpsert {
-		if err := validate(entry.SystemSpanConfigTarget); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -607,20 +607,6 @@ func (a internalClientAdapter) UpdateSpanConfigs(
 	return a.server.UpdateSpanConfigs(ctx, req)
 }
 
-// GetSystemSpanConfigs is part of the roachpb.InternalClient interface.
-func (a internalClientAdapter) GetSystemSpanConfigs(
-	ctx context.Context, req *roachpb.GetSystemSpanConfigsRequest, _ ...grpc.CallOption,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	return a.server.GetSystemSpanConfigs(ctx, req)
-}
-
-// UpdateSystemSpanConfigs is part of the roachpb.InternalClient interface.
-func (a internalClientAdapter) UpdateSystemSpanConfigs(
-	ctx context.Context, req *roachpb.UpdateSystemSpanConfigsRequest, _ ...grpc.CallOption,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	return a.server.UpdateSystemSpanConfigs(ctx, req)
-}
-
 type respStreamClientAdapter struct {
 	ctx   context.Context
 	respC chan interface{}

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -270,18 +270,6 @@ func (*internalServer) GetSpanConfigs(
 	panic("unimplemented")
 }
 
-func (*internalServer) UpdateSystemSpanConfigs(
-	context.Context, *roachpb.UpdateSystemSpanConfigsRequest,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
-func (*internalServer) GetSystemSpanConfigs(
-	context.Context, *roachpb.GetSystemSpanConfigsRequest,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
 func (*internalServer) UpdateSpanConfigs(
 	context.Context, *roachpb.UpdateSpanConfigsRequest,
 ) (*roachpb.UpdateSpanConfigsResponse, error) {

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -598,18 +598,6 @@ func (*internalServer) UpdateSpanConfigs(
 	panic("unimplemented")
 }
 
-func (*internalServer) GetSystemSpanConfigs(
-	context.Context, *roachpb.GetSystemSpanConfigsRequest,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
-func (*internalServer) UpdateSystemSpanConfigs(
-	context.Context, *roachpb.UpdateSystemSpanConfigsRequest,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
 func (*internalServer) TenantSettings(
 	*roachpb.TenantSettingsRequest, roachpb.Internal_TenantSettingsServer,
 ) error {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1517,12 +1517,19 @@ func (emptyMetricStruct) MetricStruct() {}
 func (n *Node) GetSpanConfigs(
 	ctx context.Context, req *roachpb.GetSpanConfigsRequest,
 ) (*roachpb.GetSpanConfigsResponse, error) {
-	entries, err := n.spanConfigAccessor.GetSpanConfigEntriesFor(ctx, req.Spans)
+	targets := make([]spanconfig.Target, 0, len(req.Spans))
+	for _, span := range req.Spans {
+		targets = append(targets, spanconfig.MakeSpanTarget(span))
+	}
+
+	records, err := n.spanConfigAccessor.GetSpanConfigRecords(ctx, targets)
 	if err != nil {
 		return nil, err
 	}
 
-	return &roachpb.GetSpanConfigsResponse{SpanConfigEntries: entries}, nil
+	return &roachpb.GetSpanConfigsResponse{
+		SpanConfigEntries: spanconfig.RecordsToSpanConfigEntries(records),
+	}, nil
 }
 
 // UpdateSpanConfigs implements the roachpb.InternalServer interface.
@@ -1532,7 +1539,15 @@ func (n *Node) UpdateSpanConfigs(
 	// TODO(irfansharif): We want to protect ourselves from tenants creating
 	// outlandishly large string buffers here and OOM-ing the host cluster. Is
 	// the maximum protobuf message size enough of a safeguard?
-	err := n.spanConfigAccessor.UpdateSpanConfigEntries(ctx, req.ToDelete, req.ToUpsert)
+
+	toDelete := make([]spanconfig.Target, 0, len(req.ToDelete))
+	for _, toDel := range req.ToDelete {
+		toDelete = append(toDelete, spanconfig.MakeSpanTarget(toDel))
+	}
+
+	toUpsert := spanconfig.EntriesToRecords(req.ToUpsert)
+
+	err := n.spanConfigAccessor.UpdateSpanConfigRecords(ctx, toDelete, toUpsert)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1538,26 +1538,3 @@ func (n *Node) UpdateSpanConfigs(
 	}
 	return &roachpb.UpdateSpanConfigsResponse{}, nil
 }
-
-// GetSystemSpanConfigs implements the roachpb.InternalServer interface.
-func (n *Node) GetSystemSpanConfigs(
-	ctx context.Context, _ *roachpb.GetSystemSpanConfigsRequest,
-) (*roachpb.GetSystemSpanConfigsResponse, error) {
-	entries, err := n.spanConfigAccessor.GetSystemSpanConfigEntries(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &roachpb.GetSystemSpanConfigsResponse{SystemSpanConfigEntries: entries}, nil
-}
-
-// UpdateSystemSpanConfigs implements the roachpb.InternalServer interface.
-func (n *Node) UpdateSystemSpanConfigs(
-	ctx context.Context, req *roachpb.UpdateSystemSpanConfigsRequest,
-) (*roachpb.UpdateSystemSpanConfigsResponse, error) {
-	err := n.spanConfigAccessor.UpdateSystemSpanConfigEntries(ctx, req.ToDelete, req.ToUpsert)
-	if err != nil {
-		return nil, err
-	}
-	return &roachpb.UpdateSystemSpanConfigsResponse{}, nil
-}

--- a/pkg/spanconfig/BUILD.bazel
+++ b/pkg/spanconfig/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "spanconfig",
     srcs = [
         "spanconfig.go",
+        "target.go",
         "testing_knobs.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig",

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -44,20 +44,6 @@ type KVAccessor interface {
 		toUpsert []roachpb.SpanConfigEntry,
 	) error
 
-	// GetSystemSpanConfigEntries returns the system span config entries that
-	// have been installed by the tenant.
-	GetSystemSpanConfigEntries(ctx context.Context) ([]roachpb.SystemSpanConfigEntry, error)
-
-	// UpdateSystemSpanConfigEntries updates system span configurations for the
-	// given targets. Targets for span config entries being deleted are expected
-	// to have been present; targets must be distinct within and across the two
-	// lists.
-	UpdateSystemSpanConfigEntries(
-		ctx context.Context,
-		toDelete []roachpb.SystemSpanConfigTarget,
-		toUpsert []roachpb.SystemSpanConfigEntry,
-	) error
-
 	// WithTxn returns a KVAccessor that runs using the given transaction (with
 	// its operations discarded if aborted, valid only if committed). If nil, a
 	// transaction is created internally for every operation.

--- a/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvaccessor/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/sql/sqlutil",
         "//pkg/testutils",

--- a/pkg/spanconfig/spanconfigkvaccessor/dummy.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/dummy.go
@@ -53,20 +53,6 @@ func (k dummyKVAccessor) UpdateSpanConfigEntries(
 	return k.error
 }
 
-// GetSystemSpanConfigEntries is part of the spanconfig.KVAccessor interface.
-func (k dummyKVAccessor) GetSystemSpanConfigEntries(
-	context.Context,
-) ([]roachpb.SystemSpanConfigEntry, error) {
-	return nil, k.error
-}
-
-// UpdateSystemSpanConfigEntries is part of the spanconfig.KVAccessor interface.
-func (k dummyKVAccessor) UpdateSystemSpanConfigEntries(
-	context.Context, []roachpb.SystemSpanConfigTarget, []roachpb.SystemSpanConfigEntry,
-) error {
-	return k.error
-}
-
 func (k dummyKVAccessor) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
 	return k
 }

--- a/pkg/spanconfig/spanconfigkvaccessor/dummy.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/dummy.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/errors"
 )
@@ -39,16 +38,16 @@ type dummyKVAccessor struct {
 
 var _ spanconfig.KVAccessor = &dummyKVAccessor{}
 
-// GetSpanConfigEntriesFor is part of the KVAccessor interface.
-func (k dummyKVAccessor) GetSpanConfigEntriesFor(
-	context.Context, []roachpb.Span,
-) ([]roachpb.SpanConfigEntry, error) {
+// GetSpanConfigRecords is part of the KVAccessor interface.
+func (k dummyKVAccessor) GetSpanConfigRecords(
+	context.Context, []spanconfig.Target,
+) ([]spanconfig.Record, error) {
 	return nil, k.error
 }
 
-// UpdateSpanConfigEntries is part of the KVAccessor interface.
-func (k dummyKVAccessor) UpdateSpanConfigEntries(
-	context.Context, []roachpb.Span, []roachpb.SpanConfigEntry,
+// UpdateSpanConfigRecords is part of the KVAccessor interface.
+func (k dummyKVAccessor) UpdateSpanConfigRecords(
+	context.Context, []spanconfig.Target, []spanconfig.Record,
 ) error {
 	return k.error
 }

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -68,18 +68,18 @@ func (k *KVAccessor) WithTxn(ctx context.Context, txn *kv.Txn) spanconfig.KVAcce
 	return newKVAccessor(k.db, k.ie, k.settings, k.configurationsTableFQN, txn)
 }
 
-// GetSpanConfigEntriesFor is part of the KVAccessor interface.
-func (k *KVAccessor) GetSpanConfigEntriesFor(
-	ctx context.Context, spans []roachpb.Span,
-) (resp []roachpb.SpanConfigEntry, retErr error) {
-	if len(spans) == 0 {
-		return resp, nil
+// GetSpanConfigRecords is part of the KVAccessor interface.
+func (k *KVAccessor) GetSpanConfigRecords(
+	ctx context.Context, targets []spanconfig.Target,
+) (records []spanconfig.Record, retErr error) {
+	if len(targets) == 0 {
+		return records, nil
 	}
-	if err := validateSpans(spans); err != nil {
+	if err := validateSpanTargets(targets); err != nil {
 		return nil, err
 	}
 
-	getStmt, getQueryArgs := k.constructGetStmtAndArgs(spans)
+	getStmt, getQueryArgs := k.constructGetStmtAndArgs(targets)
 	it, err := k.ie.QueryIteratorEx(ctx, "get-span-cfgs", k.optionalTxn,
 		sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 		getStmt, getQueryArgs...,
@@ -89,7 +89,7 @@ func (k *KVAccessor) GetSpanConfigEntriesFor(
 	}
 	defer func() {
 		if closeErr := it.Close(); closeErr != nil {
-			resp, retErr = nil, errors.CombineErrors(retErr, closeErr)
+			records, retErr = nil, errors.CombineErrors(retErr, closeErr)
 		}
 	}()
 
@@ -105,27 +105,27 @@ func (k *KVAccessor) GetSpanConfigEntriesFor(
 			return nil, err
 		}
 
-		resp = append(resp, roachpb.SpanConfigEntry{
-			Span:   span,
+		records = append(records, spanconfig.Record{
+			Target: spanconfig.DecodeTarget(span),
 			Config: conf,
 		})
 	}
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return records, nil
 }
 
-// UpdateSpanConfigEntries is part of the KVAccessor interface.
-func (k *KVAccessor) UpdateSpanConfigEntries(
-	ctx context.Context, toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEntry,
+// UpdateSpanConfigRecords is part of the KVAccessor interface.
+func (k *KVAccessor) UpdateSpanConfigRecords(
+	ctx context.Context, toDelete []spanconfig.Target, toUpsert []spanconfig.Record,
 ) error {
 	if k.optionalTxn != nil {
-		return k.updateSpanConfigEntriesWithTxn(ctx, toDelete, toUpsert, k.optionalTxn)
+		return k.updateSpanConfigRecordsWithTxn(ctx, toDelete, toUpsert, k.optionalTxn)
 	}
 
 	return k.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return k.updateSpanConfigEntriesWithTxn(ctx, toDelete, toUpsert, txn)
+		return k.updateSpanConfigRecordsWithTxn(ctx, toDelete, toUpsert, txn)
 	})
 }
 
@@ -145,8 +145,8 @@ func newKVAccessor(
 	}
 }
 
-func (k *KVAccessor) updateSpanConfigEntriesWithTxn(
-	ctx context.Context, toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEntry, txn *kv.Txn,
+func (k *KVAccessor) updateSpanConfigRecordsWithTxn(
+	ctx context.Context, toDelete []spanconfig.Target, toUpsert []spanconfig.Record, txn *kv.Txn,
 ) error {
 	if txn == nil {
 		log.Fatalf(ctx, "expected non-nil txn")
@@ -215,7 +215,7 @@ func (k *KVAccessor) updateSpanConfigEntriesWithTxn(
 
 // constructGetStmtAndArgs constructs the statement and query arguments needed
 // to fetch span configs for the given spans.
-func (k *KVAccessor) constructGetStmtAndArgs(spans []roachpb.Span) (string, []interface{}) {
+func (k *KVAccessor) constructGetStmtAndArgs(targets []spanconfig.Target) (string, []interface{}) {
 	// We want to fetch the overlapping span configs for each requested span in
 	// a single round trip and using only constrained index scans. For a single
 	// requested span, we effectively want to query the following:
@@ -254,15 +254,16 @@ func (k *KVAccessor) constructGetStmtAndArgs(spans []roachpb.Span) (string, []in
 	//   ...
 	//
 	var getStmtBuilder strings.Builder
-	queryArgs := make([]interface{}, len(spans)*2)
-	for i, sp := range spans {
+	queryArgs := make([]interface{}, len(targets)*2)
+	for i, target := range targets {
 		if i > 0 {
 			getStmtBuilder.WriteString(`UNION ALL`)
 		}
 
 		startKeyIdx, endKeyIdx := i*2, (i*2)+1
-		queryArgs[startKeyIdx] = sp.Key
-		queryArgs[endKeyIdx] = sp.EndKey
+		encodedSp := target.Encode()
+		queryArgs[startKeyIdx] = encodedSp.Key
+		queryArgs[endKeyIdx] = encodedSp.EndKey
 
 		fmt.Fprintf(&getStmtBuilder, `
 SELECT start_key, end_key, config FROM %[1]s
@@ -283,7 +284,9 @@ SELECT start_key, end_key, config FROM (
 
 // constructDeleteStmtAndArgs constructs the statement and query arguments
 // needed to delete span configs for the given spans.
-func (k *KVAccessor) constructDeleteStmtAndArgs(toDelete []roachpb.Span) (string, []interface{}) {
+func (k *KVAccessor) constructDeleteStmtAndArgs(
+	toDelete []spanconfig.Target,
+) (string, []interface{}) {
 	// We're constructing a single delete statement to delete all requested
 	// spans. It's of the form:
 	//
@@ -292,10 +295,11 @@ func (k *KVAccessor) constructDeleteStmtAndArgs(toDelete []roachpb.Span) (string
 	//
 	values := make([]string, len(toDelete))
 	deleteQueryArgs := make([]interface{}, len(toDelete)*2)
-	for i, sp := range toDelete {
+	for i, toDel := range toDelete {
 		startKeyIdx, endKeyIdx := i*2, (i*2)+1
-		deleteQueryArgs[startKeyIdx] = sp.Key
-		deleteQueryArgs[endKeyIdx] = sp.EndKey
+		encodedSp := toDel.Encode()
+		deleteQueryArgs[startKeyIdx] = encodedSp.Key
+		deleteQueryArgs[endKeyIdx] = encodedSp.EndKey
 		values[i] = fmt.Sprintf("($%d::BYTES, $%d::BYTES)",
 			startKeyIdx+1, endKeyIdx+1) // prepared statement placeholders (1-indexed)
 	}
@@ -307,7 +311,7 @@ func (k *KVAccessor) constructDeleteStmtAndArgs(toDelete []roachpb.Span) (string
 // constructUpsertStmtAndArgs constructs the statement and query arguments
 // needed to upsert the given span config entries.
 func (k *KVAccessor) constructUpsertStmtAndArgs(
-	toUpsert []roachpb.SpanConfigEntry,
+	toUpsert []spanconfig.Record,
 ) (string, []interface{}, error) {
 	// We're constructing a single upsert statement to upsert all requested
 	// spans. It's of the form:
@@ -317,15 +321,15 @@ func (k *KVAccessor) constructUpsertStmtAndArgs(
 	//
 	upsertValues := make([]string, len(toUpsert))
 	upsertQueryArgs := make([]interface{}, len(toUpsert)*3)
-	for i, entry := range toUpsert {
-		marshaled, err := protoutil.Marshal(&entry.Config)
+	for i, record := range toUpsert {
+		marshaled, err := protoutil.Marshal(&record.Config)
 		if err != nil {
 			return "", nil, err
 		}
 
 		startKeyIdx, endKeyIdx, configIdx := i*3, (i*3)+1, (i*3)+2
-		upsertQueryArgs[startKeyIdx] = entry.Span.Key
-		upsertQueryArgs[endKeyIdx] = entry.Span.EndKey
+		upsertQueryArgs[startKeyIdx] = record.Target.Encode().Key
+		upsertQueryArgs[endKeyIdx] = record.Target.Encode().EndKey
 		upsertQueryArgs[configIdx] = marshaled
 		upsertValues[i] = fmt.Sprintf("($%d::BYTES, $%d::BYTES, $%d::BYTES)",
 			startKeyIdx+1, endKeyIdx+1, configIdx+1) // prepared statement placeholders (1-indexed)
@@ -339,18 +343,18 @@ func (k *KVAccessor) constructUpsertStmtAndArgs(
 // needed to validate that the spans being upserted don't violate table
 // invariants (spans are non overlapping).
 func (k *KVAccessor) constructValidationStmtAndArgs(
-	toUpsert []roachpb.SpanConfigEntry,
+	toUpsert []spanconfig.Record,
 ) (string, []interface{}) {
 	// We want to validate that upserting spans does not break the invariant
 	// that spans in the table are non-overlapping. We only need to validate
 	// the spans that are being upserted, and can use a query similar to
-	// what we do in GetSpanConfigEntriesFor. For a single upserted span, we
+	// what we do in GetSpanConfigRecords. For a single upserted span, we
 	// want effectively validate using:
 	//
 	//   SELECT count(*) = 1 FROM system.span_configurations
 	//    WHERE start_key < $end AND end_key > $start
 	//
-	// Applying the GetSpanConfigEntriesFor treatment, we can arrive at:
+	// Applying the GetSpanConfigRecords treatment, we can arrive at:
 	//
 	//   SELECT count(*) = 1 FROM (
 	//    SELECT * FROM span_configurations
@@ -380,8 +384,8 @@ func (k *KVAccessor) constructValidationStmtAndArgs(
 		}
 
 		startKeyIdx, endKeyIdx := i*2, (i*2)+1
-		validationQueryArgs[startKeyIdx] = entry.Span.Key
-		validationQueryArgs[endKeyIdx] = entry.Span.EndKey
+		validationQueryArgs[startKeyIdx] = entry.Target.Encode().Key
+		validationQueryArgs[endKeyIdx] = entry.Target.Encode().EndKey
 
 		fmt.Fprintf(&validationInnerStmtBuilder, `
 SELECT count(*) = 1 FROM (
@@ -403,35 +407,38 @@ SELECT count(*) = 1 FROM (
 	return validationStmt, validationQueryArgs
 }
 
-// validateUpdateArgs returns an error the arguments to UpdateSpanConfigEntries
+// validateUpdateArgs returns an error the arguments to UpdateSpanConfigRecords
 // are malformed. All spans included in the toDelete and toUpsert list are
 // expected to be valid and to have non-empty end keys. Spans are also expected
 // to be non-overlapping with other spans in the same list.
-func validateUpdateArgs(toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEntry) error {
-	spansToUpdate := func(ents []roachpb.SpanConfigEntry) []roachpb.Span {
-		spans := make([]roachpb.Span, len(ents))
-		for i, ent := range ents {
-			spans[i] = ent.Span
+func validateUpdateArgs(toDelete []spanconfig.Target, toUpsert []spanconfig.Record) error {
+	targetsToUpdate := func(recs []spanconfig.Record) []spanconfig.Target {
+		targets := make([]spanconfig.Target, len(recs))
+		for i, ent := range recs {
+			targets[i] = ent.Target
 		}
-		return spans
+		return targets
 	}(toUpsert)
 
-	for _, list := range [][]roachpb.Span{toDelete, spansToUpdate} {
-		if err := validateSpans(list); err != nil {
+	for _, list := range [][]spanconfig.Target{toDelete, targetsToUpdate} {
+		if err := validateSpanTargets(list); err != nil {
 			return err
 		}
 
-		spans := make([]roachpb.Span, len(list))
-		copy(spans, list)
-		sort.Sort(roachpb.Spans(spans))
-		for i := range spans {
+		targets := make([]spanconfig.Target, len(list))
+		copy(targets, list)
+		sort.Sort(spanconfig.Targets(targets))
+		for i := range targets {
 			if i == 0 {
 				continue
 			}
 
-			if spans[i].Overlaps(spans[i-1]) {
+			curSpan := *targets[i].GetSpan()
+			prevSpan := *targets[i-1].GetSpan()
+
+			if curSpan.Overlaps(prevSpan) {
 				return errors.AssertionFailedf("overlapping spans %s and %s in same list",
-					spans[i-1], spans[i])
+					prevSpan, curSpan)
 			}
 		}
 	}
@@ -439,9 +446,25 @@ func validateUpdateArgs(toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEn
 	return nil
 }
 
+// validateSpanTargets returns an error if any spans in the supplied targets
+// are invalid or have an empty end key.
+func validateSpanTargets(targets []spanconfig.Target) error {
+	for _, target := range targets {
+		sp := target.GetSpan()
+		if sp == nil {
+			// Nothing to do.
+			continue
+		}
+		if err := validateSpans(*sp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateSpans returns an error if any of the spans are invalid or have an
 // empty end key.
-func validateSpans(spans []roachpb.Span) error {
+func validateSpans(spans ...roachpb.Span) error {
 	for _, span := range spans {
 		if !span.Valid() || len(span.EndKey) == 0 {
 			return errors.AssertionFailedf("invalid span: %s", span)

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -68,7 +68,7 @@ func (k *KVAccessor) WithTxn(ctx context.Context, txn *kv.Txn) spanconfig.KVAcce
 	return newKVAccessor(k.db, k.ie, k.settings, k.configurationsTableFQN, txn)
 }
 
-// GetSpanConfigEntriesFor is part of the spanconfig.KVAccessor interface.
+// GetSpanConfigEntriesFor is part of the KVAccessor interface.
 func (k *KVAccessor) GetSpanConfigEntriesFor(
 	ctx context.Context, spans []roachpb.Span,
 ) (resp []roachpb.SpanConfigEntry, retErr error) {
@@ -116,7 +116,7 @@ func (k *KVAccessor) GetSpanConfigEntriesFor(
 	return resp, nil
 }
 
-// UpdateSpanConfigEntries is part of the spanconfig.KVAccessor interface.
+// UpdateSpanConfigEntries is part of the KVAccessor interface.
 func (k *KVAccessor) UpdateSpanConfigEntries(
 	ctx context.Context, toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEntry,
 ) error {
@@ -127,20 +127,6 @@ func (k *KVAccessor) UpdateSpanConfigEntries(
 	return k.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return k.updateSpanConfigEntriesWithTxn(ctx, toDelete, toUpsert, txn)
 	})
-}
-
-// GetSystemSpanConfigEntries is part of the spanconfig.KVAccessor interface.
-func (k *KVAccessor) GetSystemSpanConfigEntries(
-	context.Context,
-) ([]roachpb.SystemSpanConfigEntry, error) {
-	return nil, errors.New("unimplemented")
-}
-
-// UpdateSystemSpanConfigEntries is part of the spanconfig.KVAccessor interface.
-func (k *KVAccessor) UpdateSystemSpanConfigEntries(
-	context.Context, []roachpb.SystemSpanConfigTarget, []roachpb.SystemSpanConfigEntry,
-) error {
-	return errors.New("unimplemented")
 }
 
 func newKVAccessor(

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
@@ -42,7 +42,7 @@ import (
 // 		upsert [d,e):D
 //      ----
 //
-// They tie into GetSpanConfigEntriesFor and UpdateSpanConfigEntries
+// They tie into GetSpanConfigRecords and UpdateSpanConfigRecords
 // respectively. For kvaccessor-get, each listed span is added to the set of
 // spans being read. For kvaccessor-update, the lines prefixed with "delete"
 // count towards the spans being deleted, and for "upsert" they correspond to
@@ -69,20 +69,20 @@ func TestDataDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "kvaccessor-get":
-				spans := spanconfigtestutils.ParseKVAccessorGetArguments(t, d.Input)
-				entries, err := accessor.GetSpanConfigEntriesFor(ctx, spans)
+				targets := spanconfigtestutils.ParseKVAccessorGetArguments(t, d.Input)
+				records, err := accessor.GetSpanConfigRecords(ctx, targets)
 				if err != nil {
 					return fmt.Sprintf("err: %s", err.Error())
 				}
 
 				var output strings.Builder
-				for _, entry := range entries {
-					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigEntry(entry)))
+				for _, record := range records {
+					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigRecord(record)))
 				}
 				return output.String()
 			case "kvaccessor-update":
 				toDelete, toUpsert := spanconfigtestutils.ParseKVAccessorUpdateArguments(t, d.Input)
-				if err := accessor.UpdateSpanConfigEntries(ctx, toDelete, toUpsert); err != nil {
+				if err := accessor.UpdateSpanConfigRecords(ctx, toDelete, toUpsert); err != nil {
 					return fmt.Sprintf("err: %s", err.Error())
 				}
 				return "ok"

--- a/pkg/spanconfig/spanconfigkvaccessor/validation_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/validation_test.go
@@ -14,17 +14,20 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidation(t *testing.T) {
+// TestValidateUpdateArgs ensures we validate arguments to
+// UpdateSpanConfigRecords correctly.
+func TestValidateUpdateArgs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	for _, tc := range []struct {
-		toDelete []roachpb.Span
-		toUpsert []roachpb.SpanConfigEntry
+		toDelete []spanconfig.Target
+		toUpsert []spanconfig.Record
 		expErr   string
 	}{
 		{
@@ -32,61 +35,80 @@ func TestValidation(t *testing.T) {
 			expErr: "",
 		},
 		{
-			toDelete: []roachpb.Span{
-				{Key: roachpb.Key("a")}, // empty end key in delete list
+			toDelete: []spanconfig.Target{
+				spanconfig.MakeSpanTarget(
+					roachpb.Span{Key: roachpb.Key("a")}, // empty end key in delete list
+				),
 			},
 			expErr: "invalid span: a",
 		},
 		{
-			toUpsert: []roachpb.SpanConfigEntry{
+			toUpsert: []spanconfig.Record{
 				{
-					Span: roachpb.Span{Key: roachpb.Key("a")}, // empty end key in update list
+					Target: spanconfig.MakeSpanTarget(
+						roachpb.Span{Key: roachpb.Key("a")}, // empty end key in update list
+					),
 				},
 			},
 			expErr: "invalid span: a",
 		},
 		{
-			toUpsert: []roachpb.SpanConfigEntry{
+			toUpsert: []spanconfig.Record{
 				{
-					Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("a")}, // invalid span; end < start
+					Target: spanconfig.MakeSpanTarget(
+						roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("a")}, // invalid span; end < start
+					),
 				},
 			},
 			expErr: "invalid span: {b-a}",
 		},
 		{
-			toDelete: []roachpb.Span{
-				{Key: roachpb.Key("b"), EndKey: roachpb.Key("a")}, // invalid span; end < start
+			toDelete: []spanconfig.Target{
+				spanconfig.MakeSpanTarget(
+					roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("a")}, // invalid span; end < start
+				),
 			},
 			expErr: "invalid span: {b-a}",
 		},
 		{
-			toDelete: []roachpb.Span{
-				{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")}, // overlapping spans in the same list
-				{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+			toDelete: []spanconfig.Target{
+				// overlapping spans in the same list.
+				spanconfig.MakeSpanTarget(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")}),
+				spanconfig.MakeSpanTarget(roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}),
 			},
 			expErr: "overlapping spans {a-c} and {b-c} in same list",
 		},
 		{
-			toUpsert: []roachpb.SpanConfigEntry{ // overlapping spans in the same list
+			toUpsert: []spanconfig.Record{ // overlapping spans in the same list
 				{
-					Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+					Target: spanconfig.MakeSpanTarget(
+						roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+					),
 				},
 				{
-					Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+					Target: spanconfig.MakeSpanTarget(
+						roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+					),
 				},
 			},
 			expErr: "overlapping spans {a-c} and {b-c} in same list",
 		},
 		{
-			toDelete: []roachpb.Span{
-				{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
+			// Overlapping spans in different lists.
+			toDelete: []spanconfig.Target{
+				// Overlapping spans in the same list.
+				spanconfig.MakeSpanTarget(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("c")}),
 			},
-			toUpsert: []roachpb.SpanConfigEntry{ // overlapping spans in different lists
+			toUpsert: []spanconfig.Record{
 				{
-					Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+					Target: spanconfig.MakeSpanTarget(
+						roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+					),
 				},
 				{
-					Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+					Target: spanconfig.MakeSpanTarget(
+						roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+					),
 				},
 			},
 			expErr: "",

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -81,10 +81,10 @@ import (
 //      ----
 //      ok
 //
-// - update and get tie into GetSpanConfigEntriesFor and
-//   UpdateSpanConfigEntries respectively on the KVAccessor interface, and are a
-//   convenient shorthand to populate the system table that the KVSubscriber
-//   subscribes to. The input is processed in a single batch.
+// - update and get tie into GetSpanConfigRecords and UpdateSpanConfigRecords
+//   respectively on the KVAccessor interface, and are a convenient shorthand to
+//   populate the system table that the KVSubscriber subscribes to. The input is
+//   processed in a single batch.
 // - start starts the subscription process. It can also be used to verify
 //   behavior when re-establishing subscriptions after hard errors.
 // - updates lists the span updates the KVSubscriber receives, in the listed
@@ -97,7 +97,7 @@ import (
 //   kvsubscriber and is useful to test teardown and recovery behavior.
 //
 // Text of the form [a,b) and [a,b):C correspond to spans and span config
-// entries; see spanconfigtestutils.Parse{Span,Config,SpanConfigEntry} for more
+// records; see spanconfigtestutils.Parse{Span,Config,SpanConfigRecord} for more
 // details.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -175,19 +175,19 @@ func TestDataDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "get":
-				spans := spanconfigtestutils.ParseKVAccessorGetArguments(t, d.Input)
-				entries, err := kvAccessor.GetSpanConfigEntriesFor(ctx, spans)
+				targets := spanconfigtestutils.ParseKVAccessorGetArguments(t, d.Input)
+				records, err := kvAccessor.GetSpanConfigRecords(ctx, targets)
 				require.NoError(t, err)
 
 				var output strings.Builder
-				for _, entry := range entries {
-					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigEntry(entry)))
+				for _, record := range records {
+					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigRecord(record)))
 				}
 				return output.String()
 
 			case "update":
 				toDelete, toUpsert := spanconfigtestutils.ParseKVAccessorUpdateArguments(t, d.Input)
-				require.NoError(t, kvAccessor.UpdateSpanConfigEntries(ctx, toDelete, toUpsert))
+				require.NoError(t, kvAccessor.UpdateSpanConfigRecords(ctx, toDelete, toUpsert))
 				lastUpdateTS = ts.Clock().Now()
 
 			case "start":

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -250,7 +250,13 @@ func (s *KVSubscriber) handlePartialUpdate(
 
 	for _, h := range handlers {
 		for _, ev := range events {
-			h.invoke(ev.(*bufferEvent).Update.Span)
+			// TODO(arul): In the future, once we start reacting to system span
+			// configurations, we'll want to invoke handlers with the correct span
+			// here as well.
+			sp := ev.(*bufferEvent).Update.Target.GetSpan()
+			if sp != nil {
+				h.invoke(*sp)
+			}
 		}
 	}
 }

--- a/pkg/spanconfig/spanconfigkvsubscriber/span_config_decoder_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/span_config_decoder_test.go
@@ -80,8 +80,8 @@ func TestSpanConfigDecoder(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Truef(t, span.Equal(got.Span),
-		"expected span=%s, got span=%s", span, got.Span)
+	require.Truef(t, span.Equal(*got.Target.GetSpan()),
+		"expected span=%s, got span=%s", span, *got.Target.GetSpan())
 	require.Truef(t, conf.Equal(got.Config),
 		"expected config=%s, got config=%s", conf, got.Config)
 }

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -57,17 +57,17 @@ func New(
 // Translate is part of the spanconfig.SQLTranslator interface.
 func (s *SQLTranslator) Translate(
 	ctx context.Context, ids descpb.IDs,
-) ([]roachpb.SpanConfigEntry, hlc.Timestamp, error) {
-	var entries []roachpb.SpanConfigEntry
+) ([]spanconfig.Record, hlc.Timestamp, error) {
+	var records []spanconfig.Record
 	// txn used to translate the IDs, so that we can get its commit timestamp
 	// later.
 	var translateTxn *kv.Txn
 	if err := sql.DescsTxn(ctx, s.execCfg, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
-		// We're in a retryable closure, so clear any entries from previous
+		// We're in a retryable closure, so clear any records from previous
 		// attempts.
-		entries = entries[:0]
+		records = records[:0]
 
 		// Construct an in-memory view of the system.protected_ts_records table to
 		// populate the protected timestamp field on the emitted span configs.
@@ -102,27 +102,27 @@ func (s *SQLTranslator) Translate(
 			}
 		}
 
-		pseudoTableEntries, err := s.maybeGeneratePseudoTableEntries(ctx, txn, ids)
+		pseudoTableRecords, err := s.maybeGeneratePseudoTableRecords(ctx, txn, ids)
 		if err != nil {
 			return err
 		}
-		entries = append(entries, pseudoTableEntries...)
+		records = append(records, pseudoTableRecords...)
 
-		scratchRangeEntry, err := s.maybeGenerateScratchRangeEntry(ctx, txn, ids)
+		scratchRangeRecord, err := s.maybeGenerateScratchRangeRecord(ctx, txn, ids)
 		if err != nil {
 			return err
 		}
-		if !scratchRangeEntry.Empty() {
-			entries = append(entries, scratchRangeEntry)
+		if !scratchRangeRecord.IsEmpty() {
+			records = append(records, scratchRangeRecord)
 		}
 
 		// For every unique leaf ID, generate span configurations.
 		for _, leafID := range leafIDs {
-			translatedEntries, err := s.generateSpanConfigurations(ctx, leafID, txn, descsCol, ptsStateReader)
+			translatedRecords, err := s.generateSpanConfigurations(ctx, leafID, txn, descsCol, ptsStateReader)
 			if err != nil {
 				return err
 			}
-			entries = append(entries, translatedEntries...)
+			records = append(records, translatedRecords...)
 		}
 		translateTxn = txn
 		return nil
@@ -130,7 +130,7 @@ func (s *SQLTranslator) Translate(
 		return nil, hlc.Timestamp{}, err
 	}
 
-	return entries, translateTxn.CommitTimestamp(), nil
+	return records, translateTxn.CommitTimestamp(), nil
 }
 
 // descLookupFlags is the set of look up flags used when fetching descriptors.
@@ -154,7 +154,7 @@ func (s *SQLTranslator) generateSpanConfigurations(
 	txn *kv.Txn,
 	descsCol *descs.Collection,
 	ptsStateReader *protectedTimestampStateReader,
-) (entries []roachpb.SpanConfigEntry, err error) {
+) (_ []spanconfig.Record, err error) {
 	if zonepb.IsNamedZoneID(id) {
 		return s.generateSpanConfigurationsForNamedZone(ctx, txn, id)
 	}
@@ -184,7 +184,7 @@ func (s *SQLTranslator) generateSpanConfigurations(
 // zone and generates the span configurations for it.
 func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 	ctx context.Context, txn *kv.Txn, id descpb.ID,
-) ([]roachpb.SpanConfigEntry, error) {
+) ([]spanconfig.Record, error) {
 	name, ok := zonepb.NamedZonesByID[uint32(id)]
 	if !ok {
 		return nil, errors.AssertionFailedf("id %d does not belong to a named zone", id)
@@ -230,14 +230,14 @@ func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 		return nil, err
 	}
 	spanConfig := zoneConfig.AsSpanConfig()
-	var entries []roachpb.SpanConfigEntry
+	var records []spanconfig.Record
 	for _, span := range spans {
-		entries = append(entries, roachpb.SpanConfigEntry{
-			Span:   span,
+		records = append(records, spanconfig.Record{
+			Target: spanconfig.MakeSpanTarget(span),
 			Config: spanConfig,
 		})
 	}
-	return entries, nil
+	return records, nil
 }
 
 // generateSpanConfigurationsForTable generates the span configurations
@@ -248,7 +248,7 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 	txn *kv.Txn,
 	desc catalog.Descriptor,
 	ptsStateReader *protectedTimestampStateReader,
-) ([]roachpb.SpanConfigEntry, error) {
+) ([]spanconfig.Record, error) {
 	if desc.DescriptorType() != catalog.Table {
 		return nil, errors.AssertionFailedf(
 			"expected table descriptor, but got descriptor of type %s", desc.DescriptorType(),
@@ -278,7 +278,7 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 		ptsStateReader.getProtectionPoliciesForSchemaObject(desc.GetID()),
 		ptsStateReader.getProtectionPoliciesForSchemaObject(desc.GetParentID())...)
 
-	entries := make([]roachpb.SpanConfigEntry, 0)
+	records := make([]spanconfig.Record, 0)
 	if desc.GetID() == keys.DescriptorTableID {
 		// We have some special handling for `system.descriptor` on account of
 		// it being the first non-empty table in every tenant's keyspace.
@@ -289,11 +289,11 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 			// there's no data within [/Tenant/<id>/ - /Tenant/<id>/Table/3),
 			// but looking at range boundaries, it's slightly less confusing
 			// this way.
-			entries = append(entries, roachpb.SpanConfigEntry{
-				Span: roachpb.Span{
+			records = append(records, spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(roachpb.Span{
 					Key:    s.codec.TenantPrefix(),
 					EndKey: tableEndKey,
-				},
+				}),
 				Config: tableSpanConfig,
 			})
 		} else {
@@ -306,16 +306,16 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 			// somewhat useful for understandability reasons and reducing the
 			// (tiny) re-splitting costs when switching between the two
 			// subsystems.
-			entries = append(entries, roachpb.SpanConfigEntry{
-				Span: roachpb.Span{
+			records = append(records, spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(roachpb.Span{
 					Key:    keys.SystemConfigSpan.Key,
 					EndKey: tableEndKey,
-				},
+				}),
 				Config: tableSpanConfig,
 			})
 		}
 
-		return entries, nil
+		return records, nil
 
 		// TODO(irfansharif): There's an attack vector here that we haven't
 		// addressed satisfactorily. By splitting only on start keys of span
@@ -369,9 +369,9 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 		// If there is a "hole" in the spans covered by the subzones array we fill
 		// it using the parent zone configuration.
 		if !prevEndKey.Equal(span.Key) {
-			entries = append(entries,
-				roachpb.SpanConfigEntry{
-					Span:   roachpb.Span{Key: prevEndKey, EndKey: span.Key},
+			records = append(records,
+				spanconfig.Record{
+					Target: spanconfig.MakeSpanTarget(roachpb.Span{Key: prevEndKey, EndKey: span.Key}),
 					Config: tableSpanConfig,
 				},
 			)
@@ -386,9 +386,9 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 			subzoneSpanConfig.RangefeedEnabled = true
 			subzoneSpanConfig.GCPolicy.IgnoreStrictEnforcement = true
 		}
-		entries = append(entries,
-			roachpb.SpanConfigEntry{
-				Span:   roachpb.Span{Key: span.Key, EndKey: span.EndKey},
+		records = append(records,
+			spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(roachpb.Span{Key: span.Key, EndKey: span.EndKey}),
 				Config: subzoneSpanConfig,
 			},
 		)
@@ -399,14 +399,14 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 	// If the last subzone span doesn't cover the entire table's keyspace then
 	// we cover the remaining key range with the table's zone configuration.
 	if !prevEndKey.Equal(tableEndKey) {
-		entries = append(entries,
-			roachpb.SpanConfigEntry{
-				Span:   roachpb.Span{Key: prevEndKey, EndKey: tableEndKey},
+		records = append(records,
+			spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(roachpb.Span{Key: prevEndKey, EndKey: tableEndKey}),
 				Config: tableSpanConfig,
 			},
 		)
 	}
-	return entries, nil
+	return records, nil
 }
 
 // findDescendantLeafIDs finds all leaf IDs below the given ID in the zone
@@ -527,11 +527,11 @@ func (s *SQLTranslator) findDescendantLeafIDsForNamedZone(
 	return descendantIDs, nil
 }
 
-// maybeGeneratePseudoTableEntries generates span configs for
+// maybeGeneratePseudoTableRecords generates span configs for
 // pseudo table ID key spans, if applicable.
-func (s *SQLTranslator) maybeGeneratePseudoTableEntries(
+func (s *SQLTranslator) maybeGeneratePseudoTableRecords(
 	ctx context.Context, txn *kv.Txn, ids descpb.IDs,
-) ([]roachpb.SpanConfigEntry, error) {
+) ([]spanconfig.Record, error) {
 	if !s.codec.ForSystemTenant() {
 		return nil, nil
 	}
@@ -567,30 +567,30 @@ func (s *SQLTranslator) maybeGeneratePseudoTableEntries(
 			return nil, err
 		}
 		tableSpanConfig := zone.AsSpanConfig()
-		var entries []roachpb.SpanConfigEntry
+		var records []spanconfig.Record
 		for _, pseudoTableID := range keys.PseudoTableIDs {
 			tableStartKey := s.codec.TablePrefix(pseudoTableID)
 			tableEndKey := tableStartKey.PrefixEnd()
-			entries = append(entries, roachpb.SpanConfigEntry{
-				Span: roachpb.Span{
+			records = append(records, spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(roachpb.Span{
 					Key:    tableStartKey,
 					EndKey: tableEndKey,
-				},
+				}),
 				Config: tableSpanConfig,
 			})
 		}
 
-		return entries, nil
+		return records, nil
 	}
 
 	return nil, nil
 }
 
-func (s *SQLTranslator) maybeGenerateScratchRangeEntry(
+func (s *SQLTranslator) maybeGenerateScratchRangeRecord(
 	ctx context.Context, txn *kv.Txn, ids descpb.IDs,
-) (roachpb.SpanConfigEntry, error) {
+) (spanconfig.Record, error) {
 	if !s.knobs.ConfigureScratchRange || !s.codec.ForSystemTenant() {
-		return roachpb.SpanConfigEntry{}, nil // nothing to do
+		return spanconfig.Record{}, nil // nothing to do
 	}
 
 	for _, id := range ids {
@@ -600,17 +600,17 @@ func (s *SQLTranslator) maybeGenerateScratchRangeEntry(
 
 		zone, err := sql.GetHydratedZoneConfigForDatabase(ctx, txn, s.codec, keys.RootNamespaceID)
 		if err != nil {
-			return roachpb.SpanConfigEntry{}, err
+			return spanconfig.Record{}, err
 		}
 
-		return roachpb.SpanConfigEntry{
-			Span: roachpb.Span{
+		return spanconfig.Record{
+			Target: spanconfig.MakeSpanTarget(roachpb.Span{
 				Key:    keys.ScratchRangeMin,
 				EndKey: keys.ScratchRangeMax,
-			},
+			}),
 			Config: zone.AsSpanConfig(),
 		}, nil
 	}
 
-	return roachpb.SpanConfigEntry{}, nil
+	return spanconfig.Record{}, nil
 }

--- a/pkg/spanconfig/spanconfigstore/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigstore/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "spanconfigstore",
-    srcs = ["store.go"],
+    srcs = [
+        "spanconfigstore.go",
+        "store.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore",
     visibility = ["//visibility:public"],
     deps = [
@@ -20,7 +23,10 @@ go_library(
 
 go_test(
     name = "spanconfigstore_test",
-    srcs = ["store_test.go"],
+    srcs = [
+        "spanconfigstore_test.go",
+        "store_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":spanconfigstore"],
     deps = [

--- a/pkg/spanconfig/spanconfigstore/spanconfigstore.go
+++ b/pkg/spanconfig/spanconfigstore/spanconfigstore.go
@@ -1,0 +1,447 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigstore
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// spanConfigStore is an in-memory data structure to store and retrieve
+// SpanConfigs associated with a single span. Internally it makes use of an
+// interval tree to store non-overlapping span configurations. It isn't safe for
+// concurrent use.
+type spanConfigStore struct {
+	tree    interval.Tree
+	idAlloc int64
+}
+
+// newSpanConfigStore constructs and returns a new spanConfigStore.
+func newSpanConfigStore() *spanConfigStore {
+	s := &spanConfigStore{}
+	s.tree = interval.NewTree(interval.ExclusiveOverlapper)
+	return s
+}
+
+// copy returns a copy of the spanConfigStore.
+func (s *spanConfigStore) copy(ctx context.Context) *spanConfigStore {
+	clone := newSpanConfigStore()
+	_ = s.forEachOverlapping(keys.EverythingSpan, func(entry spanConfigEntry) error {
+		_, _, err := clone.apply(false /* dryrun */, spanconfig.Update{
+			Target: spanconfig.MakeSpanTarget(entry.span),
+			Config: entry.config,
+		})
+		if err != nil {
+			log.Fatalf(ctx, "%v", err)
+		}
+		return nil
+	})
+	return clone
+}
+
+// forEachOverlapping iterates through the set of entries that overlap with the
+// given span, in sorted order. It does not return an error if the callback
+// doesn't.
+func (s *spanConfigStore) forEachOverlapping(sp roachpb.Span, f func(spanConfigEntry) error) error {
+	// Iterate over all overlapping ranges and invoke the callback with the
+	// corresponding span config entries.
+	for _, overlapping := range s.tree.Get(sp.AsRange()) {
+		entry := overlapping.(*spanConfigStoreEntry).spanConfigEntry
+		if err := f(entry); err != nil {
+			if iterutil.Done(err) {
+				err = nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// computeSplitKey returns the first key we should split on because of the
+// presence a span config given a start and end key pair.
+func (s *spanConfigStore) computeSplitKey(start, end roachpb.RKey) roachpb.RKey {
+	sp := roachpb.Span{Key: start.AsRawKey(), EndKey: end.AsRawKey()}
+
+	// We don't want to split within the system config span while we're still
+	// also using it to disseminate zone configs.
+	//
+	// TODO(irfansharif): Once we've fully phased out the system config span, we
+	// can get rid of this special handling.
+	if keys.SystemConfigSpan.Contains(sp) {
+		return nil
+	}
+	if keys.SystemConfigSpan.ContainsKey(sp.Key) {
+		return roachpb.RKey(keys.SystemConfigSpan.EndKey)
+	}
+
+	idx := 0
+	var splitKey roachpb.RKey = nil
+	s.tree.DoMatching(func(i interval.Interface) (done bool) {
+		if idx > 0 {
+			splitKey = roachpb.RKey(i.(*spanConfigStoreEntry).span.Key)
+			return true // we found our split key, we're done
+		}
+
+		idx++
+		return false // more
+	}, sp.AsRange())
+
+	return splitKey
+}
+
+// getSpanConfigForKey returns the span config corresponding to the supplied
+// key.
+func (s *spanConfigStore) getSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, bool, error) {
+	sp := roachpb.Span{Key: key.AsRawKey(), EndKey: key.Next().AsRawKey()}
+
+	var conf roachpb.SpanConfig
+	found := false
+	s.tree.DoMatching(func(i interval.Interface) (done bool) {
+		conf = i.(*spanConfigStoreEntry).config
+		found = true
+		return true
+	}, sp.AsRange())
+
+	if !found {
+		if log.ExpensiveLogEnabled(ctx, 1) {
+			log.Warningf(ctx, "span config not found for %s", key.String())
+		}
+	}
+	return conf, found, nil
+}
+
+// apply takes an incremental set of updates and returns the spans/span<->config
+// entries deleted/added as a result of applying them. It also updates its state
+// by applying them if dryrun is false.
+func (s *spanConfigStore) apply(
+	dryrun bool, updates ...spanconfig.Update,
+) (deleted []roachpb.Span, added []spanConfigStoreEntry, err error) {
+	if err := validateApplyArgs(updates...); err != nil {
+		return nil, nil, err
+	}
+
+	sorted := make([]spanconfig.Update, len(updates))
+	copy(sorted, updates)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Target.Less(sorted[j].Target)
+	})
+	updates = sorted // re-use the same variable
+
+	entriesToDelete, entriesToAdd := s.accumulateOpsFor(updates)
+
+	deleted = make([]roachpb.Span, len(entriesToDelete))
+	for i := range entriesToDelete {
+		entry := &entriesToDelete[i]
+		if !dryrun {
+			if err := s.tree.Delete(entry, false); err != nil {
+				return nil, nil, err
+			}
+		}
+		deleted[i] = entry.span
+	}
+
+	added = make([]spanConfigStoreEntry, len(entriesToAdd))
+	for i := range entriesToAdd {
+		entry := &entriesToAdd[i]
+		if !dryrun {
+			if err := s.tree.Insert(entry, false); err != nil {
+				return nil, nil, err
+			}
+		}
+		added[i] = *entry
+	}
+
+	return deleted, added, nil
+}
+
+// accumulateOpsFor returns the list of store entries that would be
+// deleted and added if the given set of updates were to be applied.
+//
+// To apply a single update, we want to find all overlapping spans and clear out
+// just the intersections. If the update is adding a new span config, we'll also
+// want to add the corresponding store entry after. We do this by deleting all
+// overlapping spans in their entirety and re-adding the non-overlapping
+// segments. Pseudo-code:
+//
+//   for entry in store.overlapping(update.span):
+//       union, intersection = union(update.span, entry), intersection(update.span, entry)
+//       pre  = span{union.start_key, intersection.start_key}
+//       post = span{intersection.end_key, union.end_key}
+//
+//       delete {span=entry.span, conf=entry.conf}
+//       if entry.contains(update.span.start_key):
+//           # First entry overlapping with update.
+//           add {span=pre, conf=entry.conf} if non-empty
+//       if entry.contains(update.span.end_key):
+//           # Last entry overlapping with update.
+//           add {span=post, conf=entry.conf} if non-empty
+//
+//   if adding:
+//       add {span=update.span, conf=update.conf} # add ourselves
+//
+// When extending to a set of updates, things are more involved (but only
+// slightly!). Let's assume that the updates are non-overlapping and sorted
+// by start key. As before, we want to delete overlapping entries in their
+// entirety and re-add the non-overlapping segments. With multiple updates, it's
+// possible that a segment being re-added will overlap another update. If
+// processing one update at a time in sorted order, we want to only re-add the
+// gap between the consecutive updates.
+//
+//   keyspace         a  b  c  d  e  f  g  h  i  j
+//   existing state      [--------X--------)
+//   updates          [--A--)           [--B--)
+//
+// When processing [a,c):A, after deleting [b,h):X, it would be incorrect to
+// re-add [c,h):X since we're also looking to apply [g,i):B. Instead of
+// re-adding the trailing segment right away, we carry it forward and process it
+// when iterating over the second, possibly overlapping update. In our example,
+// when iterating over [g,i):B we can subtract the overlap from [c,h):X and only
+// re-add [c,g):X.
+//
+// It's also possible for the segment to extend past the second update. In the
+// example below, when processing [d,f):B and having [b,h):X carried over, we
+// want to re-add [c,d):X and carry forward [f,h):X to the update after (i.e.
+// [g,i):C)).
+//
+//   keyspace         a  b  c  d  e  f  g  h  i  j
+//   existing state      [--------X--------)
+//   updates          [--A--)  [--B--)  [--C--)
+//
+// One final note: we're iterating through the updates without actually applying
+// any mutations. Going back to our first example, when processing [g,i):B,
+// retrieving the set of overlapping spans would (again) retrieve [b,h):X -- an
+// entry we've already encountered when processing [a,c):A. Re-adding
+// non-overlapping segments naively would re-add [b,g):X -- an entry that
+// overlaps with our last update [a,c):A. When retrieving overlapping entries,
+// we need to exclude any that overlap with the segment that was carried over.
+// Pseudo-code:
+//
+//   carry-over = <empty>
+//   for update in updates:
+//       carried-over, carry-over = carry-over, <empty>
+//       if update.overlap(carried-over):
+//           # Fill in the gap between consecutive updates.
+//           add {span=span{carried-over.start_key, update.start_key}, conf=carried-over.conf}
+//           # Consider the trailing span after update; carry it forward if non-empty.
+//           carry-over = {span=span{update.end_key, carried-over.end_key}, conf=carried-over.conf}
+//       else:
+//           add {span=carried-over.span, conf=carried-over.conf} if non-empty
+//
+//       for entry in store.overlapping(update.span):
+//          if entry.overlap(processed):
+//               continue # already processed
+//
+//           union, intersection = union(update.span, entry), intersection(update.span, entry)
+//           pre  = span{union.start_key, intersection.start_key}
+//           post = span{intersection.end_key, union.end_key}
+//
+//           delete {span=entry.span, conf=entry.conf}
+//           if entry.contains(update.span.start_key):
+//               # First entry overlapping with update.
+//               add {span=pre, conf=entry.conf} if non-empty
+//           if entry.contains(update.span.end_key):
+//               # Last entry overlapping with update.
+//               carry-over = {span=post, conf=entry.conf}
+//
+//        if adding:
+//           add {span=update.span, conf=update.conf} # add ourselves
+//
+//   add {span=carry-over.span, conf=carry-over.conf} if non-empty
+//
+func (s *spanConfigStore) accumulateOpsFor(
+	updates []spanconfig.Update,
+) (toDelete, toAdd []spanConfigStoreEntry) {
+	var carryOver spanConfigEntry
+	for _, update := range updates {
+		var carriedOver spanConfigEntry
+		carriedOver, carryOver = carryOver, spanConfigEntry{}
+		if update.Target.GetSpan().Overlaps(carriedOver.span) {
+			gapBetweenUpdates := roachpb.Span{Key: carriedOver.span.Key, EndKey: update.Target.GetSpan().Key}
+			if gapBetweenUpdates.Valid() {
+				toAdd = append(toAdd, s.makeEntry(gapBetweenUpdates, carriedOver.config))
+			}
+
+			carryOverSpanAfterUpdate := roachpb.Span{Key: update.Target.GetSpan().EndKey, EndKey: carriedOver.span.EndKey}
+			if carryOverSpanAfterUpdate.Valid() {
+				carryOver = spanConfigEntry{
+					span:   carryOverSpanAfterUpdate,
+					config: carriedOver.config,
+				}
+			}
+		} else if !carriedOver.isEmpty() {
+			toAdd = append(toAdd, s.makeEntry(carriedOver.span, carriedOver.config))
+		}
+
+		skipAddingSelf := false
+		for _, overlapping := range s.tree.Get(update.Target.GetSpan().AsRange()) {
+			existing := overlapping.(*spanConfigStoreEntry)
+			if existing.span.Overlaps(carriedOver.span) {
+				continue // we've already processed this entry above.
+			}
+
+			var (
+				union = existing.span.Combine(*update.Target.GetSpan())
+				inter = existing.span.Intersect(*update.Target.GetSpan())
+
+				pre  = roachpb.Span{Key: union.Key, EndKey: inter.Key}
+				post = roachpb.Span{Key: inter.EndKey, EndKey: union.EndKey}
+			)
+
+			if update.Addition() {
+				if existing.span.Equal(*update.Target.GetSpan()) && existing.config.Equal(update.Config) {
+					skipAddingSelf = true
+					break // no-op; peep-hole optimization
+				}
+			}
+
+			// Delete the existing span in its entirety. Below we'll re-add the
+			// non-intersecting parts of the span.
+			toDelete = append(toDelete, *existing)
+			// existing entry contains the update span's start key
+			if existing.span.ContainsKey(update.Target.GetSpan().Key) {
+				// ex:     [-----------------)
+				//
+				// up:         [-------)
+				// up:         [-------------)
+				// up:         [--------------
+				// up:     [-------)
+				// up:     [-----------------)
+				// up:     [------------------
+
+				// Re-add the non-intersecting span, if any.
+				if pre.Valid() {
+					toAdd = append(toAdd, s.makeEntry(pre, existing.config))
+				}
+			}
+
+			if existing.span.ContainsKey(update.Target.GetSpan().EndKey) { // existing entry contains the update span's end key
+				// ex:     [-----------------)
+				//
+				// up:     -------------)
+				// up:     [------------)
+				// up:        [---------)
+
+				// Carry over the non-intersecting span.
+				carryOver = spanConfigEntry{
+					span:   post,
+					config: existing.config,
+				}
+			}
+		}
+
+		if update.Addition() && !skipAddingSelf {
+			// Add the update itself.
+			toAdd = append(toAdd, s.makeEntry(*update.Target.GetSpan(), update.Config))
+
+			// TODO(irfansharif): If we're adding an entry, we could inspect the
+			// entries before and after and check whether either of them have
+			// the same config. If they do, we could coalesce them into a single
+			// span. Given that these boundaries determine where we split
+			// ranges, we'd be able to reduce the number of ranges drastically
+			// (think adjacent tables/indexes/partitions with the same config).
+			// This would be especially significant for secondary tenants, where
+			// we'd be able to avoid unconditionally splitting on table
+			// boundaries. We'd still want to split on tenant boundaries, so
+			// certain preconditions would need to hold. For performance
+			// reasons, we'd probably also want to offer a primitive to allow
+			// manually splitting on specific table boundaries.
+		}
+	}
+
+	if !carryOver.isEmpty() {
+		toAdd = append(toAdd, s.makeEntry(carryOver.span, carryOver.config))
+	}
+	return toDelete, toAdd
+}
+
+func (s *spanConfigStore) makeEntry(sp roachpb.Span, conf roachpb.SpanConfig) spanConfigStoreEntry {
+	s.idAlloc++
+	return spanConfigStoreEntry{
+		spanConfigEntry: spanConfigEntry{span: sp, config: conf},
+		id:              s.idAlloc,
+	}
+}
+
+// validateApplyArgs validates the supplied updates can be applied to the
+// spanConfigStore. In particular, updates are expected to correspond to target
+// spans, those spans be valid, and non-overlapping.
+func validateApplyArgs(updates ...spanconfig.Update) error {
+	for i := range updates {
+		sp := updates[i].Target.GetSpan()
+
+		if sp == nil {
+			return errors.New("expected update to target a span")
+		}
+		if !sp.Valid() || len(sp.EndKey) == 0 {
+			return errors.New("invalid span")
+		}
+	}
+
+	sorted := make([]spanconfig.Update, len(updates))
+	copy(sorted, updates)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Target.GetSpan().Key.Compare(sorted[j].Target.GetSpan().Key) < 0
+	})
+	updates = sorted // re-use the same variable
+
+	for i := range updates {
+		if i == 0 {
+			continue
+		}
+		if updates[i].Target.GetSpan().Overlaps(*updates[i-1].Target.GetSpan()) {
+			return errors.Newf(
+				"found overlapping updates %s and %s",
+				*updates[i-1].Target.GetSpan(),
+				*updates[i].Target.GetSpan(),
+			)
+		}
+	}
+	return nil
+}
+
+// spanConfigEntry captures a span <->config pair.
+type spanConfigEntry struct {
+	span   roachpb.Span
+	config roachpb.SpanConfig
+}
+
+func (s *spanConfigEntry) isEmpty() bool {
+	return s.span.Equal(roachpb.Span{}) && s.config.IsEmpty()
+}
+
+// spanConfigStoreEntry is the type used to store and sort values in the
+// span config store.
+type spanConfigStoreEntry struct {
+	spanConfigEntry
+	id int64
+}
+
+var _ interval.Interface = &spanConfigStoreEntry{}
+
+// Range implements interval.Interface.
+func (s *spanConfigStoreEntry) Range() interval.Range {
+	return s.span.AsRange()
+}
+
+// ID implements interval.Interface.
+func (s *spanConfigStoreEntry) ID() uintptr {
+	return uintptr(s.id)
+}

--- a/pkg/spanconfig/spanconfigstore/spanconfigstore_test.go
+++ b/pkg/spanconfig/spanconfigstore/spanconfigstore_test.go
@@ -1,0 +1,202 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigstore
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRandomized randomly sets/deletes span configs for arbitrary keyspans
+// within some alphabet. For a test span, it then asserts that the config we
+// retrieve is what we expect to find from the store. It also ensures that all
+// ranges are non-overlapping.
+func TestRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	randutil.SeedForTests()
+	ctx := context.Background()
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+	configs := "ABCDEF"
+	ops := []string{"set", "del"}
+
+	genRandomSpan := func() roachpb.Span {
+		startIdx, endIdx := rand.Intn(len(alphabet)-1), 1+rand.Intn(len(alphabet)-1)
+		if startIdx == endIdx {
+			endIdx = (endIdx + 1) % len(alphabet)
+		}
+		if endIdx < startIdx {
+			startIdx, endIdx = endIdx, startIdx
+		}
+		spanStr := fmt.Sprintf("[%s, %s)", string(alphabet[startIdx]), string(alphabet[endIdx]))
+		sp := spanconfigtestutils.ParseSpan(t, spanStr)
+		require.True(t, sp.Valid())
+		return sp
+	}
+
+	getRandomConf := func() roachpb.SpanConfig {
+		confStr := fmt.Sprintf("conf_%s", string(configs[rand.Intn(len(configs))]))
+		return spanconfigtestutils.ParseConfig(t, confStr)
+	}
+
+	getRandomOp := func() string {
+		return ops[rand.Intn(2)]
+	}
+
+	getRandomUpdate := func() spanconfig.Update {
+		sp, conf, op := genRandomSpan(), getRandomConf(), getRandomOp()
+		switch op {
+		case "set":
+			return spanconfig.Addition(spanconfig.MakeSpanTarget(sp), conf)
+		case "del":
+			return spanconfig.Deletion(spanconfig.MakeSpanTarget(sp))
+		default:
+		}
+		t.Fatalf("unexpected op: %s", op)
+		return spanconfig.Update{}
+	}
+
+	getRandomUpdates := func() []spanconfig.Update {
+		numUpdates := 1 + rand.Intn(3)
+		updates := make([]spanconfig.Update, numUpdates)
+		for {
+			for i := 0; i < numUpdates; i++ {
+				updates[i] = getRandomUpdate()
+			}
+			sort.Slice(updates, func(i, j int) bool {
+				return updates[i].Target.Less(updates[j].Target)
+			})
+			invalid := false
+			for i := 1; i < numUpdates; i++ {
+				if updates[i].Target.GetSpan().Overlaps(*updates[i-1].Target.GetSpan()) {
+					invalid = true
+				}
+			}
+
+			if invalid {
+				continue // try again
+			}
+
+			rand.Shuffle(len(updates), func(i, j int) {
+				updates[i], updates[j] = updates[j], updates[i]
+			})
+			return updates
+		}
+	}
+
+	testSpan := spanconfigtestutils.ParseSpan(t, "[f,g)") // pin a single character span to test with
+	var expConfig roachpb.SpanConfig
+	var expFound bool
+
+	const numOps = 5000
+	store := newSpanConfigStore()
+	for i := 0; i < numOps; i++ {
+		updates := getRandomUpdates()
+		_, _, err := store.apply(false /* dryrun */, updates...)
+		require.NoError(t, err)
+		for _, update := range updates {
+			if testSpan.Overlaps(*update.Target.GetSpan()) {
+				if update.Addition() {
+					expConfig, expFound = update.Config, true
+				} else {
+					expConfig, expFound = roachpb.SpanConfig{}, false
+				}
+			}
+		}
+	}
+
+	if !expFound {
+		_ = store.forEachOverlapping(testSpan,
+			func(entry spanConfigEntry) error {
+				t.Fatalf("found unexpected entry: %s",
+					spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
+						Target: spanconfig.MakeSpanTarget(entry.span),
+						Config: entry.config,
+					}))
+				return nil
+			},
+		)
+	} else {
+		var foundEntry spanConfigEntry
+		_ = store.forEachOverlapping(testSpan,
+			func(entry spanConfigEntry) error {
+				if !foundEntry.isEmpty() {
+					t.Fatalf("expected single overlapping entry, found second: %s",
+						spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
+							Target: spanconfig.MakeSpanTarget(entry.span),
+							Config: entry.config,
+						}))
+				}
+				foundEntry = entry
+
+				// Check that the entry is exactly what we'd expect.
+				gotSpan, gotConfig := entry.span, entry.config
+				require.Truef(t, gotSpan.Contains(testSpan),
+					"improper result: expected retrieved span (%s) to contain test span (%s)",
+					spanconfigtestutils.PrintSpan(gotSpan), spanconfigtestutils.PrintSpan(testSpan))
+
+				require.Truef(t, expConfig.Equal(gotConfig),
+					"mismatched configs: expected %s, got %s",
+					spanconfigtestutils.PrintSpanConfig(expConfig), spanconfigtestutils.PrintSpanConfig(gotConfig))
+
+				return nil
+			},
+		)
+
+		// Ensure that the config accessed through the StoreReader interface is
+		// the same as above.
+		storeReaderConfig, found, err := store.getSpanConfigForKey(ctx, roachpb.RKey(testSpan.Key))
+		require.NoError(t, err)
+		require.True(t, found)
+		require.True(t, foundEntry.config.Equal(storeReaderConfig))
+	}
+
+	everythingSpan := spanconfigtestutils.ParseSpan(t, fmt.Sprintf("[%s,%s)",
+		string(alphabet[0]), string(alphabet[len(alphabet)-1])))
+
+	var last spanConfigEntry
+	_ = store.forEachOverlapping(everythingSpan,
+		func(cur spanConfigEntry) error {
+			// All spans are expected to be valid.
+			require.True(t, cur.span.Valid(),
+				"expected to only find valid spans, found %s",
+				spanconfigtestutils.PrintSpan(cur.span),
+			)
+
+			if last.isEmpty() {
+				last = cur
+				return nil
+			}
+
+			// Span configs are returned in strictly sorted order.
+			require.True(t, last.span.Key.Compare(cur.span.Key) < 0,
+				"expected to find spans in strictly sorted order, found %s then %s",
+				spanconfigtestutils.PrintSpan(last.span), spanconfigtestutils.PrintSpan(cur.span))
+
+			// Span configs must also be non-overlapping.
+			require.Falsef(t, last.span.Overlaps(cur.span),
+				"expected non-overlapping spans, found %s and %s",
+				spanconfigtestutils.PrintSpan(last.span), spanconfigtestutils.PrintSpan(cur.span))
+
+			return nil
+		},
+	)
+}

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -12,17 +12,13 @@ package spanconfigstore
 
 import (
 	"context"
-	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
-	"github.com/cockroachdb/cockroach/pkg/util/interval"
-	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/errors"
 )
 
 // EnabledSetting is a hidden cluster setting to enable the use of the span
@@ -47,8 +43,7 @@ var EnabledSetting = settings.RegisterBoolSetting(
 type Store struct {
 	mu struct {
 		syncutil.RWMutex
-		tree    interval.Tree
-		idAlloc int64
+		spanConfigStore *spanConfigStore
 	}
 
 	// TODO(irfansharif): We're using a static fall back span config here, we
@@ -67,7 +62,7 @@ var _ spanconfig.Store = &Store{}
 // New instantiates a span config store with the given fallback.
 func New(fallback roachpb.SpanConfig) *Store {
 	s := &Store{fallback: fallback}
-	s.mu.tree = interval.NewTree(interval.ExclusiveOverlapper)
+	s.mu.spanConfigStore = newSpanConfigStore()
 	return s
 }
 
@@ -81,33 +76,7 @@ func (s *Store) ComputeSplitKey(_ context.Context, start, end roachpb.RKey) roac
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	sp := roachpb.Span{Key: start.AsRawKey(), EndKey: end.AsRawKey()}
-
-	// We don't want to split within the system config span while we're still
-	// also using it to disseminate zone configs.
-	//
-	// TODO(irfansharif): Once we've fully phased out the system config span, we
-	// can get rid of this special handling.
-	if keys.SystemConfigSpan.Contains(sp) {
-		return nil
-	}
-	if keys.SystemConfigSpan.ContainsKey(sp.Key) {
-		return roachpb.RKey(keys.SystemConfigSpan.EndKey)
-	}
-
-	idx := 0
-	var splitKey roachpb.RKey = nil
-	s.mu.tree.DoMatching(func(i interval.Interface) (done bool) {
-		if idx > 0 {
-			splitKey = roachpb.RKey(i.(*spanConfigStoreEntry).span.Key)
-			return true // we found our split key, we're done
-		}
-
-		idx++
-		return false // more
-	}, sp.AsRange())
-
-	return splitKey
+	return s.mu.spanConfigStore.computeSplitKey(start, end)
 }
 
 // GetSpanConfigForKey is part of the spanconfig.StoreReader interface.
@@ -117,20 +86,11 @@ func (s *Store) GetSpanConfigForKey(
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	sp := roachpb.Span{Key: key.AsRawKey(), EndKey: key.Next().AsRawKey()}
-
-	var conf roachpb.SpanConfig
-	found := false
-	s.mu.tree.DoMatching(func(i interval.Interface) (done bool) {
-		conf = i.(*spanConfigStoreEntry).config
-		found = true
-		return true
-	}, sp.AsRange())
-
+	conf, found, err := s.mu.spanConfigStore.getSpanConfigForKey(ctx, key)
+	if err != nil {
+		return roachpb.SpanConfig{}, err
+	}
 	if !found {
-		if log.ExpensiveLogEnabled(ctx, 1) {
-			log.Warningf(ctx, "span config not found for %s", key.String())
-		}
 		return s.fallback, nil
 	}
 	return conf, nil
@@ -153,47 +113,8 @@ func (s *Store) Copy(ctx context.Context) *Store {
 	defer s.mu.Unlock()
 
 	clone := New(s.fallback)
-	_ = s.forEachOverlappingRLocked(keys.EverythingSpan, func(entry spanConfigEntry) error {
-		clone.Apply(ctx, false /* dryrun */, spanconfig.Update{
-			Target: spanconfig.MakeSpanTarget(entry.span),
-			Config: entry.config,
-		})
-		return nil
-	})
+	clone.mu.spanConfigStore = s.mu.spanConfigStore.copy(ctx)
 	return clone
-}
-
-// Iterate iterates through all the entries in the Store in sorted order.
-func (s *Store) Iterate(f func(spanconfig.Record) error) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.forEachOverlappingRLocked(
-		keys.EverythingSpan,
-		func(s spanConfigEntry) error {
-			return f(spanconfig.Record{
-				Target: spanconfig.MakeSpanTarget(s.span),
-				Config: s.config,
-			})
-		})
-}
-
-// forEachOverlapping iterates through the set of entries that overlap with the
-// given span, in sorted order. It does not return an error if the callback
-// doesn't.
-func (s *Store) forEachOverlappingRLocked(sp roachpb.Span, f func(spanConfigEntry) error) error {
-	// Iterate over all overlapping ranges and invoke the callback with the
-	// corresponding span config entries.
-	for _, overlapping := range s.mu.tree.Get(sp.AsRange()) {
-		entry := overlapping.(*spanConfigStoreEntry).spanConfigEntry
-		if err := f(entry); err != nil {
-			if iterutil.Done(err) {
-				err = nil
-			}
-			return err
-		}
-	}
-	return nil
 }
 
 func (s *Store) applyInternal(
@@ -212,60 +133,16 @@ func (s *Store) applyInternal(
 			spanStoreUpdates = append(spanStoreUpdates, update)
 		}
 	}
-
-	{
-		// Validate that the supplied updates target spans and can be applied to the
-		// underlying interval tree. (non-overlapping, valid).
-		for i := range updates {
-			sp := updates[i].Target.GetSpan()
-
-			if sp == nil {
-				return nil, nil, errors.New("expected update to target a span")
-			}
-			if !sp.Valid() || len(sp.EndKey) == 0 {
-				return nil, nil, errors.New("invalid span")
-			}
-		}
-
-		sorted := make([]spanconfig.Update, len(updates))
-		copy(sorted, updates)
-		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Target.GetSpan().Key.Compare(sorted[j].Target.GetSpan().Key) < 0
-		})
-		updates = sorted // re-use the same variable
-
-		for i := range updates {
-			if i == 0 {
-				continue
-			}
-			if updates[i].Target.GetSpan().Overlaps(*updates[i-1].Target.GetSpan()) {
-				return nil, nil, errors.Newf(
-					"found overlapping updates %s and %s",
-					*updates[i-1].Target.GetSpan(),
-					*updates[i].Target.GetSpan(),
-				)
-			}
-		}
-	}
-	entriesToDelete, entriesToAdd := s.accumulateOpsForRLocked(updates)
-
-	for i := range entriesToDelete {
-		entry := &entriesToDelete[i]
-		if !dryrun {
-			if err := s.mu.tree.Delete(entry, false); err != nil {
-				return nil, nil, err
-			}
-		}
-		deleted = append(deleted, spanconfig.MakeSpanTarget(entry.span))
+	deletedSpans, addedEntries, err := s.mu.spanConfigStore.apply(dryrun, spanStoreUpdates...)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	for i := range entriesToAdd {
-		entry := &entriesToAdd[i]
-		if !dryrun {
-			if err := s.mu.tree.Insert(entry, false); err != nil {
-				return nil, nil, err
-			}
-		}
+	for _, sp := range deletedSpans {
+		deleted = append(deleted, spanconfig.MakeSpanTarget(sp))
+	}
+
+	for _, entry := range addedEntries {
 		added = append(added, spanconfig.Record{
 			Target: spanconfig.MakeSpanTarget(entry.span),
 			Config: entry.config,
@@ -274,239 +151,16 @@ func (s *Store) applyInternal(
 	return deleted, added, nil
 }
 
-// accumulateOpsForRLocked returns the list of store entries that would be
-// deleted and added if the given set of updates were to be applied.
-//
-// To apply a single update, we want to find all overlapping spans and clear out
-// just the intersections. If the update is adding a new span config, we'll also
-// want to add the corresponding store entry after. We do this by deleting all
-// overlapping spans in their entirety and re-adding the non-overlapping
-// segments. Pseudo-code:
-//
-//   for entry in store.overlapping(update.span):
-//       union, intersection = union(update.span, entry), intersection(update.span, entry)
-//       pre  = span{union.start_key, intersection.start_key}
-//       post = span{intersection.end_key, union.end_key}
-//
-//       delete {span=entry.span, conf=entry.conf}
-//       if entry.contains(update.span.start_key):
-//           # First entry overlapping with update.
-//           add {span=pre, conf=entry.conf} if non-empty
-//       if entry.contains(update.span.end_key):
-//           # Last entry overlapping with update.
-//           add {span=post, conf=entry.conf} if non-empty
-//
-//   if adding:
-//       add {span=update.span, conf=update.conf} # add ourselves
-//
-// When extending to a set of updates, things are more involved (but only
-// slightly!). Let's assume that the updates are non-overlapping and sorted
-// by start key. As before, we want to delete overlapping entries in their
-// entirety and re-add the non-overlapping segments. With multiple updates, it's
-// possible that a segment being re-added will overlap another update. If
-// processing one update at a time in sorted order, we want to only re-add the
-// gap between the consecutive updates.
-//
-//   keyspace         a  b  c  d  e  f  g  h  i  j
-//   existing state      [--------X--------)
-//   updates          [--A--)           [--B--)
-//
-// When processing [a,c):A, after deleting [b,h):X, it would be incorrect to
-// re-add [c,h):X since we're also looking to apply [g,i):B. Instead of
-// re-adding the trailing segment right away, we carry it forward and process it
-// when iterating over the second, possibly overlapping update. In our example,
-// when iterating over [g,i):B we can subtract the overlap from [c,h):X and only
-// re-add [c,g):X.
-//
-// It's also possible for the segment to extend past the second update. In the
-// example below, when processing [d,f):B and having [b,h):X carried over, we
-// want to re-add [c,d):X and carry forward [f,h):X to the update after (i.e.
-// [g,i):C)).
-//
-//   keyspace         a  b  c  d  e  f  g  h  i  j
-//   existing state      [--------X--------)
-//   updates          [--A--)  [--B--)  [--C--)
-//
-// One final note: we're iterating through the updates without actually applying
-// any mutations. Going back to our first example, when processing [g,i):B,
-// retrieving the set of overlapping spans would (again) retrieve [b,h):X -- an
-// entry we've already encountered when processing [a,c):A. Re-adding
-// non-overlapping segments naively would re-add [b,g):X -- an entry that
-// overlaps with our last update [a,c):A. When retrieving overlapping entries,
-// we need to exclude any that overlap with the segment that was carried over.
-// Pseudo-code:
-//
-//   carry-over = <empty>
-//   for update in updates:
-//       carried-over, carry-over = carry-over, <empty>
-//       if update.overlap(carried-over):
-//           # Fill in the gap between consecutive updates.
-//           add {span=span{carried-over.start_key, update.start_key}, conf=carried-over.conf}
-//           # Consider the trailing span after update; carry it forward if non-empty.
-//           carry-over = {span=span{update.end_key, carried-over.end_key}, conf=carried-over.conf}
-//       else:
-//           add {span=carried-over.span, conf=carried-over.conf} if non-empty
-//
-//       for entry in store.overlapping(update.span):
-//          if entry.overlap(processed):
-//               continue # already processed
-//
-//           union, intersection = union(update.span, entry), intersection(update.span, entry)
-//           pre  = span{union.start_key, intersection.start_key}
-//           post = span{intersection.end_key, union.end_key}
-//
-//           delete {span=entry.span, conf=entry.conf}
-//           if entry.contains(update.span.start_key):
-//               # First entry overlapping with update.
-//               add {span=pre, conf=entry.conf} if non-empty
-//           if entry.contains(update.span.end_key):
-//               # Last entry overlapping with update.
-//               carry-over = {span=post, conf=entry.conf}
-//
-//        if adding:
-//           add {span=update.span, conf=update.conf} # add ourselves
-//
-//   add {span=carry-over.span, conf=carry-over.conf} if non-empty
-//
-func (s *Store) accumulateOpsForRLocked(
-	updates []spanconfig.Update,
-) (toDelete, toAdd []spanConfigStoreEntry) {
-	var carryOver spanConfigEntry
-	for _, update := range updates {
-		var carriedOver spanConfigEntry
-		carriedOver, carryOver = carryOver, spanConfigEntry{}
-		if update.Target.GetSpan().Overlaps(carriedOver.span) {
-			gapBetweenUpdates := roachpb.Span{Key: carriedOver.span.Key, EndKey: update.Target.GetSpan().Key}
-			if gapBetweenUpdates.Valid() {
-				toAdd = append(toAdd, s.makeEntryRLocked(gapBetweenUpdates, carriedOver.config))
-			}
-
-			carryOverSpanAfterUpdate := roachpb.Span{Key: update.Target.GetSpan().EndKey, EndKey: carriedOver.span.EndKey}
-			if carryOverSpanAfterUpdate.Valid() {
-				carryOver = spanConfigEntry{
-					span:   carryOverSpanAfterUpdate,
-					config: carriedOver.config,
-				}
-			}
-		} else if !carriedOver.isEmpty() {
-			toAdd = append(toAdd, s.makeEntryRLocked(carriedOver.span, carriedOver.config))
-		}
-
-		skipAddingSelf := false
-		for _, overlapping := range s.mu.tree.Get(update.Target.GetSpan().AsRange()) {
-			existing := overlapping.(*spanConfigStoreEntry)
-			if existing.span.Overlaps(carriedOver.span) {
-				continue // we've already processed this entry above.
-			}
-
-			var (
-				union = existing.span.Combine(*update.Target.GetSpan())
-				inter = existing.span.Intersect(*update.Target.GetSpan())
-
-				pre  = roachpb.Span{Key: union.Key, EndKey: inter.Key}
-				post = roachpb.Span{Key: inter.EndKey, EndKey: union.EndKey}
-			)
-
-			if update.Addition() {
-				if existing.span.Equal(*update.Target.GetSpan()) && existing.config.Equal(update.Config) {
-					skipAddingSelf = true
-					break // no-op; peep-hole optimization
-				}
-			}
-
-			// Delete the existing span in its entirety. Below we'll re-add the
-			// non-intersecting parts of the span.
-			toDelete = append(toDelete, *existing)
-			// existing entry contains the update span's start key
-			if existing.span.ContainsKey(update.Target.GetSpan().Key) {
-				// ex:     [-----------------)
-				//
-				// up:         [-------)
-				// up:         [-------------)
-				// up:         [--------------
-				// up:     [-------)
-				// up:     [-----------------)
-				// up:     [------------------
-
-				// Re-add the non-intersecting span, if any.
-				if pre.Valid() {
-					toAdd = append(toAdd, s.makeEntryRLocked(pre, existing.config))
-				}
-			}
-
-			if existing.span.ContainsKey(update.Target.GetSpan().EndKey) { // existing entry contains the update span's end key
-				// ex:     [-----------------)
-				//
-				// up:     -------------)
-				// up:     [------------)
-				// up:        [---------)
-
-				// Carry over the non-intersecting span.
-				carryOver = spanConfigEntry{
-					span:   post,
-					config: existing.config,
-				}
-			}
-		}
-
-		if update.Addition() && !skipAddingSelf {
-			// Add the update itself.
-			toAdd = append(toAdd, s.makeEntryRLocked(*update.Target.GetSpan(), update.Config))
-
-			// TODO(irfansharif): If we're adding an entry, we could inspect the
-			// entries before and after and check whether either of them have
-			// the same config. If they do, we could coalesce them into a single
-			// span. Given that these boundaries determine where we split
-			// ranges, we'd be able to reduce the number of ranges drastically
-			// (think adjacent tables/indexes/partitions with the same config).
-			// This would be especially significant for secondary tenants, where
-			// we'd be able to avoid unconditionally splitting on table
-			// boundaries. We'd still want to split on tenant boundaries, so
-			// certain preconditions would need to hold. For performance
-			// reasons, we'd probably also want to offer a primitive to allow
-			// manually splitting on specific table boundaries.
-		}
-	}
-
-	if !carryOver.isEmpty() {
-		toAdd = append(toAdd, s.makeEntryRLocked(carryOver.span, carryOver.config))
-	}
-	return toDelete, toAdd
-}
-
-func (s *Store) makeEntryRLocked(sp roachpb.Span, conf roachpb.SpanConfig) spanConfigStoreEntry {
-	s.mu.idAlloc++
-	return spanConfigStoreEntry{
-		spanConfigEntry: spanConfigEntry{span: sp, config: conf},
-		id:              s.mu.idAlloc,
-	}
-}
-
-// spanConfigEntry captures a span <->config pair.
-type spanConfigEntry struct {
-	span   roachpb.Span
-	config roachpb.SpanConfig
-}
-
-func (s *spanConfigEntry) isEmpty() bool {
-	return s.span.Equal(roachpb.Span{}) && s.config.IsEmpty()
-}
-
-// spanConfigStoreEntry is the type used to store and sort values in the
-// span config store.
-type spanConfigStoreEntry struct {
-	spanConfigEntry
-	id int64
-}
-
-var _ interval.Interface = &spanConfigStoreEntry{}
-
-// Range implements interval.Interface.
-func (s *spanConfigStoreEntry) Range() interval.Range {
-	return s.span.AsRange()
-}
-
-// ID implements interval.Interface.
-func (s *spanConfigStoreEntry) ID() uintptr {
-	return uintptr(s.id)
+// Iterate iterates through all the entries in the Store in sorted order.
+func (s *Store) Iterate(f func(spanconfig.Record) error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.mu.spanConfigStore.forEachOverlapping(
+		keys.EverythingSpan,
+		func(s spanConfigEntry) error {
+			return f(spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(s.span),
+				Config: s.config,
+			})
+		})
 }

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -37,9 +37,13 @@ var EnabledSetting = settings.RegisterBoolSetting(
 	true,
 )
 
-// Store is an in-memory data structure to store and retrieve span configs.
-// Internally it makes use of an interval tree to store non-overlapping span
-// configs. It's safe for concurrent use.
+// Store is an in-memory data structure to store, retrieve, and incrementally
+// update the span configuration state. Internally, it makes use of an interval
+// tree based spanConfigStore to store non-overlapping span configurations that
+// target keyspans. It's safe for concurrent use.
+//
+// TODO(arul): In the future we'll teach this thing about system span
+// configurations as well.
 type Store struct {
 	mu struct {
 		syncutil.RWMutex
@@ -74,6 +78,9 @@ func (s *Store) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
 
 // ComputeSplitKey is part of the spanconfig.StoreReader interface.
 func (s *Store) ComputeSplitKey(_ context.Context, start, end roachpb.RKey) roachpb.RKey {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	sp := roachpb.Span{Key: start.AsRawKey(), EndKey: end.AsRawKey()}
 
 	// We don't want to split within the system config span while we're still
@@ -88,14 +95,11 @@ func (s *Store) ComputeSplitKey(_ context.Context, start, end roachpb.RKey) roac
 		return roachpb.RKey(keys.SystemConfigSpan.EndKey)
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	idx := 0
 	var splitKey roachpb.RKey = nil
 	s.mu.tree.DoMatching(func(i interval.Interface) (done bool) {
 		if idx > 0 {
-			splitKey = roachpb.RKey(i.(*storeEntry).Span.Key)
+			splitKey = roachpb.RKey(i.(*spanConfigStoreEntry).span.Key)
 			return true // we found our split key, we're done
 		}
 
@@ -110,15 +114,15 @@ func (s *Store) ComputeSplitKey(_ context.Context, start, end roachpb.RKey) roac
 func (s *Store) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, error) {
-	sp := roachpb.Span{Key: key.AsRawKey(), EndKey: key.Next().AsRawKey()}
-
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	sp := roachpb.Span{Key: key.AsRawKey(), EndKey: key.Next().AsRawKey()}
 
 	var conf roachpb.SpanConfig
 	found := false
 	s.mu.tree.DoMatching(func(i interval.Interface) (done bool) {
-		conf = i.(*storeEntry).Config
+		conf = i.(*spanConfigStoreEntry).config
 		found = true
 		return true
 	}, sp.AsRange())
@@ -127,7 +131,7 @@ func (s *Store) GetSpanConfigForKey(
 		if log.ExpensiveLogEnabled(ctx, 1) {
 			log.Warningf(ctx, "span config not found for %s", key.String())
 		}
-		conf = s.fallback
+		return s.fallback, nil
 	}
 	return conf, nil
 }
@@ -135,7 +139,7 @@ func (s *Store) GetSpanConfigForKey(
 // Apply is part of the spanconfig.StoreWriter interface.
 func (s *Store) Apply(
 	ctx context.Context, dryrun bool, updates ...spanconfig.Update,
-) (deleted []roachpb.Span, added []roachpb.SpanConfigEntry) {
+) (deleted []spanconfig.Target, added []spanconfig.Record) {
 	deleted, added, err := s.applyInternal(dryrun, updates...)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
@@ -145,27 +149,43 @@ func (s *Store) Apply(
 
 // Copy returns a copy of the Store.
 func (s *Store) Copy(ctx context.Context) *Store {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	clone := New(s.fallback)
-	_ = s.ForEachOverlapping(ctx, keys.EverythingSpan, func(entry roachpb.SpanConfigEntry) error {
-		clone.Apply(ctx, false /* dryrun */, spanconfig.Update(entry))
+	_ = s.forEachOverlappingRLocked(keys.EverythingSpan, func(entry spanConfigEntry) error {
+		clone.Apply(ctx, false /* dryrun */, spanconfig.Update{
+			Target: spanconfig.MakeSpanTarget(entry.span),
+			Config: entry.config,
+		})
 		return nil
 	})
 	return clone
 }
 
-// ForEachOverlapping iterates through the set of entries that overlap with the
-// given span, in sorted order. It does not return an error if the callback
-// doesn't.
-func (s *Store) ForEachOverlapping(
-	_ context.Context, sp roachpb.Span, f func(roachpb.SpanConfigEntry) error,
-) error {
+// Iterate iterates through all the entries in the Store in sorted order.
+func (s *Store) Iterate(f func(spanconfig.Record) error) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	return s.forEachOverlappingRLocked(
+		keys.EverythingSpan,
+		func(s spanConfigEntry) error {
+			return f(spanconfig.Record{
+				Target: spanconfig.MakeSpanTarget(s.span),
+				Config: s.config,
+			})
+		})
+}
+
+// forEachOverlapping iterates through the set of entries that overlap with the
+// given span, in sorted order. It does not return an error if the callback
+// doesn't.
+func (s *Store) forEachOverlappingRLocked(sp roachpb.Span, f func(spanConfigEntry) error) error {
 	// Iterate over all overlapping ranges and invoke the callback with the
 	// corresponding span config entries.
 	for _, overlapping := range s.mu.tree.Get(sp.AsRange()) {
-		entry := overlapping.(*storeEntry).SpanConfigEntry
+		entry := overlapping.(*spanConfigStoreEntry).spanConfigEntry
 		if err := f(entry); err != nil {
 			if iterutil.Done(err) {
 				err = nil
@@ -178,35 +198,57 @@ func (s *Store) ForEachOverlapping(
 
 func (s *Store) applyInternal(
 	dryrun bool, updates ...spanconfig.Update,
-) (deleted []roachpb.Span, added []roachpb.SpanConfigEntry, err error) {
+) (deleted []spanconfig.Target, added []spanconfig.Record, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for i := range updates {
-		if !updates[i].Span.Valid() || len(updates[i].Span.EndKey) == 0 {
-			return nil, nil, errors.New("invalid span")
+	// Accumulate all spanStoreUpdates. We do this because we want to apply
+	// a set of updates at once instead of individually, to correctly construct
+	// the deleted/added slices.
+	spanStoreUpdates := make([]spanconfig.Update, 0, len(updates))
+	for _, update := range updates {
+		// TODO(arul): We'll hijack system span configurations here.
+		if update.Target.GetSpan() != nil {
+			spanStoreUpdates = append(spanStoreUpdates, update)
 		}
 	}
 
-	sorted := make([]spanconfig.Update, len(updates))
-	copy(sorted, updates)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Span.Key.Compare(sorted[j].Span.Key) < 0
-	})
-	updates = sorted // re-use the same variable
+	{
+		// Validate that the supplied updates target spans and can be applied to the
+		// underlying interval tree. (non-overlapping, valid).
+		for i := range updates {
+			sp := updates[i].Target.GetSpan()
 
-	for i := range updates {
-		if i == 0 {
-			continue
+			if sp == nil {
+				return nil, nil, errors.New("expected update to target a span")
+			}
+			if !sp.Valid() || len(sp.EndKey) == 0 {
+				return nil, nil, errors.New("invalid span")
+			}
 		}
-		if updates[i].Span.Overlaps(updates[i-1].Span) {
-			return nil, nil, errors.Newf("found overlapping updates %s and %s", updates[i-1].Span, updates[i].Span)
+
+		sorted := make([]spanconfig.Update, len(updates))
+		copy(sorted, updates)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Target.GetSpan().Key.Compare(sorted[j].Target.GetSpan().Key) < 0
+		})
+		updates = sorted // re-use the same variable
+
+		for i := range updates {
+			if i == 0 {
+				continue
+			}
+			if updates[i].Target.GetSpan().Overlaps(*updates[i-1].Target.GetSpan()) {
+				return nil, nil, errors.Newf(
+					"found overlapping updates %s and %s",
+					*updates[i-1].Target.GetSpan(),
+					*updates[i].Target.GetSpan(),
+				)
+			}
 		}
 	}
+	entriesToDelete, entriesToAdd := s.accumulateOpsForRLocked(updates)
 
-	entriesToDelete, entriesToAdd := s.accumulateOpsForLocked(updates)
-
-	deleted = make([]roachpb.Span, len(entriesToDelete))
 	for i := range entriesToDelete {
 		entry := &entriesToDelete[i]
 		if !dryrun {
@@ -214,10 +256,9 @@ func (s *Store) applyInternal(
 				return nil, nil, err
 			}
 		}
-		deleted[i] = entry.Span
+		deleted = append(deleted, spanconfig.MakeSpanTarget(entry.span))
 	}
 
-	added = make([]roachpb.SpanConfigEntry, len(entriesToAdd))
 	for i := range entriesToAdd {
 		entry := &entriesToAdd[i]
 		if !dryrun {
@@ -225,13 +266,15 @@ func (s *Store) applyInternal(
 				return nil, nil, err
 			}
 		}
-		added[i] = entry.SpanConfigEntry
+		added = append(added, spanconfig.Record{
+			Target: spanconfig.MakeSpanTarget(entry.span),
+			Config: entry.config,
+		})
 	}
-
 	return deleted, added, nil
 }
 
-// accumulateOpsForLocked returns the list of store entries that would be
+// accumulateOpsForRLocked returns the list of store entries that would be
 // deleted and added if the given set of updates were to be applied.
 //
 // To apply a single update, we want to find all overlapping spans and clear out
@@ -325,45 +368,47 @@ func (s *Store) applyInternal(
 //
 //   add {span=carry-over.span, conf=carry-over.conf} if non-empty
 //
-func (s *Store) accumulateOpsForLocked(updates []spanconfig.Update) (toDelete, toAdd []storeEntry) {
-	var carryOver roachpb.SpanConfigEntry
+func (s *Store) accumulateOpsForRLocked(
+	updates []spanconfig.Update,
+) (toDelete, toAdd []spanConfigStoreEntry) {
+	var carryOver spanConfigEntry
 	for _, update := range updates {
-		var carriedOver roachpb.SpanConfigEntry
-		carriedOver, carryOver = carryOver, roachpb.SpanConfigEntry{}
-		if update.Span.Overlaps(carriedOver.Span) {
-			gapBetweenUpdates := roachpb.Span{Key: carriedOver.Span.Key, EndKey: update.Span.Key}
+		var carriedOver spanConfigEntry
+		carriedOver, carryOver = carryOver, spanConfigEntry{}
+		if update.Target.GetSpan().Overlaps(carriedOver.span) {
+			gapBetweenUpdates := roachpb.Span{Key: carriedOver.span.Key, EndKey: update.Target.GetSpan().Key}
 			if gapBetweenUpdates.Valid() {
-				toAdd = append(toAdd, s.makeEntryLocked(gapBetweenUpdates, carriedOver.Config))
+				toAdd = append(toAdd, s.makeEntryRLocked(gapBetweenUpdates, carriedOver.config))
 			}
 
-			carryOverSpanAfterUpdate := roachpb.Span{Key: update.Span.EndKey, EndKey: carriedOver.Span.EndKey}
+			carryOverSpanAfterUpdate := roachpb.Span{Key: update.Target.GetSpan().EndKey, EndKey: carriedOver.span.EndKey}
 			if carryOverSpanAfterUpdate.Valid() {
-				carryOver = roachpb.SpanConfigEntry{
-					Span:   carryOverSpanAfterUpdate,
-					Config: carriedOver.Config,
+				carryOver = spanConfigEntry{
+					span:   carryOverSpanAfterUpdate,
+					config: carriedOver.config,
 				}
 			}
-		} else if !carriedOver.Empty() {
-			toAdd = append(toAdd, s.makeEntryLocked(carriedOver.Span, carriedOver.Config))
+		} else if !carriedOver.isEmpty() {
+			toAdd = append(toAdd, s.makeEntryRLocked(carriedOver.span, carriedOver.config))
 		}
 
 		skipAddingSelf := false
-		for _, overlapping := range s.mu.tree.Get(update.Span.AsRange()) {
-			existing := overlapping.(*storeEntry)
-			if existing.Span.Overlaps(carriedOver.Span) {
+		for _, overlapping := range s.mu.tree.Get(update.Target.GetSpan().AsRange()) {
+			existing := overlapping.(*spanConfigStoreEntry)
+			if existing.span.Overlaps(carriedOver.span) {
 				continue // we've already processed this entry above.
 			}
 
 			var (
-				union = existing.Span.Combine(update.Span)
-				inter = existing.Span.Intersect(update.Span)
+				union = existing.span.Combine(*update.Target.GetSpan())
+				inter = existing.span.Intersect(*update.Target.GetSpan())
 
 				pre  = roachpb.Span{Key: union.Key, EndKey: inter.Key}
 				post = roachpb.Span{Key: inter.EndKey, EndKey: union.EndKey}
 			)
 
 			if update.Addition() {
-				if existing.Span.Equal(update.Span) && existing.Config.Equal(update.Config) {
+				if existing.span.Equal(*update.Target.GetSpan()) && existing.config.Equal(update.Config) {
 					skipAddingSelf = true
 					break // no-op; peep-hole optimization
 				}
@@ -372,7 +417,8 @@ func (s *Store) accumulateOpsForLocked(updates []spanconfig.Update) (toDelete, t
 			// Delete the existing span in its entirety. Below we'll re-add the
 			// non-intersecting parts of the span.
 			toDelete = append(toDelete, *existing)
-			if existing.Span.ContainsKey(update.Span.Key) { // existing entry contains the update span's start key
+			// existing entry contains the update span's start key
+			if existing.span.ContainsKey(update.Target.GetSpan().Key) {
 				// ex:     [-----------------)
 				//
 				// up:         [-------)
@@ -384,11 +430,11 @@ func (s *Store) accumulateOpsForLocked(updates []spanconfig.Update) (toDelete, t
 
 				// Re-add the non-intersecting span, if any.
 				if pre.Valid() {
-					toAdd = append(toAdd, s.makeEntryLocked(pre, existing.Config))
+					toAdd = append(toAdd, s.makeEntryRLocked(pre, existing.config))
 				}
 			}
 
-			if existing.Span.ContainsKey(update.Span.EndKey) { // existing entry contains the update span's end key
+			if existing.span.ContainsKey(update.Target.GetSpan().EndKey) { // existing entry contains the update span's end key
 				// ex:     [-----------------)
 				//
 				// up:     -------------)
@@ -396,16 +442,16 @@ func (s *Store) accumulateOpsForLocked(updates []spanconfig.Update) (toDelete, t
 				// up:        [---------)
 
 				// Carry over the non-intersecting span.
-				carryOver = roachpb.SpanConfigEntry{
-					Span:   post,
-					Config: existing.Config,
+				carryOver = spanConfigEntry{
+					span:   post,
+					config: existing.config,
 				}
 			}
 		}
 
 		if update.Addition() && !skipAddingSelf {
 			// Add the update itself.
-			toAdd = append(toAdd, s.makeEntryLocked(update.Span, update.Config))
+			toAdd = append(toAdd, s.makeEntryRLocked(*update.Target.GetSpan(), update.Config))
 
 			// TODO(irfansharif): If we're adding an entry, we could inspect the
 			// entries before and after and check whether either of them have
@@ -422,36 +468,45 @@ func (s *Store) accumulateOpsForLocked(updates []spanconfig.Update) (toDelete, t
 		}
 	}
 
-	if !carryOver.Empty() {
-		toAdd = append(toAdd, s.makeEntryLocked(carryOver.Span, carryOver.Config))
+	if !carryOver.isEmpty() {
+		toAdd = append(toAdd, s.makeEntryRLocked(carryOver.span, carryOver.config))
 	}
-
 	return toDelete, toAdd
 }
 
-func (s *Store) makeEntryLocked(sp roachpb.Span, conf roachpb.SpanConfig) storeEntry {
+func (s *Store) makeEntryRLocked(sp roachpb.Span, conf roachpb.SpanConfig) spanConfigStoreEntry {
 	s.mu.idAlloc++
-	return storeEntry{
-		SpanConfigEntry: roachpb.SpanConfigEntry{Span: sp, Config: conf},
+	return spanConfigStoreEntry{
+		spanConfigEntry: spanConfigEntry{span: sp, config: conf},
 		id:              s.mu.idAlloc,
 	}
 }
 
-// storeEntry is the type used to store and sort values in the span config
-// store.
-type storeEntry struct {
-	roachpb.SpanConfigEntry
+// spanConfigEntry captures a span <->config pair.
+type spanConfigEntry struct {
+	span   roachpb.Span
+	config roachpb.SpanConfig
+}
+
+func (s *spanConfigEntry) isEmpty() bool {
+	return s.span.Equal(roachpb.Span{}) && s.config.IsEmpty()
+}
+
+// spanConfigStoreEntry is the type used to store and sort values in the
+// span config store.
+type spanConfigStoreEntry struct {
+	spanConfigEntry
 	id int64
 }
 
-var _ interval.Interface = &storeEntry{}
+var _ interval.Interface = &spanConfigStoreEntry{}
 
 // Range implements interval.Interface.
-func (s *storeEntry) Range() interval.Range {
-	return s.Span.AsRange()
+func (s *spanConfigStoreEntry) Range() interval.Range {
+	return s.span.AsRange()
 }
 
 // ID implements interval.Interface.
-func (s *storeEntry) ID() uintptr {
+func (s *spanConfigStoreEntry) ID() uintptr {
 	return uintptr(s.id)
 }

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -13,7 +13,6 @@ package spanconfigstore
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sort"
 	"strings"
 	"testing"
@@ -23,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +38,7 @@ func (s *Store) TestingSpanConfigStoreForEachOverlapping(
 ) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.forEachOverlappingRLocked(span, f)
+	return s.mu.spanConfigStore.forEachOverlapping(span, f)
 }
 
 // TestDataDriven runs datadriven tests against the Store interface.
@@ -198,178 +196,4 @@ func TestStoreClone(t *testing.T) {
 		)
 		require.True(t, originalRecords[i].Config.Equal(clonedRecords[i].Config))
 	}
-}
-
-// TestRandomized randomly sets/deletes span configs for arbitrary keyspans
-// within some alphabet. For a test span, it then asserts that the config we
-// retrieve is what we expect to find from the store. It also ensures that all
-// ranges are non-overlapping.
-func TestRandomized(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	randutil.SeedForTests()
-	ctx := context.Background()
-	alphabet := "abcdefghijklmnopqrstuvwxyz"
-	configs := "ABCDEF"
-	ops := []string{"set", "del"}
-
-	getRandomSpanTarget := func() spanconfig.Target {
-		startIdx, endIdx := rand.Intn(len(alphabet)-1), 1+rand.Intn(len(alphabet)-1)
-		if startIdx == endIdx {
-			endIdx = (endIdx + 1) % len(alphabet)
-		}
-		if endIdx < startIdx {
-			startIdx, endIdx = endIdx, startIdx
-		}
-		spanStr := fmt.Sprintf("[%s, %s)", string(alphabet[startIdx]), string(alphabet[endIdx]))
-		sp := spanconfigtestutils.ParseSpan(t, spanStr)
-		require.True(t, sp.Valid())
-		return spanconfig.MakeSpanTarget(sp)
-	}
-
-	getRandomConf := func() roachpb.SpanConfig {
-		confStr := fmt.Sprintf("conf_%s", string(configs[rand.Intn(len(configs))]))
-		return spanconfigtestutils.ParseConfig(t, confStr)
-	}
-
-	getRandomOp := func() string {
-		return ops[rand.Intn(2)]
-	}
-
-	getRandomUpdate := func() spanconfig.Update {
-		target, conf, op := getRandomSpanTarget(), getRandomConf(), getRandomOp()
-		switch op {
-		case "set":
-			return spanconfig.Addition(target, conf)
-		case "del":
-			return spanconfig.Deletion(target)
-		default:
-		}
-		t.Fatalf("unexpected op: %s", op)
-		return spanconfig.Update{}
-	}
-
-	getRandomUpdates := func() []spanconfig.Update {
-		numUpdates := 1 + rand.Intn(3)
-		updates := make([]spanconfig.Update, numUpdates)
-		for {
-			for i := 0; i < numUpdates; i++ {
-				updates[i] = getRandomUpdate()
-			}
-			sort.Slice(updates, func(i, j int) bool {
-				return updates[i].Target.Less(updates[j].Target)
-			})
-			invalid := false
-			for i := 1; i < numUpdates; i++ {
-				if updates[i].Target.GetSpan().Overlaps(*updates[i-1].Target.GetSpan()) {
-					invalid = true
-				}
-			}
-
-			if invalid {
-				continue // try again
-			}
-
-			rand.Shuffle(len(updates), func(i, j int) {
-				updates[i], updates[j] = updates[j], updates[i]
-			})
-			return updates
-		}
-	}
-
-	testSpan := spanconfigtestutils.ParseSpan(t, "[f,g)") // pin a single character span to test with
-	var expConfig roachpb.SpanConfig
-	var expFound bool
-
-	const numOps = 5000
-	store := New(roachpb.TestingDefaultSpanConfig())
-	for i := 0; i < numOps; i++ {
-		updates := getRandomUpdates()
-		store.Apply(ctx, false /* dryrun */, updates...)
-		for _, update := range updates {
-			if testSpan.Overlaps(*update.Target.GetSpan()) {
-				if update.Addition() {
-					expConfig, expFound = update.Config, true
-				} else {
-					expConfig, expFound = roachpb.SpanConfig{}, false
-				}
-			}
-		}
-	}
-
-	if !expFound {
-		_ = store.TestingSpanConfigStoreForEachOverlapping(testSpan,
-			func(entry spanConfigEntry) error {
-				t.Fatalf("found unexpected entry: %s",
-					spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
-						Target: spanconfig.MakeSpanTarget(entry.span),
-						Config: entry.config,
-					}))
-				return nil
-			},
-		)
-	} else {
-		var foundEntry spanConfigEntry
-		_ = store.TestingSpanConfigStoreForEachOverlapping(testSpan,
-			func(entry spanConfigEntry) error {
-				if !foundEntry.isEmpty() {
-					t.Fatalf("expected single overlapping entry, found second: %s",
-						spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
-							Target: spanconfig.MakeSpanTarget(entry.span),
-							Config: entry.config,
-						}))
-				}
-				foundEntry = entry
-
-				// Check that the entry is exactly what we'd expect.
-				gotSpan, gotConfig := entry.span, entry.config
-				require.Truef(t, gotSpan.Contains(testSpan),
-					"improper result: expected retrieved span (%s) to contain test span (%s)",
-					spanconfigtestutils.PrintSpan(gotSpan), spanconfigtestutils.PrintSpan(testSpan))
-
-				require.Truef(t, expConfig.Equal(gotConfig),
-					"mismatched configs: expected %s, got %s",
-					spanconfigtestutils.PrintSpanConfig(expConfig), spanconfigtestutils.PrintSpanConfig(gotConfig))
-
-				return nil
-			},
-		)
-
-		// Ensure that the config accessed through the StoreReader interface is
-		// the same as above.
-		storeReaderConfig, err := store.GetSpanConfigForKey(ctx, roachpb.RKey(testSpan.Key))
-		require.NoError(t, err)
-		require.True(t, foundEntry.config.Equal(storeReaderConfig))
-	}
-
-	everythingSpan := spanconfigtestutils.ParseSpan(t, fmt.Sprintf("[%s,%s)",
-		string(alphabet[0]), string(alphabet[len(alphabet)-1])))
-
-	var last spanConfigEntry
-	_ = store.TestingSpanConfigStoreForEachOverlapping(everythingSpan,
-		func(cur spanConfigEntry) error {
-			// All spans are expected to be valid.
-			require.True(t, cur.span.Valid(),
-				"expected to only find valid spans, found %s",
-				spanconfigtestutils.PrintSpan(cur.span),
-			)
-
-			if last.isEmpty() {
-				last = cur
-				return nil
-			}
-
-			// Span configs are returned in strictly sorted order.
-			require.True(t, last.span.Key.Compare(cur.span.Key) < 0,
-				"expected to find spans in strictly sorted order, found %s then %s",
-				spanconfigtestutils.PrintSpan(last.span), spanconfigtestutils.PrintSpan(cur.span))
-
-			// Span configs must also be non-overlapping.
-			require.Falsef(t, last.span.Overlaps(cur.span),
-				"expected non-overlapping spans, found %s and %s",
-				spanconfigtestutils.PrintSpan(last.span), spanconfigtestutils.PrintSpan(cur.span))
-
-			return nil
-		},
-	)
 }

--- a/pkg/spanconfig/spanconfigtestutils/recorder.go
+++ b/pkg/spanconfig/spanconfigtestutils/recorder.go
@@ -126,17 +126,3 @@ func (r *KVAccessorRecorder) Recording(clear bool) string {
 
 	return output.String()
 }
-
-// GetSystemSpanConfigEntries is part of the spanconfig.KVAccessor interface.
-func (r *KVAccessorRecorder) GetSystemSpanConfigEntries(
-	context.Context,
-) ([]roachpb.SystemSpanConfigEntry, error) {
-	panic("unimplemented")
-}
-
-// UpdateSystemSpanConfigEntries is part of the spanconfig.KVAccessor interface.
-func (r *KVAccessorRecorder) UpdateSystemSpanConfigEntries(
-	context.Context, []roachpb.SystemSpanConfigTarget, []roachpb.SystemSpanConfigEntry,
-) error {
-	panic("unimplemented")
-}

--- a/pkg/spanconfig/spanconfigtestutils/recorder.go
+++ b/pkg/spanconfig/spanconfigtestutils/recorder.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -48,18 +47,18 @@ type mutation struct {
 	batchIdx int
 }
 
-// GetSpanConfigEntriesFor is part of the KVAccessor interface.
-func (r *KVAccessorRecorder) GetSpanConfigEntriesFor(
-	ctx context.Context, spans []roachpb.Span,
-) ([]roachpb.SpanConfigEntry, error) {
-	return r.underlying.GetSpanConfigEntriesFor(ctx, spans)
+// GetSpanConfigRecords is part of the KVAccessor interface.
+func (r *KVAccessorRecorder) GetSpanConfigRecords(
+	ctx context.Context, targets []spanconfig.Target,
+) ([]spanconfig.Record, error) {
+	return r.underlying.GetSpanConfigRecords(ctx, targets)
 }
 
-// UpdateSpanConfigEntries is part of the KVAccessor interface.
-func (r *KVAccessorRecorder) UpdateSpanConfigEntries(
-	ctx context.Context, toDelete []roachpb.Span, toUpsert []roachpb.SpanConfigEntry,
+// UpdateSpanConfigRecords is part of the KVAccessor interface.
+func (r *KVAccessorRecorder) UpdateSpanConfigRecords(
+	ctx context.Context, toDelete []spanconfig.Target, toUpsert []spanconfig.Record,
 ) error {
-	if err := r.underlying.UpdateSpanConfigEntries(ctx, toDelete, toUpsert); err != nil {
+	if err := r.underlying.UpdateSpanConfigRecords(ctx, toDelete, toUpsert); err != nil {
 		return err
 	}
 
@@ -99,8 +98,8 @@ func (r *KVAccessorRecorder) Recording(clear bool) string {
 		if mi.batchIdx != mj.batchIdx { // sort by batch/ts order
 			return mi.batchIdx < mj.batchIdx
 		}
-		if !mi.update.Span.Key.Equal(mj.update.Span.Key) { // sort by key order
-			return mi.update.Span.Key.Compare(mj.update.Span.Key) < 0
+		if !mi.update.Target.Key.Equal(mj.update.Target.Key) { // sort by key order
+			return mi.update.Target.Key.Compare(mj.update.Target.Key) < 0
 		}
 
 		return mi.update.Deletion() // sort deletes before upserts
@@ -112,9 +111,9 @@ func (r *KVAccessorRecorder) Recording(clear bool) string {
 	var output strings.Builder
 	for _, m := range r.mu.mutations {
 		if m.update.Deletion() {
-			output.WriteString(fmt.Sprintf("delete %s\n", m.update.Span))
+			output.WriteString(fmt.Sprintf("delete %s\n", m.update.Target))
 		} else {
-			output.WriteString(fmt.Sprintf("upsert %-35s %s\n", m.update.Span,
+			output.WriteString(fmt.Sprintf("upsert %-35s %s\n", m.update.Target,
 				PrintSpanConfigDiffedAgainstDefaults(m.update.Config)))
 		}
 	}

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -1,0 +1,102 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfig
+
+import "github.com/cockroachdb/cockroach/pkg/roachpb"
+
+// Target specifies the target of an associated span configuration.
+//
+// TODO(arul): In the future, we will expand this to include system targets.
+type Target roachpb.Span
+
+// MakeSpanTarget constructs and returns a span target.
+func MakeSpanTarget(span roachpb.Span) Target {
+	return Target(span)
+}
+
+// GetSpan returns the underlying roachpb.Span if the target is a span target
+// and nil otherwise.
+func (t *Target) GetSpan() *roachpb.Span {
+	sp := roachpb.Span(*t)
+	return &sp
+}
+
+// Encode returns an encoded span suitable for persistence in
+// system.span_configurations.
+func (t Target) Encode() roachpb.Span {
+	return roachpb.Span(t)
+}
+
+// Less returns true if the receiver is less than the supplied target.
+func (t *Target) Less(o Target) bool {
+	return t.Key.Compare(o.Key) < 0
+}
+
+// Equal returns true iff the receiver is equal to the supplied target.
+func (t *Target) Equal(o Target) bool {
+	return t.GetSpan().Equal(*o.GetSpan())
+}
+
+// String returns a formatted version of the traget suitable for printing.
+func (t Target) String() string {
+	return t.GetSpan().String()
+}
+
+// IsEmpty returns true if the receiver is an empty target.
+func (t Target) IsEmpty() bool {
+	return t.GetSpan().Equal(roachpb.Span{})
+}
+
+// DecodeTarget takes a raw span and decodes it into a Target given its
+// encoding. It is the inverse of Encode.
+func DecodeTarget(sp roachpb.Span) Target {
+	return Target(sp)
+}
+
+// Targets is  a slice of span config targets.
+type Targets []Target
+
+// Len implement sort.Interface.
+func (t Targets) Len() int { return len(t) }
+
+// Swap implements sort.Interface.
+func (t Targets) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+
+// Less implements Sort.Interface.
+func (t Targets) Less(i, j int) bool {
+	return t[i].Less(t[j])
+}
+
+// RecordsToSpanConfigEntries converts a list of records to a list
+// roachpb.SpanConfigEntry protos suitable for sending over the wire.
+func RecordsToSpanConfigEntries(records []Record) []roachpb.SpanConfigEntry {
+	entries := make([]roachpb.SpanConfigEntry, 0, len(records))
+	for _, rec := range records {
+		entries = append(entries, roachpb.SpanConfigEntry{
+			Span:   *rec.Target.GetSpan(),
+			Config: rec.Config,
+		})
+	}
+	return entries
+}
+
+// EntriesToRecords converts a list of roachpb.SpanConfigEntries
+// (received over the wire) to a list of Records.
+func EntriesToRecords(entries []roachpb.SpanConfigEntry) []Record {
+	records := make([]Record, 0, len(entries))
+	for _, entry := range entries {
+		records = append(records, Record{
+			Target: MakeSpanTarget(entry.Span),
+			Config: entry.Config,
+		})
+	}
+	return records
+}

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -149,17 +150,17 @@ func CreateTenantRecord(
 	// reconciling?
 	tenantSpanConfig := execCfg.DefaultZoneConfig.AsSpanConfig()
 	tenantPrefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(tenID))
-	toUpsert := []roachpb.SpanConfigEntry{
+	toUpsert := []spanconfig.Record{
 		{
-			Span: roachpb.Span{
+			Target: spanconfig.MakeSpanTarget(roachpb.Span{
 				Key:    tenantPrefix,
 				EndKey: tenantPrefix.Next(),
-			},
+			}),
 			Config: tenantSpanConfig,
 		},
 	}
 	scKVAccessor := execCfg.SpanConfigKVAccessor.WithTxn(ctx, txn)
-	return scKVAccessor.UpdateSpanConfigEntries(
+	return scKVAccessor.UpdateSpanConfigRecords(
 		ctx, nil /* toDelete */, toUpsert,
 	)
 }
@@ -440,7 +441,7 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Ten
 			return nil
 		}
 
-		// Clear out all span config entries left over by the tenant.
+		// Clear out all span config records left over by the tenant.
 		tenantPrefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(info.ID))
 		tenantSpan := roachpb.Span{
 			Key:    tenantPrefix,
@@ -448,16 +449,18 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Ten
 		}
 
 		scKVAccessor := execCfg.SpanConfigKVAccessor.WithTxn(ctx, txn)
-		entries, err := scKVAccessor.GetSpanConfigEntriesFor(ctx, []roachpb.Span{tenantSpan})
+		records, err := scKVAccessor.GetSpanConfigRecords(
+			ctx, []spanconfig.Target{spanconfig.MakeSpanTarget(tenantSpan)},
+		)
 		if err != nil {
 			return err
 		}
 
-		toDelete := make([]roachpb.Span, len(entries))
-		for i, entry := range entries {
-			toDelete[i] = entry.Span
+		toDelete := make([]spanconfig.Target, len(records))
+		for i, record := range records {
+			toDelete[i] = record.Target
 		}
-		return scKVAccessor.UpdateSpanConfigEntries(ctx, toDelete, nil /* toUpsert */)
+		return scKVAccessor.UpdateSpanConfigRecords(ctx, toDelete, nil /* toUpsert */)
 	})
 	return errors.Wrapf(err, "deleting tenant %d record", info.ID)
 }


### PR DESCRIPTION
See individual commits for details. 

Polished up and carved out from https://github.com/cockroachdb/cockroach/pull/76138. 

In the next patch, we'll modify the existing span configuration RPC arguments to something similar in the draft PR above. Then, we'll make `spanconfig.Target` a union over system targets and spans (instead of the alias for roachpb.Spans as in this PR). We'll also add all the encoding and decoding methods for system targets that we've seen in prior draft patches. 