### PR TITLE
release-21.2: server,ui: fix admin database details stats collection

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -542,6 +542,11 @@ func (s *adminServer) getDatabaseStats(
 	responses := make(chan tableStatsResponse, len(tableSpans))
 
 	for tableName, tableSpan := range tableSpans {
+		// Because Go reuses loop variables across iterations, we must
+		// make these local, stable copies for the async task to close
+		// over, else our results will be nondeterministic.
+		tableName := tableName
+		tableSpan := tableSpan
 		if err := s.server.stopper.RunAsyncTask(
 			ctx, "server.adminServer: requesting table stats",
 			func(ctx context.Context) {


### PR DESCRIPTION
Backport 1/1 commits from #76315.

/cc @cockroachdb/release

---

Fixes #72776.

This code was previously subject to the [common Go mistake][0] of
passing a loop iterator variable to a goroutine, making the results of
the asynchronous fanout nondeterministic.

I have attempted an integration-level test to demonstrate the bug, but I
cannot seem to get any nonzero sizes back from the admin API at test
time. My limited hypothesis is that the test needs to do something to
trigger the `ApproximateDiskBytes` recalculation, whether that's waiting,
inserting many rows, or inserting MiB of data, but so far nothing has
helped. In the meantime, I have manually verified the fix on a custom
roachprod cluster running with the good commit.

[0]: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables

Release note (bug fix): The DB console Databases page now shows stable,
consistent values for database sizes.

---

Release justification: Category 2: Bug fixes and low-risk updates to new functionality