### PR TITLE
prometheus: simplify snapshot visualization

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1506,7 +1506,7 @@ func setupPrometheus(
 			snapshotCtx,
 			c,
 			t.L(),
-			filepath.Join(t.ArtifactsDir(), "prometheus-snapshot.tar.gz"),
+			t.ArtifactsDir(),
 		); err != nil {
 			t.L().Printf("failed to get prometheus snapshot: %v", err)
 		}


### PR DESCRIPTION
Make it *really easy* to look at `prometheus-snapshot.tgz` by putting a
shell script next to it that spins it up via docker, so you can just
run:

```
$ ./prometheus-docker-run.sh
[...]
ts=2022-02-09T09:07:06.254Z caller=main.go:896 level=info msg="Server is ready to receive web requests."
```

I got motivated to do this while working on the roachtest in #76147 but
I imagine it'll come in handy in general as well.

Release note: None
