### PR TITLE
dev: various improvements to `--cross` compilation

### DIFF
--- a/build/bazelutil/empty.bazelrc
+++ b/build/bazelutil/empty.bazelrc
@@ -1,0 +1,1 @@
+# intentionally empty (this file is mounted as .bazelrc.user for cross builds)

--- a/build/bazelutil/whereis/BUILD.bazel
+++ b/build/bazelutil/whereis/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "whereis_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach/build/bazelutil/whereis",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "whereis",
+    embed = [":whereis_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/build/bazelutil/whereis/main.go
+++ b/build/bazelutil/whereis/main.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// whereis is a helper executable that is basically just `realpath`. It's meant
+// to be used like:
+//     bazel run ... --run_under //build/bazelutil/whereis
+// ... which will print the location of the binary you're running. Useful
+// because Bazel can be a little unclear about where exactly to find any given
+// executable.
+func main() {
+	if len(os.Args) != 2 {
+		panic("expected a single argument")
+	}
+	abs, err := filepath.Abs(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", abs)
+}

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":dev_lib"],
     deps = [
+        "//pkg/build/bazel",
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
         "//pkg/testutils",

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -134,6 +134,7 @@ func (d *dev) getDockerRunArgs(
 	}
 	args = append(args, "-v", workspace+":/cockroach")
 	args = append(args, "--workdir=/cockroach")
+	args = append(args, "-v", filepath.Join(workspace, "build", "bazelutil", "empty.bazelrc")+":/cockroach/.bazelrc.user")
 	// Create the artifacts directory.
 	artifacts := filepath.Join(workspace, "artifacts")
 	err = d.os.MkdirAll(artifacts)

--- a/pkg/cmd/dev/recorderdriven_test.go
+++ b/pkg/cmd/dev/recorderdriven_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/exec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/dev/io/os"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -74,7 +75,7 @@ func TestRecorderDriven(t *testing.T) {
 	if f := flag.Lookup("rewrite"); f != nil && f.Value.String() == "true" {
 		rewriting = true
 	}
-	if rewriting {
+	if rewriting && bazel.BuiltWithBazel() {
 		t.Fatalf("not supported under bazel") // needs to shell out to bazel itself
 	}
 

--- a/pkg/cmd/dev/testdata/recorderdriven/builder
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder
@@ -6,7 +6,7 @@ bazel info workspace --color=no
 cat crdb-checkout/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
-docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220121-121551
 
 dev builder echo hi
 ----
@@ -16,4 +16,4 @@ bazel info workspace --color=no
 cat crdb-checkout/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551 echo hi
+docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220121-121551 echo hi

--- a/pkg/cmd/dev/testdata/recorderdriven/builder.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder.rec
@@ -4,7 +4,7 @@ which docker
 
 id
 ----
-503:20
+502:20
 
 cat crdb-checkout/build/teamcity-bazel-support.sh
 ----
@@ -62,6 +62,9 @@ _tc_release_branch() {
 #   `GO_TEST_JSON_OUTPUT_FILE`.
 # create_tarball: whether to create a tarball with full logs. If the test's
 #   exit code is passed, the tarball is generated on failures.
+#
+# The variable BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS can be set to add extra
+# arguments to $github_post.
 process_test_json() {
   local testfilter=$1
   local github_post=$2
@@ -90,7 +93,7 @@ process_test_json() {
       echo "GITHUB_API_TOKEN must be set"
       exit 1
     else
-      $github_post < "$test_json"
+      $github_post ${BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS:+$BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS} < "$test_json"
     fi
   fi
 
@@ -121,7 +124,7 @@ docker volume inspect bzlhome
 ----
 [
     {
-        "CreatedAt": "2022-02-04T03:10:06Z",
+        "CreatedAt": "2022-01-21T18:57:42Z",
         "Driver": "local",
         "Labels": {},
         "Mountpoint": "/var/lib/docker/volumes/bzlhome/_data",
@@ -134,7 +137,7 @@ docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
 ----
 
-docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220121-121551
 ----
 
 which docker
@@ -143,7 +146,7 @@ which docker
 
 id
 ----
-503:20
+502:20
 
 cat crdb-checkout/build/teamcity-bazel-support.sh
 ----
@@ -201,6 +204,9 @@ _tc_release_branch() {
 #   `GO_TEST_JSON_OUTPUT_FILE`.
 # create_tarball: whether to create a tarball with full logs. If the test's
 #   exit code is passed, the tarball is generated on failures.
+#
+# The variable BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS can be set to add extra
+# arguments to $github_post.
 process_test_json() {
   local testfilter=$1
   local github_post=$2
@@ -229,7 +235,7 @@ process_test_json() {
       echo "GITHUB_API_TOKEN must be set"
       exit 1
     else
-      $github_post < "$test_json"
+      $github_post ${BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS:+$BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS} < "$test_json"
     fi
   fi
 
@@ -260,7 +266,7 @@ docker volume inspect bzlhome
 ----
 [
     {
-        "CreatedAt": "2022-02-04T03:10:06Z",
+        "CreatedAt": "2022-01-21T18:57:42Z",
         "Driver": "local",
         "Labels": {},
         "Mountpoint": "/var/lib/docker/volumes/bzlhome/_data",
@@ -273,6 +279,6 @@ docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
 ----
 
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551 echo hi
+docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220121-121551 echo hi
 ----
 


### PR DESCRIPTION
1. We bind-mount an empty file over `.bazelrc.user` so that user
   configuration doesn't interfere with or break cross builds.
2. Add a new `whereis` executable. It's basically just `realpath` except
   portable.
3. Update how `dev cache` finds the location of the `bazel-remote`
   binary: now we use `bazel run --run_under=whereis`, which doesn't
   require doing any funny stuff with `cquery`.
4. Allow cross-building `cmake` and `go_test` targets, using `realpath`
   to find where test and binary targets are placed.

Closes #76094.
Closes #76260.

Release note: None