### PR TITLE
backup: restore using mvcc at-now addsstable

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -142,6 +142,7 @@ go_test(
         "backup_destination_test.go",
         "backup_intents_test.go",
         "backup_rand_test.go",
+        "backup_tenant_test.go",
         "backup_test.go",
         "bench_covering_test.go",
         "bench_test.go",
@@ -167,6 +168,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/blobs",
+        "//pkg/ccl/importccl",
         "//pkg/ccl/kvccl",
         "//pkg/ccl/multiregionccl",
         "//pkg/ccl/multitenantccl",

--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -1,0 +1,121 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/importccl"
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupTenantImportingTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	tSrv, tSQL := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
+		TenantID:     roachpb.MakeTenantID(10),
+		TestingKnobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	})
+	defer tSQL.Close()
+
+	if _, err := tSQL.Exec("SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tSQL.Exec("CREATE TABLE x (id INT PRIMARY KEY, n INT, s STRING)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tSQL.Exec("INSERT INTO x VALUES (1000, 1, 'existing')"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tSQL.Exec("IMPORT INTO x CSV DATA ('workload:///csv/bank/bank?rows=100&version=1.0.0')"); !testutils.IsError(err, "pause") {
+		t.Fatal(err)
+	}
+	var jobID int
+	if err := tSQL.QueryRow(`SELECT job_id FROM [show jobs] WHERE job_type = 'IMPORT'`).Scan(&jobID); err != nil {
+		t.Fatal(err)
+	}
+	tc.Servers[0].JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+	// wait for it to pause
+
+	testutils.SucceedsSoon(t, func() error {
+		var status string
+		if err := tSQL.QueryRow(`SELECT status FROM [show jobs] WHERE job_id = $1`, jobID).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(jobs.StatusPaused) {
+			return nil
+		}
+		return errors.Newf("%s", status)
+	})
+
+	// tenant now has a fully ingested, paused import, so back them up.
+	const dst = "userfile:///t"
+	if _, err := sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO $1`, dst); err != nil {
+		t.Fatal(err)
+	}
+	// Destroy the tenant, then restore it.
+	tSrv.Stopper().Stop(ctx)
+	if _, err := sqlDB.DB.ExecContext(ctx, "SELECT crdb_internal.destroy_tenant(10, true)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.DB.ExecContext(ctx, "RESTORE TENANT 10 FROM $1", dst); err != nil {
+		t.Fatal(err)
+	}
+	tSrv, tSQL = serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
+		TenantID:     roachpb.MakeTenantID(10),
+		Existing:     true,
+		TestingKnobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
+	})
+	defer tSQL.Close()
+
+	if _, err := tSQL.Exec(`UPDATE system.jobs SET claim_session_id = NULL, claim_instance_id = NULL WHERE id = $1`, jobID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tSQL.Exec(`DELETE FROM system.lease`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tSQL.Exec(`CANCEL JOB $1`, jobID); err != nil {
+		t.Fatal(err)
+	}
+	tSrv.JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+	testutils.SucceedsSoon(t, func() error {
+		var status string
+		if err := tSQL.QueryRow(`SELECT status FROM [show jobs] WHERE job_id = $1`, jobID).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(jobs.StatusCanceled) {
+			return nil
+		}
+		return errors.Newf("%s", status)
+	})
+
+	var rowCount int
+	if err := tSQL.QueryRow(`SELECT count(*) FROM x`).Scan(&rowCount); err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, 1, rowCount)
+}

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -402,6 +402,11 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 				t.Fatalf("%+v", err)
 			}
 			kvs := clientKVsToEngineKVs(clientKVs)
+			for i := range kvs {
+				if i < len(expectedKVs) {
+					expectedKVs[i].Key.Timestamp = kvs[i].Key.Timestamp
+				}
+			}
 
 			if !reflect.DeepEqual(kvs, expectedKVs) {
 				for i := 0; i < len(kvs) || i < len(expectedKVs); i++ {

--- a/pkg/ccl/importccl/import_job.go
+++ b/pkg/ccl/importccl/import_job.go
@@ -283,6 +283,9 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			return err
 		}
 	}
+	if err := p.ExecCfg().JobRegistry.CheckPausepoint("import.after_ingest"); err != nil {
+		return err
+	}
 
 	// If the table being imported into referenced UDTs, ensure that a concurrent
 	// schema change on any of the typeDescs has not modified the type descriptor. If

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -3417,7 +3417,11 @@ func TestPausepoints(t *testing.T) {
 				return registry.CreateStartableJobWithTxn(ctx, &sj, jobID, txn, rec)
 			}))
 			require.NoError(t, sj.Start(ctx))
-			require.NoError(t, sj.AwaitCompletion(ctx))
+			if tc.expected == jobs.StatusSucceeded {
+				require.NoError(t, sj.AwaitCompletion(ctx))
+			} else {
+				require.Error(t, sj.AwaitCompletion(ctx))
+			}
 			status, err := sj.TestingCurrentStatus(ctx, nil)
 			// Map pause-requested to paused to avoid races.
 			if status == jobs.StatusPauseRequested {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1141,7 +1141,10 @@ func (r *Registry) stepThroughStateMachine(
 		}
 
 		if errors.Is(err, errPauseSelfSentinel) {
-			return r.PauseRequested(ctx, nil, job.ID(), err.Error())
+			if err := r.PauseRequested(ctx, nil, job.ID(), err.Error()); err != nil {
+				return err
+			}
+			return errPauseSelfSentinel
 		}
 		// TODO(spaskob): enforce a limit on retries.
 


### PR DESCRIPTION
Release note (sql change): Restored data now appears to have been written at the time it was restored, rather than the time at which it was backed up, when reading the lower-level write timestamps from the rows themselves. This affects various internal operations and the result of crdb_internal_mvcc_timestamp.