### PR TITLE
bazel: optimize test execution

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -165,6 +165,7 @@ go_test(
     ],
     data = glob(["testdata/**"]) + ["@cockroach//c-deps:libgeos"],
     embed = [":backupccl"],
+    shard_count = 16,
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -143,6 +143,7 @@ go_test(
         "validations_test.go",
     ],
     embed = [":changefeedccl"],
+    shard_count = 16,
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":multiregionccl"],
+    shard_count = 16,
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -318,6 +318,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":cli"],
+    shard_count = 16,
     deps = [
         "//pkg/base",
         "//pkg/build",

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -303,7 +303,8 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
-    tags = ["exclusive"],
+    shard_count = 4,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/base",
         "//pkg/cli/exit",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -559,6 +559,7 @@ go_test(
         "//pkg/sql/vtable:pg_catalog.go",
     ],
     embed = [":sql"],
+    shard_count = 16,
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",
     ],
     embed = [":logictest"],
+    tags = ["cpu:4"],
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",


### PR DESCRIPTION
We shard `kvserver_test` a bit and give each shard 4 CPU's to avoid
spurious errors in time-sensitive tests. Also shard some tests that are
particularly long-running.

Closes https://github.com/cockroachdb/cockroach/issues/76347.

Release note: None