### PR TITLE
build: turn off metamorphic constants for more gen rules

### DIFF
--- a/pkg/sql/colexec/COLEXEC.bzl
+++ b/pkg/sql/colexec/COLEXEC.bzl
@@ -5,10 +5,10 @@ def gen_sort_partitioner_rule(name, target, visibility = ["//visibility:private"
         name = name,
         srcs = ["//pkg/sql/colexec/colexecbase:distinct_tmpl.go"],
         outs = [target],
-        cmd = """
-          $(location :execgen) -template $(SRCS) \
-              -fmt=false pkg/sql/colexec/$@ > $@
-          $(location :goimports) -w $@
-          """,
+        cmd = """\
+export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
+$(location :execgen) -template $(SRCS) -fmt=false pkg/sql/colexec/$@ > $@
+$(location :goimports) -w $@
+""",
         tools = [":execgen", ":goimports"],
     )

--- a/pkg/util/fsm/gen/REPORTS.bzl
+++ b/pkg/util/fsm/gen/REPORTS.bzl
@@ -52,7 +52,10 @@ def gen_reports(name, dep, transitions_variable, starting_state_name):
     lower = transitions_variable.lower()
     native.genrule(
         name = name,
-        cmd = "$(location :{template_name}_bin) $(location {lower}_diagram.gv) $(location {lower}_report.txt) 'bazel build {name}'".format(
+        cmd = """\
+export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
+$(location :{template_name}_bin) $(location {lower}_diagram.gv) $(location {lower}_report.txt) 'bazel build {name}'
+""".format(
             template_name = template_name,
             lower = lower,
             name = name,


### PR DESCRIPTION
This add `COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true` to more
tool invocations to cut down on log spam.

Informs #76363

Release note: None