### PR TITLE
build: disable metamorphic constants when calling execgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1650,7 +1650,7 @@ pkg/util/log/log_channels_generated.go: pkg/util/log/gen/main.go pkg/util/log/lo
 .PHONY: execgen
 execgen: ## Regenerate generated code for the vectorized execution engine.
 execgen: $(EXECGEN_TARGETS) bin/execgen
-	for i in $(EXECGEN_TARGETS); do echo EXECGEN $$i && ./bin/execgen -fmt=false $$i > $$i; done
+	for i in $(EXECGEN_TARGETS); do echo EXECGEN $$i && COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true ./bin/execgen -fmt=false $$i > $$i; done
 	goimports -w $(EXECGEN_TARGETS)
 
 # Add a catch-all rule for any non-existent execgen generated

--- a/pkg/sql/colexecop/EXECGEN.bzl
+++ b/pkg/sql/colexecop/EXECGEN.bzl
@@ -41,6 +41,7 @@ def gen_eg_go_rules(targets):
             # [2]: https://docs.bazel.build/versions/3.7.0/be/general.html#general-advice
             # [3]: https://github.com/cockroachdb/cockroach/pull/57027
             cmd = """
+              export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
               ln -s external/cockroach/pkg pkg
               $(location :execgen) -template $(SRCS) \
                   -fmt=false pkg/sql/colexec/$@ > $@


### PR DESCRIPTION
Commands such as `./dev test --verbose` might previously produce
two log lines everytime it happens to have to call the genrule for
execgen targets:

```
INFO: From Executing genrule //pkg/sql/colexec/colexecwindow:gen-window-framer:
initialized metamorphic constant "span-reuse-rate" with value 10
```

This is because execgen has the tracing package in its dependency tree

```
> go list -f '{{ join .Deps "\n" }}' ./pkg/sql/colexec/execgen/ | grep tracing | head -1
github.com/cockroachdb/cockroach/pkg/util/tracing
```

and that package instantiates this metamorphic constant.

This PR sets COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true when
calling the generator so we don't get metamorphic constants enabled.

Something like #75065 would give us more complete coverage of commands
that might be generating noise.

Release note: None