### PR TITLE
server: make the Drain interfaces available to SQL-only servers

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -75,6 +75,12 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 		return delegateDrain(ctx, req, client, stream)
 	}
 
+	return s.handleDrain(ctx, req, stream)
+}
+
+func (s *adminServer) handleDrain(
+	ctx context.Context, req *serverpb.DrainRequest, stream serverpb.Admin_DrainServer,
+) error {
 	log.Ops.Infof(ctx, "drain request received with doDrain = %v, shutdown = %v", req.DoDrain, req.Shutdown)
 
 	res := serverpb.DrainResponse{}

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -72,7 +72,7 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 		// Connect to the target node.
 		client, err := s.dialNode(ctx, nodeID)
 		if err != nil {
-			return err
+			return serverError(ctx, err)
 		}
 		return delegateDrain(ctx, req, client, stream)
 	}

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -16,10 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -75,17 +77,53 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 		return delegateDrain(ctx, req, client, stream)
 	}
 
-	return s.handleDrain(ctx, req, stream)
+	return s.server.drain.handleDrain(ctx, req, stream)
 }
 
-func (s *adminServer) handleDrain(
+type drainServer struct {
+	stopper      *stop.Stopper
+	grpc         *grpcServer
+	sqlServer    *SQLServer
+	drainSleepFn func(time.Duration)
+
+	kvServer struct {
+		nodeLiveness *liveness.NodeLiveness
+		node         *Node
+	}
+}
+
+// newDrainServer constructs a drainServer suitable for any kind of server.
+func newDrainServer(
+	cfg BaseConfig, stopper *stop.Stopper, grpc *grpcServer, sqlServer *SQLServer,
+) *drainServer {
+	var drainSleepFn = time.Sleep
+	if cfg.TestingKnobs.Server != nil {
+		if cfg.TestingKnobs.Server.(*TestingKnobs).DrainSleepFn != nil {
+			drainSleepFn = cfg.TestingKnobs.Server.(*TestingKnobs).DrainSleepFn
+		}
+	}
+	return &drainServer{
+		stopper:      stopper,
+		grpc:         grpc,
+		sqlServer:    sqlServer,
+		drainSleepFn: drainSleepFn,
+	}
+}
+
+// setNode configures the drainServer to also support KV node shutdown.
+func (s *drainServer) setNode(node *Node, nodeLiveness *liveness.NodeLiveness) {
+	s.kvServer.node = node
+	s.kvServer.nodeLiveness = nodeLiveness
+}
+
+func (s *drainServer) handleDrain(
 	ctx context.Context, req *serverpb.DrainRequest, stream serverpb.Admin_DrainServer,
 ) error {
 	log.Ops.Infof(ctx, "drain request received with doDrain = %v, shutdown = %v", req.DoDrain, req.Shutdown)
 
 	res := serverpb.DrainResponse{}
 	if req.DoDrain {
-		remaining, info, err := s.server.Drain(ctx, req.Verbose)
+		remaining, info, err := s.runDrain(ctx, req.Verbose)
 		if err != nil {
 			log.Ops.Errorf(ctx, "drain failed: %v", err)
 			return err
@@ -93,7 +131,7 @@ func (s *adminServer) handleDrain(
 		res.DrainRemainingIndicator = remaining
 		res.DrainRemainingDescription = info.StripMarkers()
 	}
-	if s.server.isDraining() {
+	if s.isDraining() {
 		res.IsDraining = true
 	}
 
@@ -104,7 +142,7 @@ func (s *adminServer) handleDrain(
 	return s.maybeShutdownAfterDrain(ctx, req)
 }
 
-func (s *adminServer) maybeShutdownAfterDrain(
+func (s *drainServer) maybeShutdownAfterDrain(
 	ctx context.Context, req *serverpb.DrainRequest,
 ) error {
 	if !req.Shutdown {
@@ -121,12 +159,12 @@ func (s *adminServer) maybeShutdownAfterDrain(
 		// first seems more reasonable since grpc.Stop closes the listener right
 		// away (and who knows whether gRPC-goroutines are tied up in some
 		// stopper task somewhere).
-		s.server.grpc.Stop()
-		s.server.stopper.Stop(ctx)
+		s.grpc.Stop()
+		s.stopper.Stop(ctx)
 	}()
 
 	select {
-	case <-s.server.stopper.IsStopped():
+	case <-s.stopper.IsStopped():
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -192,7 +230,7 @@ func delegateDrain(
 	return nil
 }
 
-// Drain idempotently activates the draining mode.
+// runDrain idempotently activates the draining mode.
 // Note: new code should not be taught to use this method
 // directly. Use the Drain() RPC instead with a suitably crafted
 // DrainRequest.
@@ -203,11 +241,7 @@ func delegateDrain(
 //
 // The reporter function, if non-nil, is called for each
 // packet of load shed away from the server during the drain.
-//
-// TODO(knz): This method is currently exported for use by the
-// shutdown code in cli/start.go; however, this is a mis-design. The
-// start code should use the Drain() RPC like quit does.
-func (s *Server) Drain(
+func (s *drainServer) runDrain(
 	ctx context.Context, verbose bool,
 ) (remaining uint64, info redact.RedactableString, err error) {
 	reports := make(map[redact.SafeString]int)
@@ -235,14 +269,14 @@ func (s *Server) Drain(
 		}
 	}()
 
-	if err = s.doDrain(ctx, reporter, verbose); err != nil {
+	if err = s.drainInner(ctx, reporter, verbose); err != nil {
 		return 0, "", err
 	}
 
 	return
 }
 
-func (s *Server) doDrain(
+func (s *drainServer) drainInner(
 	ctx context.Context, reporter func(int, redact.SafeString), verbose bool,
 ) (err error) {
 	// First drain all clients and SQL leases.
@@ -256,12 +290,14 @@ func (s *Server) doDrain(
 
 // isDraining returns true if either clients are being drained
 // or one of the stores on the node is not accepting replicas.
-func (s *Server) isDraining() bool {
-	return s.sqlServer.pgServer.IsDraining() || s.node.IsDraining()
+func (s *drainServer) isDraining() bool {
+	return s.sqlServer.pgServer.IsDraining() || (s.kvServer.node != nil && s.kvServer.node.IsDraining())
 }
 
 // drainClients starts draining the SQL layer.
-func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.SafeString)) error {
+func (s *drainServer) drainClients(
+	ctx context.Context, reporter func(int, redact.SafeString),
+) error {
 	shouldDelayDraining := !s.isDraining()
 	// Mark the server as draining in a way that probes to
 	// /health?ready=1 will notice.
@@ -271,11 +307,11 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 	// delay draining so that client traffic can move off this node.
 	// Note delay only happens on first call to drain.
 	if shouldDelayDraining {
-		s.drainSleepFn(drainWait.Get(&s.st.SV))
+		s.drainSleepFn(drainWait.Get(&s.sqlServer.execCfg.Settings.SV))
 	}
 
 	// Disable incoming SQL clients up to the queryWait timeout.
-	queryMaxWait := queryWait.Get(&s.st.SV)
+	queryMaxWait := queryWait.Get(&s.sqlServer.execCfg.Settings.SV)
 	if err := s.sqlServer.pgServer.Drain(ctx, queryMaxWait, reporter); err != nil {
 		return err
 	}
@@ -292,11 +328,15 @@ func (s *Server) drainClients(ctx context.Context, reporter func(int, redact.Saf
 
 // drainNode initiates the draining mode for the node, which
 // starts draining range leases.
-func (s *Server) drainNode(
+func (s *drainServer) drainNode(
 	ctx context.Context, reporter func(int, redact.SafeString), verbose bool,
 ) (err error) {
-	if err = s.nodeLiveness.SetDraining(ctx, true /* drain */, reporter); err != nil {
+	if s.kvServer.node == nil {
+		// No KV subsystem. Nothing to do.
+		return nil
+	}
+	if err = s.kvServer.nodeLiveness.SetDraining(ctx, true /* drain */, reporter); err != nil {
 		return err
 	}
-	return s.node.SetDraining(true /* drain */, reporter, verbose)
+	return s.kvServer.node.SetDraining(true /* drain */, reporter, verbose)
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -310,6 +310,9 @@ type sqlServerArgs struct {
 	// settingsStorage is an optional interface to drive storing of settings
 	// data on disk to provide a fresh source of settings upon next startup.
 	settingsStorage settingswatcher.Storage
+
+	// grpc is the RPC service.
+	grpc *grpcServer
 }
 
 type monitorAndMetrics struct {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -475,6 +475,11 @@ func makeTenantSQLServerArgs(
 		db,
 	)
 
+	grpcServer := newGRPCServer(rpcContext)
+	// In a SQL-only server, there is no separate node initialization
+	// phase. Start RPC immediately in the operational state.
+	grpcServer.setMode(modeOperational)
+
 	sessionRegistry := sql.NewSessionRegistry()
 	flowScheduler := flowinfra.NewFlowScheduler(baseCfg.AmbientCtx, stopper, st)
 	return sqlServerArgs{
@@ -482,6 +487,7 @@ func makeTenantSQLServerArgs(
 			nodesStatusServer: serverpb.MakeOptionalNodesStatusServer(nil),
 			nodeLiveness:      optionalnodeliveness.MakeContainer(nil),
 			gossip:            gossip.MakeOptionalGossip(nil),
+			grpcServer:        grpcServer.Server,
 			isMeta1Leaseholder: func(_ context.Context, _ hlc.ClockTimestamp) (bool, error) {
 				return false, errors.New("isMeta1Leaseholder is not available to secondary tenants")
 			},

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -178,7 +178,9 @@ func startTenantInternal(
 		return nil, nil, "", "", err
 	}
 
-	tenantAdminServer := newTenantAdminServer(baseCfg.AmbientCtx, s)
+	drainServer := newDrainServer(baseCfg, args.stopper, args.grpc, s)
+
+	tenantAdminServer := newTenantAdminServer(baseCfg.AmbientCtx, s, tenantStatusServer, drainServer)
 
 	// TODO(asubiotto): remove this. Right now it is needed to initialize the
 	// SpanResolver.
@@ -524,6 +526,7 @@ func makeTenantSQLServerArgs(
 		regionsServer:            tenantConnect,
 		costController:           costController,
 		allowSessionRevival:      true,
+		grpc:                     grpcServer,
 	}, nil
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -815,7 +815,7 @@ func (ts *TestServer) SQLAddr() string {
 
 // DrainClients exports the drainClients() method for use by tests.
 func (ts *TestServer) DrainClients(ctx context.Context) error {
-	return ts.drainClients(ctx, nil /* reporter */)
+	return ts.drain.drainClients(ctx, nil /* reporter */)
 }
 
 // Readiness returns nil when the server's health probe reports

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -513,6 +513,7 @@ type TestTenant struct {
 	sqlAddr  string
 	httpAddr string
 	*httpTestServer
+	drain *drainServer
 }
 
 var _ serverutils.TestTenantInterface = &TestTenant{}
@@ -625,6 +626,11 @@ func (t *TestTenant) SpanConfigSQLWatcher() interface{} {
 	return t.SQLServer.spanconfigSQLWatcher
 }
 
+// DrainClients exports the drainClients() method for use by tests.
+func (t *TestTenant) DrainClients(ctx context.Context) error {
+	return t.drain.drainClients(ctx, nil /* reporter */)
+}
+
 // StartTenant starts a SQL tenant communicating with this TestServer.
 func (ts *TestServer) StartTenant(
 	ctx context.Context, params base.TestTenantArgs,
@@ -718,7 +724,7 @@ func (ts *TestServer) StartTenant(
 	if params.RPCHeartbeatInterval != 0 {
 		baseCfg.RPCHeartbeatInterval = params.RPCHeartbeatInterval
 	}
-	sqlServer, authServer, addr, httpAddr, err := startTenantInternal(
+	sqlServer, authServer, drainServer, addr, httpAddr, err := startTenantInternal(
 		ctx,
 		stopper,
 		ts.Cfg.ClusterName,
@@ -739,6 +745,7 @@ func (ts *TestServer) StartTenant(
 		sqlAddr:        addr,
 		httpAddr:       httpAddr,
 		httpTestServer: hts,
+		drain:          drainServer,
 	}, err
 }
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -42,8 +42,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
-	"github.com/jackc/pgproto3/v2"
-	"github.com/jackc/pgx/v4"
+	pgproto3 "github.com/jackc/pgproto3/v2"
+	pgx "github.com/jackc/pgx/v4"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +66,8 @@ func trivialQuery(pgURL url.URL) error {
 
 // TestPGWireDrainClient makes sure that in draining mode, the server refuses
 // new connections and allows sessions with ongoing transactions to finish.
+//
+// TODO(knz): This test should also exercise SQL-only servers.
 func TestPGWireDrainClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -104,7 +106,7 @@ func TestPGWireDrainClient(t *testing.T) {
 	go func() {
 		defer close(errChan)
 		errChan <- func() error {
-			return s.(*server.TestServer).DrainClients(ctx)
+			return s.DrainClients(ctx)
 		}()
 	}()
 

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -123,6 +123,9 @@ type TestTenantInterface interface {
 	// authenticated to access Admin API methods (via a cookie).
 	GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error)
 
+	// DrainClients shuts down client connections.
+	DrainClients(ctx context.Context) error
+
 	// TODO(irfansharif): We'd benefit from an API to construct a *gosql.DB, or
 	// better yet, a *sqlutils.SQLRunner. We use it all the time, constructing
 	// it by hand each time.


### PR DESCRIPTION
Fixes #74412

First commit from #76292; the reviewers are invited to ignore it in this PR.

See individual commits for details.

cc @cockroachdb/obs-inf-prs 