### PR TITLE
pprofui: Increase concurrency for profiles

### DIFF
--- a/pkg/server/debug/pprofui/BUILD.bazel
+++ b/pkg/server/debug/pprofui/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/build/bazel",
         "//pkg/server/serverpb",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/debug/pprofui/server.go
+++ b/pkg/server/debug/pprofui/server.go
@@ -40,6 +40,22 @@ type Profiler interface {
 	) (*serverpb.JSONResponse, error)
 }
 
+const (
+	// ProfileConcurrency governs how many concurrent profiles can be collected.
+	// This impacts the maximum number of profiles stored in memory at any given point
+	// in time. Increasing this number further will increase the number of profile
+	// requests that can be served concurrently but will also increase
+	// storage requirements and should be done with caution.
+	ProfileConcurrency = 2
+
+	// ProfileExpiry governs how long a profile is retained in memory during concurrent
+	// profile requests. A profile is considered expired once its profile expiry duration
+	// is met. However, expired profiles are only cleaned up from memory when a new profile
+	// is requested. So ProfileExpiry can be considered as a soft expiry which impacts
+	// duration for which a profile is stored only when other profile requests are received.
+	ProfileExpiry = 2 * time.Second
+)
+
 // A Server serves up the pprof web ui. A request to /<profiletype>
 // generates a profile of the desired type and redirects to the UI for
 // it at /<profiletype>/<id>. Valid profile types at the time of

--- a/pkg/server/debug/pprofui/storage_mem.go
+++ b/pkg/server/debug/pprofui/storage_mem.go
@@ -102,5 +102,8 @@ func (s *MemStorage) Get(id string, read func(io.Reader) error) error {
 			return read(bytes.NewReader(v.b))
 		}
 	}
-	return errors.Errorf("profile not found; it may have expired")
+	return errors.Errorf("profile not found; it may have expired, please regenerate the profile.\n" +
+		"To generate profile for a node, use the profile generation link from the Advanced Debug page.\n" +
+		"Attempting to generate a profile by modifying the node query parameter in the URL will not work.",
+	)
 }

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -125,7 +125,7 @@ func NewServer(
 	}
 	mux.HandleFunc("/debug/logspy", spy.handleDebugLogSpy)
 
-	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0), profiler)
+	ps := pprofui.NewServer(pprofui.NewMemStorage(pprofui.ProfileConcurrency, pprofui.ProfileExpiry), profiler)
 	mux.Handle("/debug/pprof/ui/", http.StripPrefix("/debug/pprof/ui", ps))
 
 	mux.HandleFunc("/debug/pprof/goroutineui/", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
In this PR, we increase the concurrency limit while
running performance profiles (e.g. heap, CPU) from
the Advanced Debug page within DB Console. Previously,
attempting to run performance profiling in parallel
for the same node would result in race condition causing
one of the profiles to overwrite the other. This would cause
"Profile not found: profile may have expired" errors.
The occurrence of these errors was exacerbated by the new
feature enabling running profiles on any nodes as it
increased the likelihood of race conditions for profiles
being run on a node at the same time.
By allowing atleast two profile runs at the same time
decreases the likelihood of one request overwriting
the other. This does not completely eliminate
the problem but will reduce the frequency of occurrence.
This PR also updates the error message returned when
a profile is not found to provide more details on
the potential causes and remediation steps.

Release note: None