### PR TITLE
server, ui: aggregate statements on period selected

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -708,20 +708,6 @@ export class StatementDetails extends React.Component<
             <Col className="gutter-row" span={12}>
               <SummaryCard className={cx("summary-card")}>
                 <Heading type="h5">Statement details</Heading>
-                <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text>Aggregation Interval (UTC)</Text>
-                  <Text>
-                    {intervalStartTime.format("MMM D, h:mm A")} -{" "}
-                    {intervalEndTime.format(
-                      `${
-                        intervalStartTime.isSame(intervalEndTime, "day")
-                          ? ""
-                          : "MMM D,"
-                      }h:mm A`,
-                    )}
-                  </Text>
-                </div>
-
                 {!isTenant && (
                   <div>
                     <div className={summaryCardStylesCx("summary--card__item")}>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -93,17 +93,6 @@ function makeCommonColumns(
 
   return [
     {
-      name: "aggregationInterval",
-      title: statisticsTableTitles.aggregationInterval(statType),
-      className: cx("statements-table__interval_time"),
-      cell: (stmt: AggregateStatistics) =>
-        formatAggregationIntervalColumn(
-          stmt.aggregatedTs,
-          stmt.aggregationInterval,
-        ),
-      sort: (stmt: AggregateStatistics) => stmt.aggregatedTs,
-    },
-    {
       name: "executionCount",
       title: statisticsTableTitles.executionCount(statType),
       className: cx("statements-table__col-count"),

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -35,7 +35,6 @@ export const statisticsColumnLabels = {
   database: "Database",
   diagnostics: "Diagnostics",
   executionCount: "Execution Count",
-  aggregationInterval: "Aggregation Interval (UTC)",
   maxMemUsage: "Max Memory",
   networkBytes: "Network",
   regionNodes: "Regions/Nodes",
@@ -137,27 +136,6 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("transactions")}
-      </Tooltip>
-    );
-  },
-  aggregationInterval: () => {
-    return (
-      <Tooltip
-        placement="bottom"
-        style="tableTitle"
-        content={
-          <div>
-            <p>
-              The time interval of the statement execution. By default,
-              statements are configured to aggregate over an hour interval.
-              <br />
-              For example, if a statement is executed at 1:23PM it will fall in
-              the 1:00PM - 2:00PM time interval.
-            </p>
-          </div>
-        }
-      >
-        {getLabel("aggregationInterval")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -163,17 +163,6 @@ export function makeTransactionsColumns(
       alwaysShow: true,
     },
     {
-      name: "aggregationInterval",
-      title: statisticsTableTitles.aggregationInterval("transaction"),
-      cell: (item: TransactionInfo) =>
-        formatAggregationIntervalColumn(
-          TimestampToNumber(item.stats_data?.aggregated_ts),
-          DurationToNumber(item.stats_data?.aggregation_interval),
-        ),
-      sort: (item: TransactionInfo) =>
-        TimestampToNumber(item.stats_data?.aggregated_ts),
-    },
-    {
       name: "executionCount",
       title: statisticsTableTitles.executionCount(statType),
       cell: countBar,


### PR DESCRIPTION
Previously, the aggregation timestamp was used as part
of the key of a statement. The new query to collect
statement now ignores aggregation timestamp as keys.
This commit also removes the aggregated timestamp value on the UI,
 since it no longer applies.

Fixes #74513

Release note (ui change): We don't show information about
aggregations timestamp in Statements overview and Details pages, since
now all the statement fingerprints are grouped inside the same
time selection.