### PR TITLE
util/tracing: don't regenerate SpanID on reallocation

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -493,7 +493,6 @@ func (sp *Span) parentFinished() {
 // the crdbSpan's lock, though. That will avoid some races.
 func (sp *Span) reset(
 	traceID tracingpb.TraceID,
-	spanID tracingpb.SpanID,
 	operation string,
 	goroutineID uint64,
 	startTime time.Time,
@@ -553,7 +552,6 @@ func (sp *Span) reset(
 	}
 
 	c.traceID = traceID
-	c.spanID = spanID
 	c.operation = operation
 	c.startTime = startTime
 	c.logTags = logTags


### PR DESCRIPTION
When a span is reallocated, have it reuse the SpanID from last time in
order to save on a random call.

Release note: None