### PR TITLE
server: standardize error handling across all RPC endpoints

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -179,20 +179,20 @@ func (s *adminServer) RegisterGateway(
 
 // serverError logs the provided error and returns an error that should be returned by
 // the RPC endpoint method.
-func (s *adminServer) serverError(err error) error {
-	log.ErrorfDepth(context.TODO(), 1, "%+s", err)
+func serverError(ctx context.Context, err error) error {
+	log.ErrorfDepth(ctx, 1, "%+s", err)
 	return errAdminAPIError
 }
 
 // serverErrorf logs the provided error and returns an error that should be returned by
 // the RPC endpoint method.
-func (s *adminServer) serverErrorf(format string, args ...interface{}) error {
-	log.ErrorfDepth(context.TODO(), 1, format, args...)
+func serverErrorf(ctx context.Context, format string, args ...interface{}) error {
+	log.ErrorfDepth(ctx, 1, format, args...)
 	return errAdminAPIError
 }
 
 // isNotFoundError returns true if err is a table/database not found error.
-func (s *adminServer) isNotFoundError(err error) bool {
+func isNotFoundError(err error) bool {
 	// TODO(cdo): Replace this crude suffix-matching with something more structured once we have
 	// more structured errors.
 	return err != nil && strings.HasSuffix(err.Error(), "does not exist")
@@ -217,9 +217,8 @@ func (s *adminServer) ChartCatalog(
 	metricsMetadata := s.server.recorder.GetMetricsMetadata()
 
 	chartCatalog, err := catalog.GenerateCatalog(metricsMetadata)
-
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	resp := &serverpb.ChartCatalogResponse{
@@ -233,25 +232,19 @@ func (s *adminServer) ChartCatalog(
 func (s *adminServer) Databases(
 	ctx context.Context, req *serverpb.DatabasesRequest,
 ) (_ *serverpb.DatabasesResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	ctx = s.server.AnnotateCtx(ctx)
 
 	sessionUser, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
-	return s.databasesHelper(ctx, req, sessionUser, 0, 0)
+	r, err := s.databasesHelper(ctx, req, sessionUser, 0, 0)
+	return r, maybeHandleNotFoundError(ctx, err)
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) databasesHelper(
 	ctx context.Context,
 	req *serverpb.DatabasesRequest,
@@ -268,7 +261,7 @@ func (s *adminServer) databasesHelper(
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 
 	var resp serverpb.DatabasesResponse
 	var hasNext bool
@@ -288,14 +281,17 @@ func (s *adminServer) databasesHelper(
 	return &resp, nil
 }
 
-func (s *adminServer) maybeHandleNotFoundError(err error) error {
-	if s.isNotFoundError(err) {
+// maybeHandleNotFoundError checks the provided error and
+// conditionally returns a gRPC NotFound code.
+// It returns a gRPC error in any case.
+func maybeHandleNotFoundError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if isNotFoundError(err) {
 		return status.Errorf(codes.NotFound, "%s", err)
 	}
-	if err != nil {
-		return s.serverError(err)
-	}
-	return nil
+	return serverError(ctx, err)
 }
 
 // DatabaseDetails is an endpoint that returns grants and a list of table names
@@ -306,12 +302,15 @@ func (s *adminServer) DatabaseDetails(
 	ctx = s.server.AnnotateCtx(ctx)
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
-	return s.databaseDetailsHelper(ctx, req, userName)
+	r, err := s.databaseDetailsHelper(ctx, req, userName)
+	return r, maybeHandleNotFoundError(ctx, err)
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) getDatabaseGrants(
 	ctx context.Context,
 	req *serverpb.DatabaseDetailsRequest,
@@ -341,17 +340,12 @@ func (s *adminServer) getDatabaseGrants(
 		// We only want to show the grants on the database.
 		query.String(), query.QueryArguments()...,
 	)
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func(it sqlutil.InternalRows) {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = s.maybeHandleNotFoundError(closeErr)
-		}
-	}(it)
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 	{
 		const (
 			userCol       = "grantee"
@@ -359,7 +353,7 @@ func (s *adminServer) getDatabaseGrants(
 		)
 
 		ok, err := it.Next(ctx)
-		if err = s.maybeHandleNotFoundError(err); err != nil {
+		if err != nil {
 			return nil, err
 		}
 		if ok {
@@ -379,14 +373,16 @@ func (s *adminServer) getDatabaseGrants(
 				grant.Privileges = strings.Split(privileges, ",")
 				resp = append(resp, grant)
 			}
-			if err = s.maybeHandleNotFoundError(err); err != nil {
+			if err = maybeHandleNotFoundError(ctx, err); err != nil {
 				return nil, err
 			}
 		}
 	}
-	return resp, retErr
+	return resp, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) getDatabaseTables(
 	ctx context.Context,
 	req *serverpb.DatabaseDetailsRequest,
@@ -408,20 +404,15 @@ WHERE table_catalog = $ AND table_type != 'SYSTEM VIEW'`, req.Database)
 		ctx, "admin-show-tables", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: userName, Database: req.Database},
 		query.String(), query.QueryArguments()...)
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func(it sqlutil.InternalRows) {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = s.maybeHandleNotFoundError(closeErr)
-		}
-	}(it)
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 	{
 		ok, err := it.Next(ctx)
-		if err = s.maybeHandleNotFoundError(err); err != nil {
+		if err != nil {
 			return nil, err
 		}
 
@@ -440,14 +431,16 @@ WHERE table_catalog = $ AND table_type != 'SYSTEM VIEW'`, req.Database)
 				resp = append(resp, fmt.Sprintf("%s.%s",
 					tree.NameStringP(&schemaName), tree.NameStringP(&tableName)))
 			}
-			if err = s.maybeHandleNotFoundError(err); err != nil {
+			if err != nil {
 				return nil, err
 			}
 		}
 	}
-	return resp, retErr
+	return resp, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) getMiscDatabaseDetails(
 	ctx context.Context,
 	req *serverpb.DatabaseDetailsRequest,
@@ -460,13 +453,13 @@ func (s *adminServer) getMiscDatabaseDetails(
 	// Query the descriptor ID and zone configuration for this database.
 	databaseID, err := s.queryDatabaseID(ctx, userName, req.Database)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
 	resp.DescriptorID = int64(databaseID)
 
 	id, zone, zoneExists, err := s.queryZonePath(ctx, userName, []descpb.ID{databaseID})
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
 
 	if !zoneExists {
@@ -483,6 +476,8 @@ func (s *adminServer) getMiscDatabaseDetails(
 	return resp, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) databaseDetailsHelper(
 	ctx context.Context, req *serverpb.DatabaseDetailsRequest, userName security.SQLUsername,
 ) (_ *serverpb.DatabaseDetailsResponse, retErr error) {
@@ -517,6 +512,8 @@ func (s *adminServer) databaseDetailsHelper(
 	return &resp, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) getDatabaseTableSpans(
 	ctx context.Context, userName security.SQLUsername, dbName string, tableNames []string,
 ) (map[string]roachpb.Span, error) {
@@ -529,13 +526,15 @@ func (s *adminServer) getDatabaseTableSpans(
 		}
 		tableID, err := s.queryTableID(ctx, userName, dbName, fullyQualifiedTableName)
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 		tableSpans[tableName] = generateTableSpan(tableID)
 	}
 	return tableSpans, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) getDatabaseStats(
 	ctx context.Context, tableSpans map[string]roachpb.Span,
 ) (*serverpb.DatabaseDetailsResponse_Stats, error) {
@@ -604,6 +603,9 @@ func (s *adminServer) getDatabaseStats(
 // is a unqualified name or a schema-qualified name, returns a maximally
 // qualified name: either database.table if the input wasn't schema qualified,
 // or database.schema.table if it was.
+//
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func getFullyQualifiedTableName(dbName string, tableName string) (string, error) {
 	name, err := parser.ParseQualifiedTableName(tableName)
 	if err != nil {
@@ -636,12 +638,15 @@ func (s *adminServer) TableDetails(
 	ctx = s.server.AnnotateCtx(ctx)
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
-	return s.tableDetailsHelper(ctx, req, userName)
+	r, err := s.tableDetailsHelper(ctx, req, userName)
+	return r, maybeHandleNotFoundError(ctx, err)
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) tableDetailsHelper(
 	ctx context.Context, req *serverpb.TableDetailsRequest, userName security.SQLUsername,
 ) (_ *serverpb.TableDetailsResponse, retErr error) {
@@ -659,17 +664,12 @@ func (s *adminServer) tableDetailsHelper(
 		sessiondata.InternalExecutorOverride{User: userName},
 		fmt.Sprintf("SHOW COLUMNS FROM %s", escQualTable),
 	)
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func(it sqlutil.InternalRows) {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = s.maybeHandleNotFoundError(closeErr)
-		}
-	}(it)
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 	// TODO(cdo): protobuf v3's default behavior for fields with zero values (e.g. empty strings)
 	// is to suppress them. So, if protobuf field "foo" is an empty string, "foo" won't show
 	// up in the marshaled JSON. I feel that this is counterintuitive, and this should be fixed
@@ -684,7 +684,7 @@ func (s *adminServer) tableDetailsHelper(
 			hiddenCol  = "is_hidden"
 		)
 		ok, err := it.Next(ctx)
-		if err = s.maybeHandleNotFoundError(err); err != nil {
+		if err != nil {
 			return nil, err
 		}
 		if ok {
@@ -725,7 +725,7 @@ func (s *adminServer) tableDetailsHelper(
 				}
 				resp.Columns = append(resp.Columns, col)
 			}
-			if err = s.maybeHandleNotFoundError(err); err != nil {
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -737,17 +737,12 @@ func (s *adminServer) tableDetailsHelper(
 		sessiondata.InternalExecutorOverride{User: userName},
 		fmt.Sprintf("SHOW INDEX FROM %s", escQualTable),
 	)
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func(it sqlutil.InternalRows) {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = s.maybeHandleNotFoundError(closeErr)
-		}
-	}(it)
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 	{
 		const (
 			nameCol      = "index_name"
@@ -759,7 +754,7 @@ func (s *adminServer) tableDetailsHelper(
 			implicitCol  = "implicit"
 		)
 		ok, err := it.Next(ctx)
-		if err = s.maybeHandleNotFoundError(err); err != nil {
+		if err != nil {
 			return nil, err
 		}
 		if ok {
@@ -794,7 +789,7 @@ func (s *adminServer) tableDetailsHelper(
 				}
 				resp.Indexes = append(resp.Indexes, index)
 			}
-			if err = s.maybeHandleNotFoundError(err); err != nil {
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -806,24 +801,19 @@ func (s *adminServer) tableDetailsHelper(
 		sessiondata.InternalExecutorOverride{User: userName},
 		fmt.Sprintf("SHOW GRANTS ON TABLE %s", escQualTable),
 	)
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func(it sqlutil.InternalRows) {
-		closeErr := it.Close()
-		if retErr == nil {
-			retErr = s.maybeHandleNotFoundError(closeErr)
-		}
-	}(it)
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 	{
 		const (
 			userCol       = "grantee"
 			privilegesCol = "privilege_type"
 		)
 		ok, err := it.Next(ctx)
-		if err = s.maybeHandleNotFoundError(err); err != nil {
+		if err != nil {
 			return nil, err
 		}
 		if ok {
@@ -843,7 +833,7 @@ func (s *adminServer) tableDetailsHelper(
 				grant.Privileges = strings.Split(privileges, ",")
 				resp.Grants = append(resp.Grants, grant)
 			}
-			if err = s.maybeHandleNotFoundError(err); err != nil {
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -855,13 +845,13 @@ func (s *adminServer) tableDetailsHelper(
 		sessiondata.InternalExecutorOverride{User: userName},
 		fmt.Sprintf("SHOW CREATE %s", escQualTable),
 	)
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	{
 		const createCol = "create_statement"
 		if row == nil {
-			return nil, s.serverErrorf("create response not available.")
+			return nil, errors.New("create response not available")
 		}
 
 		scanner := makeResultScanner(cols)
@@ -878,13 +868,13 @@ func (s *adminServer) tableDetailsHelper(
 		ctx, "admin-show-zone-config", nil, /* txn */
 		sessiondata.InternalExecutorOverride{User: userName},
 		fmt.Sprintf("SHOW ZONE CONFIGURATION FOR TABLE %s", escQualTable))
-	if err = s.maybeHandleNotFoundError(err); err != nil {
+	if err != nil {
 		return nil, err
 	}
 	{
 		const rawConfigSQLColName = "raw_config_sql"
 		if row == nil {
-			return nil, s.serverErrorf("show zone config response not available.")
+			return nil, errors.New("show zone config response not available")
 		}
 
 		scanner := makeResultScanner(cols)
@@ -900,17 +890,17 @@ func (s *adminServer) tableDetailsHelper(
 	{
 		databaseID, err := s.queryDatabaseID(ctx, userName, req.Database)
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 		tableID, err = s.queryTableID(ctx, userName, req.Database, escQualTable)
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 		resp.DescriptorID = int64(tableID)
 
 		id, zone, zoneExists, err := s.queryZonePath(ctx, userName, []descpb.ID{databaseID, tableID})
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 
 		if !zoneExists {
@@ -934,11 +924,11 @@ func (s *adminServer) tableDetailsHelper(
 		tableSpan := generateTableSpan(tableID)
 		tableRSpan, err := keys.SpanAddr(tableSpan)
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 		rangeCount, err := s.server.distSender.CountRanges(ctx, tableRSpan)
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 		resp.RangeCount = rangeCount
 	}
@@ -964,20 +954,26 @@ func (s *adminServer) TableStats(
 	ctx = s.server.AnnotateCtx(ctx)
 	userName, err := s.requireAdminUser(ctx)
 	if err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 	escQualTable, err := getFullyQualifiedTableName(req.Database, req.Table)
 	if err != nil {
-		return nil, err
+		return nil, maybeHandleNotFoundError(ctx, err)
 	}
 
 	tableID, err := s.queryTableID(ctx, userName, req.Database, escQualTable)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, serverError(ctx, err)
 	}
 	tableSpan := generateTableSpan(tableID)
 
-	return s.statsForSpan(ctx, tableSpan)
+	r, err := s.statsForSpan(ctx, tableSpan)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
 }
 
 // NonTableStats is an endpoint that returns disk usage and replication
@@ -987,6 +983,8 @@ func (s *adminServer) NonTableStats(
 ) (*serverpb.NonTableStatsResponse, error) {
 	ctx = s.server.AnnotateCtx(ctx)
 	if _, err := s.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -995,7 +993,7 @@ func (s *adminServer) NonTableStats(
 		EndKey: keys.TimeseriesPrefix.PrefixEnd(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	response := serverpb.NonTableStatsResponse{
 		TimeSeriesStats: timeSeriesStats,
@@ -1014,7 +1012,7 @@ func (s *adminServer) NonTableStats(
 	for _, span := range spansForInternalUse {
 		nonTableStats, err := s.statsForSpan(ctx, span)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		if response.InternalUseStats == nil {
 			response.InternalUseStats = nonTableStats
@@ -1035,16 +1033,18 @@ func (s *adminServer) NonTableStats(
 	return &response, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) statsForSpan(
 	ctx context.Context, span roachpb.Span,
 ) (*serverpb.TableStatsResponse, error) {
 	startKey, err := keys.Addr(span.Key)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
 	endKey, err := keys.Addr(span.EndKey)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
 
 	// Get current range descriptors for table. This is done by scanning over
@@ -1064,7 +1064,7 @@ func (s *adminServer) statsForSpan(
 
 	rangeDescKVs, err := s.server.db.Scan(ctx, startMetaKey, keys.RangeMetaKey(endKey), 0)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
 
 	// This map will store the nodes we need to fan out to.
@@ -1072,7 +1072,7 @@ func (s *adminServer) statsForSpan(
 	for _, kv := range rangeDescKVs {
 		var rng roachpb.RangeDescriptor
 		if err := kv.Value.GetProto(&rng); err != nil {
-			return nil, s.serverError(err)
+			return nil, err
 		}
 		for _, repl := range rng.Replicas().Descriptors() {
 			nodeIDs[repl.NodeID] = struct{}{}
@@ -1176,12 +1176,24 @@ func (s *adminServer) statsForSpan(
 // Users returns a list of users, stripped of any passwords.
 func (s *adminServer) Users(
 	ctx context.Context, req *serverpb.UsersRequest,
-) (*serverpb.UsersResponse, error) {
+) (_ *serverpb.UsersResponse, retErr error) {
 	ctx = s.server.AnnotateCtx(ctx)
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
+	r, err := s.usersHelper(ctx, req, userName)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}
+
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
+func (s *adminServer) usersHelper(
+	ctx context.Context, req *serverpb.UsersRequest, userName security.SQLUsername,
+) (_ *serverpb.UsersResponse, retErr error) {
 	query := `SELECT username FROM system.users WHERE "isRole" = false`
 	it, err := s.server.sqlServer.internalExecutor.QueryIteratorEx(
 		ctx, "admin-users", nil, /* txn */
@@ -1189,8 +1201,10 @@ func (s *adminServer) Users(
 		query,
 	)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
+	// We have to make sure to close the iterator.
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 
 	var resp serverpb.UsersResponse
 	var ok bool
@@ -1199,7 +1213,7 @@ func (s *adminServer) Users(
 		resp.Users = append(resp.Users, serverpb.UsersResponse_User{Username: string(tree.MustBeDString(row[0]))})
 	}
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, err
 	}
 	return &resp, nil
 }
@@ -1223,19 +1237,12 @@ func combineAllErrors(errs []error) error {
 func (s *adminServer) Events(
 	ctx context.Context, req *serverpb.EventsRequest,
 ) (_ *serverpb.EventsResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil && !errors.Is(retErr, errRequiresAdmin) {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	ctx = s.server.AnnotateCtx(ctx)
 
 	userName, err := s.requireAdminUser(ctx)
 	if err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 	redactEvents := !req.UnredactedEvents
@@ -1245,9 +1252,15 @@ func (s *adminServer) Events(
 		limit = defaultAPIEventLimit
 	}
 
-	return s.eventsHelper(ctx, req, userName, int(limit), 0, redactEvents)
+	r, err := s.eventsHelper(ctx, req, userName, int(limit), 0, redactEvents)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) eventsHelper(
 	ctx context.Context,
 	req *serverpb.EventsRequest,
@@ -1285,7 +1298,7 @@ func (s *adminServer) eventsHelper(
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 
 	// Marshal response.
 	var resp serverpb.EventsResponse
@@ -1372,23 +1385,26 @@ func redactStatement(info string) string {
 func (s *adminServer) RangeLog(
 	ctx context.Context, req *serverpb.RangeLogRequest,
 ) (_ *serverpb.RangeLogResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	ctx = s.server.AnnotateCtx(ctx)
 
 	// Range keys, even when pretty-printed, contain PII.
 	userName, err := s.requireAdminUser(ctx)
 	if err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
+	r, err := s.rangeLogHelper(ctx, req, userName)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}
+
+func (s *adminServer) rangeLogHelper(
+	ctx context.Context, req *serverpb.RangeLogRequest, userName security.SQLUsername,
+) (_ *serverpb.RangeLogResponse, retErr error) {
 	limit := req.Limit
 	if limit == 0 {
 		limit = defaultAPIEventLimit
@@ -1419,7 +1435,7 @@ func (s *adminServer) RangeLog(
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 
 	// Marshal response.
 	var resp serverpb.RangeLogResponse
@@ -1605,7 +1621,7 @@ func (s *adminServer) SetUIData(
 
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	if len(req.KeyValues) == 0 {
@@ -1623,10 +1639,10 @@ func (s *adminServer) SetUIData(
 			},
 			query, makeUIKey(userName, key), val)
 		if err != nil {
-			return nil, s.serverError(err)
+			return nil, serverError(ctx, err)
 		}
 		if rowsAffected != 1 {
-			return nil, s.serverErrorf("rows affected %d != expected %d", rowsAffected, 1)
+			return nil, serverErrorf(ctx, "rows affected %d != expected %d", rowsAffected, 1)
 		}
 	}
 
@@ -1646,7 +1662,7 @@ func (s *adminServer) GetUIData(
 
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	if len(req.Keys) == 0 {
@@ -1655,7 +1671,7 @@ func (s *adminServer) GetUIData(
 
 	resp, err := s.getUIData(ctx, userName, req.Keys)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, serverError(ctx, err)
 	}
 
 	return resp, nil
@@ -1665,6 +1681,8 @@ func (s *adminServer) GetUIData(
 func (s *adminServer) Settings(
 	ctx context.Context, req *serverpb.SettingsRequest,
 ) (*serverpb.SettingsResponse, error) {
+	ctx = s.server.AnnotateCtx(ctx)
+
 	keys := req.Keys
 	if len(keys) == 0 {
 		keys = settings.Keys(settings.ForSystemTenant)
@@ -1672,7 +1690,7 @@ func (s *adminServer) Settings(
 
 	_, isAdmin, err := s.getUserAndRole(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	var lookupPurpose settings.LookupPurpose
@@ -1754,6 +1772,7 @@ func (s *adminServer) Health(
 	return resp, nil
 }
 
+// checkReadinessForHealthCheck returns a gRPC error.
 func (s *adminServer) checkReadinessForHealthCheck(ctx context.Context) error {
 	serveMode := s.server.grpc.mode.get()
 	switch serveMode {
@@ -1766,7 +1785,7 @@ func (s *adminServer) checkReadinessForHealthCheck(ctx context.Context) error {
 	case modeOperational:
 		break
 	default:
-		return s.serverError(errors.Newf("unknown mode: %v", serveMode))
+		return serverError(ctx, errors.Newf("unknown mode: %v", serveMode))
 	}
 
 	// TODO(knz): update this code when progress is made on
@@ -1836,22 +1855,25 @@ func (s *adminServer) Liveness(
 func (s *adminServer) Jobs(
 	ctx context.Context, req *serverpb.JobsRequest,
 ) (_ *serverpb.JobsResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	ctx = s.server.AnnotateCtx(ctx)
 
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
+	j, err := s.jobsHelper(ctx, req, userName)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return j, nil
+}
+
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
+func (s *adminServer) jobsHelper(
+	ctx context.Context, req *serverpb.JobsRequest, userName security.SQLUsername,
+) (_ *serverpb.JobsResponse, retErr error) {
 	retryRunningCondition := "status='running' AND next_run > now() AND num_runs > 1"
 	retryRevertingCondition := "status='reverting' AND next_run > now() AND num_runs > 1"
 
@@ -1892,7 +1914,7 @@ func (s *adminServer) Jobs(
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 
 	ok, err := it.Next(ctx)
 	if err != nil {
@@ -1989,22 +2011,24 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 func (s *adminServer) Job(
 	ctx context.Context, request *serverpb.JobRequest,
 ) (_ *serverpb.JobResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	ctx = s.server.AnnotateCtx(ctx)
 
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
+	r, err := s.jobHelper(ctx, request, userName)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
+func (s *adminServer) jobHelper(
+	ctx context.Context, request *serverpb.JobRequest, userName security.SQLUsername,
+) (_ *serverpb.JobResponse, retErr error) {
 	const query = `
       SELECT job_id, job_type, description, statement, user_name, descriptor_ids, status,
 						 running_status, created, started, finished, modified,
@@ -2044,22 +2068,24 @@ func (s *adminServer) Job(
 func (s *adminServer) Locations(
 	ctx context.Context, req *serverpb.LocationsRequest,
 ) (_ *serverpb.LocationsResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	ctx = s.server.AnnotateCtx(ctx)
 
+	// Require authentication.
 	_, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
+	r, err := s.locationsHelper(ctx, req)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}
+
+func (s *adminServer) locationsHelper(
+	ctx context.Context, req *serverpb.LocationsRequest,
+) (_ *serverpb.LocationsResponse, retErr error) {
 	q := makeSQLQuery()
 	q.Append(`SELECT "localityKey", "localityValue", latitude, longitude FROM system.locations`)
 	it, err := s.server.sqlServer.internalExecutor.QueryIteratorEx(
@@ -2072,7 +2098,7 @@ func (s *adminServer) Locations(
 	}
 	// We have to make sure to close the iterator since we might return from the
 	// for loop early (before Next() returns false).
-	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+	defer func(it sqlutil.InternalRows) { retErr = errors.CombineErrors(retErr, it.Close()) }(it)
 
 	ok, err := it.Next(ctx)
 	if err != nil {
@@ -2117,17 +2143,17 @@ func (s *adminServer) QueryPlan(
 
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	// As long as there's only one query provided it's safe to construct the
 	// explain query.
 	stmts, err := parser.Parse(req.Query)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, serverError(ctx, err)
 	}
 	if len(stmts) > 1 {
-		return nil, s.serverErrorf("more than one query provided")
+		return nil, serverErrorf(ctx, "more than one query provided")
 	}
 
 	explain := fmt.Sprintf(
@@ -2139,15 +2165,15 @@ func (s *adminServer) QueryPlan(
 		explain,
 	)
 	if err != nil {
-		return nil, s.serverError(err)
+		return nil, serverError(ctx, err)
 	}
 	if row == nil {
-		return nil, s.serverError(errors.New("failed to query the physical plan"))
+		return nil, serverErrorf(ctx, "failed to query the physical plan")
 	}
 
 	dbDatum, ok := tree.AsDString(row[0])
 	if !ok {
-		return nil, s.serverErrorf("type assertion failed on json: %T", row)
+		return nil, serverErrorf(ctx, "type assertion failed on json: %T", row)
 	}
 
 	return &serverpb.QueryPlanResponse{
@@ -2210,6 +2236,18 @@ func (s *adminServer) getStatementBundle(ctx context.Context, id int64, w http.R
 
 // DecommissionStatus returns the DecommissionStatus for all or the given nodes.
 func (s *adminServer) DecommissionStatus(
+	ctx context.Context, req *serverpb.DecommissionStatusRequest,
+) (*serverpb.DecommissionStatusResponse, error) {
+	r, err := s.decommissionStatusHelper(ctx, req)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}
+
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
+func (s *adminServer) decommissionStatusHelper(
 	ctx context.Context, req *serverpb.DecommissionStatusRequest,
 ) (*serverpb.DecommissionStatusResponse, error) {
 	// Get the number of replicas on each node. We *may* not need all of them,
@@ -2316,6 +2354,8 @@ func (s *adminServer) Decommission(
 	// Mark the target nodes with their new membership status. They'll find out
 	// as they heartbeat their liveness.
 	if err := s.server.Decommission(ctx, req.TargetMembership, nodeIDs); err != nil {
+		// NB: not using serverError() here since Decommission
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2333,27 +2373,32 @@ func (s *adminServer) Decommission(
 func (s *adminServer) DataDistribution(
 	ctx context.Context, req *serverpb.DataDistributionRequest,
 ) (_ *serverpb.DataDistributionResponse, retErr error) {
-	// All errors returned by this method must be serverErrors. We are careful
-	// to not use serverError* methods in the body of the function, so we can
-	// just do it here.
-	defer func() {
-		if retErr != nil {
-			retErr = s.serverError(retErr)
-		}
-	}()
-
 	if _, err := s.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
-	}
-
-	resp := &serverpb.DataDistributionResponse{
-		DatabaseInfo: make(map[string]serverpb.DataDistributionResponse_DatabaseInfo),
-		ZoneConfigs:  make(map[string]serverpb.DataDistributionResponse_ZoneConfig),
 	}
 
 	userName, err := userFromContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
+	}
+
+	r, err := s.dataDistributionHelper(ctx, req, userName)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}
+
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
+func (s *adminServer) dataDistributionHelper(
+	ctx context.Context, req *serverpb.DataDistributionRequest, userName security.SQLUsername,
+) (resp *serverpb.DataDistributionResponse, retErr error) {
+	resp = &serverpb.DataDistributionResponse{
+		DatabaseInfo: make(map[string]serverpb.DataDistributionResponse_DatabaseInfo),
+		ZoneConfigs:  make(map[string]serverpb.DataDistributionResponse_ZoneConfig),
 	}
 
 	// Get ids and names for databases and tables.
@@ -2543,6 +2588,8 @@ func (s *adminServer) EnqueueRange(
 	ctx = s.server.AnnotateCtx(ctx)
 
 	if _, err := s.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2564,7 +2611,7 @@ func (s *adminServer) EnqueueRange(
 	} else if req.NodeID != 0 {
 		admin, err := s.dialNode(ctx, req.NodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return admin.EnqueueRange(ctx, req)
 	}
@@ -2600,7 +2647,7 @@ func (s *adminServer) EnqueueRange(
 		)
 	}); err != nil {
 		if len(response.Details) == 0 {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		response.Details = append(response.Details, &serverpb.EnqueueRangeResponse_Details{
 			Error: err.Error(),
@@ -2614,6 +2661,9 @@ func (s *adminServer) EnqueueRange(
 // requested range that can be run through the queue, running it through the
 // queue and returning trace/error information if so. If not, returns an empty
 // response.
+//
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) enqueueRangeLocal(
 	ctx context.Context, req *serverpb.EnqueueRangeRequest,
 ) (*serverpb.EnqueueRangeResponse, error) {
@@ -2679,21 +2729,24 @@ func (s *adminServer) enqueueRangeLocal(
 func (s *adminServer) SendKVBatch(
 	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
+	ctx = s.server.AnnotateCtx(ctx)
 	// Note: the root user will bypass SQL auth checks, which is useful in case of
 	// a cluster outage.
 	user, err := s.requireAdminUser(ctx)
 	if err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 	if ba == nil {
-		return nil, errors.New("BatchRequest cannot be nil")
+		return nil, status.Errorf(codes.InvalidArgument, "BatchRequest cannot be nil")
 	}
 
 	// Emit a structured log event for the call.
 	jsonpb := protoutil.JSONPb{}
 	baJSON, err := jsonpb.Marshal(ba)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to encode BatchRequest as JSON")
+		return nil, serverError(ctx, errors.Wrap(err, "failed to encode BatchRequest as JSON"))
 	}
 	event := &eventpb.DebugSendKvBatch{
 		CommonEventDetails: eventpb.CommonEventDetails{
@@ -2969,6 +3022,9 @@ func (rs resultScanner) Scan(row tree.Datums, colName string, dst interface{}) e
 //
 // queryZone retrieves the specific ZoneConfig associated with the supplied ID,
 // if it exists.
+//
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) queryZone(
 	ctx context.Context, userName security.SQLUsername, id descpb.ID,
 ) (zonepb.ZoneConfig, bool, error) {
@@ -3012,6 +3068,9 @@ func (s *adminServer) queryZone(
 // queryZonePath queries a path of sql object IDs, as generated by
 // queryDescriptorIDPath(), for a ZoneConfig. It returns the most specific
 // ZoneConfig specified for the object IDs in the path.
+//
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) queryZonePath(
 	ctx context.Context, userName security.SQLUsername, path []descpb.ID,
 ) (descpb.ID, zonepb.ZoneConfig, bool, error) {
@@ -3025,6 +3084,8 @@ func (s *adminServer) queryZonePath(
 }
 
 // queryDatabaseID queries for the ID of the database with the given name.
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) queryDatabaseID(
 	ctx context.Context, userName security.SQLUsername, name string,
 ) (descpb.ID, error) {
@@ -3060,6 +3121,8 @@ func (s *adminServer) queryDatabaseID(
 
 // queryTableID queries for the ID of the table with the given name in the
 // database with the given name. The table name may contain a schema qualifier.
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) queryTableID(
 	ctx context.Context, username security.SQLUsername, database string, tableName string,
 ) (descpb.ID, error) {
@@ -3077,6 +3140,8 @@ func (s *adminServer) queryTableID(
 	return descpb.ID(tree.MustBeDOid(row[0]).DInt), nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *adminServer) dialNode(
 	ctx context.Context, nodeID roachpb.NodeID,
 ) (serverpb.AdminClient, error) {
@@ -3098,12 +3163,13 @@ type adminPrivilegeChecker struct {
 	ie *sql.InternalExecutor
 }
 
+// requireAdminUser's error return is a gRPC error.
 func (c *adminPrivilegeChecker) requireAdminUser(
 	ctx context.Context,
 ) (userName security.SQLUsername, err error) {
 	userName, isAdmin, err := c.getUserAndRole(ctx)
 	if err != nil {
-		return userName, err
+		return userName, serverError(ctx, err)
 	}
 	if !isAdmin {
 		return userName, errRequiresAdmin
@@ -3111,15 +3177,16 @@ func (c *adminPrivilegeChecker) requireAdminUser(
 	return userName, nil
 }
 
+// requireViewActivityPermission's error return is a gRPC error.
 func (c *adminPrivilegeChecker) requireViewActivityPermission(ctx context.Context) (err error) {
 	userName, isAdmin, err := c.getUserAndRole(ctx)
 	if err != nil {
-		return err
+		return serverError(ctx, err)
 	}
 	if !isAdmin {
 		hasViewActivity, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY)
 		if err != nil {
-			return err
+			return serverError(ctx, err)
 		}
 
 		if !hasViewActivity {
@@ -3131,23 +3198,24 @@ func (c *adminPrivilegeChecker) requireViewActivityPermission(ctx context.Contex
 	return nil
 }
 
+// requireViewActivityOrViewActivityRedactedPermission's error return is a gRPC error.
 func (c *adminPrivilegeChecker) requireViewActivityOrViewActivityRedactedPermission(
 	ctx context.Context,
 ) (err error) {
 	userName, isAdmin, err := c.getUserAndRole(ctx)
 	if err != nil {
-		return err
+		return serverError(ctx, err)
 	}
 	if !isAdmin {
 		hasViewActivity, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY)
 		if err != nil {
-			return err
+			return serverError(ctx, err)
 		}
 
 		if !hasViewActivity {
 			hasViewActivityRedacted, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITYREDACTED)
 			if err != nil {
-				return err
+				return serverError(ctx, err)
 			}
 
 			if !hasViewActivityRedacted {
@@ -3162,18 +3230,19 @@ func (c *adminPrivilegeChecker) requireViewActivityOrViewActivityRedactedPermiss
 
 // This function requires that the user have the VIEWACTIVITY role, but does not
 // have the VIEWACTIVITYREDACTED role.
+// This function's error return is a gRPC error.
 func (c *adminPrivilegeChecker) requireViewActivityAndNoViewActivityRedactedPermission(
 	ctx context.Context,
 ) (err error) {
 	userName, isAdmin, err := c.getUserAndRole(ctx)
 	if err != nil {
-		return err
+		return serverError(ctx, err)
 	}
 
 	if !isAdmin {
 		hasViewActivityRedacted, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITYREDACTED)
 		if err != nil {
-			return err
+			return serverError(ctx, err)
 		}
 		if hasViewActivityRedacted {
 			return status.Errorf(
@@ -3185,6 +3254,8 @@ func (c *adminPrivilegeChecker) requireViewActivityAndNoViewActivityRedactedPerm
 	return nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (c *adminPrivilegeChecker) getUserAndRole(
 	ctx context.Context,
 ) (userName security.SQLUsername, isAdmin bool, err error) {
@@ -3196,6 +3267,8 @@ func (c *adminPrivilegeChecker) getUserAndRole(
 	return userName, isAdmin, err
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (c *adminPrivilegeChecker) hasAdminRole(
 	ctx context.Context, user security.SQLUsername,
 ) (bool, error) {
@@ -3223,6 +3296,8 @@ func (c *adminPrivilegeChecker) hasAdminRole(
 	return bool(dbDatum), nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (c *adminPrivilegeChecker) hasRoleOption(
 	ctx context.Context, user security.SQLUsername, roleOption roleoption.Option,
 ) (bool, error) {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2395,14 +2395,14 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 			_, err := c.DataDistribution(ctx, &serverpb.DataDistributionRequest{})
 			return err
 		}},
-		{"Decommission", codes.Unknown, func(c serverpb.AdminClient) error {
+		{"Decommission", codes.Internal, func(c serverpb.AdminClient) error {
 			_, err := c.Decommission(ctx, &serverpb.DecommissionRequest{
 				NodeIDs:          []roachpb.NodeID{srv.NodeID(), decomSrv.NodeID()},
 				TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONED,
 			})
 			return err
 		}},
-		{"DecommissionStatus", codes.Unknown, func(c serverpb.AdminClient) error {
+		{"DecommissionStatus", codes.Internal, func(c serverpb.AdminClient) error {
 			_, err := c.DecommissionStatus(ctx, &serverpb.DecommissionStatusRequest{
 				NodeIDs: []roachpb.NodeID{srv.NodeID(), decomSrv.NodeID()},
 			})

--- a/pkg/server/api_v2_sql_schema.go
+++ b/pkg/server/api_v2_sql_schema.go
@@ -13,7 +13,6 @@ package server
 import (
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -22,10 +21,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-func isNotFoundError(err error) bool {
-	return err != nil && strings.HasSuffix(err.Error(), "not found")
-}
 
 // Response for listUsers.
 //

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -52,6 +52,7 @@ func getPingCheckDecommissionFn(
 }
 
 // Decommission idempotently sets the decommissioning flag for specified nodes.
+// The error return is a gRPC error.
 func (s *Server) Decommission(
 	ctx context.Context, targetStatus livenesspb.MembershipStatus, nodeIDs []roachpb.NodeID,
 ) error {
@@ -93,7 +94,8 @@ func (s *Server) Decommission(
 			if errors.Is(err, liveness.ErrMissingRecord) {
 				return grpcstatus.Error(codes.NotFound, liveness.ErrMissingRecord.Error())
 			}
-			return err
+			log.Errorf(ctx, "%+s", err)
+			return grpcstatus.Errorf(codes.Internal, err.Error())
 		}
 		if statusChanged {
 			nodeDetails.TargetNodeID = int32(nodeID)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -154,15 +155,18 @@ func (b *baseStatusServer) getLocalSessions(
 
 	sessionUser, isAdmin, err := b.privilegeChecker.getUserAndRole(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	reqUsername, err := security.MakeSQLUsernameFromPreNormalizedStringChecked(req.Username)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	errViewActivity := b.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx)
+	// TODO(knz): The following check on errViewActivity is incorrect, it
+	// does not properly handle non-privilege errors.
+	// See: https://github.com/cockroachdb/cockroach/issues/76288
 	if !isAdmin && errViewActivity != nil {
 		// For non-superusers, requests with an empty username is
 		// implicitly a request for the client's own sessions.
@@ -258,14 +262,14 @@ func (b *baseStatusServer) checkCancelPrivilege(
 
 	hasAdmin, err := b.privilegeChecker.hasAdminRole(ctx, reqUser)
 	if err != nil {
-		return err
+		return serverError(ctx, err)
 	}
 
 	if !hasAdmin {
 		// Check if the user has permission to see the session.
 		session, err := findSession(b.sessionRegistry.SerializeAll())
 		if err != nil {
-			return err
+			return serverError(ctx, err)
 		}
 
 		sessionUser := security.MakeSQLUsernameFromPreNormalizedString(session.Username)
@@ -274,7 +278,7 @@ func (b *baseStatusServer) checkCancelPrivilege(
 			// sessions/queries.
 			ok, err := b.privilegeChecker.hasRoleOption(ctx, reqUser, roleoption.CANCELQUERY)
 			if err != nil {
-				return err
+				return serverError(ctx, err)
 			}
 			if !ok {
 				return errRequiresRoleOption(roleoption.CANCELQUERY)
@@ -282,7 +286,7 @@ func (b *baseStatusServer) checkCancelPrivilege(
 			// Non-admins cannot cancel admins' sessions/queries.
 			isAdminSession, err := b.privilegeChecker.hasAdminRole(ctx, sessionUser)
 			if err != nil {
-				return err
+				return serverError(ctx, err)
 			}
 			if isAdminSession {
 				return status.Error(
@@ -302,6 +306,8 @@ func (b *baseStatusServer) ListLocalContentionEvents(
 	ctx = b.AnnotateCtx(ctx)
 
 	if err := b.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -317,6 +323,8 @@ func (b *baseStatusServer) ListLocalDistSQLFlows(
 	ctx = b.AnnotateCtx(ctx)
 
 	if err := b.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -501,6 +509,8 @@ func (s *statusServer) Gossip(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -515,7 +525,7 @@ func (s *statusServer) Gossip(
 	}
 	status, err := s.dialNode(ctx, nodeID)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return status.Gossip(ctx, req)
 }
@@ -527,6 +537,8 @@ func (s *statusServer) EngineStats(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -538,7 +550,7 @@ func (s *statusServer) EngineStats(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.EngineStats(ctx, req)
 	}
@@ -555,7 +567,7 @@ func (s *statusServer) EngineStats(
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return resp, nil
 }
@@ -568,6 +580,8 @@ func (s *statusServer) Allocator(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -579,7 +593,7 @@ func (s *statusServer) Allocator(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Allocator(ctx, req)
 	}
@@ -632,7 +646,7 @@ func (s *statusServer) Allocator(
 		return nil
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, serverError(ctx, err)
 	}
 	return output, nil
 }
@@ -659,6 +673,8 @@ func (s *statusServer) AllocatorRange(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -700,7 +716,7 @@ func (s *statusServer) AllocatorRange(
 					return nil
 				})
 			}); err != nil {
-			return nil, status.Errorf(codes.Internal, err.Error())
+			return nil, serverError(ctx, err)
 		}
 	}
 
@@ -734,7 +750,7 @@ func (s *statusServer) AllocatorRange(
 			}
 			fmt.Fprintf(&buf, "n%d: %s", nodeID, err)
 		}
-		return nil, status.Errorf(codes.Internal, buf.String())
+		return nil, serverErrorf(ctx, "%v", buf)
 	}
 	return &serverpb.AllocatorRangeResponse{}, nil
 }
@@ -747,6 +763,8 @@ func (s *statusServer) Certificates(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -756,27 +774,27 @@ func (s *statusServer) Certificates(
 	}
 
 	if s.cfg.Insecure {
-		return nil, errors.New("server is in insecure mode, cannot examine certificates")
+		return nil, status.Errorf(codes.Unavailable, "server is in insecure mode, cannot examine certificates")
 	}
 
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Certificates(ctx, req)
 	}
 
 	cm, err := s.rpcCtx.GetCertificateManager()
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	// The certificate manager gives us a list of CertInfo objects to avoid
 	// making security depend on serverpb.
 	certs, err := cm.ListCertificates()
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	cr := &serverpb.CertificatesResponse{}
@@ -796,7 +814,7 @@ func (s *statusServer) Certificates(
 		case security.ClientPem:
 			details.Type = serverpb.CertificateDetails_CLIENT
 		default:
-			return nil, errors.Errorf("unknown certificate type %v for file %s", cert.FileUsage, cert.Filename)
+			return nil, serverErrorf(ctx, "unknown certificate type %v for file %s", cert.FileUsage, cert.Filename)
 		}
 
 		if cert.Error == nil {
@@ -867,6 +885,8 @@ func (s *statusServer) Details(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -877,7 +897,7 @@ func (s *statusServer) Details(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Details(ctx, req)
 	}
@@ -906,6 +926,8 @@ func (s *statusServer) GetFiles(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -916,7 +938,7 @@ func (s *statusServer) GetFiles(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.GetFiles(ctx, req)
 	}
@@ -951,14 +973,14 @@ func (s *statusServer) GetFiles(
 			if !req.ListOnly {
 				contents, err = ioutil.ReadFile(path)
 				if err != nil {
-					return nil, status.Errorf(codes.Internal, err.Error())
+					return nil, serverError(ctx, err)
 				}
 			}
 			resp.Files = append(resp.Files,
 				&serverpb.File{Name: fileinfo.Name(), FileSize: fileinfo.Size(), Contents: contents})
 		}
 	}
-	return &resp, err
+	return &resp, nil
 }
 
 // checkFilePattern checks if a pattern is acceptable for the GetFiles call.
@@ -996,6 +1018,8 @@ func (s *statusServer) LogFilesList(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -1006,16 +1030,16 @@ func (s *statusServer) LogFilesList(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.LogFilesList(ctx, req)
 	}
 	log.Flush()
 	logFiles, err := log.ListLogFiles()
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
-	return &serverpb.LogFilesListResponse{Files: logFiles}, err
+	return &serverpb.LogFilesListResponse{Files: logFiles}, nil
 }
 
 // LogFile returns a single log file.
@@ -1029,6 +1053,8 @@ func (s *statusServer) LogFile(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -1039,7 +1065,7 @@ func (s *statusServer) LogFile(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.LogFile(ctx, req)
 	}
@@ -1053,14 +1079,14 @@ func (s *statusServer) LogFile(
 	// Read the logs.
 	reader, err := log.GetLogReader(req.File)
 	if err != nil {
-		return nil, errors.Wrapf(err, "log file %q could not be opened", req.File)
+		return nil, serverError(ctx, errors.Wrapf(err, "log file %q could not be opened", req.File))
 	}
 	defer reader.Close()
 
 	var resp serverpb.LogEntriesResponse
 	decoder, err := log.NewEntryDecoder(reader, inputEditMode)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	for {
 		var entry logpb.Entry
@@ -1068,7 +1094,7 @@ func (s *statusServer) LogFile(
 			if err == io.EOF {
 				break
 			}
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		resp.Entries = append(resp.Entries, entry)
 	}
@@ -1114,6 +1140,8 @@ func (s *statusServer) Logs(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -1124,7 +1152,7 @@ func (s *statusServer) Logs(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Logs(ctx, req)
 	}
@@ -1171,7 +1199,7 @@ func (s *statusServer) Logs(
 	entries, err := log.FetchEntriesFromFiles(
 		startTimestamp, endTimestamp, int(maxEntries), regex, inputEditMode)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	return &serverpb.LogEntriesResponse{Entries: entries}, nil
@@ -1185,6 +1213,8 @@ func (s *statusServer) Stacks(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -1196,7 +1226,7 @@ func (s *statusServer) Stacks(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Stacks(ctx, req)
 	}
@@ -1213,7 +1243,7 @@ func (s *statusServer) Stacks(
 
 	var buf bytes.Buffer
 	if err := pprof.Lookup("goroutine").WriteTo(&buf, debug); err != nil {
-		return nil, status.Errorf(codes.Unknown, "failed to write goroutine stack: %s", err)
+		return nil, serverError(ctx, err)
 	}
 	return &serverpb.JSONResponse{Data: buf.Bytes()}, nil
 }
@@ -1230,6 +1260,8 @@ func (s *statusServer) Profile(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -1241,7 +1273,7 @@ func (s *statusServer) Profile(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Profile(ctx, req)
 	}
@@ -1275,7 +1307,7 @@ func profileLocal(
 				return nil
 			}
 		}); err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return &serverpb.JSONResponse{Data: buf.Bytes()}, nil
 	default:
@@ -1302,7 +1334,7 @@ func (s *statusServer) Regions(
 ) (*serverpb.RegionsResponse, error) {
 	resp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return regionsResponseFromNodesResponse(resp), nil
 }
@@ -1350,16 +1382,19 @@ func regionsResponseFromNodesResponse(nr *serverpb.NodesResponse) *serverpb.Regi
 func (s *statusServer) NodesList(
 	ctx context.Context, _ *serverpb.NodesListRequest,
 ) (*serverpb.NodesListResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
 	// The node status contains details about the command line, network
 	// addresses, env vars etc which are admin-only.
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
-	ctx = propagateGatewayMetadata(ctx)
-	ctx = s.AnnotateCtx(ctx)
 	statuses, _, err := s.getNodeStatuses(ctx, 0 /* limit */, 0 /* offset */)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	resp := &serverpb.NodesListResponse{
 		Nodes: make([]serverpb.NodeDetails, len(statuses)),
@@ -1386,30 +1421,38 @@ func (s *statusServer) NodesList(
 func (s *statusServer) Nodes(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
 	// The node status contains details about the command line, network
 	// addresses, env vars etc which are admin-only.
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
 	resp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
-	return resp, err
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return resp, nil
 }
 
 func (s *statusServer) NodesUI(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponseExternal, error) {
-	// The node status contains details about the command line, network
-	// addresses, env vars etc which are admin-only.
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
 
 	_, isAdmin, err := s.privilegeChecker.getUserAndRole(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	internalResp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	resp := &serverpb.NodesResponseExternal{
 		Nodes:            make([]serverpb.NodeResponse, len(internalResp.Nodes)),
@@ -1419,7 +1462,7 @@ func (s *statusServer) NodesUI(
 		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, isAdmin)
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 func nodeStatusToResp(n *statuspb.NodeStatus, isAdmin bool) serverpb.NodeResponse {
@@ -1522,6 +1565,9 @@ func nodeStatusToResp(n *statuspb.NodeStatus, isAdmin bool) serverpb.NodeRespons
 
 // ListNodesInternal is a helper function for the benefit of SQL exclusively.
 // It skips the privilege check, assuming that SQL is doing privilege checking already.
+//
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *statusServer) ListNodesInternal(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponse, error) {
@@ -1529,6 +1575,8 @@ func (s *statusServer) ListNodesInternal(
 	return resp, err
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *statusServer) getNodeStatuses(
 	ctx context.Context, limit, offset int,
 ) (statuses []statuspb.NodeStatus, next int, _ error) {
@@ -1538,8 +1586,7 @@ func (s *statusServer) getNodeStatuses(
 	b := &kv.Batch{}
 	b.Scan(startKey, endKey)
 	if err := s.db.Run(ctx, b); err != nil {
-		log.Errorf(ctx, "%v", err)
-		return nil, 0, status.Errorf(codes.Internal, err.Error())
+		return nil, 0, err
 	}
 
 	var rows []kv.KeyValue
@@ -1552,13 +1599,14 @@ func (s *statusServer) getNodeStatuses(
 	statuses = make([]statuspb.NodeStatus, len(rows))
 	for i, row := range rows {
 		if err := row.ValueProto(&statuses[i]); err != nil {
-			log.Errorf(ctx, "%v", err)
-			return nil, 0, status.Errorf(codes.Internal, err.Error())
+			return nil, 0, err
 		}
 	}
 	return statuses, next, nil
 }
 
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *statusServer) nodesHelper(
 	ctx context.Context, limit, offset int,
 ) (*serverpb.NodesResponse, int, error) {
@@ -1580,6 +1628,9 @@ func (s *statusServer) nodesHelper(
 
 // nodesStatusWithLiveness is like Nodes but for internal
 // use within this package.
+//
+// Note that the function returns plain errors, and it is the caller's
+// responsibility to convert them to serverErrors.
 func (s *statusServer) nodesStatusWithLiveness(
 	ctx context.Context,
 ) (map[roachpb.NodeID]nodeStatusWithLiveness, error) {
@@ -1621,9 +1672,13 @@ func (s *statusServer) Node(
 	// The node status contains details about the command line, network
 	// addresses, env vars etc which are admin-only.
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
+	// NB: not using serverError() here since nodeStatus
+	// already returns a proper gRPC error status.
 	return s.nodeStatus(ctx, req)
 }
 
@@ -1639,15 +1694,13 @@ func (s *statusServer) nodeStatus(
 	b := &kv.Batch{}
 	b.Get(key)
 	if err := s.db.Run(ctx, b); err != nil {
-		log.Errorf(ctx, "%v", err)
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, serverError(ctx, err)
 	}
 
 	var nodeStatus statuspb.NodeStatus
 	if err := b.Results[0].Rows[0].ValueProto(&nodeStatus); err != nil {
 		err = errors.Wrapf(err, "could not unmarshal NodeStatus from %s", key)
-		log.Errorf(ctx, "%v", err)
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, serverError(ctx, err)
 	}
 	return &nodeStatus, nil
 }
@@ -1662,11 +1715,13 @@ func (s *statusServer) NodeUI(
 	// addresses, env vars etc which are admin-only.
 	_, isAdmin, err := s.privilegeChecker.getUserAndRole(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	nodeStatus, err := s.nodeStatus(ctx, req)
 	if err != nil {
+		// NB: not using serverError() here since nodeStatus
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 	resp := nodeStatusToResp(nodeStatus, isAdmin)
@@ -1679,6 +1734,7 @@ func (s *statusServer) Metrics(
 ) (*serverpb.JSONResponse, error) {
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
+
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, err.Error())
@@ -1687,11 +1743,15 @@ func (s *statusServer) Metrics(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Metrics(ctx, req)
 	}
-	return marshalJSONResponse(s.metricSource)
+	j, err := marshalJSONResponse(s.metricSource)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return j, nil
 }
 
 // RaftDebug returns raft debug information for all known nodes.
@@ -1702,12 +1762,14 @@ func (s *statusServer) RaftDebug(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
 	nodes, err := s.ListNodesInternal(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	mu := struct {
@@ -2008,6 +2070,8 @@ func (s *statusServer) HotRanges(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2031,7 +2095,7 @@ func (s *statusServer) HotRanges(
 		// Only hot ranges from one non-local node.
 		status, err := s.dialNode(ctx, requestedNodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.HotRanges(ctx, req)
 	}
@@ -2057,7 +2121,7 @@ func (s *statusServer) HotRanges(
 	}
 
 	if err := s.iterateNodes(ctx, "hot ranges", dialFn, nodeFn, responseFn, errorFn); err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	return response, nil
@@ -2093,6 +2157,8 @@ func (s *statusServer) Range(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2136,7 +2202,7 @@ func (s *statusServer) Range(
 	if err := s.iterateNodes(
 		ctx, fmt.Sprintf("details about range %d", req.RangeId), dialFn, nodeFn, responseFn, errorFn,
 	); err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return response, nil
 }
@@ -2147,6 +2213,8 @@ func (s *statusServer) ListLocalSessions(
 ) (*serverpb.ListSessionsResponse, error) {
 	sessions, err := s.getLocalSessions(ctx, req)
 	if err != nil {
+		// NB: not using serverError() here since getLocalSessions
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 	for i := range sessions {
@@ -2376,11 +2444,16 @@ func (s *statusServer) ListSessions(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, _, err := s.privilegeChecker.getUserAndRole(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
 	resp, _, err := s.listSessionsHelper(ctx, req, 0 /* limit */, paginationState{})
-	return resp, err
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return resp, nil
 }
 
 // CancelSession responds to a session cancellation request by canceling the
@@ -2399,21 +2472,27 @@ func (s *statusServer) CancelSession(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.CancelSession(ctx, req)
 	}
 
 	reqUsername, err := security.MakeSQLUsernameFromPreNormalizedStringChecked(req.Username)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	if err := s.checkCancelPrivilege(ctx, reqUsername, findSessionBySessionID(req.SessionID)); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
-	return s.sessionRegistry.CancelSession(req.SessionID)
+	r, err := s.sessionRegistry.CancelSession(req.SessionID)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
 }
 
 // CancelQuery responds to a query cancellation request, and cancels
@@ -2431,17 +2510,19 @@ func (s *statusServer) CancelQuery(
 		ctx = s.AnnotateCtx(ctx)
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.CancelQuery(ctx, req)
 	}
 
 	reqUsername, err := security.MakeSQLUsernameFromPreNormalizedStringChecked(req.Username)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	if err := s.checkCancelPrivilege(ctx, reqUsername, findSessionByQueryID(req.QueryID)); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2463,6 +2544,8 @@ func (s *statusServer) ListContentionEvents(
 
 	// Check permissions early to avoid fan-out to all nodes.
 	if err := s.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2495,7 +2578,7 @@ func (s *statusServer) ListContentionEvents(
 	}
 
 	if err := s.iterateNodes(ctx, "contention events list", dialFn, nodeFn, responseFn, errorFn); err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return &response, nil
 }
@@ -2508,6 +2591,8 @@ func (s *statusServer) ListDistSQLFlows(
 
 	// Check permissions early to avoid fan-out to all nodes.
 	if err := s.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2540,7 +2625,7 @@ func (s *statusServer) ListDistSQLFlows(
 	}
 
 	if err := s.iterateNodes(ctx, "distsql flows list", dialFn, nodeFn, responseFn, errorFn); err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return &response, nil
 }
@@ -2599,6 +2684,8 @@ func (s *statusServer) SpanStats(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2610,7 +2697,7 @@ func (s *statusServer) SpanStats(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.SpanStats(ctx, req)
 	}
@@ -2627,7 +2714,7 @@ func (s *statusServer) SpanStats(
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 
 	return output, nil
@@ -2647,7 +2734,7 @@ func (s *statusServer) Diagnostics(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Diagnostics(ctx, req)
 	}
@@ -2663,6 +2750,8 @@ func (s *statusServer) Stores(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2674,7 +2763,7 @@ func (s *statusServer) Stores(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.Stores(ctx, req)
 	}
@@ -2703,7 +2792,7 @@ func (s *statusServer) Stores(
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, serverError(ctx, err)
 	}
 	return resp, nil
 }
@@ -2813,6 +2902,8 @@ func (s *statusServer) JobRegistryStatus(
 	ctx = s.AnnotateCtx(ctx)
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
@@ -2823,7 +2914,7 @@ func (s *statusServer) JobRegistryStatus(
 	if !local {
 		status, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return nil, err
+			return nil, serverError(ctx, err)
 		}
 		return status.JobRegistryStatus(ctx, req)
 	}
@@ -2849,12 +2940,17 @@ func (s *statusServer) JobStatus(
 	ctx = s.AnnotateCtx(propagateGatewayMetadata(ctx))
 
 	if _, err := s.privilegeChecker.requireAdminUser(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
 		return nil, err
 	}
 
 	j, err := s.admin.server.sqlServer.jobRegistry.LoadJob(ctx, jobspb.JobID(req.JobId))
 	if err != nil {
-		return nil, err
+		if je := (*jobs.JobNotFoundError)(nil); errors.As(err, &je) {
+			return nil, status.Errorf(codes.NotFound, "%v", err)
+		}
+		return nil, serverError(ctx, err)
 	}
 	res := &jobspb.Job{
 		Payload:  &jobspb.Payload{},

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -116,8 +116,8 @@ var requireConstFmt = map[string]bool{
 	"(*github.com/cockroachdb/cockroach/pkg/sql/logictest.logicTest).Errorf": true,
 	"(*github.com/cockroachdb/cockroach/pkg/sql/logictest.logicTest).Fatalf": true,
 
-	"(*github.com/cockroachdb/cockroach/pkg/server.adminServer).serverErrorf": true,
-	"github.com/cockroachdb/cockroach/pkg/server.guaranteedExitFatal":         true,
+	"github.com/cockroachdb/cockroach/pkg/server.serverErrorf":        true,
+	"github.com/cockroachdb/cockroach/pkg/server.guaranteedExitFatal": true,
 
 	"(*github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl.kafkaLogAdapter).Printf": true,
 


### PR DESCRIPTION
Arguably, there is still a lot of boilerplate in here, so a later
iteration of this work could consider handling errors at a higher
level.

However, before we can do this we want all the API handlers to handle
errors in a consistent manner, so that there's no surprise left during
the later refactoring.

This change also takes care of logging a few errors that were not
logged before.

Release note: None