### PR TITLE
dev: `dev cache --clean` cleans out only the cache subdirectory

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=11
+DEV_VERSION=12
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -256,7 +256,7 @@ func (d *dev) cleanCache(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return os.RemoveAll(dir)
+	return os.RemoveAll(filepath.Join(dir, "cache"))
 }
 
 func (d *dev) getCacheBazelrcLine(ctx context.Context) (string, error) {


### PR DESCRIPTION
Without this change `dev cache --clean` can trample your configuration
file.

Release note: None