### PR TITLE
sql: add documentation to distql versioning

### DIFF
--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -37,6 +37,31 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //    servers only accept versions >= 2 (by setting
 //    MinAcceptedVersion to 2).
 //
+// Why does this all matter? Because of rolling upgrades, distsql servers across
+// nodes may not have an overlapping window of compatibility, so only a subset
+// of nodes can participate in a distsql flow on a given version -- hurting
+// performance. However, we'll take the performance hit to prevent a distsql
+// flow from blowing up. Here's an example:
+//
+// Suppose that nodes running 21.2 can handle flows with distsql version 59.
+// Say we introduced a new distsql processor spec, ExportSpec,
+// in 22.1 but didn't bump the distsql version from 59 to 60.
+//
+// During a rolling upgrade, suppose Node A has upgraded to 22.1 and plans a
+// distSQL flow that uses the new ExportSpec. Node A thinks any node with distsql
+// version 59 can handle this flow, which includes nodes still running a 21.2
+// binary! As soon as a node running a 21.2 binary receives a ExportSpec proto,
+// it will not recognize it, causing the distsql flow to error out.
+//
+// To avoid this sad tale, consider bumping the distsql version if you:
+// - Modify a distsql processor spec in a released binary
+// - Create a new distql processor spec
+// - More examples below
+//
+// A few changes don't need to bump the distsql version:
+// - Modifying a distsql processor spec that isn't on a released binary yet
+// - Renaming any field or the processor spec itself. Nodes are naive to proto field names.
+//
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
 const Version execinfrapb.DistSQLVersion = 60


### PR DESCRIPTION
Added more context on why and when an engineer should bump the distsql version.

Release note: None