### PR TITLE
rowexec: lower the minimum limit in join reader from 8MiB to 100KiB

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1091,6 +1091,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 // is closed.
 func TestJoinReaderDrain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())


### PR DESCRIPTION
If `distsql_workmem` limit is set to a value lower than 8MiB we bump it
up to 8MiB (this was introduced in 306f8edada31e3386e0414eb8a69436b67fd11d8).
The reasoning is that the joinReader doesn't know how to spill most of
its in-memory state to disk (except for the buffered rows stored in the
disk-backed row container). The value was chosen based on 4MiB batch
size hint for the index join strategy. This commit lowers the value to
100KiB while making a corresponding adjustment to the batch size hint.
Namely, whenever the Streamer API is used, then a quarter of workmem
limit is used as the hint; if the Streamer API is not used, then a half
of workmem limit is used.

This should not really matter in the production setting since workmem
should not go lower than 8MiB, but it helps us to work with smaller
blobs in some tests.

Release note: None