### PR TITLE
blobs,server: defer resolution of nodeID in BlobClientFactory

### DIFF
--- a/pkg/blobs/BUILD.bazel
+++ b/pkg/blobs/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/blobs",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
         "//pkg/blobs/blobspb",
         "//pkg/roachpb",
         "//pkg/rpc",
@@ -36,6 +37,7 @@ go_test(
     ],
     embed = [":blobs"],
     deps = [
+        "//pkg/base",
         "//pkg/blobs/blobspb",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -180,9 +181,10 @@ type BlobClientFactory func(ctx context.Context, dialing roachpb.NodeID) (BlobCl
 
 // NewBlobClientFactory returns a BlobClientFactory
 func NewBlobClientFactory(
-	localNodeID roachpb.NodeID, dialer *nodedialer.Dialer, externalIODir string,
+	localNodeIDContainer *base.NodeIDContainer, dialer *nodedialer.Dialer, externalIODir string,
 ) BlobClientFactory {
 	return func(ctx context.Context, dialing roachpb.NodeID) (BlobClient, error) {
+		localNodeID := localNodeIDContainer.Get()
 		if dialing == 0 || localNodeID == dialing {
 			return NewLocalClient(externalIODir)
 		}

--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -87,8 +88,10 @@ func setUpService(
 			return nil, errors.Errorf("node %d not found", nodeID)
 		},
 	)
+	localNodeIDContainer := &base.NodeIDContainer{}
+	localNodeIDContainer.Set(context.Background(), localNodeID)
 	return NewBlobClientFactory(
-		localNodeID,
+		localNodeIDContainer,
 		localDialer,
 		localExternalDir,
 	)

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -53,7 +53,7 @@ func (e *externalStorageBuilder) init(
 		blobClientFactory = p.BlobClientFactory
 	}
 	if blobClientFactory == nil {
-		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer.Get(), nodeDialer, settings.ExternalIODir)
+		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer, nodeDialer, settings.ExternalIODir)
 	}
 	e.conf = conf
 	e.settings = settings

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -927,8 +927,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// Initialize the external storage builders configuration params now that the
 	// engines have been created. The object can be used to create ExternalStorage
 	// objects hereafter.
-	// TODO(aditya): This call seems to occur too early, see
-	// https://github.com/cockroachdb/cockroach/issues/75725
 	fileTableInternalExecutor := sql.MakeInternalExecutor(ctx, s.PGServer().SQLServer, sql.MemoryMetrics{}, s.st)
 	s.externalStorageBuilder.init(
 		s.cfg.ExternalIODirConfig,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -462,8 +462,6 @@ func makeTenantSQLServerArgs(
 	externalStorage := esb.makeExternalStorage
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
-	// TODO(aditya): This call seems to occur too early, see
-	// https://github.com/cockroachdb/cockroach/issues/75725
 	esb.init(
 		sqlCfg.ExternalIODirConfig,
 		baseCfg.Settings,


### PR DESCRIPTION
This change teaches the BlobClientFactory closure to resolve
the nodeID when the factory is invoked to create a blob client
instance. Previously, we would do this in `(*Server) PreStart()`
and capture the nodeID in the factory closure, but as explained
in #75725 this might be too early.

Fixes: #75725

Release note: None