### PR TITLE
multitenant: add more log messages around RU limiting

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostserver/configure.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/configure.go
@@ -44,7 +44,7 @@ func (s *instance) ReconfigureTokenBucket(
 	now := s.timeSource.Now()
 	state.update(now)
 	state.Bucket.Reconfigure(
-		availableRU, refillRate, maxBurstRU, asOf, asOfConsumedRequestUnits,
+		ctx, tenantID, availableRU, refillRate, maxBurstRU, asOf, asOfConsumedRequestUnits,
 		now, state.Consumption.RU,
 	)
 	if err := h.updateTenantState(state); err != nil {

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["tenant_token_bucket.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/roachpb"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/util/log",
+    ],
 )
 
 go_test(

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
@@ -154,6 +154,8 @@ func (s *State) Request(
 //  - currentConsumedRequestUnits is the current total number of consumed RUs.
 //
 func (s *State) Reconfigure(
+	ctx context.Context,
+	tenantID roachpb.TenantID,
 	availableRU float64,
 	refillRate float64,
 	maxBurstRU float64,
@@ -167,4 +169,8 @@ func (s *State) Reconfigure(
 	s.RUCurrent = availableRU
 	s.RURefillRate = refillRate
 	s.RUBurstLimit = maxBurstRU
+	log.Infof(
+		ctx, "token bucket for tenant %s reconfigured: available=%g refill-rate=%g burst-limit=%g",
+		tenantID.String(), s.RUCurrent, s.RURefillRate, s.RUBurstLimit,
+	)
 }

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
@@ -12,10 +12,12 @@
 package tenanttokenbucket
 
 import (
+	"context"
 	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // State of the distributed token bucket.
@@ -53,13 +55,18 @@ func (s *State) Update(since time.Duration) {
 
 // Request processes a request for more tokens and updates the State
 // accordingly.
-func (s *State) Request(req *roachpb.TokenBucketRequest) roachpb.TokenBucketResponse {
+func (s *State) Request(
+	ctx context.Context, req *roachpb.TokenBucketRequest,
+) roachpb.TokenBucketResponse {
 	var res roachpb.TokenBucketResponse
 
 	// Calculate the fallback rate.
 	res.FallbackRate = s.RURefillRate
 	if s.RUCurrent > 0 {
 		res.FallbackRate += s.RUCurrent / fallbackRateTimeFrame.Seconds()
+	}
+	if log.V(1) {
+		log.Infof(ctx, "token bucket request (tenant=%d requested=%g current=%g)", req.TenantID, req.RequestedRU, s.RUCurrent)
 	}
 
 	needed := req.RequestedRU
@@ -70,6 +77,9 @@ func (s *State) Request(req *roachpb.TokenBucketRequest) roachpb.TokenBucketResp
 	if s.RUCurrent >= needed {
 		s.RUCurrent -= needed
 		res.GrantedRU = needed
+		if log.V(1) {
+			log.Infof(ctx, "request granted (tenant=%d remaining=%g)", req.TenantID, s.RUCurrent)
+		}
 		return res
 	}
 
@@ -111,6 +121,9 @@ func (s *State) Request(req *roachpb.TokenBucketRequest) roachpb.TokenBucketResp
 	s.RUCurrent -= grantedTokens
 	res.GrantedRU = grantedTokens
 	res.TrickleDuration = duration
+	if log.V(1) {
+		log.Infof(ctx, "request granted over time (tenant=%d granted=%g trickle=%s)", req.TenantID, res.GrantedRU, res.TrickleDuration)
+	}
 	return res
 }
 

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket_test.go
@@ -9,6 +9,7 @@
 package tenanttokenbucket
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -95,7 +96,7 @@ func (ts *testState) request(t *testing.T, d *datadriven.TestData) string {
 		RequestedRU:         vals.RU,
 		TargetRequestPeriod: parseDuration(t, d, vals.Period),
 	}
-	resp := ts.State.Request(&req)
+	resp := ts.State.Request(context.Background(), &req)
 	return fmt.Sprintf(
 		strings.Join(
 			[]string{

--- a/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
@@ -103,7 +103,7 @@ func (s *instance) TokenBucketRequest(
 		}
 
 		// TODO(radu): update shares.
-		*result = tenant.Bucket.Request(in)
+		*result = tenant.Bucket.Request(ctx, in)
 
 		instance.LastUpdate.Time = now
 		if err := h.updateTenantAndInstanceState(tenant, instance); err != nil {


### PR DESCRIPTION
#### tenantcostserver: add some verbose logs

This commit adds some verbose logs describing the token bucket
requests that are happening.

Release note: None

#### tenantcostserver: add logs when reconfiguring RUs for a tenant

This commit adds a log message when a tenant token bucket is
reconfigured.

Release note: None

#### tenantcostclient: add trace event for delayed requests

This change adds a trace event for any request that has to wait for
more than 1 second in the RU limiting subsystem.

Release note: None