### PR TITLE
dev: pass `-t` argument to `docker` if necessary for `builder`

### DIFF
--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -41,12 +41,18 @@ func makeBuilderCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.C
 func (d *dev) builder(cmd *cobra.Command, extraArgs []string) error {
 	ctx := cmd.Context()
 	volume := mustGetFlagString(cmd, volumeFlag)
-	args, err := d.getDockerRunArgs(ctx, volume, false)
+	var tty bool
+	if len(extraArgs) == 0 {
+		tty = true
+	}
+	args, err := d.getDockerRunArgs(ctx, volume, tty)
 	args = append(args, extraArgs...)
 	if err != nil {
 		return err
 	}
-	logCommand("docker", args...)
+	if tty {
+		logCommand("docker", args...)
+	}
 	return d.exec.CommandContextInheritingStdStreams(ctx, "docker", args...)
 }
 

--- a/pkg/cmd/dev/testdata/recorderdriven/builder
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder
@@ -6,7 +6,7 @@ bazel info workspace --color=no
 cat crdb-checkout/build/teamcity-bazel-support.sh
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551
 
 dev builder echo hi
 ----

--- a/pkg/cmd/dev/testdata/recorderdriven/builder.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder.rec
@@ -134,7 +134,7 @@ docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
 ----
 
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 503:503 cockroachdb/bazel:20220121-121551
 ----
 
 which docker


### PR DESCRIPTION
If there are extra arguments on the command line, assume we don't need
a `tty`; otherwise pass `-t` to `docker run`.

Release note: None