### PR TITLE
bazel: add `# keep` comment in `pkg/ui/BUILD.bazel`

### DIFF
--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "tracing_ui.go",
         "ui.go",
     ],
+    # keep
     embedsrcs = select({
         "//pkg/ui:cockroach_with_ui": [
             "dist_vendor/list.min.js",


### PR DESCRIPTION
Otherwise Gazelle complains:

```
gazelle: /Users/ricky/go/src/github.com/cockroachdb/cockroach/pkg/ui/BUILD.bazel:10.17-20.7: could not merge expression
```

Release note: None