### PR TITLE
pkg/cmd/publish-artifacts: fix test failure under bazel

### DIFF
--- a/pkg/cmd/publish-artifacts/BUILD.bazel
+++ b/pkg/cmd/publish-artifacts/BUILD.bazel
@@ -26,7 +26,6 @@ go_test(
     size = "small",
     srcs = ["main_test.go"],
     embed = [":publish-artifacts_lib"],
-    tags = ["broken_in_bazel"],
     deps = [
         "//pkg/testutils/skip",
         "@com_github_aws_aws_sdk_go//service/s3",

--- a/pkg/cmd/publish-artifacts/main_test.go
+++ b/pkg/cmd/publish-artifacts/main_test.go
@@ -52,7 +52,12 @@ func mockPutter(p s3putter) func() {
 	return f
 }
 
-func TestMain(t *testing.T) {
+// NB: the function name TestMain is special as it is expected to be a function
+// which takes a *testing.M as a parameter. Somehow `go test` allows TestMain to
+// also work if passed a *testing.T, in which case it acts like a normal test
+// function. Bazel prohibits this, so give this test function a name which
+// doesn't collide with TestMain.
+func TestMainF(t *testing.T) {
 	if !slow {
 		skip.IgnoreLint(t, "only to be run manually via `./build/builder.sh go test -tags slow -timeout 1h -v ./pkg/cmd/publish-artifacts`")
 	}


### PR DESCRIPTION
The function name `TestMain` is special as it is expected to be a
function which takes a `*testing.M` as a parameter. Somehow `go test`
allows `TestMain` to also work if passed a `*testing.T`, in which case
it acts like a normal test function. Bazel prohibits this, so give this
test function a name which doesn't collide with `TestMain`.

Note that this renaming only avoids bazel failing when running the tests
in `publish-artifacts`, but the tests don't actually run as there is no
facility for passing `-tags=slow` when running the tests.

Release note: none