### PR TITLE
tree: correctly cast float8 -> float4

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -159,3 +159,27 @@ query BB
 SELECT 'nan'::decimal IS NAN, 'nan'::decimal IS NOT NAN
 ----
 true  false
+
+# Regression for #73743.
+query R
+SELECT 18754999.99::FLOAT8::FLOAT4::FLOAT8;
+----
+1.8755e+07
+
+statement ok
+CREATE TABLE regression_73472 (
+  f4 FLOAT4,
+  f8 FLOAT8
+);
+INSERT INTO regression_73472 VALUES (18754999.99, 18754999.99)
+
+query RR
+SELECT * FROM regression_73472
+----
+1.8755e+07  1.875499999e+07
+
+statement error float out of range
+INSERT INTO regression_73472 VALUES ('-4e+38', '-4e+38')
+
+statement error float out of range
+SELECT '4e+38'::float8::float4

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -1556,6 +1556,16 @@ func AdjustValueToType(typ *types.T, inVal Datum) (outVal Datum, err error) {
 				}
 			}
 		}
+	case types.FloatFamily:
+		if v, ok := inVal.(*DFloat); ok {
+			switch typ.Width() {
+			case 32:
+				if *v > math.MaxFloat32 || *v < -math.MaxFloat32 {
+					return nil, ErrFloatOutOfRange
+				}
+				return NewDFloat(DFloat(float32(*v))), nil
+			}
+		}
 	case types.BitFamily:
 		if v, ok := AsDBitArray(inVal); ok {
 			if typ.Width() > 0 {


### PR DESCRIPTION
Resolves #73743, but there are many more issues.

Release note (bug fix): Previously, inserting or casting into a FLOAT4
with a range out of value would still work and be treated as a FLOAT8.
This can also means more precision is stored than necessary. This has
been resolved.