### PR TITLE
changefeedccl: remove methods from testServerShim

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
+++ b/pkg/ccl/changefeedccl/helpers_tenant_shim_test.go
@@ -10,7 +10,6 @@ package changefeedccl
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -76,14 +75,6 @@ func (t *testServerShim) NodeLiveness() interface{}             { panic(unsuppor
 func (t *testServerShim) HeartbeatNodeLiveness() error          { panic(unsupportedShimMethod) }
 func (t *testServerShim) NodeDialer() interface{}               { panic(unsupportedShimMethod) }
 func (t *testServerShim) SetDistSQLSpanResolver(spanResolver interface{}) {
-	panic(unsupportedShimMethod)
-}
-func (t *testServerShim) AdminURL() string                    { panic(unsupportedShimMethod) }
-func (t *testServerShim) GetHTTPClient() (http.Client, error) { panic(unsupportedShimMethod) }
-func (t *testServerShim) GetAdminAuthenticatedHTTPClient() (http.Client, error) {
-	panic(unsupportedShimMethod)
-}
-func (t *testServerShim) GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error) {
 	panic(unsupportedShimMethod)
 }
 func (t *testServerShim) MustGetSQLCounter(name string) int64        { panic(unsupportedShimMethod) }


### PR DESCRIPTION
In #75852 these methods have recently been added to the underlying
TestTenantInterface, so we no longer need to stub them out in this
shim.

Release note: None