### PR TITLE
sql: support partitioned hash sharded index

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_all_by_nothing
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_all_by_nothing
@@ -3,7 +3,7 @@
 statement ok
 SET experimental_enable_implicit_column_partitioning = true
 
-statement error cannot define PARTITION BY on an unique constraint if the table has a PARTITION ALL BY definition
+statement error cannot define PARTITION BY on an index if the table is implicitly partitioned with PARTITION ALL BY or LOCALITY REGIONAL BY ROW definition
 CREATE TABLE partition_all_by_nothing_with_partition (
   pk INT PRIMARY KEY,
   a INT,

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
@@ -1,0 +1,287 @@
+# LogicTest: 5node
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true;
+
+statement ok
+SET experimental_enable_implicit_column_partitioning = true;
+
+statement ok
+CREATE TABLE t_hashed (
+  a INT PRIMARY KEY,
+  b STRING,
+  c INT,
+  INDEX idx_t_hashed_b_c (b, c) USING HASH
+);
+
+statement error cannot set explicit partitioning with ALTER INDEX PARTITION BY on a hash sharded index
+ALTER INDEX idx_t_hashed_b_c PARTITION BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+);
+
+statement ok
+CREATE TABLE t_pk_hashed (
+  a STRING,
+  b INT,
+  PRIMARY KEY (a, b) USING HASH
+);
+
+statement error cannot set explicit partitioning with PARTITION BY on hash sharded primary key
+ALTER TABLE t_pk_hashed PARTITION BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+);
+
+statement ok
+CREATE TABLE t_partition_all (
+  a INT PRIMARY KEY,
+  b STRING NOT NULL,
+  c INT
+) PARTITION ALL BY LIST (b) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE INDEX ON t_partition_all (b, c) USING HASH;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE UNIQUE INDEX ON t_partition_all (b, c) USING HASH;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+ALTER TABLE t_partition_all ALTER PRIMARY KEY USING COLUMNS (b) USING HASH;
+
+statement error hash sharded indexes cannot be explicitly partitioned
+CREATE TABLE t_pk_hashed_bad (
+  a STRING PRIMARY KEY USING HASH,
+  b INT
+) PARTITION BY LIST (a) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+statement error hash sharded indexes cannot be explicitly partitioned
+CREATE TABLE t_pk_hashed_bad (
+  a STRING,
+  b INT,
+  PRIMARY KEY (a) USING HASH
+) PARTITION BY LIST (a) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+statement error hash sharded indexes cannot be explicitly partitioned
+CREATE TABLE t_idx_hashed_bad (
+  a INT PRIMARY KEY,
+  b STRING,
+  c INT,
+  INDEX (b, c) USING HASH PARTITION BY LIST (b) (
+    PARTITION us_west VALUES IN (('seattle')),
+    PARTITION us_east VALUES IN (('new york'))
+  )
+);
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE TABLE t_idx_hashed_bad (
+  a INT PRIMARY KEY,
+  b STRING,
+  c INT,
+  INDEX (b, c) USING HASH
+) PARTITION ALL BY LIST (b) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+statement ok
+CREATE TABLE t_to_be_hashed (
+  a INT PRIMARY KEY,
+  b STRING NOT NULL,
+  c INT,
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+  a INT8 NOT NULL,
+  b STRING NOT NULL,
+  c INT8 NULL,
+  CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (a ASC),
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+statement ok
+CREATE INDEX ON t_to_be_hashed (c) USING HASH;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+  a INT8 NOT NULL,
+  b STRING NOT NULL,
+  c INT8 NULL,
+  crdb_internal_c_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 16:::INT8)) VIRTUAL,
+  CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (a ASC),
+  INDEX t_to_be_hashed_c_idx (c ASC) USING HASH WITH (bucket_count=16),
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+statement ok
+CREATE UNIQUE INDEX ON t_to_be_hashed (c) USING HASH;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+  a INT8 NOT NULL,
+  b STRING NOT NULL,
+  c INT8 NULL,
+  crdb_internal_c_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 16:::INT8)) VIRTUAL,
+  CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (a ASC),
+  INDEX t_to_be_hashed_c_idx (c ASC) USING HASH WITH (bucket_count=16),
+  UNIQUE INDEX t_to_be_hashed_c_key (c ASC) USING HASH WITH (bucket_count=16),
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+statement ok
+ALTER TABLE t_to_be_hashed ALTER PRIMARY KEY USING COLUMNS (a) USING HASH;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+  a INT8 NOT NULL,
+  b STRING NOT NULL,
+  c INT8 NULL,
+  crdb_internal_c_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 16:::INT8)) VIRTUAL,
+  crdb_internal_a_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
+  CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
+  INDEX t_to_be_hashed_c_idx (c ASC) USING HASH WITH (bucket_count=16),
+  UNIQUE INDEX t_to_be_hashed_c_key (c ASC) USING HASH WITH (bucket_count=16),
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+statement ok
+CREATE TABLE t_idx_pk_hashed_1 (
+  a INT PRIMARY KEY USING HASH,
+  b STRING,
+  c INT,
+  INDEX (c) USING HASH,
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_idx_pk_hashed_1];
+----
+CREATE TABLE public.t_idx_pk_hashed_1 (
+  crdb_internal_a_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  b STRING NOT NULL,
+  c INT8 NULL,
+  crdb_internal_c_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 16:::INT8)) VIRTUAL,
+  CONSTRAINT t_idx_pk_hashed_1_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
+  INDEX t_idx_pk_hashed_1_c_idx (c ASC) USING HASH WITH (bucket_count=16),
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+statement ok
+CREATE TABLE t_idx_pk_hashed_2 (
+  a INT,
+  b STRING,
+  c INT,
+  INDEX (c) USING HASH,
+  PRIMARY KEY (a) USING HASH,
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_idx_pk_hashed_2];
+----
+CREATE TABLE public.t_idx_pk_hashed_2 (
+  a INT8 NOT NULL,
+  b STRING NOT NULL,
+  c INT8 NULL,
+  crdb_internal_c_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 16:::INT8)) VIRTUAL,
+  crdb_internal_a_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
+  CONSTRAINT t_idx_pk_hashed_2_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
+  INDEX t_idx_pk_hashed_2_c_idx (c ASC) USING HASH WITH (bucket_count=16),
+  FAMILY fam_0_a_b_c (a, b, c)
+) PARTITION ALL BY LIST (b) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+)
+-- Warning: Partitioned table with no zone configurations.
+
+subtest test_presplit_with_partitioning
+
+statement ok
+CREATE TABLE t_presplit (
+  user_id INT PRIMARY KEY,
+  city STRING NOT NULL CHECK (city IN ('seattle', 'new york')),
+  member_id INT
+) PARTITION ALL BY LIST (city) (
+    PARTITION us_west VALUES IN (('seattle')),
+    PARTITION us_east VALUES IN (('new york'))
+);
+
+statement ok
+CREATE INDEX t_presplit_idx_member_id ON t_presplit (member_id) USING HASH WITH (bucket_count=8);
+
+skipif config 3node-tenant
+query TITTT colnames,retry
+SELECT t.name, r.table_id, r.index_name, r.start_pretty, r.end_pretty
+FROM crdb_internal.tables t
+JOIN crdb_internal.ranges r ON t.table_id = r.table_id
+WHERE t.name = 't_presplit'
+AND t.state = 'PUBLIC'
+AND r.split_enforced_until IS NOT NULL;
+----
+name        table_id  index_name                start_pretty               end_pretty
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2               /Table/116/2/"new york"/0
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/0  /Table/116/2/"new york"/1
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/1  /Table/116/2/"new york"/2
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/2  /Table/116/2/"new york"/3
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/3  /Table/116/2/"new york"/4
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/4  /Table/116/2/"new york"/5
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/5  /Table/116/2/"new york"/6
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/6  /Table/116/2/"new york"/7
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"new york"/7  /Table/116/2/"seattle"/0
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/0   /Table/116/2/"seattle"/1
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/1   /Table/116/2/"seattle"/2
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/2   /Table/116/2/"seattle"/3
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/3   /Table/116/2/"seattle"/4
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/4   /Table/116/2/"seattle"/5
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/5   /Table/116/2/"seattle"/6
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/6   /Table/116/2/"seattle"/7
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/7   /Max

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -1101,19 +1101,12 @@ vectorized: true
     │ render column3: column3
     │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
     │
-    └── • cross join (right anti)
+    └── • lookup join (anti)
         │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
         │ estimated row count: 0 (missing stats)
-        │
-        ├── • project
-        │   │ columns: ()
-        │   │ estimated row count: 1 (missing stats)
-        │   │
-        │   └── • scan
-        │         columns: (id, part)
-        │         estimated row count: 1 (missing stats)
-        │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-        │         spans: /"seattle"/4321/0
+        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+        │ equality cols are key
+        │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
         └── • lookup join (anti)
             │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
@@ -1126,35 +1119,30 @@ vectorized: true
                 │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
                 │ estimated row count: 0 (missing stats)
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ equality: (column3, crdb_internal_email_shard_16_cast, column2) = (part,crdb_internal_email_shard_16,email)
                 │ equality cols are key
-                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
                 │
-                └── • hash join (right anti)
+                └── • cross join (anti)
                     │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
                     │ estimated row count: 0 (missing stats)
-                    │ equality: (email, part, crdb_internal_email_shard_16) = (column2, column3, crdb_internal_email_shard_16_cast)
-                    │ right cols are key
                     │
-                    ├── • render
-                    │   │ columns: (crdb_internal_email_shard_16, email, part)
-                    │   │ estimated row count: 1,000 (missing stats)
-                    │   │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
-                    │   │ render email: email
-                    │   │ render part: part
-                    │   │
-                    │   └── • scan
-                    │         columns: (email, part)
-                    │         estimated row count: 1,000 (missing stats)
-                    │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                    │         spans: FULL SCAN
+                    ├── • values
+                    │     columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+                    │     size: 4 columns, 1 row
+                    │     row 0, expr 0: 4321
+                    │     row 0, expr 1: 'some_email'
+                    │     row 0, expr 2: 'seattle'
+                    │     row 0, expr 3: 13
                     │
-                    └── • values
-                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
-                          size: 4 columns, 1 row
-                          row 0, expr 0: 4321
-                          row 0, expr 1: 'some_email'
-                          row 0, expr 2: 'seattle'
-                          row 0, expr 3: 13
+                    └── • project
+                        │ columns: ()
+                        │ estimated row count: 1 (missing stats)
+                        │
+                        └── • scan
+                              columns: (id, part)
+                              estimated row count: 1 (missing stats)
+                              table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                              spans: /"seattle"/4321/0
 
 # TODO (issue #75498): we're using unique without index on (a) as an arbiter and
 # using the original hash sharded index as an arbiter is not necessary.

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -1,0 +1,1936 @@
+# LogicTest: 5node
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true;
+
+statement ok
+SET experimental_enable_implicit_column_partitioning = true;
+
+# Make sure foreign key references checked is planned
+subtest test_fk_constraint
+
+statement ok
+CREATE TABLE t_parent (
+  id INT PRIMARY KEY USING HASH,
+  part STRING CHECK (part IN ('seattle', 'new york')),
+  FAMILY fam_0 (id, part)
+) PARTITION ALL BY LIST (part) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+statement ok
+CREATE TABLE t_child (
+  id INT PRIMARY KEY,
+  pid INT REFERENCES t_parent (id),
+  FAMILY fam_0 (id, pid)
+);
+
+statement ok
+CREATE TABLE t_child_partitioned (
+  id INT PRIMARY KEY,
+  pid INT REFERENCES t_parent (id),
+  part STRING CHECK (part IN ('seattle', 'new york')),
+  FAMILY fam_0 (id, pid, part)
+) PARTITION ALL BY LIST (part) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321);
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_child(id, pid)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1, column2)
+│             size: 2 columns, 1 row
+│             row 0, expr 0: 123
+│             row 0, expr 1: 321
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_parent@t_parent_pkey
+            │ equality cols are key
+            │ lookup condition: ((column2 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • project
+                │ columns: (column2)
+                │ estimated row count: 1
+                │
+                └── • scan buffer
+                      columns: (column1, column2)
+                      label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_child_partitioned VALUES (123, 321, 'seattle');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_child_partitioned(id, pid, part)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, check1)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1, column2, column3, check1)
+│             size: 4 columns, 1 row
+│             row 0, expr 0: 123
+│             row 0, expr 1: 321
+│             row 0, expr 2: 'seattle'
+│             row 0, expr 3: true
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (column1)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (column1, column3)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_child_partitioned@t_child_partitioned_pkey
+│               │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+│               │ pred: column3 != part
+│               │
+│               └── • project
+│                   │ columns: (column1, column3)
+│                   │ estimated row count: 1
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, column3, check1)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_parent@t_parent_pkey
+            │ equality cols are key
+            │ lookup condition: ((column2 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • project
+                │ columns: (column2)
+                │ estimated row count: 1
+                │
+                └── • scan buffer
+                      columns: (column1, column2, column3, check1)
+                      label: buffer 1
+
+subtest test_uniqueness_check_uuid
+
+# Make sure uniqueness check is omitted with gen_random_uuid().
+statement ok
+CREATE TABLE t_gen_random_uuid (
+  user_id UUID DEFAULT gen_random_uuid() PRIMARY KEY USING HASH,
+  val STRING NOT NULL,
+  part STRING CHECK (part IN ('seattle', 'new york')),
+  FAMILY fam_0 (user_id, val, part)
+) PARTITION ALL BY LIST (part) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle');
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, part)
+│ auto commit
+│
+└── • render
+    │ columns: (crdb_internal_user_id_shard_16_cast, user_id_default, val_cast, column2, check1, check2)
+    │ estimated row count: 1
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_user_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column2: column2
+    │ render val_cast: val_cast
+    │ render user_id_default: user_id_default
+    │ render crdb_internal_user_id_shard_16_cast: crdb_internal_user_id_shard_16_cast
+    │
+    └── • render
+        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+        │ estimated row count: 1
+        │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+        │ render column2: column2
+        │ render val_cast: val_cast
+        │ render user_id_default: user_id_default
+        │
+        └── • values
+              columns: (column2, val_cast, user_id_default)
+              size: 3 columns, 1 row
+              row 0, expr 0: 'seattle'
+              row 0, expr 1: '4321'
+              row 0, expr 2: gen_random_uuid()
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, part)
+│ auto commit
+│ arbiter indexes: t_gen_random_uuid_pkey
+│ arbiter constraints: t_gen_random_uuid_pkey
+│
+└── • render
+    │ columns: (crdb_internal_user_id_shard_16_cast, user_id_default, val_cast, column2, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_user_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column2: column2
+    │ render val_cast: val_cast
+    │ render user_id_default: user_id_default
+    │ render crdb_internal_user_id_shard_16_cast: crdb_internal_user_id_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: user_id_default
+        │ nulls are distinct
+        │
+        └── • distinct
+            │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+            │ estimated row count: 0 (missing stats)
+            │ distinct on: crdb_internal_user_id_shard_16_cast, user_id_default
+            │ nulls are distinct
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                │ equality cols are key
+                │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                    │ equality: (column2, crdb_internal_user_id_shard_16_cast, user_id_default) = (part,crdb_internal_user_id_shard_16,user_id)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+                        │ estimated row count: 1
+                        │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                        │ render column2: column2
+                        │ render val_cast: val_cast
+                        │ render user_id_default: user_id_default
+                        │
+                        └── • values
+                              columns: (column2, val_cast, user_id_default)
+                              size: 3 columns, 1 row
+                              row 0, expr 0: 'seattle'
+                              row 0, expr 1: '4321'
+                              row 0, expr 2: gen_random_uuid()
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, part)
+│ auto commit
+│ arbiter indexes: t_gen_random_uuid_pkey
+│ arbiter constraints: t_gen_random_uuid_pkey
+│
+└── • render
+    │ columns: (crdb_internal_user_id_shard_16_cast, user_id_default, val_cast, column2, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_user_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column2: column2
+    │ render val_cast: val_cast
+    │ render user_id_default: user_id_default
+    │ render crdb_internal_user_id_shard_16_cast: crdb_internal_user_id_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: user_id_default
+        │ nulls are distinct
+        │
+        └── • distinct
+            │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+            │ estimated row count: 0 (missing stats)
+            │ distinct on: crdb_internal_user_id_shard_16_cast, column2, user_id_default
+            │ nulls are distinct
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                │ equality cols are key
+                │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                    │ equality: (column2, crdb_internal_user_id_shard_16_cast, user_id_default) = (part,crdb_internal_user_id_shard_16,user_id)
+                    │ equality cols are key
+                    │
+                    └── • render
+                        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
+                        │ estimated row count: 2
+                        │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                        │ render column2: column2
+                        │ render val_cast: val_cast
+                        │ render user_id_default: user_id_default
+                        │
+                        └── • render
+                            │ columns: (user_id_default, column2, val_cast)
+                            │ estimated row count: 2
+                            │ render user_id_default: gen_random_uuid()
+                            │ render column2: column2
+                            │ render val_cast: val_cast
+                            │
+                            └── • values
+                                  columns: (val_cast, column2)
+                                  size: 2 columns, 2 rows
+                                  row 0, expr 0: '4321'
+                                  row 0, expr 1: 'seattle'
+                                  row 1, expr 0: '8765'
+                                  row 1, expr 1: 'new york'
+
+subtest test_uniqueness_check_pk
+
+statement ok
+CREATE TABLE t_unique_hash_pk (
+  id INT PRIMARY KEY USING HASH,
+  part STRING CHECK (part IN ('seattle', 'new york')),
+  FAMILY fam_0 (id, part)
+) PARTITION ALL BY LIST (part) (
+  PARTITION us_west VALUES IN (('seattle')),
+  PARTITION us_east VALUES IN (('new york'))
+);
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+│             size: 5 columns, 1 row
+│             row 0, expr 0: 4321
+│             row 0, expr 1: 'seattle'
+│             row 0, expr 2: 9
+│             row 0, expr 3: true
+│             row 0, expr 4: true
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (column2 != part)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+                    │ estimated row count: 1
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+                          label: buffer 1
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│ auto commit
+│ arbiter indexes: t_unique_hash_pk_pkey
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column1: column1
+    │ render column2: column2
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • lookup join (anti)
+        │ columns: (column1, column2, crdb_internal_id_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │
+        └── • cross join (anti)
+            │ columns: (column1, column2, crdb_internal_id_shard_16_cast)
+            │ estimated row count: 0 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, column2, crdb_internal_id_shard_16_cast)
+            │     size: 3 columns, 1 row
+            │     row 0, expr 0: 4321
+            │     row 0, expr 1: 'seattle'
+            │     row 0, expr 2: 9
+            │
+            └── • scan
+                  columns: (crdb_internal_id_shard_16, id, part)
+                  estimated row count: 1 (missing stats)
+                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                  spans: /"seattle"/9/4321/0
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│ auto commit
+│ arbiter indexes: t_unique_hash_pk_pkey
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column1: column1
+    │ render column2: column2
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: crdb_internal_id_shard_16_cast, column1, column2
+        │ nulls are distinct
+        │
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ equality: (column2, crdb_internal_id_shard_16_cast, column1) = (part,crdb_internal_id_shard_16,id)
+                │ equality cols are key
+                │
+                └── • render
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+                    │ estimated row count: 2
+                    │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+                    │ render column1: column1
+                    │ render column2: column2
+                    │
+                    └── • values
+                          columns: (column1, column2)
+                          size: 2 columns, 2 rows
+                          row 0, expr 0: 4321
+                          row 0, expr 1: 'seattle'
+                          row 1, expr 0: 8765
+                          row 1, expr 1: 'new york'
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column1: column1
+    │ render column2: column2
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • cross join (anti)
+        │ columns: (column1, column2, crdb_internal_id_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │
+        ├── • values
+        │     columns: (column1, column2, crdb_internal_id_shard_16_cast)
+        │     size: 3 columns, 1 row
+        │     row 0, expr 0: 4321
+        │     row 0, expr 1: 'seattle'
+        │     row 0, expr 2: 9
+        │
+        └── • scan
+              columns: (id)
+              estimated row count: 1 (missing stats)
+              table: t_unique_hash_pk@t_unique_hash_pk_pkey
+              spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
+              parallel
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column2 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column1: column1
+    │ render column2: column2
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • lookup join (anti)
+        │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+        │ estimated row count: 0 (missing stats)
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │
+        └── • render
+            │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+            │ estimated row count: 2
+            │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+            │ render column1: column1
+            │ render column2: column2
+            │
+            └── • values
+                  columns: (column1, column2)
+                  size: 2 columns, 2 rows
+                  row 0, expr 0: 4321
+                  row 0, expr 1: 'seattle'
+                  row 1, expr 0: 8765
+                  row 1, expr 1: 'new york'
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO UPDATE SET id = excluded.id
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│   │ arbiter constraints: t_unique_hash_pk_pkey
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, column1, part, check1, check2, upsert_part)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, column1, part, check1, check2, upsert_part)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part, upsert_part)
+│               │ estimated row count: 1 (missing stats)
+│               │ render check1: upsert_part IN ('new york', 'seattle')
+│               │ render check2: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│               │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│               │ render id: id
+│               │ render part: part
+│               │ render upsert_part: upsert_part
+│               │
+│               └── • render
+│                   │ columns: (upsert_part, column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part)
+│                   │ estimated row count: 1 (missing stats)
+│                   │ render upsert_part: CASE WHEN part IS NULL THEN column2 ELSE part END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│                   │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│                   │ render id: id
+│                   │ render part: part
+│                   │
+│                   └── • cross join (left outer)
+│                       │ columns: (column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part)
+│                       │ estimated row count: 1 (missing stats)
+│                       │
+│                       ├── • values
+│                       │     columns: (column1, column2, crdb_internal_id_shard_16_cast)
+│                       │     size: 3 columns, 1 row
+│                       │     row 0, expr 0: 4321
+│                       │     row 0, expr 1: 'seattle'
+│                       │     row 0, expr 2: 9
+│                       │
+│                       └── • scan
+│                             columns: (crdb_internal_id_shard_16, id, part)
+│                             estimated row count: 1 (missing stats)
+│                             table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                             spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
+│                             parallel
+│                             locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_part)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (upsert_part != part)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_part)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, column1, part, check1, check2, upsert_part)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york') ON CONFLICT (id) DO UPDATE SET id = excluded.id
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│   │ arbiter constraints: t_unique_hash_pk_pkey
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, column1, part, check1, check2, upsert_part)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, column1, part, check1, check2, upsert_part)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part, upsert_part)
+│               │ estimated row count: 2 (missing stats)
+│               │ render check1: upsert_part IN ('new york', 'seattle')
+│               │ render check2: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│               │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│               │ render id: id
+│               │ render part: part
+│               │ render upsert_part: upsert_part
+│               │
+│               └── • render
+│                   │ columns: (upsert_part, column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render upsert_part: CASE WHEN part IS NULL THEN column2 ELSE part END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│                   │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│                   │ render id: id
+│                   │ render part: part
+│                   │
+│                   └── • lookup join (left outer)
+│                       │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part)
+│                       │ estimated row count: 2 (missing stats)
+│                       │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                       │ equality cols are key
+│                       │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                       │ locking strength: for update
+│                       │
+│                       └── • render
+│                           │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+│                           │ estimated row count: 2
+│                           │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+│                           │ render column1: column1
+│                           │ render column2: column2
+│                           │
+│                           └── • values
+│                                 columns: (column1, column2)
+│                                 size: 2 columns, 2 rows
+│                                 row 0, expr 0: 4321
+│                                 row 0, expr 1: 'seattle'
+│                                 row 1, expr 0: 8765
+│                                 row 1, expr 1: 'new york'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_part)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (upsert_part != part)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_part)
+                    │ estimated row count: 2 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, column1, part, check1, check2, upsert_part)
+                          label: buffer 1
+
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle');
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • project
+    │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, column2, part, check1, check2)
+    │
+    └── • render
+        │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part)
+        │ estimated row count: 1 (missing stats)
+        │ render check1: column2 IN ('new york', 'seattle')
+        │ render check2: CASE WHEN part IS NULL THEN crdb_internal_id_shard_16_cast ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        │ render column1: column1
+        │ render column2: column2
+        │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+        │ render id: id
+        │ render part: part
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, column2, crdb_internal_id_shard_16_cast)
+            │     size: 3 columns, 1 row
+            │     row 0, expr 0: 4321
+            │     row 0, expr 1: 'seattle'
+            │     row 0, expr 2: 9
+            │
+            └── • scan
+                  columns: (crdb_internal_id_shard_16, id, part)
+                  estimated row count: 1 (missing stats)
+                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                  spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
+                  parallel
+                  locking strength: for update
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle'), (8765, 'new york');
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • project
+    │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part, column2, part, check1, check2)
+    │
+    └── • render
+        │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, part)
+        │ estimated row count: 2 (missing stats)
+        │ render check1: column2 IN ('new york', 'seattle')
+        │ render check2: CASE WHEN part IS NULL THEN crdb_internal_id_shard_16_cast ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        │ render column1: column1
+        │ render column2: column2
+        │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+        │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+        │ render id: id
+        │ render part: part
+        │
+        └── • lookup join (left outer)
+            │ columns: (crdb_internal_id_shard_16_cast, column1, column2, crdb_internal_id_shard_16, id, part)
+            │ estimated row count: 2 (missing stats)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ locking strength: for update
+            │
+            └── • render
+                │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
+                │ estimated row count: 2
+                │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+                │ render column1: column1
+                │ render column2: column2
+                │
+                └── • values
+                      columns: (column1, column2)
+                      size: 2 columns, 2 rows
+                      row 0, expr 0: 4321
+                      row 0, expr 1: 'seattle'
+                      row 1, expr 0: 8765
+                      row 1, expr 1: 'new york'
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: t_unique_hash_pk
+│   │ set: crdb_internal_id_shard_16, id
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, id_new, check2)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, id_new, check2)
+│           │ estimated row count: 1 (missing stats)
+│           │ render check2: true
+│           │ render crdb_internal_id_shard_16_cast: 6
+│           │ render id_new: 1234
+│           │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│           │ render id: id
+│           │ render part: part
+│           │
+│           └── • scan
+│                 columns: (crdb_internal_id_shard_16, id, part)
+│                 estimated row count: 1 (missing stats)
+│                 table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                 spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
+│                 parallel
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (id_new)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, id_new, part)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((id_new = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (part != part)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, id_new, part)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_cast, id_new, check2)
+                          label: buffer 1
+
+subtest test_uniqueness_check_sec_key
+
+statement ok
+CREATE TABLE t_unique_hash_sec_key (
+  id INT PRIMARY KEY,
+  email STRING,
+  part STRING CHECK (part IN ('seattle', 'new york')),
+  FAMILY fam_0 (id, email, part)
+) PARTITION ALL BY LIST (part) (
+   PARTITION us_west VALUES IN (('seattle')),
+   PARTITION us_east VALUES IN (('new york'))
+);
+
+statement ok
+CREATE UNIQUE INDEX idx_uniq_hash_email ON t_unique_hash_sec_key (email) USING HASH;
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│             size: 6 columns, 1 row
+│             row 0, expr 0: 4321
+│             row 0, expr 1: 'some_email'
+│             row 0, expr 2: 'seattle'
+│             row 0, expr 3: 13
+│             row 0, expr 4: true
+│             row 0, expr 5: true
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (column1)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (column1, column3)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+│               │ pred: column3 != part
+│               │
+│               └── • project
+│                   │ columns: (column1, column3)
+│                   │ estimated row count: 1
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (column1, column2, column3)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (column1 != id) OR (column3 != part)
+                │
+                └── • project
+                    │ columns: (column1, column2, column3)
+                    │ estimated row count: 1
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+                          label: buffer 1
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│ auto commit
+│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│
+└── • render
+    │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column3 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column1: column1
+    │ render column2: column2
+    │ render column3: column3
+    │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+    │
+    └── • cross join (right anti)
+        │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │
+        ├── • project
+        │   │ columns: ()
+        │   │ estimated row count: 1 (missing stats)
+        │   │
+        │   └── • scan
+        │         columns: (id, part)
+        │         estimated row count: 1 (missing stats)
+        │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+        │         spans: /"seattle"/4321/0
+        │
+        └── • lookup join (anti)
+            │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+            │ equality cols are key
+            │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+            │
+            └── • lookup join (anti)
+                │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ equality cols are key
+                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │
+                └── • hash join (right anti)
+                    │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+                    │ estimated row count: 0 (missing stats)
+                    │ equality: (email, part, crdb_internal_email_shard_16) = (column2, column3, crdb_internal_email_shard_16_cast)
+                    │ right cols are key
+                    │
+                    ├── • render
+                    │   │ columns: (crdb_internal_email_shard_16, email, part)
+                    │   │ estimated row count: 1,000 (missing stats)
+                    │   │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+                    │   │ render email: email
+                    │   │ render part: part
+                    │   │
+                    │   └── • scan
+                    │         columns: (email, part)
+                    │         estimated row count: 1,000 (missing stats)
+                    │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                    │         spans: FULL SCAN
+                    │
+                    └── • values
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+                          size: 4 columns, 1 row
+                          row 0, expr 0: 4321
+                          row 0, expr 1: 'some_email'
+                          row 0, expr 2: 'seattle'
+                          row 0, expr 3: 13
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│ auto commit
+│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│
+└── • render
+    │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: column3 IN ('new york', 'seattle')
+    │ render check2: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render column1: column1
+    │ render column2: column2
+    │ render column3: column3
+    │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: crdb_internal_email_shard_16_cast, column2, column3
+        │ nulls are distinct
+        │
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ equality cols are key
+            │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ equality cols are key
+                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+                │
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                    │ equality: (column3, column1) = (part,id)
+                    │ equality cols are key
+                    │
+                    └── • lookup join (anti)
+                        │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+                        │ estimated row count: 0 (missing stats)
+                        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                        │ equality: (column3, crdb_internal_email_shard_16_cast, column2) = (part,crdb_internal_email_shard_16,email)
+                        │ equality cols are key
+                        │
+                        └── • render
+                            │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+                            │ estimated row count: 2
+                            │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+                            │ render column1: column1
+                            │ render column2: column2
+                            │ render column3: column3
+                            │
+                            └── • values
+                                  columns: (column1, column2, column3)
+                                  size: 3 columns, 2 rows
+                                  row 0, expr 0: 4321
+                                  row 0, expr 1: 'some_email'
+                                  row 0, expr 2: 'seattle'
+                                  row 1, expr 0: 8765
+                                  row 1, expr 1: 'another_email'
+                                  row 1, expr 2: 'new york'
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│           │ estimated row count: 0 (missing stats)
+│           │ render check1: column3 IN ('new york', 'seattle')
+│           │ render check2: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render column3: column3
+│           │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│           │
+│           └── • cross join (anti)
+│               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+│               │ estimated row count: 0 (missing stats)
+│               │
+│               ├── • values
+│               │     columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+│               │     size: 4 columns, 1 row
+│               │     row 0, expr 0: 4321
+│               │     row 0, expr 1: 'some_email'
+│               │     row 0, expr 2: 'seattle'
+│               │     row 0, expr 3: 13
+│               │
+│               └── • project
+│                   │ columns: ()
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   └── • scan
+│                         columns: (email)
+│                         estimated row count: 1 (missing stats)
+│                         table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                         spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
+│                         parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (column1, column3)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+                │ pred: column3 != part
+                │
+                └── • project
+                    │ columns: (column1, column3)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+│           │ estimated row count: 0 (missing stats)
+│           │ render check1: column3 IN ('new york', 'seattle')
+│           │ render check2: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render column3: column3
+│           │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│           │
+│           └── • lookup join (anti)
+│               │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│               │ equality cols are key
+│               │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│               │
+│               └── • render
+│                   │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+│                   │ estimated row count: 2
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │
+│                   └── • values
+│                         columns: (column1, column2, column3)
+│                         size: 3 columns, 2 rows
+│                         row 0, expr 0: 4321
+│                         row 0, expr 1: 'some_email'
+│                         row 0, expr 2: 'seattle'
+│                         row 1, expr 0: 8765
+│                         row 1, expr 1: 'another_email'
+│                         row 1, expr 2: 'new york'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (column1, column3)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+                │ pred: column3 != part
+                │
+                └── • project
+                    │ columns: (column1, column3)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16)
+│               │ estimated row count: 1 (missing stats)
+│               │ render check1: upsert_part IN ('new york', 'seattle')
+│               │ render check2: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render column3: column3
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render part: part
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │ render upsert_id: upsert_id
+│               │ render upsert_email: upsert_email
+│               │ render upsert_part: upsert_part
+│               │ render upsert_crdb_internal_email_shard_16: upsert_crdb_internal_email_shard_16
+│               │
+│               └── • render
+│                   │ columns: (upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16)
+│                   │ estimated row count: 1 (missing stats)
+│                   │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
+│                   │ render upsert_email: CASE WHEN part IS NULL THEN column2 ELSE 'bad_email' END
+│                   │ render upsert_part: CASE WHEN part IS NULL THEN column3 ELSE part END
+│                   │ render upsert_crdb_internal_email_shard_16: CASE WHEN part IS NULL THEN crdb_internal_email_shard_16_cast ELSE 6 END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                   │ render id: id
+│                   │ render email: email
+│                   │ render part: part
+│                   │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│                   │
+│                   └── • cross join (left outer)
+│                       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, crdb_internal_email_shard_16, id, email, part)
+│                       │ estimated row count: 1 (missing stats)
+│                       │
+│                       ├── • values
+│                       │     columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+│                       │     size: 4 columns, 1 row
+│                       │     row 0, expr 0: 4321
+│                       │     row 0, expr 1: 'some_email'
+│                       │     row 0, expr 2: 'seattle'
+│                       │     row 0, expr 3: 13
+│                       │
+│                       └── • render
+│                           │ columns: (crdb_internal_email_shard_16, id, email, part)
+│                           │ estimated row count: 1 (missing stats)
+│                           │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+│                           │ render id: id
+│                           │ render email: email
+│                           │ render part: part
+│                           │
+│                           └── • scan
+│                                 columns: (id, email, part)
+│                                 estimated row count: 1 (missing stats)
+│                                 table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                                 spans: /"new york"/13/"some_email"/0 /"seattle"/13/"some_email"/0
+│                                 parallel
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (upsert_id)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (upsert_id, upsert_part)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │ lookup condition: (upsert_id = id) AND (part IN ('new york', 'seattle'))
+│               │ pred: upsert_part != part
+│               │
+│               └── • project
+│                   │ columns: (upsert_id, upsert_part)
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (upsert_email)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, upsert_email, upsert_part)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((upsert_email = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (upsert_part != part)
+                │
+                └── • project
+                    │ columns: (upsert_id, upsert_email, upsert_part)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle'), (8765, 'another_email', 'new york') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16)
+│               │ estimated row count: 2 (missing stats)
+│               │ render check1: upsert_part IN ('new york', 'seattle')
+│               │ render check2: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render column3: column3
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render part: part
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │ render upsert_id: upsert_id
+│               │ render upsert_email: upsert_email
+│               │ render upsert_part: upsert_part
+│               │ render upsert_crdb_internal_email_shard_16: upsert_crdb_internal_email_shard_16
+│               │
+│               └── • render
+│                   │ columns: (upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
+│                   │ render upsert_email: CASE WHEN part IS NULL THEN column2 ELSE 'bad_email' END
+│                   │ render upsert_part: CASE WHEN part IS NULL THEN column3 ELSE part END
+│                   │ render upsert_crdb_internal_email_shard_16: CASE WHEN part IS NULL THEN crdb_internal_email_shard_16_cast ELSE 6 END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                   │ render id: id
+│                   │ render email: email
+│                   │ render part: part
+│                   │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│                   │
+│                   └── • render
+│                       │ columns: (crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part)
+│                       │ estimated row count: 2 (missing stats)
+│                       │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
+│                       │ render column1: column1
+│                       │ render column2: column2
+│                       │ render column3: column3
+│                       │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                       │ render id: id
+│                       │ render email: email
+│                       │ render part: part
+│                       │
+│                       └── • project
+│                           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part)
+│                           │ estimated row count: 2 (missing stats)
+│                           │
+│                           └── • lookup join (left outer)
+│                               │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3, id, email, part, crdb_internal_email_shard_16)
+│                               │ estimated row count: 2 (missing stats)
+│                               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                               │ equality cols are key
+│                               │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                               │ locking strength: for update
+│                               │
+│                               └── • render
+│                                   │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+│                                   │ estimated row count: 2
+│                                   │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+│                                   │ render column1: column1
+│                                   │ render column2: column2
+│                                   │ render column3: column3
+│                                   │
+│                                   └── • values
+│                                         columns: (column1, column2, column3)
+│                                         size: 3 columns, 2 rows
+│                                         row 0, expr 0: 4321
+│                                         row 0, expr 1: 'some_email'
+│                                         row 0, expr 2: 'seattle'
+│                                         row 1, expr 0: 8765
+│                                         row 1, expr 1: 'another_email'
+│                                         row 1, expr 2: 'new york'
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (upsert_id)
+│           │ estimated row count: 1 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (upsert_id, upsert_part)
+│               │ estimated row count: 1 (missing stats)
+│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │ lookup condition: (upsert_id = id) AND (part IN ('new york', 'seattle'))
+│               │ pred: upsert_part != part
+│               │
+│               └── • project
+│                   │ columns: (upsert_id, upsert_part)
+│                   │ estimated row count: 2 (missing stats)
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (upsert_email)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, upsert_email, upsert_part)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((upsert_email = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (upsert_part != part)
+                │
+                └── • project
+                    │ columns: (upsert_id, upsert_email, upsert_part)
+                    │ estimated row count: 2 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │ arbiter constraints: t_unique_hash_sec_key_pkey
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_cast, part, check1, check2, upsert_id)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_cast, part, check1, check2, upsert_id)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, upsert_id, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16)
+│               │ estimated row count: 1 (missing stats)
+│               │ render check1: column3 IN ('new york', 'seattle')
+│               │ render check2: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render column3: column3
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render part: part
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │
+│               └── • cross join (left outer)
+│                   │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, crdb_internal_email_shard_16, id, email, part)
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   ├── • values
+│                   │     columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+│                   │     size: 4 columns, 1 row
+│                   │     row 0, expr 0: 1
+│                   │     row 0, expr 1: 'email1'
+│                   │     row 0, expr 2: 'seattle'
+│                   │     row 0, expr 3: 5
+│                   │
+│                   └── • render
+│                       │ columns: (crdb_internal_email_shard_16, id, email, part)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+│                       │ render id: id
+│                       │ render email: email
+│                       │ render part: part
+│                       │
+│                       └── • scan
+│                             columns: (id, email, part)
+│                             estimated row count: 1 (missing stats)
+│                             table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                             spans: /"new york"/1/0 /"seattle"/1/0
+│                             parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, column2, column3)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (column3 != part)
+                │
+                └── • project
+                    │ columns: (upsert_id, column2, column3)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_cast, part, check1, check2, upsert_id)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1', 'seattle'), (8765, 'email2', 'new york');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
+│   │ arbiter constraints: t_unique_hash_sec_key_pkey
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_cast, part, check1, check2, upsert_id)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_cast, part, check1, check2, upsert_id)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, upsert_id, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16)
+│               │ estimated row count: 2 (missing stats)
+│               │ render check1: column3 IN ('new york', 'seattle')
+│               │ render check2: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render column3: column3
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render part: part
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │
+│               └── • render
+│                   │ columns: (crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render column3: column3
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                   │ render id: id
+│                   │ render email: email
+│                   │ render part: part
+│                   │
+│                   └── • lookup join (left outer)
+│                       │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3, id, email, part)
+│                       │ estimated row count: 2 (missing stats)
+│                       │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                       │ equality cols are key
+│                       │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+│                       │ locking strength: for update
+│                       │
+│                       └── • render
+│                           │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
+│                           │ estimated row count: 2
+│                           │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+│                           │ render column1: column1
+│                           │ render column2: column2
+│                           │ render column3: column3
+│                           │
+│                           └── • values
+│                                 columns: (column1, column2, column3)
+│                                 size: 3 columns, 2 rows
+│                                 row 0, expr 0: 1
+│                                 row 0, expr 1: 'email1'
+│                                 row 0, expr 2: 'seattle'
+│                                 row 1, expr 0: 8765
+│                                 row 1, expr 1: 'email2'
+│                                 row 1, expr 2: 'new york'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, column2, column3)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (column3 != part)
+                │
+                └── • project
+                    │ columns: (upsert_id, column2, column3)
+                    │ estimated row count: 2 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_cast, part, check1, check2, upsert_id)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: t_unique_hash_sec_key
+│   │ set: email, crdb_internal_email_shard_16
+│   │
+│   └── • buffer
+│       │ columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_cast, check2)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_cast, check2)
+│           │ estimated row count: 1 (missing stats)
+│           │ render check2: true
+│           │ render crdb_internal_email_shard_16_cast: 5
+│           │ render email_new: 'email1'
+│           │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+│           │ render id: id
+│           │ render email: email
+│           │ render part: part
+│           │
+│           └── • scan
+│                 columns: (id, email, part)
+│                 estimated row count: 1 (missing stats)
+│                 table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                 spans: /"new york"/2/0 /"seattle"/2/0
+│                 parallel
+│                 locking strength: for update
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (email_new)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (id, email_new, part)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((email_new = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (id != id) OR (part != part)
+                │
+                └── • project
+                    │ columns: (id, email_new, part)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_cast, check2)
+                          label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -414,7 +414,7 @@ ALTER TABLE t PARTITION ALL BY LIST (a) (
 statement ok
 DROP TABLE t CASCADE
 
-statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
+statement error cannot define PARTITION BY on an index if the table is implicitly partitioned with PARTITION ALL BY or LOCALITY REGIONAL BY ROW definition
 CREATE TABLE public.t (
   pk int PRIMARY KEY,
   partition_by int,
@@ -427,7 +427,7 @@ CREATE TABLE public.t (
   PARTITION two VALUES IN (2)
 )
 
-statement error cannot define PARTITION BY on an unique constraint if the table has a PARTITION ALL BY definition
+statement error cannot define PARTITION BY on an unique constraint if the table is implicitly partitioned with PARTITION ALL BY or LOCALITY REGIONAL BY ROW definition
 CREATE TABLE public.t (
   pk int PRIMARY KEY,
   partition_by int,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -43,28 +43,6 @@ CREATE TABLE regional_by_row_table (
 )
 LOCALITY REGIONAL BY ROW
 
-statement ok
-SET experimental_enable_hash_sharded_indexes = true
-
-statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-CREATE TABLE regional_by_row_table (
-  pk INT PRIMARY KEY USING HASH WITH (bucket_count=8)
-) LOCALITY REGIONAL BY ROW
-
-statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-CREATE TABLE regional_by_row_table (
-  pk INT NOT NULL,
-  a INT,
-  PRIMARY KEY(pk) USING HASH WITH (bucket_count=8)
-) LOCALITY REGIONAL BY ROW
-
-statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-CREATE TABLE regional_by_row_table (
-  pk INT NOT NULL,
-  a INT,
-  INDEX(a) USING HASH WITH (bucket_count=8)
-) LOCALITY REGIONAL BY ROW
-
 statement error multi-region tables with an INDEX containing PARTITION BY are not supported
 CREATE TABLE regional_by_row_table (
   pk int,
@@ -331,12 +309,6 @@ statement error cannot define PARTITION BY on a new INDEX in a multi-region data
 CREATE INDEX bad_idx ON regional_by_row_table(a) PARTITION BY LIST (a) (
   PARTITION one VALUES IN (1)
 )
-
-statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-CREATE INDEX bad_idx ON regional_by_row_table(a) USING HASH WITH (bucket_count=8)
-
-statement error hash sharded indexes are not compatible with REGIONAL BY ROW tables
-ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS(pk2) USING HASH WITH (bucket_count=8)
 
 # Try add a new unique column.
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
@@ -1,0 +1,153 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+statement ok
+CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
+
+statement ok
+USE multi_region_test_db
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true
+
+statement ok
+CREATE TABLE t_regional (
+  pk INT PRIMARY KEY,
+  b INT
+) LOCALITY REGIONAL BY ROW;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE INDEX ON t_regional (crdb_region, b) USING HASH;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE UNIQUE INDEX ON t_regional (crdb_region, b) USING HASH;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+ALTER TABLE t_regional ALTER PRIMARY KEY USING COLUMNS (crdb_region, pk) USING HASH;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE TABLE t_regional_bad (
+  pk INT PRIMARY KEY,
+  b INT,
+  INDEX (crdb_region, b) USING HASH
+) LOCALITY REGIONAL BY ROW;
+
+statement error hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"
+CREATE TABLE t_regional_bad (
+  pk INT,
+  b INT,
+  PRIMARY KEY (crdb_region, pk) USING HASH
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE t_to_be_hashed (
+  pk INT PRIMARY KEY,
+  b INT,
+  FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+                            pk INT8 NOT NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (pk ASC),
+                            FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE INDEX ON t_to_be_hashed (b) USING HASH;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+                            pk INT8 NOT NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            crdb_internal_b_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+                            CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (pk ASC),
+                            INDEX t_to_be_hashed_b_idx (b ASC) USING HASH WITH (bucket_count=16),
+                            FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE UNIQUE INDEX ON t_to_be_hashed (b) USING HASH;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+                            pk INT8 NOT NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            crdb_internal_b_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+                            CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (pk ASC),
+                            INDEX t_to_be_hashed_b_idx (b ASC) USING HASH WITH (bucket_count=16),
+                            UNIQUE INDEX t_to_be_hashed_b_key (b ASC) USING HASH WITH (bucket_count=16),
+                            FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER TABLE t_to_be_hashed ALTER PRIMARY KEY USING COLUMNS (pk) USING HASH;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_to_be_hashed];
+----
+CREATE TABLE public.t_to_be_hashed (
+                            pk INT8 NOT NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            crdb_internal_b_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+                            crdb_internal_pk_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(pk)), 16:::INT8)) VIRTUAL,
+                            CONSTRAINT t_to_be_hashed_pkey PRIMARY KEY (pk ASC) USING HASH WITH (bucket_count=16),
+                            INDEX t_to_be_hashed_b_idx (b ASC) USING HASH WITH (bucket_count=16),
+                            UNIQUE INDEX t_to_be_hashed_b_key (b ASC) USING HASH WITH (bucket_count=16),
+                            FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE t_regional_pk_hashed_1 (
+  pk INT PRIMARY KEY USING HASH,
+  b INT,
+  INDEX (b) USING HASH,
+  FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_regional_pk_hashed_1];
+----
+CREATE TABLE public.t_regional_pk_hashed_1 (
+                            crdb_internal_pk_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(pk)), 16:::INT8)) VIRTUAL,
+                            pk INT8 NOT NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            crdb_internal_b_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+                            CONSTRAINT t_regional_pk_hashed_1_pkey PRIMARY KEY (pk ASC) USING HASH WITH (bucket_count=16),
+                            INDEX t_regional_pk_hashed_1_b_idx (b ASC) USING HASH WITH (bucket_count=16),
+                            FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE t_regional_pk_hashed_2 (
+  pk INT,
+  b INT,
+  PRIMARY KEY (pk) USING HASH,
+  INDEX (b) USING HASH,
+  FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+query T
+SELECT @2 FROM [SHOW CREATE TABLE t_regional_pk_hashed_2];
+----
+CREATE TABLE public.t_regional_pk_hashed_2 (
+                            pk INT8 NOT NULL,
+                            b INT8 NULL,
+                            crdb_region public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region,
+                            crdb_internal_pk_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(pk)), 16:::INT8)) VIRTUAL,
+                            crdb_internal_b_shard_16 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+                            CONSTRAINT t_regional_pk_hashed_2_pkey PRIMARY KEY (pk ASC) USING HASH WITH (bucket_count=16),
+                            INDEX t_regional_pk_hashed_2_b_idx (b ASC) USING HASH WITH (bucket_count=16),
+                            FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
+) LOCALITY REGIONAL BY ROW

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -1163,19 +1163,12 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
     │
-    └── • cross join (right anti)
+    └── • lookup join (anti)
         │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
         │ estimated row count: 0 (missing stats)
-        │
-        ├── • project
-        │   │ columns: ()
-        │   │ estimated row count: 1 (missing stats)
-        │   │
-        │   └── • scan
-        │         columns: (id, crdb_region)
-        │         estimated row count: 1 (missing stats)
-        │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-        │         spans: /"@"/4321/0
+        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+        │ equality cols are key
+        │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
         └── • lookup join (anti)
             │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
@@ -1188,35 +1181,30 @@ vectorized: true
                 │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
                 │ estimated row count: 0 (missing stats)
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ equality: (crdb_region_default, crdb_internal_email_shard_16_cast, column2) = (crdb_region,crdb_internal_email_shard_16,email)
                 │ equality cols are key
-                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
                 │
-                └── • hash join (right anti)
+                └── • cross join (anti)
                     │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
                     │ estimated row count: 0 (missing stats)
-                    │ equality: (email, crdb_region, crdb_internal_email_shard_16) = (column2, crdb_region_default, crdb_internal_email_shard_16_cast)
-                    │ right cols are key
                     │
-                    ├── • render
-                    │   │ columns: (crdb_internal_email_shard_16, email, crdb_region)
-                    │   │ estimated row count: 1,000 (missing stats)
-                    │   │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
-                    │   │ render email: email
-                    │   │ render crdb_region: crdb_region
-                    │   │
-                    │   └── • scan
-                    │         columns: (email, crdb_region)
-                    │         estimated row count: 1,000 (missing stats)
-                    │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                    │         spans: FULL SCAN
+                    ├── • values
+                    │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+                    │     size: 4 columns, 1 row
+                    │     row 0, expr 0: 4321
+                    │     row 0, expr 1: 'some_email'
+                    │     row 0, expr 2: 'ap-southeast-2'
+                    │     row 0, expr 3: 13
                     │
-                    └── • values
-                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
-                          size: 4 columns, 1 row
-                          row 0, expr 0: 4321
-                          row 0, expr 1: 'some_email'
-                          row 0, expr 2: 'ap-southeast-2'
-                          row 0, expr 3: 13
+                    └── • project
+                        │ columns: ()
+                        │ estimated row count: 1 (missing stats)
+                        │
+                        └── • scan
+                              columns: (id, crdb_region)
+                              estimated row count: 1 (missing stats)
+                              table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                              spans: /"@"/4321/0
 
 # TODO (issue #75498): we're using unique without index on (a) as an arbiter and
 # using the original hash sharded index as an arbiter is not necessary.

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -1,0 +1,2051 @@
+# LogicTest: multiregion-9node-3region-3azs
+# TODO(#75864): enable multiregion-9node-3region-3azs-tenant
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms';
+
+statement ok
+CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
+
+statement ok
+USE multi_region_test_db
+
+statement ok
+SET experimental_enable_hash_sharded_indexes = true
+
+# Make sure foreign key references checked is planned
+subtest test_fk_constraint
+
+statement ok
+CREATE TABLE t_parent (
+  id INT PRIMARY KEY USING HASH
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE t_child (
+  id INT PRIMARY KEY,
+  pid INT REFERENCES t_parent (id),
+  FAMILY fam_0 (id, pid)
+);
+
+statement ok
+CREATE TABLE t_child_regional (
+  id INT PRIMARY KEY,
+  pid INT REFERENCES t_parent (id),
+  FAMILY fam_0 (id, pid)
+) LOCALITY REGIONAL BY ROW;
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_child VALUES (123, 321);
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_child(id, pid)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1, column2)
+│             size: 2 columns, 1 row
+│             row 0, expr 0: 123
+│             row 0, expr 1: 321
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_parent@t_parent_pkey
+            │ equality cols are key
+            │ lookup condition: ((column2 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • lookup join (anti)
+                │ columns: (column2)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_parent@t_parent_pkey
+                │ equality cols are key
+                │ lookup condition: ((column2 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │
+                └── • project
+                    │ columns: (column2)
+                    │ estimated row count: 1
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_child_regional VALUES (123, 321);
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_child_regional(id, pid, crdb_region)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, check1)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1, column2, crdb_region_default, check1)
+│             size: 4 columns, 1 row
+│             row 0, expr 0: 123
+│             row 0, expr 1: 321
+│             row 0, expr 2: 'ap-southeast-2'
+│             row 0, expr 3: true
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (column1)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (column1, crdb_region_default)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_child_regional@t_child_regional_pkey
+│               │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│               │ pred: crdb_region_default != crdb_region
+│               │
+│               └── • project
+│                   │ columns: (column1, crdb_region_default)
+│                   │ estimated row count: 1
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, crdb_region_default, check1)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_parent@t_parent_pkey
+            │ equality cols are key
+            │ lookup condition: ((column2 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • lookup join (anti)
+                │ columns: (column2)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_parent@t_parent_pkey
+                │ equality cols are key
+                │ lookup condition: ((column2 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │
+                └── • project
+                    │ columns: (column2)
+                    │ estimated row count: 1
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, check1)
+                          label: buffer 1
+
+subtest test_uniqueness_check_uuid
+
+# Make sure uniqueness check is omitted with gen_random_uuid().
+statement ok
+CREATE TABLE t_gen_random_uuid (
+  user_id UUID DEFAULT gen_random_uuid() PRIMARY KEY USING HASH,
+  val STRING NOT NULL,
+  FAMILY fam_0 (user_id, val)
+) LOCALITY REGIONAL BY ROW;
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321);
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, crdb_region)
+│ auto commit
+│
+└── • render
+    │ columns: (crdb_internal_user_id_shard_16_cast, user_id_default, val_cast, crdb_region_default, check1, check2)
+    │ estimated row count: 1
+    │ render check1: crdb_internal_user_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render val_cast: val_cast
+    │ render user_id_default: user_id_default
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_user_id_shard_16_cast: crdb_internal_user_id_shard_16_cast
+    │
+    └── • render
+        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+        │ estimated row count: 1
+        │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+        │ render val_cast: val_cast
+        │ render user_id_default: user_id_default
+        │ render crdb_region_default: crdb_region_default
+        │
+        └── • values
+              columns: (val_cast, user_id_default, crdb_region_default)
+              size: 3 columns, 1 row
+              row 0, expr 0: '4321'
+              row 0, expr 1: gen_random_uuid()
+              row 0, expr 2: 'ap-southeast-2'
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321) ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, crdb_region)
+│ auto commit
+│ arbiter indexes: t_gen_random_uuid_pkey
+│ arbiter constraints: t_gen_random_uuid_pkey
+│
+└── • render
+    │ columns: (crdb_internal_user_id_shard_16_cast, user_id_default, val_cast, crdb_region_default, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_user_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render val_cast: val_cast
+    │ render user_id_default: user_id_default
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_user_id_shard_16_cast: crdb_internal_user_id_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: user_id_default
+        │ nulls are distinct
+        │
+        └── • distinct
+            │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+            │ estimated row count: 0 (missing stats)
+            │ distinct on: crdb_internal_user_id_shard_16_cast, user_id_default
+            │ nulls are distinct
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                │ equality: (crdb_region_default, crdb_internal_user_id_shard_16_cast, user_id_default) = (crdb_region,crdb_internal_user_id_shard_16,user_id)
+                │ equality cols are key
+                │
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                    │ equality cols are key
+                    │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                    │
+                    └── • lookup join (anti)
+                        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                        │ estimated row count: 1 (missing stats)
+                        │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                        │ equality cols are key
+                        │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                        │
+                        └── • render
+                            │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                            │ estimated row count: 1
+                            │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                            │ render val_cast: val_cast
+                            │ render user_id_default: user_id_default
+                            │ render crdb_region_default: crdb_region_default
+                            │
+                            └── • values
+                                  columns: (val_cast, user_id_default, crdb_region_default)
+                                  size: 3 columns, 1 row
+                                  row 0, expr 0: '4321'
+                                  row 0, expr 1: gen_random_uuid()
+                                  row 0, expr 2: 'ap-southeast-2'
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_gen_random_uuid (val) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, crdb_region)
+│ auto commit
+│ arbiter indexes: t_gen_random_uuid_pkey
+│ arbiter constraints: t_gen_random_uuid_pkey
+│
+└── • render
+    │ columns: (crdb_internal_user_id_shard_16_cast, user_id_default, val_cast, crdb_region_default, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_user_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render val_cast: val_cast
+    │ render user_id_default: user_id_default
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_user_id_shard_16_cast: crdb_internal_user_id_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: user_id_default
+        │ nulls are distinct
+        │
+        └── • distinct
+            │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+            │ estimated row count: 0 (missing stats)
+            │ distinct on: crdb_internal_user_id_shard_16_cast, user_id_default
+            │ nulls are distinct
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                │ equality: (crdb_region_default, crdb_internal_user_id_shard_16_cast, user_id_default) = (crdb_region,crdb_internal_user_id_shard_16,user_id)
+                │ equality cols are key
+                │
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                    │ equality cols are key
+                    │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                    │
+                    └── • lookup join (anti)
+                        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                        │ estimated row count: 2 (missing stats)
+                        │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+                        │ equality cols are key
+                        │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                        │
+                        └── • render
+                            │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
+                            │ estimated row count: 2
+                            │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                            │ render val_cast: val_cast
+                            │ render user_id_default: user_id_default
+                            │ render crdb_region_default: crdb_region_default
+                            │
+                            └── • render
+                                │ columns: (user_id_default, crdb_region_default, val_cast)
+                                │ estimated row count: 2
+                                │ render user_id_default: gen_random_uuid()
+                                │ render crdb_region_default: 'ap-southeast-2'
+                                │ render val_cast: val_cast
+                                │
+                                └── • values
+                                      columns: (val_cast)
+                                      size: 1 column, 2 rows
+                                      row 0, expr 0: '4321'
+                                      row 1, expr 0: '8765'
+
+subtest test_uniqueness_check_pk
+
+statement ok
+CREATE TABLE t_unique_hash_pk (
+  id INT PRIMARY KEY USING HASH
+) LOCALITY REGIONAL BY ROW;
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321);
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+│             size: 5 columns, 1 row
+│             row 0, expr 0: 4321
+│             row 0, expr 1: 'ap-southeast-2'
+│             row 0, expr 2: 9
+│             row 0, expr 3: true
+│             row 0, expr 4: true
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (crdb_region_default != crdb_region)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default)
+                    │ estimated row count: 1
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+                          label: buffer 1
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│ auto commit
+│ arbiter indexes: t_unique_hash_pk_pkey
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • lookup join (anti)
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │
+        └── • cross join (anti)
+            │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+            │ estimated row count: 0 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+            │     size: 3 columns, 1 row
+            │     row 0, expr 0: 4321
+            │     row 0, expr 1: 'ap-southeast-2'
+            │     row 0, expr 2: 9
+            │
+            └── • scan
+                  columns: (crdb_internal_id_shard_16, id, crdb_region)
+                  estimated row count: 1 (missing stats)
+                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                  spans: /"@"/9/4321/0
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│ auto commit
+│ arbiter indexes: t_unique_hash_pk_pkey
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: column1, crdb_internal_id_shard_16_cast
+        │ nulls are distinct
+        │
+        └── • project
+            │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (anti)
+                │ columns: ("lookup_join_const_col_@12", column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ equality: (lookup_join_const_col_@12, crdb_internal_id_shard_16_cast, column1) = (crdb_region,crdb_internal_id_shard_16,id)
+                │ equality cols are key
+                │
+                └── • render
+                    │ columns: ("lookup_join_const_col_@12", column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+                    │ estimated row count: 0 (missing stats)
+                    │ render lookup_join_const_col_@12: 'ap-southeast-2'
+                    │ render column1: column1
+                    │ render crdb_region_default: crdb_region_default
+                    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+                    │
+                    └── • lookup join (anti)
+                        │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+                        │ estimated row count: 0 (missing stats)
+                        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                        │ equality cols are key
+                        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                        │
+                        └── • lookup join (anti)
+                            │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+                            │ estimated row count: 2 (missing stats)
+                            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                            │ equality cols are key
+                            │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                            │
+                            └── • render
+                                │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+                                │ estimated row count: 2
+                                │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+                                │ render crdb_region_default: 'ap-southeast-2'
+                                │ render column1: column1
+                                │
+                                └── • values
+                                      columns: (column1)
+                                      size: 1 column, 2 rows
+                                      row 0, expr 0: 4321
+                                      row 1, expr 0: 8765
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • cross join (anti)
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │
+        ├── • values
+        │     columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+        │     size: 3 columns, 1 row
+        │     row 0, expr 0: 4321
+        │     row 0, expr 1: 'ap-southeast-2'
+        │     row 0, expr 2: 9
+        │
+        └── • union all
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
+            │ limit: 1
+            │
+            ├── • scan
+            │     columns: (id)
+            │     estimated row count: 1 (missing stats)
+            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │     spans: /"@"/9/4321/0
+            │
+            └── • scan
+                  columns: (id)
+                  estimated row count: 1 (missing stats)
+                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                  spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
+                  parallel
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │
+    └── • lookup join (anti)
+        │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+        │ estimated row count: 0 (missing stats)
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+            │ estimated row count: 2 (missing stats)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • render
+                │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+                │ estimated row count: 2
+                │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+                │ render crdb_region_default: 'ap-southeast-2'
+                │ render column1: column1
+                │
+                └── • values
+                      columns: (column1)
+                      size: 1 column, 2 rows
+                      row 0, expr 0: 4321
+                      row 1, expr 0: 8765
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO UPDATE SET id = excluded.id
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│   │ arbiter constraints: t_unique_hash_pk_pkey
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, column1, crdb_region, check1, check2, upsert_crdb_region)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, column1, crdb_region, check1, check2, upsert_crdb_region)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, crdb_region_default, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, crdb_region, upsert_crdb_region)
+│               │ estimated row count: 1 (missing stats)
+│               │ render check1: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render column1: column1
+│               │ render crdb_region_default: crdb_region_default
+│               │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│               │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│               │ render id: id
+│               │ render crdb_region: crdb_region
+│               │ render upsert_crdb_region: upsert_crdb_region
+│               │
+│               └── • render
+│                   │ columns: (upsert_crdb_region, column1, crdb_region_default, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, crdb_region)
+│                   │ estimated row count: 1 (missing stats)
+│                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
+│                   │ render column1: column1
+│                   │ render crdb_region_default: crdb_region_default
+│                   │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│                   │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│                   │ render id: id
+│                   │ render crdb_region: crdb_region
+│                   │
+│                   └── • cross join (left outer)
+│                       │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, crdb_region)
+│                       │ estimated row count: 1 (missing stats)
+│                       │
+│                       ├── • values
+│                       │     columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+│                       │     size: 3 columns, 1 row
+│                       │     row 0, expr 0: 4321
+│                       │     row 0, expr 1: 'ap-southeast-2'
+│                       │     row 0, expr 2: 9
+│                       │
+│                       └── • union all
+│                           │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+│                           │ estimated row count: 1 (missing stats)
+│                           │ limit: 1
+│                           │
+│                           ├── • scan
+│                           │     columns: (crdb_internal_id_shard_16, id, crdb_region)
+│                           │     estimated row count: 1 (missing stats)
+│                           │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                           │     spans: /"@"/9/4321/0
+│                           │
+│                           └── • scan
+│                                 columns: (crdb_internal_id_shard_16, id, crdb_region)
+│                                 estimated row count: 1 (missing stats)
+│                                 table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                                 spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
+│                                 parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_crdb_region)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (upsert_crdb_region != crdb_region)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, column1, crdb_region, check1, check2, upsert_crdb_region)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765) ON CONFLICT (id) DO UPDATE SET id = excluded.id
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│   │ arbiter constraints: t_unique_hash_pk_pkey
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, column1, crdb_region, check1, check2, upsert_crdb_region)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, column1, crdb_region, check1, check2, upsert_crdb_region)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, crdb_region_default, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, crdb_region, upsert_crdb_region)
+│               │ estimated row count: 2 (missing stats)
+│               │ render check1: crdb_internal_id_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render column1: column1
+│               │ render crdb_region_default: crdb_region_default
+│               │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│               │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│               │ render id: id
+│               │ render crdb_region: crdb_region
+│               │ render upsert_crdb_region: upsert_crdb_region
+│               │
+│               └── • render
+│                   │ columns: (upsert_crdb_region, column1, crdb_region_default, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, crdb_region)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
+│                   │ render column1: column1
+│                   │ render crdb_region_default: crdb_region_default
+│                   │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+│                   │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│                   │ render id: id
+│                   │ render crdb_region: crdb_region
+│                   │
+│                   └── • lookup join (left outer)
+│                       │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+│                       │ estimated row count: 2 (missing stats)
+│                       │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                       │ equality cols are key
+│                       │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                       │ remote lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                       │ locking strength: for update
+│                       │
+│                       └── • render
+│                           │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+│                           │ estimated row count: 2
+│                           │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+│                           │ render crdb_region_default: 'ap-southeast-2'
+│                           │ render column1: column1
+│                           │
+│                           └── • values
+│                                 columns: (column1)
+│                                 size: 1 column, 2 rows
+│                                 row 0, expr 0: 4321
+│                                 row 1, expr 0: 8765
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_crdb_region)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (upsert_crdb_region != crdb_region)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, column1, upsert_crdb_region)
+                    │ estimated row count: 2 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, column1, crdb_region, check1, check2, upsert_crdb_region)
+                          label: buffer 1
+
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id) VALUES (4321);
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_region, check1, check2)
+    │ estimated row count: 1 (missing stats)
+    │ render check1: CASE WHEN crdb_region IS NULL THEN crdb_internal_id_shard_16_cast ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │ render crdb_region: crdb_region
+    │
+    └── • cross join (left outer)
+        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast, crdb_internal_id_shard_16, id, crdb_region)
+        │ estimated row count: 1 (missing stats)
+        │
+        ├── • values
+        │     columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+        │     size: 3 columns, 1 row
+        │     row 0, expr 0: 4321
+        │     row 0, expr 1: 'ap-southeast-2'
+        │     row 0, expr 2: 9
+        │
+        └── • union all
+            │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+            │ estimated row count: 1 (missing stats)
+            │ limit: 1
+            │
+            ├── • scan
+            │     columns: (crdb_internal_id_shard_16, id, crdb_region)
+            │     estimated row count: 1 (missing stats)
+            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │     spans: /"@"/9/4321/0
+            │
+            └── • scan
+                  columns: (crdb_internal_id_shard_16, id, crdb_region)
+                  estimated row count: 1 (missing stats)
+                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                  spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
+                  parallel
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_pk (id) VALUES (4321), (8765);
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
+│ auto commit
+│ arbiter constraints: t_unique_hash_pk_pkey
+│
+└── • render
+    │ columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, crdb_region, check1, check2)
+    │ estimated row count: 2 (missing stats)
+    │ render check1: CASE WHEN crdb_region IS NULL THEN crdb_internal_id_shard_16_cast ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
+    │ render crdb_region: crdb_region
+    │
+    └── • lookup join (left outer)
+        │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+        │ estimated row count: 2 (missing stats)
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │ remote lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+        │ locking strength: for update
+        │
+        └── • render
+            │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+            │ estimated row count: 2
+            │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+            │ render crdb_region_default: 'ap-southeast-2'
+            │ render column1: column1
+            │
+            └── • values
+                  columns: (column1)
+                  size: 1 column, 2 rows
+                  row 0, expr 0: 4321
+                  row 1, expr 0: 8765
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPDATE t_unique_hash_pk SET id = 1234 WHERE id = 4321;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: t_unique_hash_pk
+│   │ set: crdb_internal_id_shard_16, id
+│   │
+│   └── • buffer
+│       │ columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, id_new, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, id_new, check1)
+│           │ estimated row count: 1 (missing stats)
+│           │ render check1: true
+│           │ render crdb_internal_id_shard_16_cast: 6
+│           │ render id_new: 1234
+│           │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16
+│           │ render id: id
+│           │ render crdb_region: crdb_region
+│           │
+│           └── • union all
+│               │ columns: (crdb_internal_id_shard_16, id, crdb_region)
+│               │ estimated row count: 1 (missing stats)
+│               │ limit: 1
+│               │
+│               ├── • scan
+│               │     columns: (crdb_internal_id_shard_16, id, crdb_region)
+│               │     estimated row count: 1 (missing stats)
+│               │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│               │     spans: /"@"/9/4321/0
+│               │
+│               └── • scan
+│                     columns: (crdb_internal_id_shard_16, id, crdb_region)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+│                     spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
+│                     parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (id_new)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (crdb_internal_id_shard_16_cast, id_new, crdb_region)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+                │ lookup condition: ((id_new = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (crdb_internal_id_shard_16_cast != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
+                │
+                └── • project
+                    │ columns: (crdb_internal_id_shard_16_cast, id_new, crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_cast, id_new, check1)
+                          label: buffer 1
+
+subtest test_uniqueness_check_sec_key
+
+statement ok
+CREATE TABLE t_unique_hash_sec_key (
+  id INT PRIMARY KEY,
+  email STRING,
+  FAMILY fam_0 (id, email)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE UNIQUE INDEX idx_uniq_hash_email ON t_unique_hash_sec_key (email) USING HASH;
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│             size: 6 columns, 1 row
+│             row 0, expr 0: 4321
+│             row 0, expr 1: 'some_email'
+│             row 0, expr 2: 'ap-southeast-2'
+│             row 0, expr 3: 13
+│             row 0, expr 4: true
+│             row 0, expr 5: true
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (column1)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (column1, crdb_region_default)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│               │ pred: crdb_region_default != crdb_region
+│               │
+│               └── • project
+│                   │ columns: (column1, crdb_region_default)
+│                   │ estimated row count: 1
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (column1, column2, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (column1 != id) OR (crdb_region_default != crdb_region)
+                │
+                └── • project
+                    │ columns: (column1, column2, crdb_region_default)
+                    │ estimated row count: 1
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+                          label: buffer 1
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│ auto commit
+│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│
+└── • render
+    │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render column2: column2
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+    │
+    └── • cross join (right anti)
+        │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+        │ estimated row count: 0 (missing stats)
+        │
+        ├── • project
+        │   │ columns: ()
+        │   │ estimated row count: 1 (missing stats)
+        │   │
+        │   └── • scan
+        │         columns: (id, crdb_region)
+        │         estimated row count: 1 (missing stats)
+        │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+        │         spans: /"@"/4321/0
+        │
+        └── • lookup join (anti)
+            │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+            │ equality cols are key
+            │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+            │
+            └── • lookup join (anti)
+                │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ equality cols are key
+                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │
+                └── • hash join (right anti)
+                    │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+                    │ estimated row count: 0 (missing stats)
+                    │ equality: (email, crdb_region, crdb_internal_email_shard_16) = (column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+                    │ right cols are key
+                    │
+                    ├── • render
+                    │   │ columns: (crdb_internal_email_shard_16, email, crdb_region)
+                    │   │ estimated row count: 1,000 (missing stats)
+                    │   │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+                    │   │ render email: email
+                    │   │ render crdb_region: crdb_region
+                    │   │
+                    │   └── • scan
+                    │         columns: (email, crdb_region)
+                    │         estimated row count: 1,000 (missing stats)
+                    │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                    │         spans: FULL SCAN
+                    │
+                    └── • values
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+                          size: 4 columns, 1 row
+                          row 0, expr 0: 4321
+                          row 0, expr 1: 'some_email'
+                          row 0, expr 2: 'ap-southeast-2'
+                          row 0, expr 3: 13
+
+# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
+# using the original hash sharded index as an arbiter is not necessary.
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│ auto commit
+│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
+│
+└── • render
+    │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+    │ estimated row count: 0 (missing stats)
+    │ render check1: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+    │ render column1: column1
+    │ render column2: column2
+    │ render crdb_region_default: crdb_region_default
+    │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+    │
+    └── • distinct
+        │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+        │ estimated row count: 0 (missing stats)
+        │ distinct on: crdb_internal_email_shard_16_cast, column2
+        │ nulls are distinct
+        │
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ equality cols are key
+            │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │
+            └── • lookup join (anti)
+                │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ equality cols are key
+                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │
+                └── • lookup join (anti)
+                    │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                    │ equality: (crdb_region_default, crdb_internal_email_shard_16_cast, column2) = (crdb_region,crdb_internal_email_shard_16,email)
+                    │ equality cols are key
+                    │
+                    └── • hash join (right anti)
+                        │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+                        │ estimated row count: 0 (missing stats)
+                        │ equality: (id) = (column1)
+                        │ left cols are key
+                        │
+                        ├── • project
+                        │   │ columns: (id)
+                        │   │ estimated row count: 333 (missing stats)
+                        │   │
+                        │   └── • scan
+                        │         columns: (id, crdb_region)
+                        │         estimated row count: 333 (missing stats)
+                        │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                        │         spans: /"@"-/"@"/PrefixEnd
+                        │
+                        └── • render
+                            │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+                            │ estimated row count: 2
+                            │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+                            │ render crdb_region_default: 'ap-southeast-2'
+                            │ render column1: column1
+                            │ render column2: column2
+                            │
+                            └── • values
+                                  columns: (column1, column2)
+                                  size: 2 columns, 2 rows
+                                  row 0, expr 0: 4321
+                                  row 0, expr 1: 'some_email'
+                                  row 1, expr 0: 8765
+                                  row 1, expr 1: 'another_email'
+
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│           │ estimated row count: 0 (missing stats)
+│           │ render check1: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│           │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render crdb_region_default: crdb_region_default
+│           │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│           │
+│           └── • cross join (anti)
+│               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+│               │ estimated row count: 0 (missing stats)
+│               │
+│               ├── • values
+│               │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+│               │     size: 4 columns, 1 row
+│               │     row 0, expr 0: 4321
+│               │     row 0, expr 1: 'some_email'
+│               │     row 0, expr 2: 'ap-southeast-2'
+│               │     row 0, expr 3: 13
+│               │
+│               └── • project
+│                   │ columns: ()
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   └── • union all
+│                       │ columns: (email)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ limit: 1
+│                       │
+│                       ├── • scan
+│                       │     columns: (email)
+│                       │     estimated row count: 1 (missing stats)
+│                       │     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                       │     spans: /"@"/13/"some_email"/0
+│                       │
+│                       └── • scan
+│                             columns: (email)
+│                             estimated row count: 1 (missing stats)
+│                             table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                             spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
+│                             parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (column1, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │ pred: crdb_region_default != crdb_region
+                │
+                └── • project
+                    │ columns: (column1, crdb_region_default)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO NOTHING;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+│           │ estimated row count: 0 (missing stats)
+│           │ render check1: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│           │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render crdb_region_default: crdb_region_default
+│           │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│           │
+│           └── • lookup join (anti)
+│               │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│               │ equality cols are key
+│               │ lookup condition: ((column2 = email) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│               │
+│               └── • lookup join (anti)
+│                   │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                   │ equality cols are key
+│                   │ lookup condition: ((column2 = email) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                   │
+│                   └── • render
+│                       │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+│                       │ estimated row count: 2
+│                       │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+│                       │ render crdb_region_default: 'ap-southeast-2'
+│                       │ render column1: column1
+│                       │ render column2: column2
+│                       │
+│                       └── • values
+│                             columns: (column1, column2)
+│                             size: 2 columns, 2 rows
+│                             row 0, expr 0: 4321
+│                             row 0, expr 1: 'some_email'
+│                             row 1, expr 0: 8765
+│                             row 1, expr 1: 'another_email'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column1)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (column1, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │ pred: crdb_region_default != crdb_region
+                │
+                └── • project
+                    │ columns: (column1, crdb_region_default)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16)
+│               │ estimated row count: 1 (missing stats)
+│               │ render check1: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_region_default: crdb_region_default
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render crdb_region: crdb_region
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │ render upsert_id: upsert_id
+│               │ render upsert_email: upsert_email
+│               │ render upsert_crdb_region: upsert_crdb_region
+│               │ render upsert_crdb_internal_email_shard_16: upsert_crdb_internal_email_shard_16
+│               │
+│               └── • render
+│                   │ columns: (upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16)
+│                   │ estimated row count: 1 (missing stats)
+│                   │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
+│                   │ render upsert_email: CASE WHEN crdb_region IS NULL THEN column2 ELSE 'bad_email' END
+│                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
+│                   │ render upsert_crdb_internal_email_shard_16: CASE WHEN crdb_region IS NULL THEN crdb_internal_email_shard_16_cast ELSE 6 END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render crdb_region_default: crdb_region_default
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                   │ render id: id
+│                   │ render email: email
+│                   │ render crdb_region: crdb_region
+│                   │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│                   │
+│                   └── • cross join (left outer)
+│                       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_internal_email_shard_16, id, email, crdb_region)
+│                       │ estimated row count: 1 (missing stats)
+│                       │
+│                       ├── • values
+│                       │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+│                       │     size: 4 columns, 1 row
+│                       │     row 0, expr 0: 4321
+│                       │     row 0, expr 1: 'some_email'
+│                       │     row 0, expr 2: 'ap-southeast-2'
+│                       │     row 0, expr 3: 13
+│                       │
+│                       └── • render
+│                           │ columns: (crdb_internal_email_shard_16, id, email, crdb_region)
+│                           │ estimated row count: 1 (missing stats)
+│                           │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+│                           │ render id: id
+│                           │ render email: email
+│                           │ render crdb_region: crdb_region
+│                           │
+│                           └── • union all
+│                               │ columns: (id, email, crdb_region)
+│                               │ estimated row count: 1 (missing stats)
+│                               │ limit: 1
+│                               │
+│                               ├── • scan
+│                               │     columns: (id, email, crdb_region)
+│                               │     estimated row count: 1 (missing stats)
+│                               │     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                               │     spans: /"@"/13/"some_email"/0
+│                               │
+│                               └── • scan
+│                                     columns: (id, email, crdb_region)
+│                                     estimated row count: 1 (missing stats)
+│                                     table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                                     spans: /"\x80"/13/"some_email"/0 /"\xc0"/13/"some_email"/0
+│                                     parallel
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (upsert_id)
+│           │ estimated row count: 0 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (upsert_id, upsert_crdb_region)
+│               │ estimated row count: 0 (missing stats)
+│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │ lookup condition: (upsert_id = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│               │ pred: upsert_crdb_region != crdb_region
+│               │
+│               └── • project
+│                   │ columns: (upsert_id, upsert_crdb_region)
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (upsert_email)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((upsert_email = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (upsert_crdb_region != crdb_region)
+                │
+                └── • project
+                    │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email'), (8765, 'another_email') ON CONFLICT (email) DO UPDATE SET email = 'bad_email';
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │ arbiter constraints: idx_uniq_hash_email
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16)
+│               │ estimated row count: 2 (missing stats)
+│               │ render check1: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_region_default: crdb_region_default
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render crdb_region: crdb_region
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │ render upsert_id: upsert_id
+│               │ render upsert_email: upsert_email
+│               │ render upsert_crdb_region: upsert_crdb_region
+│               │ render upsert_crdb_internal_email_shard_16: upsert_crdb_internal_email_shard_16
+│               │
+│               └── • render
+│                   │ columns: (upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
+│                   │ render upsert_email: CASE WHEN crdb_region IS NULL THEN column2 ELSE 'bad_email' END
+│                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
+│                   │ render upsert_crdb_internal_email_shard_16: CASE WHEN crdb_region IS NULL THEN crdb_internal_email_shard_16_cast ELSE 6 END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render crdb_region_default: crdb_region_default
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                   │ render id: id
+│                   │ render email: email
+│                   │ render crdb_region: crdb_region
+│                   │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│                   │
+│                   └── • render
+│                       │ columns: (crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region)
+│                       │ estimated row count: 2 (missing stats)
+│                       │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
+│                       │ render column1: column1
+│                       │ render column2: column2
+│                       │ render crdb_region_default: crdb_region_default
+│                       │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                       │ render id: id
+│                       │ render email: email
+│                       │ render crdb_region: crdb_region
+│                       │
+│                       └── • project
+│                           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region)
+│                           │ estimated row count: 2 (missing stats)
+│                           │
+│                           └── • lookup join (left outer)
+│                               │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2, id, email, crdb_region, crdb_internal_email_shard_16)
+│                               │ estimated row count: 2 (missing stats)
+│                               │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+│                               │ equality cols are key
+│                               │ lookup condition: ((column2 = email) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                               │ remote lookup condition: ((column2 = email) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+│                               │ locking strength: for update
+│                               │
+│                               └── • render
+│                                   │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+│                                   │ estimated row count: 2
+│                                   │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+│                                   │ render crdb_region_default: 'ap-southeast-2'
+│                                   │ render column1: column1
+│                                   │ render column2: column2
+│                                   │
+│                                   └── • values
+│                                         columns: (column1, column2)
+│                                         size: 2 columns, 2 rows
+│                                         row 0, expr 0: 4321
+│                                         row 0, expr 1: 'some_email'
+│                                         row 1, expr 0: 8765
+│                                         row 1, expr 1: 'another_email'
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │ columns: ()
+│       │
+│       └── • project
+│           │ columns: (upsert_id)
+│           │ estimated row count: 1 (missing stats)
+│           │
+│           └── • lookup join (semi)
+│               │ columns: (upsert_id, upsert_crdb_region)
+│               │ estimated row count: 1 (missing stats)
+│               │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │ lookup condition: (upsert_id = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+│               │ pred: upsert_crdb_region != crdb_region
+│               │
+│               └── • project
+│                   │ columns: (upsert_id, upsert_crdb_region)
+│                   │ estimated row count: 2 (missing stats)
+│                   │
+│                   └── • scan buffer
+│                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│                         label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (upsert_email)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((upsert_email = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (upsert_crdb_region != crdb_region)
+                │
+                └── • project
+                    │ columns: (upsert_id, upsert_email, upsert_crdb_region)
+                    │ estimated row count: 2 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │ arbiter constraints: t_unique_hash_sec_key_pkey
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_region, check1, check2, upsert_id)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_region, check1, check2, upsert_id)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, upsert_id, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16)
+│               │ estimated row count: 1 (missing stats)
+│               │ render check1: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_region_default: crdb_region_default
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render crdb_region: crdb_region
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │
+│               └── • cross join (left outer)
+│                   │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_internal_email_shard_16, id, email, crdb_region)
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   ├── • values
+│                   │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+│                   │     size: 4 columns, 1 row
+│                   │     row 0, expr 0: 1
+│                   │     row 0, expr 1: 'email1'
+│                   │     row 0, expr 2: 'ap-southeast-2'
+│                   │     row 0, expr 3: 5
+│                   │
+│                   └── • render
+│                       │ columns: (crdb_internal_email_shard_16, id, email, crdb_region)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+│                       │ render id: id
+│                       │ render email: email
+│                       │ render crdb_region: crdb_region
+│                       │
+│                       └── • union all
+│                           │ columns: (id, email, crdb_region)
+│                           │ estimated row count: 1 (missing stats)
+│                           │ limit: 1
+│                           │
+│                           ├── • scan
+│                           │     columns: (id, email, crdb_region)
+│                           │     estimated row count: 1 (missing stats)
+│                           │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                           │     spans: /"@"/1/0
+│                           │
+│                           └── • scan
+│                                 columns: (id, email, crdb_region)
+│                                 estimated row count: 1 (missing stats)
+│                                 table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                                 spans: /"\x80"/1/0 /"\xc0"/1/0
+│                                 parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, column2, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (crdb_region_default != crdb_region)
+                │
+                └── • project
+                    │ columns: (upsert_id, column2, crdb_region_default)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_region, check1, check2, upsert_id)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO t_unique_hash_sec_key VALUES (1, 'email1'), (8765, 'email2');
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
+│   │ arbiter constraints: t_unique_hash_sec_key_pkey
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_region, check1, check2, upsert_id)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_region, check1, check2, upsert_id)
+│           │
+│           └── • render
+│               │ columns: (check1, check2, upsert_id, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16)
+│               │ estimated row count: 2 (missing stats)
+│               │ render check1: crdb_internal_email_shard_16_cast IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+│               │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_region_default: crdb_region_default
+│               │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│               │ render id: id
+│               │ render email: email
+│               │ render crdb_region: crdb_region
+│               │ render crdb_internal_email_shard_16: crdb_internal_email_shard_16
+│               │
+│               └── • render
+│                   │ columns: (crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region)
+│                   │ estimated row count: 2 (missing stats)
+│                   │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
+│                   │ render column1: column1
+│                   │ render column2: column2
+│                   │ render crdb_region_default: crdb_region_default
+│                   │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
+│                   │ render id: id
+│                   │ render email: email
+│                   │ render crdb_region: crdb_region
+│                   │
+│                   └── • lookup join (left outer)
+│                       │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2, id, email, crdb_region)
+│                       │ estimated row count: 2 (missing stats)
+│                       │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                       │ equality cols are key
+│                       │ lookup condition: (column1 = id) AND (crdb_region = 'ap-southeast-2')
+│                       │ remote lookup condition: (column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))
+│                       │ locking strength: for update
+│                       │
+│                       └── • render
+│                           │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
+│                           │ estimated row count: 2
+│                           │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+│                           │ render crdb_region_default: 'ap-southeast-2'
+│                           │ render column1: column1
+│                           │ render column2: column2
+│                           │
+│                           └── • values
+│                                 columns: (column1, column2)
+│                                 size: 2 columns, 2 rows
+│                                 row 0, expr 0: 1
+│                                 row 0, expr 1: 'email1'
+│                                 row 1, expr 0: 8765
+│                                 row 1, expr 1: 'email2'
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (column2)
+            │ estimated row count: 1 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (upsert_id, column2, crdb_region_default)
+                │ estimated row count: 1 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (upsert_id != id) OR (crdb_region_default != crdb_region)
+                │
+                └── • project
+                    │ columns: (upsert_id, column2, crdb_region_default)
+                    │ estimated row count: 2 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_cast, crdb_region, check1, check2, upsert_id)
+                          label: buffer 1
+
+# TODO (mgartner): there is a lookup join with lookup condition checking every
+# single shard. This is unnecessary and could be improved by having the shard
+# number calculated instead of looking at all possible shards.
+query T
+EXPLAIN (VERBOSE) UPDATE t_unique_hash_sec_key SET email = 'email1' WHERE id = 2;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: t_unique_hash_sec_key
+│   │ set: email, crdb_internal_email_shard_16
+│   │
+│   └── • buffer
+│       │ columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_cast, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_cast, check1)
+│           │ estimated row count: 1 (missing stats)
+│           │ render check1: true
+│           │ render crdb_internal_email_shard_16_cast: 5
+│           │ render email_new: 'email1'
+│           │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
+│           │ render id: id
+│           │ render email: email
+│           │ render crdb_region: crdb_region
+│           │
+│           └── • union all
+│               │ columns: (id, email, crdb_region)
+│               │ estimated row count: 1 (missing stats)
+│               │ limit: 1
+│               │
+│               ├── • scan
+│               │     columns: (id, email, crdb_region)
+│               │     estimated row count: 1 (missing stats)
+│               │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│               │     spans: /"@"/2/0
+│               │
+│               └── • scan
+│                     columns: (id, email, crdb_region)
+│                     estimated row count: 1 (missing stats)
+│                     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+│                     spans: /"\x80"/2/0 /"\xc0"/2/0
+│                     parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • project
+            │ columns: (email_new)
+            │ estimated row count: 0 (missing stats)
+            │
+            └── • lookup join (semi)
+                │ columns: (id, email_new, crdb_region)
+                │ estimated row count: 0 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+                │ lookup condition: ((email_new = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ pred: (id != id) OR (crdb_region != crdb_region)
+                │
+                └── • project
+                    │ columns: (id, email_new, crdb_region)
+                    │ estimated row count: 1 (missing stats)
+                    │
+                    └── • scan buffer
+                          columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_cast, check1)
+                          label: buffer 1

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -85,6 +85,12 @@ func (n *alterIndexNode) startExec(params runParams) error {
 					"cannot ALTER INDEX PARTITION BY on an index which already has implicit column partitioning",
 				)
 			}
+			if n.index.IsSharded() {
+				return pgerror.Newf(
+					pgcode.FeatureNotSupported,
+					"cannot set explicit partitioning with ALTER INDEX PARTITION BY on a hash sharded index",
+				)
+			}
 			allowImplicitPartitioning := params.p.EvalContext().SessionData().ImplicitColumnPartitioningEnabled ||
 				n.tableDesc.IsLocalityRegionalByRow()
 			alteredIndexDesc := n.index.IndexDescDeepCopy()

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -86,9 +86,6 @@ func (p *planner) AlterPrimaryKey(
 		if !p.EvalContext().SessionData().HashShardedIndexesEnabled {
 			return hashShardedIndexesDisabledError
 		}
-		if tableDesc.IsLocalityRegionalByRow() {
-			return pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes are not compatible with REGIONAL BY ROW tables")
-		}
 	}
 
 	// Ensure that other schema changes on this table are not currently

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -647,6 +647,12 @@ func (n *alterTableNode) startExec(params runParams) error {
 			if n.tableDesc.IsPartitionAllBy() {
 				return unimplemented.NewWithIssue(58736, "changing partition of table with PARTITION ALL BY not yet implemented")
 			}
+			if n.tableDesc.GetPrimaryIndex().IsSharded() {
+				return pgerror.New(
+					pgcode.FeatureNotSupported,
+					"cannot set explicit partitioning with PARTITION BY on hash sharded primary key",
+				)
+			}
 			oldPartitioning := n.tableDesc.GetPrimaryIndex().GetPartitioning().DeepCopy()
 			if oldPartitioning.NumImplicitColumns() > 0 {
 				return unimplemented.NewWithIssue(

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -31,10 +31,11 @@ func (desc *IndexDescriptor) IsPartial() bool {
 // ExplicitColumnStartIdx returns the start index of any explicit columns.
 func (desc *IndexDescriptor) ExplicitColumnStartIdx() int {
 	start := int(desc.Partitioning.NumImplicitColumns)
-	// We do not currently handle implicit columns along with hash sharded indexes.
-	// Thus, safe to override this to 1.
+	// Currently, we only allow implicit partitioning on hash sharded index. When
+	// that happens, the shard column always comes after implicit partition
+	// columns.
 	if desc.IsSharded() {
-		start = 1
+		start++
 	}
 	return start
 }

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1174,9 +1174,9 @@ message TableDescriptor {
 
   optional cockroach.sql.catalog.catpb.LocalityConfig locality_config = 42;
 
-  // PartitionAllBy is set if PARTITION ALL BY is set on the table.
-  // This means that all indexes implicitly inherit all partitioning
-  // from the PARTITION ALL BY clause.
+  // PartitionAllBy is set if PARTITION ALL BY or LOCALITY REGIONAL BY ROW is
+  // set on the table. This means that all indexes implicitly inherit all
+  // partitioning from the PARTITION ALL BY clause or region configuration.
   optional bool partition_all_by = 44 [(gogoproto.nullable)=false];
 
   // RowLevelTTL is set if there is a TTL set on the table.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1249,6 +1249,10 @@ func NewTableDescOptionBypassLocalityOnNonMultiRegionDatabaseCheck() NewTableDes
 // semaCtx can be nil if the table to be created has no default expression on
 // any of the columns and no check constraints.
 //
+// regionConfig indicates if the table is being created in a multi-region db.
+// A non-nil regionConfig represents the region configuration of a multi-region
+// db. A nil regionConfig means current db is not multi-regional.
+//
 // The caller must also ensure that the SchemaResolver is configured
 // to bypass caching and enable visibility of just-added descriptors.
 // This is used to resolve sequence and FK dependencies. Also see the
@@ -1320,6 +1324,7 @@ func NewTableDesc(
 		)
 	}
 
+	// PARTITION BY and PARTITION ALL BY are not supported in multi-regional table.
 	if n.Locality != nil || regionConfig != nil {
 		// Check PARTITION BY is not set on any column, index or table definition.
 		if n.PartitionByTable.ContainsPartitioningClause() {
@@ -1532,11 +1537,8 @@ func NewTableDesc(
 				if !sessionData.HashShardedIndexesEnabled {
 					return nil, hashShardedIndexesDisabledError
 				}
-				if isRegionalByRow {
-					return nil, hashShardedIndexesOnRegionalByRowError()
-				}
-				if n.PartitionByTable.ContainsPartitions() {
-					return nil, pgerror.New(pgcode.FeatureNotSupported, "sharded indexes don't support partitioning")
+				if n.PartitionByTable.ContainsPartitions() && !n.PartitionByTable.All {
+					return nil, pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes cannot be explicitly partitioned")
 				}
 				buckets, err := tabledesc.EvalShardBucketCount(ctx, semaCtx, evalCtx, d.PrimaryKey.ShardBuckets, d.PrimaryKey.StorageParams)
 				if err != nil {
@@ -1651,8 +1653,14 @@ func NewTableDesc(
 	setupShardedIndexForNewTable := func(
 		d tree.IndexTableDef, idx *descpb.IndexDescriptor,
 	) (columns tree.IndexElemList, _ error) {
-		if n.PartitionByTable.ContainsPartitions() {
-			return nil, pgerror.New(pgcode.FeatureNotSupported, "sharded indexes don't support partitioning")
+		if d.PartitionByIndex.ContainsPartitions() {
+			return nil, pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes cannot be explicitly partitioned")
+		}
+		if desc.IsPartitionAllBy() && anyColumnIsPartitioningField(d.Columns, partitionAllBy) {
+			return nil, pgerror.New(
+				pgcode.FeatureNotSupported,
+				`hash sharded indexes cannot include implicit partitioning columns from "PARTITION ALL BY" or "LOCALITY REGIONAL BY ROW"`,
+			)
 		}
 		shardCol, newColumns, err := setupShardedIndex(
 			ctx,
@@ -1765,9 +1773,6 @@ func NewTableDesc(
 			}
 			columns := d.Columns
 			if d.Sharded != nil {
-				if isRegionalByRow {
-					return nil, hashShardedIndexesOnRegionalByRowError()
-				}
 				var err error
 				columns, err = setupShardedIndexForNewTable(*d, &idx)
 				if err != nil {
@@ -1793,37 +1798,37 @@ func NewTableDesc(
 					idx.GeoConfig = *geoindex.DefaultGeographyIndexConfig()
 				}
 			}
-			if d.PartitionByIndex.ContainsPartitioningClause() || desc.PartitionAllBy {
-				partitionBy := partitionAllBy
-				if !desc.PartitionAllBy {
-					if d.PartitionByIndex.ContainsPartitions() {
-						partitionBy = d.PartitionByIndex.PartitionBy
-					}
-				} else if d.PartitionByIndex.ContainsPartitioningClause() {
-					return nil, pgerror.New(
-						pgcode.FeatureNotSupported,
-						"cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition",
-					)
-				}
 
-				if partitionBy != nil {
-					var err error
-					newImplicitCols, newPartitioning, err := CreatePartitioning(
-						ctx,
-						st,
-						evalCtx,
-						&desc,
-						idx,
-						partitionBy,
-						nil, /* allowedNewColumnNames */
-						allowImplicitPartitioning,
-					)
-					if err != nil {
-						return nil, err
-					}
-					tabledesc.UpdateIndexPartitioning(&idx, false /* isIndexPrimary */, newImplicitCols, newPartitioning)
-				}
+			var idxPartitionBy *tree.PartitionBy
+			if desc.PartitionAllBy && d.PartitionByIndex.ContainsPartitions() {
+				return nil, pgerror.New(
+					pgcode.FeatureNotSupported,
+					"cannot define PARTITION BY on an index if the table is implicitly partitioned with PARTITION ALL BY or LOCALITY REGIONAL BY ROW definition",
+				)
 			}
+			if desc.PartitionAllBy {
+				idxPartitionBy = partitionAllBy
+			} else if d.PartitionByIndex.ContainsPartitions() {
+				idxPartitionBy = d.PartitionByIndex.PartitionBy
+			}
+			if idxPartitionBy != nil {
+				var err error
+				newImplicitCols, newPartitioning, err := CreatePartitioning(
+					ctx,
+					st,
+					evalCtx,
+					&desc,
+					idx,
+					idxPartitionBy,
+					nil, /* allowedNewColumnNames */
+					allowImplicitPartitioning,
+				)
+				if err != nil {
+					return nil, err
+				}
+				tabledesc.UpdateIndexPartitioning(&idx, false /* isIndexPrimary */, newImplicitCols, newPartitioning)
+			}
+
 			if d.Predicate != nil {
 				expr, err := schemaexpr.ValidatePartialIndexPredicate(
 					ctx, &desc, d.Predicate, &n.Table, semaCtx,
@@ -1883,8 +1888,11 @@ func NewTableDesc(
 			}
 			columns := d.Columns
 			if d.Sharded != nil {
-				if isRegionalByRow {
-					return nil, hashShardedIndexesOnRegionalByRowError()
+				if d.PrimaryKey && n.PartitionByTable.ContainsPartitions() && !n.PartitionByTable.All {
+					return nil, pgerror.New(
+						pgcode.FeatureNotSupported,
+						"hash sharded indexes cannot be explicitly partitioned",
+					)
 				}
 				var err error
 				columns, err = setupShardedIndexForNewTable(d.IndexTableDef, &idx)
@@ -1905,20 +1913,21 @@ func NewTableDesc(
 			// We should only do partitioning of non-primary indexes at this point -
 			// the PRIMARY KEY CreatePartitioning is done at the of CreateTable, so
 			// avoid the duplicate work.
-			if !d.PrimaryKey && (d.PartitionByIndex.ContainsPartitioningClause() || desc.PartitionAllBy) {
-				partitionBy := partitionAllBy
-				if !desc.PartitionAllBy {
-					if d.PartitionByIndex.ContainsPartitions() {
-						partitionBy = d.PartitionByIndex.PartitionBy
-					}
-				} else if d.PartitionByIndex.ContainsPartitioningClause() {
+			if !d.PrimaryKey {
+				if desc.PartitionAllBy && d.PartitionByIndex.ContainsPartitions() {
 					return nil, pgerror.New(
 						pgcode.FeatureNotSupported,
-						"cannot define PARTITION BY on an unique constraint if the table has a PARTITION ALL BY definition",
+						"cannot define PARTITION BY on an unique constraint if the table is implicitly partitioned with PARTITION ALL BY or LOCALITY REGIONAL BY ROW definition",
 					)
 				}
+				var idxPartitionBy *tree.PartitionBy
+				if desc.PartitionAllBy {
+					idxPartitionBy = partitionAllBy
+				} else if d.PartitionByIndex.ContainsPartitions() {
+					idxPartitionBy = d.PartitionByIndex.PartitionBy
+				}
 
-				if partitionBy != nil {
+				if idxPartitionBy != nil {
 					var err error
 					newImplicitCols, newPartitioning, err := CreatePartitioning(
 						ctx,
@@ -1926,7 +1935,7 @@ func NewTableDesc(
 						evalCtx,
 						&desc,
 						idx,
-						partitionBy,
+						idxPartitionBy,
 						nil, /* allowedNewColumnNames */
 						allowImplicitPartitioning,
 					)
@@ -2761,10 +2770,6 @@ func regionalByRowDefaultColDef(
 	c.OnUpdateExpr.Expr = onUpdateExpr
 
 	return c
-}
-
-func hashShardedIndexesOnRegionalByRowError() error {
-	return pgerror.New(pgcode.FeatureNotSupported, "hash sharded indexes are not compatible with REGIONAL BY ROW tables")
 }
 
 func checkTypeIsSupported(ctx context.Context, settings *cluster.Settings, typ *types.T) error {

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -159,24 +159,28 @@ type Index interface {
 	// Span returns the KV span associated with the index.
 	Span() roachpb.Span
 
-	// ImplicitPartitioningColumnCount returns the number of implicit partitioning
-	// columns at the front of the index. For example, consider the following
-	// table:
+	// ImplicitColumnCount returns the number of implicit columns at the front of
+	// the index including implicit partitioning columns and shard columns of hash
+	// sharded indexes. For example, consider the following table:
 	//
 	// CREATE TABLE t (
 	//   x INT,
 	//   y INT,
-	//   INDEX (y) PARTITION BY LIST (x) (
-	//     PARTITION p1 VALUES IN (1)
-	//   )
+	//   z INT,
+	//   INDEX (y),
+	//   INDEX (z) USING HASH
+	// ) PARTITION ALL BY LIST (x) (
+	//   PARTITION p1 VALUES IN (1)
 	// );
 	//
-	// In this case, the number of implicit partitioning columns in the index on
-	// y is 1, since x is implicitly added to the front of the index.
+	// In this case, the number of implicit columns in the index on y is 1, since
+	// x is implicitly added to the front of the index. The number of implicit
+	// columns in the index on z is 2, since x and a shard column are implicitly
+	// added to the front of the index.
 	//
 	// The implicit partitioning columns are always a prefix of the full column
-	// list, and ImplicitPartitioningColumnCount < LaxKeyColumnCount.
-	ImplicitPartitioningColumnCount() int
+	// list, and ImplicitColumnCount < LaxKeyColumnCount.
+	ImplicitColumnCount() int
 
 	// GeoConfig returns a geospatial index configuration. If non-nil, it
 	// describes the configuration for this geospatial inverted index.

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -223,7 +223,7 @@ func formatCatalogIndex(tab Table, ord int, tp treeprinter.Node) {
 			fmt.Fprintf(&buf, " (storing)")
 		}
 
-		if i < idx.ImplicitPartitioningColumnCount() {
+		if i < idx.ImplicitColumnCount() {
 			fmt.Fprintf(&buf, " (implicit)")
 		}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -142,7 +142,7 @@ TABLE t
  ├── tableoid oid [hidden] [system]
  ├── CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
  ├── PRIMARY INDEX t_pkey
- │    ├── crdb_internal_a_shard_8 int4 not null as (mod(fnv32("crdb_internal.datums_to_bytes"(a)), 8:::INT8)) stored [hidden]
+ │    ├── crdb_internal_a_shard_8 int4 not null as (mod(fnv32("crdb_internal.datums_to_bytes"(a)), 8:::INT8)) stored [hidden] (implicit)
  │    └── a int not null
  └── UNIQUE WITHOUT INDEX (a)
 scan t
@@ -180,7 +180,7 @@ TABLE t
  ├── tableoid oid [hidden] [system]
  ├── CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
  ├── PRIMARY INDEX t_pkey
- │    ├── crdb_internal_a_shard_8 int4 not null as (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) stored [hidden]
+ │    ├── crdb_internal_a_shard_8 int4 not null as (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) stored [hidden] (implicit)
  │    └── a int not null
  └── UNIQUE WITHOUT INDEX (a)
 scan t
@@ -249,6 +249,7 @@ vectorized: true
           spans: /6/1234/0
           locking strength: for update
 
+# TODO(mgartner): We should be able to perform the UPSERT fast path in this case, because the shard column is a function of the other PK columns.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_hash_indexed VALUES (4321, 8765);
 ----
@@ -260,17 +261,39 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_hash_indexed(crdb_internal_a_shard_8, a, b)
 │ auto commit
+│ arbiter constraints: t_hash_indexed_pkey
 │
 └── • project
-    │ columns: (crdb_internal_a_shard_8_cast, column1, column2, column2, check1)
+    │ columns: (crdb_internal_a_shard_8_cast, column1, column2, crdb_internal_a_shard_8, a, b, crdb_internal_a_shard_8_cast, column2, crdb_internal_a_shard_8, check1)
     │
-    └── • values
-          columns: (column1, column2, crdb_internal_a_shard_8_cast, check1)
-          size: 4 columns, 1 row
-          row 0, expr 0: 4321
-          row 0, expr 1: 8765
-          row 0, expr 2: 1
-          row 0, expr 3: true
+    └── • render
+        │ columns: (check1, column1, column2, crdb_internal_a_shard_8_cast, crdb_internal_a_shard_8, a, b)
+        │ estimated row count: 1 (missing stats)
+        │ render check1: crdb_internal_a_shard_8_cast IN (0, 1, 2, 3, 4, 5, 6, 7)
+        │ render column1: column1
+        │ render column2: column2
+        │ render crdb_internal_a_shard_8_cast: crdb_internal_a_shard_8_cast
+        │ render crdb_internal_a_shard_8: crdb_internal_a_shard_8
+        │ render a: a
+        │ render b: b
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, column2, crdb_internal_a_shard_8_cast, crdb_internal_a_shard_8, a, b)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, column2, crdb_internal_a_shard_8_cast)
+            │     size: 3 columns, 1 row
+            │     row 0, expr 0: 4321
+            │     row 0, expr 1: 8765
+            │     row 0, expr 2: 1
+            │
+            └── • scan
+                  columns: (crdb_internal_a_shard_8, a, b)
+                  estimated row count: 1 (missing stats)
+                  table: t_hash_indexed@t_hash_indexed_pkey
+                  spans: /1/4321/0
+                  locking strength: for update
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT (a) DO UPDATE SET a = 4321

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -195,8 +195,8 @@ func (hi *hypotheticalIndex) Ordinal() int {
 	return hi.indexOrdinal
 }
 
-// ImplicitPartitioningColumnCount is part of the cat.Index interface.
-func (hi *hypotheticalIndex) ImplicitPartitioningColumnCount() int {
+// ImplicitColumnCount is part of the cat.Index interface.
+func (hi *hypotheticalIndex) ImplicitColumnCount() int {
 	return 0
 }
 

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -365,7 +365,10 @@ func (mb *mutationBuilder) needExistingRows() bool {
 	// If there are any implicit partitioning columns in the primary index,
 	// these columns will need to be fetched.
 	primaryIndex := mb.tab.Index(cat.PrimaryIndex)
-	if primaryIndex.ImplicitPartitioningColumnCount() > 0 {
+	// TODO(mgartner): It should be possible to perform an UPSERT fast path for a
+	// non-partitioned hash-sharded primary index, but this restriction disallows
+	// it.
+	if primaryIndex.ImplicitColumnCount() > 0 {
 		return true
 	}
 
@@ -862,7 +865,7 @@ func (mb *mutationBuilder) setUpsertCols(insertCols tree.NameList) {
 	// Never update primary key columns. Implicit partitioning columns are not
 	// considered part of the primary key in this case.
 	conflictIndex := mb.tab.Index(cat.PrimaryIndex)
-	skipCols := conflictIndex.ImplicitPartitioningColumnCount()
+	skipCols := conflictIndex.ImplicitColumnCount()
 	for i, n := skipCols, conflictIndex.KeyColumnCount(); i < n; i++ {
 		mb.updateColIDs[conflictIndex.Column(i).Ordinal()] = 0
 	}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1188,7 +1188,7 @@ func getUniqueConstraintOrdinals(tab cat.Table, uc cat.UniqueConstraint) util.Fa
 // columns, excluding any implicit partitioning columns in the primary index.
 func getExplicitPrimaryKeyOrdinals(tab cat.Table) util.FastIntSet {
 	index := tab.Index(cat.PrimaryIndex)
-	skipCols := index.ImplicitPartitioningColumnCount()
+	skipCols := index.ImplicitColumnCount()
 	var keyOrds util.FastIntSet
 	for i, n := skipCols, index.LaxKeyColumnCount(); i < n; i++ {
 		keyOrds.Add(index.Column(i).Ordinal())

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -402,7 +402,7 @@ func (tc *Catalog) resolveFK(tab *Table, d *tree.ForeignKeyConstraintTableDef) {
 		// If no columns are specified, attempt to default to PK, ignoring implicit
 		// columns.
 		idx := targetTable.Index(cat.PrimaryIndex)
-		numImplicitCols := idx.ImplicitPartitioningColumnCount()
+		numImplicitCols := idx.ImplicitColumnCount()
 		referencedColNames = make(
 			tree.NameList,
 			0,

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -958,8 +958,8 @@ func (ti *Index) Predicate() (string, bool) {
 	return ti.predicate, ti.predicate != ""
 }
 
-// ImplicitPartitioningColumnCount is part of the cat.Index interface.
-func (ti *Index) ImplicitPartitioningColumnCount() int {
+// ImplicitColumnCount is part of the cat.Index interface.
+func (ti *Index) ImplicitColumnCount() int {
 	return 0
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3026,7 +3026,8 @@ func (sc *SchemaChanger) preSplitHashShardedIndexRanges(ctx context.Context) err
 			}
 
 			if idx := m.AsIndex(); sc.shouldSplitAndScatter(tableDesc, m, idx) {
-				if idx.IsSharded() {
+				// TODO (issue #76507): also pre-split partitioned hash sharded index.
+				if idx.GetPartitioning().PartitioningDesc().NumImplicitColumns == 0 {
 					splitAtShards := calculateSplitAtShards(maxHashShardedIndexRangePreSplit.Get(&sc.settings.SV), idx.GetSharded().ShardBuckets)
 					for _, shard := range splitAtShards {
 						keyPrefix := sc.execCfg.Codec.IndexPrefix(uint32(tableDesc.GetID()), uint32(idx.GetID()))


### PR DESCRIPTION
Release note (sql change): Previously, crdb blocked users from creating
hash sharded index in all kinds of partitioned tables including implict
partitioned tables using `PARTITION ALL BY` or `REGIONAL BY ROW`. Now
we turn on the support of hash sharded index in implicit partitioned
tables. Which means primary key cannot be hash sharded if a table is
explicitly partitioned with `PARTITION BY` or an index cannot be hash
sharded if the index is explicitly partitioned with `PARTITION BY`.
Paritioning columns cannot be placed explicitly as key columns of a
hash sharded index as well, including regional-by-row table's `crdb_region`
column. When a hash sharded index is partitioned, ranges are pre-split 
within every single possible partition on shard boundaries. Each partition
is split up to 16 ranges, otherwise split into the number bucket count ranges.