### PR TITLE
server: remove DeprecateBaseEncryptionRegistry

### DIFF
--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -210,37 +210,6 @@ func (m *migrationServer) PurgeOutdatedReplicas(
 	return resp, nil
 }
 
-// TODO(ayang): remove this RPC and associated request/response in 22.1
-func (m *migrationServer) DeprecateBaseEncryptionRegistry(
-	ctx context.Context, req *serverpb.DeprecateBaseEncryptionRegistryRequest,
-) (*serverpb.DeprecateBaseEncryptionRegistryResponse, error) {
-	const opName = "deprecate-base-encryption-registry"
-	ctx, span := m.server.AnnotateCtxWithSpan(ctx, opName)
-	defer span.Finish()
-	ctx = logtags.AddTag(ctx, opName, nil)
-
-	if err := m.server.stopper.RunTaskWithErr(ctx, opName, func(
-		ctx context.Context,
-	) error {
-		// Same as in SyncAllEngines, because stores can be added asynchronously, we
-		// need to ensure that the bootstrap process has happened.
-		m.server.node.waitForAdditionalStoreInit()
-
-		for _, eng := range m.server.engines {
-			if err := eng.SetMinVersion(*req.Version); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	resp := &serverpb.DeprecateBaseEncryptionRegistryResponse{}
-	return resp, nil
-}
-
 // WaitForSpanConfigSubscription implements the MigrationServer interface.
 func (m *migrationServer) WaitForSpanConfigSubscription(
 	ctx context.Context, _ *serverpb.WaitForSpanConfigSubscriptionRequest,

--- a/pkg/server/serverpb/migration.proto
+++ b/pkg/server/serverpb/migration.proto
@@ -52,16 +52,6 @@ message SyncAllEnginesRequest{}
 // SyncAllEnginesResponse is the response to a SyncAllEnginesRequest.
 message SyncAllEnginesResponse{}
 
-// DeprecateBaseEncryptionRegistryRequest is used to instruct the target node
-// to stop using the Base version monolithic encryption-at-rest registry.
-message DeprecateBaseEncryptionRegistryRequest {
-  roachpb.Version version = 1;
-}
-
-// DeprecateBaseEncryptionRegistryResponse is the response to a
-// DeprecateBaseEncryptionRegistryRequest.
-message DeprecateBaseEncryptionRegistryResponse{}
-
 // WaitForSpanConfigSubscriptionRequest waits until the target node is wholly
 // subscribed to the global span configurations state.
 message WaitForSpanConfigSubscriptionRequest{}
@@ -94,10 +84,6 @@ service Migration {
    // PurgeOutdatedReplicas is used to instruct the target node to purge all
    // replicas with a version less than the one provided.
    rpc PurgeOutdatedReplicas (PurgeOutdatedReplicasRequest) returns (PurgeOutdatedReplicasResponse) { }
-
-   // DeprecateBaseRegistry is used to instruct the target node to stop
-   // using the Base version monolithic encryption-at-rest registry.
-   rpc DeprecateBaseEncryptionRegistry (DeprecateBaseEncryptionRegistryRequest) returns (DeprecateBaseEncryptionRegistryResponse) { }
 
    // WaitForSpanConfigSubscription waits until the target node is wholly
    // subscribed to the global span configurations state.


### PR DESCRIPTION
Remove the migration server DeprecateBaseEncryptionRegistry RPC. It was
used for the migration of the encryption-at-rest registry format in
21.2 and is no longer relevant.

Missed this in #74314.

Release note: None