### PR TITLE
execinfra,streamingccl: fix a span use-after-finish in eventStream

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/span",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -46,6 +47,7 @@ type eventStream struct {
 	eventsCh    chan roachpb.RangeFeedEvent // Channel receiving rangefeed events.
 	errCh       chan error                  // Signaled when error occurs in rangefeed.
 	streamCh    chan tree.Datums            // Channel signaled to forward datums to consumer.
+	sp          *tracing.Span               // Span representing the lifetime of the eventStream.
 }
 
 var _ tree.ValueGenerator = (*eventStream)(nil)
@@ -171,7 +173,9 @@ func (s *eventStream) startStreamProcessor(ctx context.Context, frontier *span.F
 	// Context group responsible for coordinating rangefeed event production with
 	// ValueGenerator implementation that consumes rangefeed events and forwards them to the
 	// destination cluster consumer.
-	s.streamGroup = ctxgroup.WithContext(ctx)
+	streamCtx, sp := tracing.ChildSpan(ctx, "event stream")
+	s.sp = sp
+	s.streamGroup = ctxgroup.WithContext(streamCtx)
 	s.streamGroup.GoCtx(withErrCapture(func(ctx context.Context) error {
 		return s.streamLoop(ctx, frontier)
 	}))
@@ -206,6 +210,8 @@ func (s *eventStream) Close(ctx context.Context) {
 		// Note: error in close is normal; we expect to be terminated with context canceled.
 		log.Errorf(ctx, "partition stream %d terminated with error %v", s.streamID, err)
 	}
+
+	s.sp.Finish()
 }
 
 func (s *eventStream) onEvent(ctx context.Context, value *roachpb.RangeFeedValue) {

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -892,7 +892,16 @@ func (pb *ProcessorBaseNoHelper) startImpl(
 //     // Perform processor specific close work.
 //   }
 func (pb *ProcessorBase) InternalClose() bool {
-	closing := pb.ProcessorBaseNoHelper.InternalClose()
+	return pb.InternalCloseEx(nil /* onClose */)
+}
+
+// InternalCloseEx is like InternalClose, but also takes a closure to run in
+// case the processor was not already closed. The closure is run before the
+// processor's span is finished, so the closure can finalize work that relies on
+// that span (e.g. async work previously started by the processor that has
+// captured the processor's span).
+func (pb *ProcessorBase) InternalCloseEx(onClose func()) bool {
+	closing := pb.ProcessorBaseNoHelper.InternalCloseEx(onClose)
 	if closing {
 		// This prevents Next() from returning more rows.
 		pb.OutputHelper.consumerClosed()
@@ -902,24 +911,33 @@ func (pb *ProcessorBase) InternalClose() bool {
 
 // InternalClose is the meat of ProcessorBase.InternalClose.
 func (pb *ProcessorBaseNoHelper) InternalClose() bool {
-	closing := !pb.Closed
+	return pb.InternalCloseEx(nil /* onClose */)
+}
+
+// InternalCloseEx is the meat of ProcessorBase.InternalCloseEx.
+func (pb *ProcessorBaseNoHelper) InternalCloseEx(onClose func()) bool {
 	// Protection around double closing is useful for allowing ConsumerClosed() to
 	// be called on processors that have already closed themselves by moving to
 	// StateTrailingMeta.
-	if closing {
-		for _, input := range pb.inputsToDrain[pb.curInputToDrain:] {
-			input.ConsumerClosed()
-		}
-
-		pb.Closed = true
-		pb.span.Finish()
-		pb.span = nil
-		// Reset the context so that any incidental uses after this point do not
-		// access the finished span.
-		pb.Ctx = pb.origCtx
-		pb.EvalCtx.Context = pb.origCtx
+	if pb.Closed {
+		return false
 	}
-	return closing
+	for _, input := range pb.inputsToDrain[pb.curInputToDrain:] {
+		input.ConsumerClosed()
+	}
+
+	if onClose != nil {
+		onClose()
+	}
+
+	pb.Closed = true
+	pb.span.Finish()
+	pb.span = nil
+	// Reset the context so that any incidental uses after this point do not
+	// access the finished span.
+	pb.Ctx = pb.origCtx
+	pb.EvalCtx.Context = pb.origCtx
+	return true
 }
 
 // ConsumerDone is part of the RowSource interface.

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -285,13 +285,13 @@ func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) rowenc.EncDa
 }
 
 func (ps *projectSetProcessor) close() {
-	if ps.InternalClose() {
+	ps.InternalCloseEx(func() {
 		for _, gen := range ps.gens {
 			if gen != nil {
 				gen.Close(ps.Ctx)
 			}
 		}
-	}
+	})
 }
 
 // ConsumerClosed is part of the RowSource interface.


### PR DESCRIPTION
The eventStream was capturing the ctx passed to its Start() method and
using it until Close(). At least in the case when the eventStream was
used by the DistSQL projectSet processors, eventStream.Close() was being
called after the respective ctx stopped being valid (because the
respective tracing span had been Finish()ed).

This patch fixes this in two separate ways:
- the eventStream creates a new span for its work, as the Start() interface
  does not guarantee that the ctx will have a longer lifetime (and
  neither should it make any such guarantees, in my opinion).
- the projectSet processor will now keep its span open for long enough
  to encompass the full lifetime of the underlying generators (of which
  the eventStream is one). Its span was already living almost long
  enough; it was just a matter of ordering. To get the ordering right,
  I've had to add some indirection through the ProcessorBase.

Fixes #75335

Release note: None