### PR TITLE
server: Change test tenant server shutdown.

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -674,7 +674,17 @@ func (ts *TestServer) StartTenant(
 		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
 		stopper = stop.NewStopper(stop.WithTracer(tr))
 		// The server's stopper stops the tenant, for convenience.
-		ts.Stopper().AddCloser(stop.CloserFn(func() { stopper.Stop(context.Background()) }))
+		// Use main server quiesce as a signal to stop tenants stopper. in the perfect world, we
+		// want to have tenant stopped before the main server.  Using ts.Stopper().AddCloser() to
+		// propagate shutdown signal could result in stuck (or slow) shutdown since closers are the very
+		// last thing that runs -- and by then, the tenant maybe stuck, or re-trying an operation
+		// (e.g. to resolve tentant ranges).
+		if err := ts.Stopper().RunAsyncTask(ctx, "propagate-cancellation-to-tenant", func(ctx context.Context) {
+			<-ts.Stopper().ShouldQuiesce()
+			stopper.Stop(context.Background())
+		}); err != nil {
+			return nil, err
+		}
 	} else if stopper.Tracer() == nil {
 		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
 		stopper.SetTracer(tr)


### PR DESCRIPTION
When starting tenant server in tests, the tenant server was stopped
by propagating stopper signal from main server to tenant test server.
Unfortunately, this could result in  slow test shutdown since
closers in stopper run as the very last thing. Use main test server
`WithCancelOnQuiesce` to propagate stop signal to the tenant test server.

Release Notes: None