### PR TITLE
distsql: add plumbing for SQL pods to send RPCs to each other

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -62,7 +62,7 @@ type sqlEncoder struct {
 	buf *roachpb.Key
 }
 
-// sqlEncoder implements the decoding logic for SQL keys.
+// sqlDecoder implements the decoding logic for SQL keys.
 //
 // The type is expressed as a pointer to a slice instead of a slice directly so
 // that its zero value is not usable. Any attempt to use the methods on the zero

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -279,9 +279,10 @@ type DistSender struct {
 	firstRangeProvider FirstRangeProvider
 	transportFactory   TransportFactory
 	rpcContext         *rpc.Context
-	nodeDialer         *nodedialer.Dialer
-	rpcRetryOptions    retry.Options
-	asyncSenderSem     *quotapool.IntPool
+	// nodeDialer allows RPC calls from the SQL layer to the KV layer.
+	nodeDialer      *nodedialer.Dialer
+	rpcRetryOptions retry.Options
+	asyncSenderSem  *quotapool.IntPool
 	// clusterID is used to verify access to enterprise features.
 	// It is copied out of the rpcContext at construction time and used in
 	// testing.
@@ -334,7 +335,8 @@ type DistSenderConfig struct {
 	nodeDescriptor  *roachpb.NodeDescriptor
 	RPCRetryOptions *retry.Options
 	RPCContext      *rpc.Context
-	NodeDialer      *nodedialer.Dialer
+	// NodeDialer is the dialer from the SQL layer to the KV layer.
+	NodeDialer *nodedialer.Dialer
 
 	// One of the following two must be provided, but not both.
 	//

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -113,12 +113,12 @@ func (requiresCCLBinaryFactory) NewConnector(_ ConnectorConfig, _ []string) (Con
 	return nil, errors.Errorf(`tenant connector requires a CCL binary`)
 }
 
-// AddressResolver wraps a Connector in an adapter that allows it be used as a
-// nodedialer.AddressResolver. Addresses are resolved to a node's KV
+// AddressResolver wraps a NodeDescStore interface in an adapter that allows it
+// be used as a nodedialer.AddressResolver. Addresses are resolved to a node's
 // address.
-func AddressResolver(c Connector) nodedialer.AddressResolver {
+func AddressResolver(s kvcoord.NodeDescStore) nodedialer.AddressResolver {
 	return func(nodeID roachpb.NodeID) (net.Addr, error) {
-		nd, err := c.GetNodeDescriptor(nodeID)
+		nd, err := s.GetNodeDescriptor(nodeID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -346,7 +346,7 @@ type Context struct {
 
 	breakerClock breakerClock
 	RemoteClocks *RemoteClockMonitor
-	masterCtx    context.Context
+	MasterCtx    context.Context
 
 	heartbeatTimeout time.Duration
 	HeartbeatCB      func()
@@ -485,7 +485,7 @@ func NewContext(ctx context.Context, opts ContextOptions) *Context {
 		RemoteClocks: newRemoteClockMonitor(
 			opts.Clock, 10*opts.Config.RPCHeartbeatInterval, opts.Config.HistogramWindowInterval()),
 		rpcCompression:   enableRPCCompression,
-		masterCtx:        masterCtx,
+		MasterCtx:        masterCtx,
 		metrics:          makeMetrics(),
 		heartbeatTimeout: 2 * opts.Config.RPCHeartbeatInterval,
 	}
@@ -511,8 +511,8 @@ func NewContext(ctx context.Context, opts ContextOptions) *Context {
 			return true
 		})
 	}
-	if err := rpcCtx.Stopper.RunAsyncTask(rpcCtx.masterCtx, "wait-rpcctx-quiesce", waitQuiesce); err != nil {
-		waitQuiesce(rpcCtx.masterCtx)
+	if err := rpcCtx.Stopper.RunAsyncTask(rpcCtx.MasterCtx, "wait-rpcctx-quiesce", waitQuiesce); err != nil {
+		waitQuiesce(rpcCtx.MasterCtx)
 	}
 	return rpcCtx
 }
@@ -814,11 +814,11 @@ func (rpcCtx *Context) removeConn(conn *Connection, keys ...connKey) {
 	for _, key := range keys {
 		rpcCtx.conns.Delete(key)
 	}
-	log.Health.Infof(rpcCtx.masterCtx, "closing %+v", keys)
+	log.Health.Infof(rpcCtx.MasterCtx, "closing %+v", keys)
 	if grpcConn := conn.grpcConn; grpcConn != nil {
 		err := grpcConn.Close() // nolint:grpcconnclose
 		if err != nil && !grpcutil.IsClosedConnection(err) {
-			log.Health.Warningf(rpcCtx.masterCtx, "failed to close client connection: %v", err)
+			log.Health.Warningf(rpcCtx.MasterCtx, "failed to close client connection: %v", err)
 		}
 	}
 }
@@ -953,7 +953,7 @@ func (rpcCtx *Context) grpcDialOptions(
 			return dialer.DialContext(ctx, "tcp", target)
 		}
 		latency := rpcCtx.Knobs.ArtificialLatencyMap[target]
-		log.VEventf(rpcCtx.masterCtx, 1, "connecting to node %s with simulated latency %dms", target, latency)
+		log.VEventf(rpcCtx.MasterCtx, 1, "connecting to node %s with simulated latency %dms", target, latency)
 		dialer := artificialLatencyDialer{
 			dialerFunc: dialerFunc,
 			latencyMS:  latency,
@@ -1136,7 +1136,7 @@ type delayingHeader struct {
 func (rpcCtx *Context) makeDialCtx(
 	target string, remoteNodeID roachpb.NodeID, class ConnectionClass,
 ) context.Context {
-	dialCtx := rpcCtx.masterCtx
+	dialCtx := rpcCtx.MasterCtx
 	var rnodeID interface{} = remoteNodeID
 	if remoteNodeID == 0 {
 		rnodeID = '?'
@@ -1210,7 +1210,7 @@ func (rpcCtx *Context) grpcDialRaw(
 
 	log.Health.Infof(ctx, "dialing")
 	conn, err := grpc.DialContext(ctx, target, dialOpts...)
-	if err != nil && rpcCtx.masterCtx.Err() != nil {
+	if err != nil && rpcCtx.MasterCtx.Err() != nil {
 		// If the node is draining, discard the error (which is likely gRPC's version
 		// of context.Canceled) and return errDialRejected which instructs callers not
 		// to retry.
@@ -1330,7 +1330,7 @@ func (rpcCtx *Context) NewBreaker(name string) *circuit.Breaker {
 	if rpcCtx.BreakerFactory != nil {
 		return rpcCtx.BreakerFactory()
 	}
-	return newBreaker(rpcCtx.masterCtx, name, &rpcCtx.breakerClock)
+	return newBreaker(rpcCtx.MasterCtx, name, &rpcCtx.breakerClock)
 }
 
 // ErrNotHeartbeated is returned by ConnHealth when we have not yet performed

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -999,13 +999,13 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 
 	for i, nodeCtx := range nodeCtxs {
 		if nodeOffset := nodeCtx.offset; nodeOffset > maxOffset {
-			if err := nodeCtx.ctx.RemoteClocks.VerifyClockOffset(nodeCtx.ctx.masterCtx); testutils.IsError(err, errOffsetGreaterThanMaxOffset) {
+			if err := nodeCtx.ctx.RemoteClocks.VerifyClockOffset(nodeCtx.ctx.MasterCtx); testutils.IsError(err, errOffsetGreaterThanMaxOffset) {
 				t.Logf("max offset: %s - node %d with excessive clock offset of %s returned expected error: %s", maxOffset, i, nodeOffset, err)
 			} else {
 				t.Errorf("max offset: %s - node %d with excessive clock offset of %s returned unexpected error: %v", maxOffset, i, nodeOffset, err)
 			}
 		} else {
-			if err := nodeCtx.ctx.RemoteClocks.VerifyClockOffset(nodeCtx.ctx.masterCtx); err != nil {
+			if err := nodeCtx.ctx.RemoteClocks.VerifyClockOffset(nodeCtx.ctx.MasterCtx); err != nil {
 				t.Errorf("max offset: %s - node %d with acceptable clock offset of %s returned unexpected error: %s", maxOffset, i, nodeOffset, err)
 			} else {
 				t.Logf("max offset: %s - node %d with acceptable clock offset of %s did not return an error, as expected", maxOffset, i, nodeOffset)
@@ -1889,13 +1889,13 @@ func TestRunHeartbeatSetsHeartbeatStateWhenExitingBeforeFirstHeartbeat(t *testin
 	redialChan := make(chan struct{})
 	close(redialChan)
 
-	c.grpcConn, _, c.dialErr = rpcCtx.grpcDialRaw(rpcCtx.masterCtx, remoteAddr, serverNodeID, DefaultClass)
+	c.grpcConn, _, c.dialErr = rpcCtx.grpcDialRaw(rpcCtx.MasterCtx, remoteAddr, serverNodeID, DefaultClass)
 	require.NoError(t, c.dialErr)
 	// It is possible that the redial chan being closed is not seen on the first
 	// pass through the loop.
 	// NB: we use rpcCtx.masterCtx and not just ctx because we need
 	// this to be cancelled when the RPC context is closed.
-	err = rpcCtx.runHeartbeat(rpcCtx.masterCtx, c, "", redialChan)
+	err = rpcCtx.runHeartbeat(rpcCtx.MasterCtx, c, "", redialChan)
 	require.EqualError(t, err, grpcutil.ErrCannotReuseClientConn.Error())
 	// Even when the runHeartbeat returns, we could have heartbeated successfully.
 	// If we did not, then we expect the `not yet heartbeated` error.

--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -56,7 +56,7 @@ func convertToVecTree(
 	// creator.
 	creator := newVectorizedFlowCreator(
 		newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, false,
-		nil, &execinfra.RowChannel{}, &fakeBatchReceiver{}, flowCtx.Cfg.NodeDialer, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
+		nil, &execinfra.RowChannel{}, &fakeBatchReceiver{}, flowCtx.Cfg.PodNodeDialer, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
 		flowCtx.Cfg.VecFDSemaphore, flowCtx.NewTypeResolver(flowCtx.EvalCtx.Txn),
 		admission.WorkInfo{},
 	)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -205,7 +205,7 @@ func (f *vectorizedFlow) Setup(
 		f.GetWaitGroup(),
 		f.GetRowSyncFlowConsumer(),
 		f.GetBatchSyncFlowConsumer(),
-		flowCtx.Cfg.NodeDialer,
+		flowCtx.Cfg.PodNodeDialer,
 		f.GetID(),
 		diskQueueCfg,
 		f.countingSemaphore,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -313,6 +313,7 @@ func startConnExecutor(
 			stopper,
 			func(base.SQLInstanceID) bool { return true }, // everybody is available
 			nil, /* nodeDialer */
+			nil, /* podNodeDialer */
 		),
 		QueryCache:              querycache.New(0),
 		TestingKnobs:            ExecutorTestingKnobs{},

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -88,11 +88,13 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// The outbox uses this stopper to run a goroutine.
 	outboxStopper := stop.NewStopper()
 	defer outboxStopper.Stop(ctx)
+	nodeDialer := nodedialer.New(rpcContext, staticAddressResolver(ln.Addr()))
 	flowCtx := execinfra.FlowCtx{
 		Cfg: &execinfra.ServerConfig{
-			Settings:   st,
-			NodeDialer: nodedialer.New(rpcContext, staticAddressResolver(ln.Addr())),
-			Stopper:    outboxStopper,
+			Settings:      st,
+			NodeDialer:    nodeDialer,
+			PodNodeDialer: nodeDialer,
+			Stopper:       outboxStopper,
 		},
 		NodeID: base.TestingIDContainer,
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -103,7 +103,11 @@ type DistSQLPlanner struct {
 	// gossip handle used to check node version compatibility.
 	gossip gossip.OptionalGossip
 
+	// nodeDialer handles communication between SQL and KV nodes.
 	nodeDialer *nodedialer.Dialer
+
+	// podNodeDialer handles communication between SQL nodes/pods.
+	podNodeDialer *nodedialer.Dialer
 
 	// nodeHealth encapsulates the various node health checks to avoid planning
 	// on unhealthy nodes.
@@ -150,6 +154,7 @@ func NewDistSQLPlanner(
 	stopper *stop.Stopper,
 	isAvailable func(base.SQLInstanceID) bool,
 	nodeDialer *nodedialer.Dialer,
+	podNodeDialer *nodedialer.Dialer,
 ) *DistSQLPlanner {
 	dsp := &DistSQLPlanner{
 		planVersion:          planVersion,
@@ -159,6 +164,7 @@ func NewDistSQLPlanner(
 		distSQLSrv:           distSQLSrv,
 		gossip:               gw,
 		nodeDialer:           nodeDialer,
+		podNodeDialer:        podNodeDialer,
 		nodeHealth: distSQLNodeHealth{
 			gossip:      gw,
 			connHealth:  nodeDialer.ConnHealthTryDial,

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -131,7 +131,11 @@ type ServerConfig struct {
 	// draining state.
 	Gossip gossip.OptionalGossip
 
+	// Dialer for communication between SQL and KV nodes.
 	NodeDialer *nodedialer.Dialer
+
+	// Dialer for communication between SQL nodes/pods.
+	PodNodeDialer *nodedialer.Dialer
 
 	// SessionBoundInternalExecutorFactory is used to construct session-bound
 	// executors. The idea is that a higher-layer binds some of the arguments

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -94,6 +94,7 @@ func newFlowCtxForExplainPurposes(planCtx *PlanningCtx, p *planner) *execinfra.F
 			ClusterID:      p.DistSQLPlanner().rpcCtx.ClusterID,
 			VecFDSemaphore: p.execCfg.DistSQLSrv.VecFDSemaphore,
 			NodeDialer:     p.DistSQLPlanner().nodeDialer,
+			PodNodeDialer:  p.DistSQLPlanner().podNodeDialer,
 		},
 		Descriptors: p.Descriptors(),
 		DiskMonitor: &mon.BytesMonitor{},

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
     tags = ["no-remote"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/gossip",
         "//pkg/keys",
         "//pkg/kv",
@@ -89,6 +90,8 @@ go_test(
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlstats",
+        "//pkg/sql/tests",
         "//pkg/sql/types",
         "//pkg/testutils",
         "//pkg/testutils/buildutil",

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -12,12 +12,14 @@ package flowinfra_test
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -31,6 +33,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -302,6 +306,300 @@ func TestClusterFlow(t *testing.T) {
 			for nodeIdx := 0; nodeIdx < numNodes; nodeIdx++ {
 				_, _ = clients[nodeIdx].CancelDeadFlows(ctx, req)
 				numQueued := tc.Server(nodeIdx).DistSQLServer().(*distsql.ServerImpl).NumRemoteFlowsInQueue()
+				if numQueued != 0 {
+					t.Fatalf("unexpectedly %d flows in queue (expected 0)", numQueued)
+				}
+			}
+		}
+	}
+}
+
+func TestTenantClusterFlow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	const numPods = 3
+	const numRows = 10
+
+	serverParams, _ := tests.CreateTestServerParams()
+	args := base.TestClusterArgs{ReplicationMode: base.ReplicationManual, ServerArgs: serverParams}
+	tci := serverutils.StartNewTestCluster(t, 1, args)
+	tc := tci.(*testcluster.TestCluster)
+	defer tc.Stopper().Stop(context.Background())
+
+	testingKnobs := base.TestingKnobs{
+		SQLStatsKnobs: &sqlstats.TestingKnobs{
+			AOSTClause: "AS OF SYSTEM TIME '-1us'",
+		},
+	}
+	pods := make([]serverutils.TestTenantInterface, numPods)
+	podConns := make([]*gosql.DB, numPods)
+	tenantID := serverutils.TestTenantID()
+	for i := 0; i < numPods; i++ {
+		pods[i], podConns[i] = serverutils.StartTenant(t, tci.Server(0), base.TestTenantArgs{
+			TenantID:     tenantID,
+			Existing:     i != 0,
+			TestingKnobs: testingKnobs,
+		})
+		defer podConns[i].Close()
+	}
+
+	sumDigitsFn := func(row int) tree.Datum {
+		sum := 0
+		for row > 0 {
+			sum += row % 10
+			row /= 10
+		}
+		return tree.NewDInt(tree.DInt(sum))
+	}
+
+	sqlutils.CreateTable(t, podConns[0], "t",
+		"num INT PRIMARY KEY, digitsum INT, numstr STRING, INDEX s (digitsum)",
+		numRows,
+		sqlutils.ToRowFn(sqlutils.RowIdxFn, sumDigitsFn, sqlutils.RowEnglishFn))
+
+	kvDB := tc.Server(0).DB()
+	codec := keys.MakeSQLCodec(tenantID)
+	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, sqlutils.TestDB, "t")
+	makeIndexSpan := func(start, end int) roachpb.Span {
+		var span roachpb.Span
+		prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(codec, desc.GetID(), desc.PublicNonPrimaryIndexes()[0].GetID()))
+		span.Key = append(prefix, encoding.EncodeVarintAscending(nil, int64(start))...)
+		span.EndKey = append(span.EndKey, prefix...)
+		span.EndKey = append(span.EndKey, encoding.EncodeVarintAscending(nil, int64(end))...)
+		return span
+	}
+
+	sqlDB := sqlutils.MakeSQLRunner(podConns[0])
+	rows := sqlDB.Query(t, "SELECT num FROM test.t")
+	defer rows.Close()
+	for rows.Next() {
+		var key int
+		if err := rows.Scan(&key); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// successful indicates whether the flow execution is successful.
+	for _, successful := range []bool{true, false} {
+		// Set up table readers on three hosts feeding data into a join reader on
+		// the third host. This is a basic test for the distributed flow
+		// infrastructure, including local and remote streams.
+		//
+		// Note that the ranges won't necessarily be local to the table readers, but
+		// that doesn't matter for the purposes of this test.
+
+		now := pods[0].Clock().NowAsClockTimestamp()
+		txnProto := roachpb.MakeTransaction(
+			"cluster-test",
+			nil, // baseKey
+			roachpb.NormalUserPriority,
+			now.ToTimestamp(),
+			0, // maxOffsetNs
+			int32(pods[0].SQLInstanceID()),
+		)
+		txn := kv.NewTxnFromProto(ctx, kvDB, roachpb.NodeID(pods[0].SQLInstanceID()), now, kv.RootTxn, &txnProto)
+		leafInputState := txn.GetLeafTxnInputState(ctx)
+
+		tr1 := execinfrapb.TableReaderSpec{
+			Table:     *desc.TableDesc(),
+			IndexIdx:  1,
+			Spans:     []roachpb.Span{makeIndexSpan(0, 8)},
+			ColumnIDs: []descpb.ColumnID{1, 2},
+		}
+
+		tr2 := execinfrapb.TableReaderSpec{
+			Table:     *desc.TableDesc(),
+			IndexIdx:  1,
+			Spans:     []roachpb.Span{makeIndexSpan(8, 12)},
+			ColumnIDs: []descpb.ColumnID{1, 2},
+		}
+
+		tr3 := execinfrapb.TableReaderSpec{
+			Table:     *desc.TableDesc(),
+			IndexIdx:  1,
+			Spans:     []roachpb.Span{makeIndexSpan(12, 100)},
+			ColumnIDs: []descpb.ColumnID{1, 2},
+		}
+
+		fid := execinfrapb.FlowID{UUID: uuid.MakeV4()}
+
+		req1 := &execinfrapb.SetupFlowRequest{
+			Version:           execinfra.Version,
+			LeafTxnInputState: leafInputState,
+			Flow: execinfrapb.FlowSpec{
+				FlowID: fid,
+				Processors: []execinfrapb.ProcessorSpec{{
+					ProcessorID: 1,
+					Core:        execinfrapb.ProcessorCoreUnion{TableReader: &tr1},
+					Output: []execinfrapb.OutputRouterSpec{{
+						Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
+						Streams: []execinfrapb.StreamEndpointSpec{
+							{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 0, TargetNodeID: pods[2].SQLInstanceID()},
+						},
+					}},
+					ResultTypes: types.TwoIntCols,
+				}},
+			},
+		}
+
+		req2 := &execinfrapb.SetupFlowRequest{
+			Version:           execinfra.Version,
+			LeafTxnInputState: leafInputState,
+			Flow: execinfrapb.FlowSpec{
+				FlowID: fid,
+				Processors: []execinfrapb.ProcessorSpec{{
+					ProcessorID: 2,
+					Core:        execinfrapb.ProcessorCoreUnion{TableReader: &tr2},
+					Output: []execinfrapb.OutputRouterSpec{{
+						Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
+						Streams: []execinfrapb.StreamEndpointSpec{
+							{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 1, TargetNodeID: pods[2].SQLInstanceID()},
+						},
+					}},
+					ResultTypes: types.TwoIntCols,
+				}},
+			},
+		}
+
+		req3 := &execinfrapb.SetupFlowRequest{
+			Version:           execinfra.Version,
+			LeafTxnInputState: leafInputState,
+			Flow: execinfrapb.FlowSpec{
+				FlowID: fid,
+				Processors: []execinfrapb.ProcessorSpec{
+					{
+						ProcessorID: 3,
+						Core:        execinfrapb.ProcessorCoreUnion{TableReader: &tr3},
+						Output: []execinfrapb.OutputRouterSpec{{
+							Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
+							Streams: []execinfrapb.StreamEndpointSpec{
+								{Type: execinfrapb.StreamEndpointSpec_LOCAL, StreamID: 2},
+							},
+						}},
+						ResultTypes: types.TwoIntCols,
+					},
+					{
+						ProcessorID: 4,
+						Input: []execinfrapb.InputSyncSpec{{
+							Type: execinfrapb.InputSyncSpec_ORDERED,
+							Ordering: execinfrapb.Ordering{Columns: []execinfrapb.Ordering_Column{
+								{ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}}},
+							Streams: []execinfrapb.StreamEndpointSpec{
+								{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 0},
+								{Type: execinfrapb.StreamEndpointSpec_REMOTE, StreamID: 1},
+								{Type: execinfrapb.StreamEndpointSpec_LOCAL, StreamID: 2},
+							},
+							ColumnTypes: types.TwoIntCols,
+						}},
+						Core: execinfrapb.ProcessorCoreUnion{JoinReader: &execinfrapb.JoinReaderSpec{Table: *desc.TableDesc(), MaintainOrdering: true}},
+						Post: execinfrapb.PostProcessSpec{
+							Projection:    true,
+							OutputColumns: []uint32{2},
+						},
+						Output: []execinfrapb.OutputRouterSpec{{
+							Type:    execinfrapb.OutputRouterSpec_PASS_THROUGH,
+							Streams: []execinfrapb.StreamEndpointSpec{{Type: execinfrapb.StreamEndpointSpec_SYNC_RESPONSE}},
+						}},
+						ResultTypes: []*types.T{types.String},
+					},
+				},
+			},
+		}
+
+		var clients []execinfrapb.DistSQLClient
+		for i := 0; i < numPods; i++ {
+			pod := pods[i]
+			conn, err := pod.RPCContext().GRPCDialPod(pod.SQLAddr(), pod.SQLInstanceID(), rpc.DefaultClass).Connect(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			clients = append(clients, execinfrapb.NewDistSQLClient(conn))
+		}
+
+		setupRemoteFlow := func(podIdx int, req *execinfrapb.SetupFlowRequest) {
+			log.Infof(ctx, "Setting up flow on %d", podIdx)
+			if resp, err := clients[podIdx].SetupFlow(ctx, req); err != nil {
+				t.Fatal(err)
+			} else if resp.Error != nil {
+				t.Fatal(resp.Error)
+			}
+		}
+
+		if successful {
+			setupRemoteFlow(0, req1)
+			setupRemoteFlow(1, req2)
+
+			log.Infof(ctx, "Running local sync flow on 2")
+			rows, err := runLocalFlowTenant(ctx, pods[2], req3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The result should be all the numbers in string form, ordered by the
+			// digit sum (and then by number).
+			var results []string
+			for sum := 1; sum <= 50; sum++ {
+				for i := 1; i <= numRows; i++ {
+					if int(tree.MustBeDInt(sumDigitsFn(i))) == sum {
+						results = append(results, fmt.Sprintf("['%s']", sqlutils.IntToEnglish(i)))
+					}
+				}
+			}
+			expected := strings.Join(results, " ")
+			expected = "[" + expected + "]"
+			if rowStr := rows.String([]*types.T{types.String}); rowStr != expected {
+				t.Errorf("Result: %s\n Expected: %s\n", rowStr, expected)
+			}
+		} else {
+			// Simulate a scenario in which the query is canceled on the gateway
+			// which results in the cancellation of already scheduled flows.
+			//
+			// First, reduce the number of active remote flows to 0.
+			sqlRunner := sqlutils.MakeSQLRunner(podConns[2])
+			sqlRunner.Exec(t, "SET CLUSTER SETTING sql.distsql.max_running_flows=0")
+			// Make sure that all nodes have the updated cluster setting value.
+			testutils.SucceedsSoon(t, func() error {
+				for i := 0; i < numPods; i++ {
+					sqlRunner = sqlutils.MakeSQLRunner(podConns[i])
+					rows := sqlRunner.Query(t, "SHOW CLUSTER SETTING sql.distsql.max_running_flows")
+					defer rows.Close()
+					rows.Next()
+					var maxRunningFlows int
+					if err := rows.Scan(&maxRunningFlows); err != nil {
+						t.Fatal(err)
+					}
+					if maxRunningFlows != 0 {
+						return errors.New("still old value")
+					}
+				}
+				return nil
+			})
+			const numScheduledPerNode = 4
+			// Now schedule some remote flows on all nodes.
+			for i := 0; i < numScheduledPerNode; i++ {
+				setupRemoteFlow(0, req1)
+				setupRemoteFlow(1, req2)
+				setupRemoteFlow(2, req3)
+			}
+			// Wait for all flows to be scheduled.
+			testutils.SucceedsSoon(t, func() error {
+				for podIdx := 0; podIdx < numPods; podIdx++ {
+
+					numQueued := pods[podIdx].DistSQLServer().(*distsql.ServerImpl).NumRemoteFlowsInQueue()
+					if numQueued != numScheduledPerNode {
+						return errors.New("not all flows are scheduled yet")
+					}
+				}
+				return nil
+			})
+			// Now, the meat of the test - cancel all queued up flows and make
+			// sure that the corresponding queues are empty.
+			req := &execinfrapb.CancelDeadFlowsRequest{
+				FlowIDs: []execinfrapb.FlowID{fid},
+			}
+			for podIdx := 0; podIdx < numPods; podIdx++ {
+				_, _ = clients[podIdx].CancelDeadFlows(ctx, req)
+				numQueued := pods[podIdx].DistSQLServer().(*distsql.ServerImpl).NumRemoteFlowsInQueue()
 				if numQueued != 0 {
 					t.Fatalf("unexpectedly %d flows in queue (expected 0)", numQueued)
 				}


### PR DESCRIPTION
This PR adds initial support for distributed flows in a multi-tenant cluster
with multiple pods. It adds a test that assigns flows to multiple pods
and executes them. In order to support communication between SQL pods in
a multi-tenant environment, this PR adds a new kind of connector that
can provide address resolution for SQL instances, and plumbs a node
dialer that uses this new connector through distsql. If distsql is not
in multi-tenant mode, the same node dialer is used whether SQL instances
are communicating with other SQL instances or KV, as before this change.

Release note: None