### PR TITLE
spanconfig: mark reconciliation job as idle

### DIFF
--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -45,6 +45,11 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 	rc := execCtx.SpanConfigReconciler()
 	stopper := execCtx.ExecCfg().DistSQLSrv.Stopper
 
+	// The reconciliation job is a forever running background job. It's always
+	// safe to wind the SQL pod down whenever it's running -- something we
+	// indicate through the job's idle status.
+	r.job.MarkIdle(true)
+
 	// Start the protected timestamp reconciler. This will periodically poll the
 	// protected timestamp table to cleanup stale records. We take advantage of
 	// the fact that there can only be one instance of the spanconfig.Resumer


### PR DESCRIPTION
Fixes #70538.

We have a forever running background AUTO SPAN CONFIG RECONCILIATION job
on tenant pods. To know when it's safe to wind down pods, we use the
number of currently running jobs as an indicator. Given the job is
forever running, we need an indicator to suggest that despite the job's
presence, it's safe to wind down.

In #74747 we added a thin API to the jobs subsystem to do just that,
with the intent of using it for idle changefeed jobs. We just cargo-cult
that same approach here to mark the reconciliation job as always idle.

Release note: None