### PR TITLE
server: add internal_app_name_prefix to ListSessionsResponse

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1768,6 +1768,7 @@ Response object for ListSessions and ListLocalSessions.
 | ----- | ---- | ----- | ----------- | -------------- |
 | sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. | [reserved](#support-status) |
 | errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
+| internal_app_name_prefix | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
 
 
 
@@ -1897,6 +1898,7 @@ Response object for ListSessions and ListLocalSessions.
 | ----- | ---- | ----- | ----------- | -------------- |
 | sessions | [Session](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.Session) | repeated | A list of sessions on this node or cluster. | [reserved](#support-status) |
 | errors | [ListSessionsError](#cockroach.server.serverpb.ListSessionsResponse-cockroach.server.serverpb.ListSessionsError) | repeated | Any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
+| internal_app_name_prefix | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -929,6 +929,11 @@
           },
           "x-go-name": "Errors"
         },
+        "internal_app_name_prefix": {
+          "description": "If set and non-empty, indicates the prefix to application_name\nused for statements/queries issued internally by CockroachDB.",
+          "type": "string",
+          "x-go-name": "InternalAppNamePrefix"
+        },
         "sessions": {
           "description": "A list of sessions on this node or cluster.",
           "type": "array",
@@ -1809,6 +1814,11 @@
             "$ref": "#/definitions/ListSessionsError"
           },
           "x-go-name": "Errors"
+        },
+        "internal_app_name_prefix": {
+          "description": "If set and non-empty, indicates the prefix to application_name\nused for statements/queries issued internally by CockroachDB.",
+          "type": "string",
+          "x-go-name": "InternalAppNamePrefix"
         },
         "next": {
           "description": "The continuation token, for use in the next paginated call in the `start`\nparameter.",

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -818,6 +818,9 @@ message ListSessionsResponse {
   repeated Session sessions = 1 [ (gogoproto.nullable) = false ];
   // Any errors that occurred during fan-out calls to other nodes.
   repeated ListSessionsError errors = 2 [ (gogoproto.nullable) = false ];
+  // If set and non-empty, indicates the prefix to application_name
+  // used for statements/queries issued internally by CockroachDB.
+  string internal_app_name_prefix = 3;
 }
 
 // Request object for issuing a query cancel request.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
@@ -2292,8 +2293,9 @@ func (s *statusServer) listSessionsHelper(
 	ctx context.Context, req *serverpb.ListSessionsRequest, limit int, start paginationState,
 ) (*serverpb.ListSessionsResponse, paginationState, error) {
 	response := &serverpb.ListSessionsResponse{
-		Sessions: make([]serverpb.Session, 0),
-		Errors:   make([]serverpb.ListSessionsError, 0),
+		Sessions:              make([]serverpb.Session, 0),
+		Errors:                make([]serverpb.ListSessionsError, 0),
+		InternalAppNamePrefix: catconstants.InternalAppNamePrefix,
 	}
 
 	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -120,7 +120,9 @@ func (t *tenantStatusServer) ListSessions(
 		return nil, status.Errorf(codes.Unavailable, "instanceID not set")
 	}
 
-	response := &serverpb.ListSessionsResponse{}
+	response := &serverpb.ListSessionsResponse{
+		InternalAppNamePrefix: catconstants.InternalAppNamePrefix,
+	}
 	nodeStatement := func(ctx context.Context, client interface{}, instanceID base.SQLInstanceID) (interface{}, error) {
 		statusClient := client.(serverpb.StatusClient)
 		localResponse, err := statusClient.ListLocalSessions(ctx, req)
@@ -166,7 +168,10 @@ func (t *tenantStatusServer) ListLocalSessions(
 		return nil, status.Errorf(codes.Unavailable, "instanceID not set")
 	}
 
-	return &serverpb.ListSessionsResponse{Sessions: sessions}, nil
+	return &serverpb.ListSessionsResponse{
+		Sessions:              sessions,
+		InternalAppNamePrefix: catconstants.InternalAppNamePrefix,
+	}, nil
 }
 
 func (t *tenantStatusServer) CancelQuery(


### PR DESCRIPTION
Previously, the `InternalAppNamePrefix` constant from `catconstants` was
only included in the Statements Response. This change adds that same
field to the `ListSessionsResponse`.

Release note (API change): `InternalAppNamePrefix` added to `ListSessionsResponse`.