### PR TITLE
pkg/storage: support suffix replacement on MVCC interval collector

### DIFF
--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -64,6 +64,7 @@ func (k EngineKey) Format(f fmt.State, c rune) {
 // look like an encoded EngineKey. By splitting, at Key + \x00, the Key looks
 // like an EngineKey with no Version.
 const (
+	sentinel               = '\x00'
 	sentinelLen            = 1
 	suffixEncodedLengthLen = 1
 )


### PR DESCRIPTION
The `SuffixReplaceableBlockCollector` interface was added to to Pebble
in cockroachdb/pebble#1377, which allows a block property collector to
indicate that it supports being updated during suffix replacement.

The existing `pebbleDataBlockMVCCTimeIntervalCollector` block property
collector does not currently support suffix replacement. However, given
a new suffix, the interval for a block can be trivially calculated.

Implement the `SuffixReplaceableBlockCollector` interface.

Release note: None