### PR TITLE
Add cluster version as feature gate for block properties

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -174,4 +174,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-62	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-64	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -186,6 +186,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-62</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-64</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -269,6 +269,16 @@ const (
 	DontProposeWriteTimestampForLeaseTransfers
 	// TenantSettingsTable adds the system table for tracking tenant usage.
 	TenantSettingsTable
+	// EnablePebbleFormatVersionBlockProperties enables a new Pebble SSTable
+	// format version for block property collectors.
+	// NB: this cluster version is paired with PebbleFormatBlockPropertyCollector
+	// in a two-phase migration. The first cluster version acts as a gate for
+	// updating the format major version on all stores, while the second cluster
+	// version is used as a feature gate. A node in a cluster that sees the second
+	// version is guaranteed to have seen the first version, and therefore has an
+	// engine running at the required format major version, as do all other nodes
+	// in the cluster.
+	EnablePebbleFormatVersionBlockProperties
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -428,6 +438,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     TenantSettingsTable,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 62},
+	},
+	{
+		Key:     EnablePebbleFormatVersionBlockProperties,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 64},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -40,11 +40,12 @@ func _() {
 	_ = x[PostAddRaftAppliedIndexTermMigration-29]
 	_ = x[DontProposeWriteTimestampForLeaseTransfers-30]
 	_ = x[TenantSettingsTable-31]
+	_ = x[EnablePebbleFormatVersionBlockProperties-32]
 }
 
-const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersTenantSettingsTable"
+const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersTenantSettingsTableEnablePebbleFormatVersionBlockProperties"
 
-var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 455, 483, 504, 517, 536, 570, 608, 642, 674, 710, 742, 778, 820, 839}
+var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 455, 483, 504, 517, 536, 570, 608, 642, 674, 710, 742, 778, 820, 839, 879}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -237,7 +237,7 @@ func (b *SSTBatcher) Reset(ctx context.Context) error {
 	// Create "Ingestion" SSTs in the newer RocksDBv2 format only if  all nodes
 	// in the cluster can support it. Until then, for backward compatibility,
 	// create SSTs in the leveldb format ("backup" ones).
-	b.sstWriter = storage.MakeIngestionSSTWriter(b.sstFile)
+	b.sstWriter = storage.MakeIngestionSSTWriter(ctx, b.settings, b.sstFile)
 	b.batchStartKey = b.batchStartKey[:0]
 	b.batchEndKey = b.batchEndKey[:0]
 	b.batchEndValue = b.batchEndValue[:0]
@@ -611,7 +611,7 @@ func createSplitSSTable(
 	settings *cluster.Settings,
 ) (*sstSpan, *sstSpan, error) {
 	sstFile := &storage.MemFile{}
-	w := storage.MakeIngestionSSTWriter(sstFile)
+	w := storage.MakeIngestionSSTWriter(ctx, settings, sstFile)
 	defer w.Close()
 
 	split := false
@@ -641,7 +641,7 @@ func createSplitSSTable(
 				disallowShadowingBelow: disallowShadowingBelow,
 			}
 			*sstFile = storage.MemFile{}
-			w = storage.MakeIngestionSSTWriter(sstFile)
+			w = storage.MakeIngestionSSTWriter(ctx, settings, sstFile)
 			split = true
 			first = nil
 			last = nil

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -79,9 +79,12 @@ func EvalAddSSTable(
 	if args.WriteAtRequestTimestamp &&
 		(args.SSTTimestamp.IsEmpty() || h.Timestamp != args.SSTTimestamp ||
 			util.ConstantWithMetamorphicTestBool("addsst-rewrite-forced", false)) {
+		st := cArgs.EvalCtx.ClusterSettings()
 		// TODO(dt): use a quotapool.
-		concurrency := int(addSSTableRewriteConcurrency.Get(&cArgs.EvalCtx.ClusterSettings().SV))
-		sst, err = storage.UpdateSSTTimestamps(sst, args.SSTTimestamp, h.Timestamp, concurrency)
+		concurrency := int(addSSTableRewriteConcurrency.Get(&st.SV))
+		sst, err = storage.UpdateSSTTimestamps(
+			ctx, st, sst, args.SSTTimestamp, h.Timestamp, concurrency,
+		)
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "updating SST timestamps")
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -434,6 +434,7 @@ func TestExportGCThreshold(t *testing.T) {
 // exportUsingGoIterator uses the legacy implementation of export, and is used
 // as an oracle to check the correctness of pebbleExportToSst.
 func exportUsingGoIterator(
+	ctx context.Context,
 	filter roachpb.MVCCFilter,
 	startTime, endTime hlc.Timestamp,
 	startKey, endKey roachpb.Key,
@@ -441,7 +442,9 @@ func exportUsingGoIterator(
 	reader storage.Reader,
 ) ([]byte, error) {
 	memFile := &storage.MemFile{}
-	sst := storage.MakeIngestionSSTWriter(memFile)
+	sst := storage.MakeIngestionSSTWriter(
+		ctx, cluster.MakeTestingClusterSettings(), memFile,
+	)
 	defer sst.Close()
 
 	var skipTombstones bool
@@ -569,7 +572,7 @@ func assertEqualKVs(
 
 		// Run the oracle which is a legacy implementation of pebbleExportToSst
 		// backed by an MVCCIncrementalIterator.
-		expected, err := exportUsingGoIterator(filter, startTime, endTime,
+		expected, err := exportUsingGoIterator(ctx, filter, startTime, endTime,
 			startKey, endKey, enableTimeBoundIteratorOptimization, e)
 		if err != nil {
 			t.Fatalf("Oracle failed to export provided key range.")

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3789,9 +3789,11 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		defer it.Close()
 		// Write a range deletion tombstone to each of the SSTs then put in the
 		// kv entries from the sender of the snapshot.
+		ctx := context.Background()
+		st := cluster.MakeTestingClusterSettings()
 		for _, r := range keyRanges {
 			sstFile := &storage.MemFile{}
-			sst := storage.MakeIngestionSSTWriter(sstFile)
+			sst := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 			if err := sst.ClearRawRange(r.Start, r.End); err != nil {
 				return err
 			}
@@ -3828,7 +3830,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		for _, k := range []roachpb.Key{keyB, keyC} {
 			rangeID := rangeIds[string(k)]
 			sstFile := &storage.MemFile{}
-			sst := storage.MakeIngestionSSTWriter(sstFile)
+			sst := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 			defer sst.Close()
 			r := rditer.MakeRangeIDLocalKeyRange(rangeID, false /* replicatedOnly */)
 			if err := sst.ClearRawRange(r.Start, r.End); err != nil {
@@ -3848,7 +3850,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 
 		// Construct an SST for the user key range of the subsumed replicas.
 		sstFile := &storage.MemFile{}
-		sst := storage.MakeIngestionSSTWriter(sstFile)
+		sst := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 		defer sst.Close()
 		desc := roachpb.RangeDescriptor{
 			StartKey: roachpb.RKey(keyD),

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -877,7 +877,9 @@ func (r *Replica) applySnapshot(
 	}(timeutil.Now())
 
 	unreplicatedSSTFile := &storage.MemFile{}
-	unreplicatedSST := storage.MakeIngestionSSTWriter(unreplicatedSSTFile)
+	unreplicatedSST := storage.MakeIngestionSSTWriter(
+		ctx, r.ClusterSettings(), unreplicatedSSTFile,
+	)
 	defer unreplicatedSST.Close()
 
 	// Clearing the unreplicated state.
@@ -1111,7 +1113,9 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 
 		// We have to create an SST for the subsumed replica's range-id local keys.
 		subsumedReplSSTFile := &storage.MemFile{}
-		subsumedReplSST := storage.MakeIngestionSSTWriter(subsumedReplSSTFile)
+		subsumedReplSST := storage.MakeIngestionSSTWriter(
+			ctx, r.ClusterSettings(), subsumedReplSSTFile,
+		)
 		defer subsumedReplSST.Close()
 		// NOTE: We set mustClearRange to true because we are setting
 		// RangeTombstoneKey. Since Clears and Puts need to be done in increasing
@@ -1167,7 +1171,9 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	for i := range keyRanges {
 		if totalKeyRanges[i].End.Compare(keyRanges[i].End) > 0 {
 			subsumedReplSSTFile := &storage.MemFile{}
-			subsumedReplSST := storage.MakeIngestionSSTWriter(subsumedReplSSTFile)
+			subsumedReplSST := storage.MakeIngestionSSTWriter(
+				ctx, r.ClusterSettings(), subsumedReplSSTFile,
+			)
 			defer subsumedReplSST.Close()
 			if err := storage.ClearRangeWithHeuristic(
 				r.store.Engine(),

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -336,8 +336,9 @@ func TestReplicaRangefeed(t *testing.T) {
 	expVal6q.SetInt(7)
 	expVal6q.InitChecksum(roachpb.Key("q"))
 
+	st := cluster.MakeTestingClusterSettings()
 	sstFile := &storage.MemFile{}
-	sstWriter := storage.MakeIngestionSSTWriter(sstFile)
+	sstWriter := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 	defer sstWriter.Close()
 	require.NoError(t, sstWriter.PutMVCC(
 		storage.MVCCKey{Key: roachpb.Key("b"), Timestamp: ts6},
@@ -366,7 +367,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	expVal7q.InitChecksum(roachpb.Key("q"))
 
 	sstFile = &storage.MemFile{}
-	sstWriter = storage.MakeIngestionSSTWriter(sstFile)
+	sstWriter = storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 	defer sstWriter.Close()
 	require.NoError(t, sstWriter.PutMVCC(
 		storage.MVCCKey{Key: roachpb.Key("b"), Timestamp: ts7},

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -706,7 +706,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 
 	// Put a sideloaded proposal on the Range.
 	key, val := "don't", "care"
-	origSSTData, _ := MakeSSTable(key, val, hlc.Timestamp{}.Add(0, 1))
+	origSSTData, _ := MakeSSTable(ctx, key, val, hlc.Timestamp{}.Add(0, 1))
 	{
 
 		var addReq roachpb.AddSSTableRequest

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -165,7 +166,9 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	}
 	keyRanges := rditer.MakeReplicatedKeyRanges(&desc)
 
-	msstw, err := newMultiSSTWriter(ctx, scratch, keyRanges, 0)
+	msstw, err := newMultiSSTWriter(
+		ctx, cluster.MakeTestingClusterSettings(), scratch, keyRanges, 0,
+	)
 	require.NoError(t, err)
 	_, err = msstw.Finish(ctx)
 	require.NoError(t, err)
@@ -184,7 +187,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	for _, r := range keyRanges {
 		func() {
 			sstFile := &storage.MemFile{}
-			sst := storage.MakeIngestionSSTWriter(sstFile)
+			sst := storage.MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), sstFile)
 			defer sst.Close()
 			err := sst.ClearRawRange(r.Start, r.End)
 			require.NoError(t, err)

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -160,6 +160,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_kr_pretty//:pretty",

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1583,8 +1583,10 @@ func runCheckSSTConflicts(b *testing.B, numEngineKeys, numVersions, numSstKeys i
 	// The engine contains keys numbered key-1, key-2, key-3, etc, while
 	// the SST contains keys numbered key-11, key-21, etc., that fit in
 	// between the engine keys without colliding.
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 	sstFile := &MemFile{}
-	sstWriter := MakeIngestionSSTWriter(sstFile)
+	sstWriter := MakeIngestionSSTWriter(ctx, st, sstFile)
 	var sstStart, sstEnd MVCCKey
 	for i := 0; i < numSstKeys; i++ {
 		keyNum := int((float64(i) / float64(numSstKeys)) * float64(numEngineKeys))

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     ],
     embed = [":metamorphic"],
     deps = [
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",

--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -111,6 +111,7 @@ type metaTestRunner struct {
 	nameToGenerator map[string]*opGenerator
 	ops             []opRun
 	weights         []int
+	st              *cluster.Settings
 }
 
 func (m *metaTestRunner) init() {

--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -78,6 +79,10 @@ func runMetaTestForEngines(run testRunForEngines) {
 		restarts:  run.restarts,
 		engineSeq: run.engineSequence,
 		path:      filepath.Join(tempDir, "store"),
+		// TODO(travers): Add metamorphic test support for different versions, which
+		// will give us better coverage across multiple format major versions and
+		// table versions.
+		st: cluster.MakeTestingClusterSettings(),
 	}
 	fmt.Printf("store path = %s\n", testRunner.path)
 

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -721,7 +721,7 @@ func (i ingestOp) run(ctx context.Context) string {
 		return fmt.Sprintf("error = %s", err.Error())
 	}
 
-	sstWriter := storage.MakeIngestionSSTWriter(f)
+	sstWriter := storage.MakeIngestionSSTWriter(ctx, i.m.st, f)
 	for _, key := range i.keys {
 		_ = sstWriter.Put(key, []byte("ingested"))
 	}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -1246,7 +1247,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	// TODO(sumeer): change this test before interleaved intents are disallowed.
 	ingest := func(it MVCCIterator, count int) {
 		memFile := &MemFile{}
-		sst := MakeIngestionSSTWriter(memFile)
+		sst := MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), memFile)
 		defer sst.Close()
 
 		for i := 0; i < count; i++ {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1589,6 +1589,16 @@ func (p *Pebble) SetMinVersion(version roachpb.Version) error {
 	// upwards. Here we map the persisted cluster version to the
 	// corresponding format major version, ratcheting Pebble's format
 	// major version if necessary.
+	//
+	// Note that when introducing a new Pebble format version that relies on _all_
+	// engines in a cluster being at the same, newer format major version, two
+	// cluster versions should be used. The first is used to enable the feature in
+	// Pebble, and should control the version ratchet below. The second is used as
+	// a feature flag. The use of two cluster versions relies on a guarantee
+	// provided by the migration framework (see pkg/migration) that if a node is
+	// at a version X+1, it is guaranteed that all nodes have already ratcheted
+	// their store version to the version X that enabled the feature at the Pebble
+	// level.
 	formatVers := pebble.FormatMostCompatible
 	// Cases are ordered from newer to older versions.
 	switch {

--- a/pkg/storage/sst_iterator_test.go
+++ b/pkg/storage/sst_iterator_test.go
@@ -11,11 +11,13 @@
 package storage
 
 import (
+	"context"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -75,8 +77,10 @@ func TestSSTIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 	sstFile := &MemFile{}
-	sst := MakeIngestionSSTWriter(sstFile)
+	sst := MakeIngestionSSTWriter(ctx, st, sstFile)
 	defer sst.Close()
 	var allKVs []MVCCKeyValue
 	for i := 0; i < 10; i++ {

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -120,8 +121,10 @@ func BenchmarkUpdateSSTTimestamps(b *testing.B) {
 
 	r := rand.New(rand.NewSource(7))
 
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 	sstFile := &MemFile{}
-	writer := MakeIngestionSSTWriter(sstFile)
+	writer := MakeIngestionSSTWriter(ctx, st, sstFile)
 	defer writer.Close()
 
 	key := make([]byte, 8)
@@ -165,7 +168,7 @@ func BenchmarkUpdateSSTTimestamps(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		ts := hlc.Timestamp{WallTime: 1634899098417970999, Logical: 9}
-		_, err := UpdateSSTTimestamps(sstFile.Bytes(), hlc.Timestamp{}, ts, 0)
+		_, err := UpdateSSTTimestamps(ctx, st, sstFile.Bytes(), hlc.Timestamp{}, ts, 0)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -11,14 +11,19 @@
 package storage_test
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,10 +54,12 @@ func makeIntTableKVs(numKeys, valueSize, maxRevisions int) []storage.MVCCKeyValu
 }
 
 func makePebbleSST(t testing.TB, kvs []storage.MVCCKeyValue, ingestion bool) []byte {
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 	f := &storage.MemFile{}
 	var w storage.SSTWriter
 	if ingestion {
-		w = storage.MakeIngestionSSTWriter(f)
+		w = storage.MakeIngestionSSTWriter(ctx, st, f)
 	} else {
 		w = storage.MakeBackupSSTWriter(f)
 	}
@@ -66,6 +73,43 @@ func makePebbleSST(t testing.TB, kvs []storage.MVCCKeyValue, ingestion bool) []b
 	err := w.Finish()
 	require.NoError(t, err)
 	return f.Data()
+}
+
+func TestMakeIngestionWriterOptions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name string
+		st   *cluster.Settings
+		want sstable.TableFormat
+	}{
+		{
+			name: "before feature gate",
+			st: cluster.MakeTestingClusterSettingsWithVersions(
+				clusterversion.ByKey(clusterversion.EnablePebbleFormatVersionBlockProperties-1),
+				clusterversion.TestingBinaryMinSupportedVersion,
+				true,
+			),
+			want: sstable.TableFormatRocksDBv2,
+		},
+		{
+			name: "at feature gate",
+			st: cluster.MakeTestingClusterSettingsWithVersions(
+				clusterversion.ByKey(clusterversion.EnablePebbleFormatVersionBlockProperties),
+				clusterversion.TestingBinaryMinSupportedVersion,
+				true,
+			),
+			want: sstable.TableFormatPebblev1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			opts := storage.MakeIngestionWriterOptions(ctx, tc.st)
+			require.Equal(t, tc.want, opts.TableFormat)
+		})
+	}
 }
 
 func BenchmarkWriteSSTable(b *testing.B) {

--- a/pkg/testutils/sstutil/BUILD.bazel
+++ b/pkg/testutils/sstutil/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",

--- a/pkg/testutils/sstutil/sstutil.go
+++ b/pkg/testutils/sstutil/sstutil.go
@@ -11,10 +11,12 @@
 package sstutil
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -27,7 +29,9 @@ func MakeSST(t *testing.T, kvs []KV) ([]byte, roachpb.Key, roachpb.Key) {
 	t.Helper()
 
 	sstFile := &storage.MemFile{}
-	writer := storage.MakeIngestionSSTWriter(sstFile)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	writer := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 	defer writer.Close()
 
 	start, end := keys.MaxKey, keys.MinKey


### PR DESCRIPTION
Two commits here - the first adds a new cluster version, the second makes use of the cluster version as a feature gate (and update various call sites all over the place).

---

pkg/clusterversion: add new version as feature gate for block properties
Prior to this change, the block properties SSTable-level feature was
enabled in a single cluster version. This introduced a subtle race in
that for the period in which each node is being updated to
`PebbleFormatBlockPropertyCollector`, there is a brief period where not
all nodes are at the same cluster version, and thus store versions. If
nodes at the newer version write SSTables that make use of block
properties, and these tables are consumed by nodes that are yet to be
updated, the older nodes could panic when attempting to read the tables
with a format they do not yet understand.

While this race is academic, given that a) there are now subsequent
cluster versions that act as barriers during the migration, and b) block
properties were disabled in https://github.com/cockroachdb/cockroach/commit/1a8fb576f5d982509cd5dbaa68c9fabb27b49e58, this patch addresses the race by
adding a second cluster version.
`EnablePebbleFormatVersionBlockProperties` acts as a barrier and a
feature gate. A guarantee of the migration framework is that any node at
this newer version is part of a cluster that has already run the
necessary migrations for the older version, and thus ratcheted the
format major version in the store, and thus enabled the block properties
feature, across all nodes.

Add additional documentation in `pebble.go` that details how to make use
of the two-version pattern for future table-level version changes.

---

pkg/storage: make MakeIngestionWriterOptions version aware
With the introduction of block properties, and soon, range keys, which
introduce backward-incompatible changes at the SSTable level, all nodes
in a cluster must all have a sufficient store version in order to avoid
runtime incompatibilities.

Update `storage.MakeIngestionWriterOptions` to add a `context.Context`
and `cluster.Settings` as parameters, which allows for determining
whether a given cluster version is active (via
`(clusterversion.Handle).IsActive()`). This allows gating the enabling /
disabling of block properties (and soon, range keys), on all nodes being
at a sufficient cluster version.

Update various call-sites to pass in the `context.Context` and
`cluster.Settings`.

---