### PR TITLE
kv/kvserver: add metrics for lock hold and lock wait duration

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -142,7 +143,7 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	lt := newLockTable(cfg.MaxLockTableSize)
+	lt := newLockTable(cfg.MaxLockTableSize, timeutil.DefaultTimeSource{})
 	*m = managerImpl{
 		st: cfg.Settings,
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -51,6 +51,11 @@ new-lock-table maxlocks=<int>
 
   Creates a lockTable. The lockTable is initially enabled.
 
+time-tick [m=<int>] [s=<int>] [ms=<int>] [ns=<int>]
+----
+
+  Forces the manual clock to tick forward m minutes, s seconds, ms milliseconds, and ns nanoseconds.
+
 new-txn txn=<name> ts=<int>[,<int>] epoch=<int> [seq=<int>]
 ----
 
@@ -166,12 +171,13 @@ func TestLockTableBasic(t *testing.T) {
 		var txnCounter uint128.Uint128
 		var requestsByName map[string]Request
 		var guardsByReqName map[string]lockTableGuard
+		testTimeProvider := timeutil.NewManualTime(time.Time{})
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "new-lock-table":
 				var maxLocks int
 				d.ScanArgs(t, "maxlocks", &maxLocks)
-				ltImpl := newLockTable(int64(maxLocks))
+				ltImpl := newLockTable(int64(maxLocks), testTimeProvider)
 				ltImpl.enabled = true
 				ltImpl.enabledSeq = 1
 				ltImpl.minLocks = 0
@@ -180,6 +186,28 @@ func TestLockTableBasic(t *testing.T) {
 				txnCounter = uint128.FromInts(0, 0)
 				requestsByName = make(map[string]Request)
 				guardsByReqName = make(map[string]lockTableGuard)
+				return ""
+
+			case "time-tick":
+				var timeDelta time.Duration
+				var delta int
+				if d.HasArg("m") {
+					d.ScanArgs(t, "m", &delta)
+					timeDelta += time.Duration(delta) * time.Minute
+				}
+				if d.HasArg("s") {
+					d.ScanArgs(t, "s", &delta)
+					timeDelta += time.Duration(delta) * time.Second
+				}
+				if d.HasArg("ms") {
+					d.ScanArgs(t, "ms", &delta)
+					timeDelta += time.Duration(delta) * time.Millisecond
+				}
+				if d.HasArg("ns") {
+					d.ScanArgs(t, "ns", &delta)
+					timeDelta += time.Duration(delta)
+				}
+				testTimeProvider.Advance(timeDelta)
 				return ""
 
 			case "new-txn":
@@ -617,7 +645,7 @@ func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) 
 }
 
 func TestLockTableMaxLocks(t *testing.T) {
-	lt := newLockTable(5)
+	lt := newLockTable(5, timeutil.DefaultTimeSource{})
 	lt.minLocks = 0
 	lt.enabled = true
 	var keys []roachpb.Key
@@ -744,7 +772,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 // TestLockTableMaxLocksWithMultipleNotRemovableRefs tests the notRemovable
 // ref counting.
 func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
-	lt := newLockTable(2)
+	lt := newLockTable(2, timeutil.DefaultTimeSource{})
 	lt.minLocks = 0
 	lt.enabled = true
 	var keys []roachpb.Key
@@ -980,7 +1008,7 @@ type workloadExecutor struct {
 
 func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecutor {
 	const maxLocks = 100000
-	lt := newLockTable(maxLocks)
+	lt := newLockTable(maxLocks, timeutil.DefaultTimeSource{})
 	lt.enabled = true
 	return &workloadExecutor{
 		lm:           spanlatch.Manager{},
@@ -1543,7 +1571,7 @@ func BenchmarkLockTable(b *testing.B) {
 						var numRequestsWaited uint64
 						var numScanCalls uint64
 						const maxLocks = 100000
-						lt := newLockTable(maxLocks)
+						lt := newLockTable(maxLocks, timeutil.DefaultTimeSource{})
 						lt.enabled = true
 						env := benchEnv{
 							lm:                &spanlatch.Manager{},
@@ -1583,7 +1611,7 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 	for _, locks := range []int{0, 1 << 0, 1 << 4, 1 << 8, 1 << 12} {
 		b.Run(fmt.Sprintf("locks=%d", locks), func(b *testing.B) {
 			const maxLocks = 100000
-			lt := newLockTable(maxLocks)
+			lt := newLockTable(maxLocks, timeutil.DefaultTimeSource{})
 			lt.enabled = true
 
 			txn := &enginepb.TxnMeta{ID: uuid.MakeV4()}

--- a/pkg/kv/kvserver/concurrency/metrics.go
+++ b/pkg/kv/kvserver/concurrency/metrics.go
@@ -18,12 +18,19 @@ import (
 // LatchMetrics holds information about the state of a latchManager.
 type LatchMetrics = spanlatch.Metrics
 
+// TopKLockMetrics holds the metrics on the top K (where K = 3) locks by
+// various orderings.
+type TopKLockMetrics = [3]LockMetrics
+
 // LockTableMetrics holds information about the state of a lockTable.
 type LockTableMetrics struct {
 	// The number of locks.
 	Locks int64
 	// The number of locks actively held by transactions.
 	LocksHeld int64
+	// The aggregate nanoseconds locks have been active in the lock table and
+	// marked as held.
+	TotalLockHoldDurationNanos int64
 	// The number of locks not held, but with reservations.
 	LocksWithReservation int64
 	// The number of locks with non-empty wait-queues.
@@ -35,13 +42,20 @@ type LockTableMetrics struct {
 	WaitingReaders int64
 	// The aggregate number of waiting writers in wait-queues across all locks.
 	WaitingWriters int64
+	// The aggregate nanoseconds spent in wait-queues, aggregated across each
+	// waiter in the wait-queue of every lock in the lock table.
+	TotalWaitDurationNanos int64
 
 	// The top-k locks with the most waiters (readers + writers) in their
 	// wait-queue, ordered in descending order.
-	TopKLocksByWaiters [3]LockMetrics
-	// TODO(nvanbenschoten): add a top-k list ordered on the duration that the
-	// locks have been held. See #67619.
-	// TopKLocksByDuration [3]LockMetrics
+	TopKLocksByWaiters TopKLockMetrics
+
+	// The top-k locks by hold duration, ordered in descending order.
+	TopKLocksByHoldDuration TopKLockMetrics
+
+	// The top-k locks by longest waiting reader or writer in the wait-queue,
+	// ordered in descending order.
+	TopKLocksByWaitDuration TopKLockMetrics
 }
 
 // LockMetrics holds information about the state of a single lock in a lockTable.
@@ -50,12 +64,18 @@ type LockMetrics struct {
 	Key roachpb.Key
 	// Is the lock actively held by a transaction, or just a reservation?
 	Held bool
+	// The number of nanoseconds this lock has been in the lock table and marked as held.
+	HoldDurationNanos int64
 	// The number of waiters in the lock's wait queue.
 	Waiters int64
 	// The number of waiting readers in the lock's wait queue.
 	WaitingReaders int64
 	// The number of waiting writers in the lock's wait queue.
 	WaitingWriters int64
+	// The total number of nanoseconds all waiters have been in the lock's wait queue.
+	WaitDurationNanos int64
+	// The maximum number of nanoseconds a waiter has been in the lock's wait queue.
+	MaxWaitDurationNanos int64
 }
 
 // addLockMetrics adds the provided LockMetrics to the receiver.
@@ -63,6 +83,8 @@ func (m *LockTableMetrics) addLockMetrics(lm LockMetrics) {
 	m.Locks++
 	if lm.Held {
 		m.LocksHeld++
+		m.TotalLockHoldDurationNanos += lm.HoldDurationNanos
+		m.addToTopKLocksByHoldDuration(lm)
 	} else {
 		m.LocksWithReservation++
 	}
@@ -71,7 +93,9 @@ func (m *LockTableMetrics) addLockMetrics(lm LockMetrics) {
 		m.Waiters += lm.Waiters
 		m.WaitingReaders += lm.WaitingReaders
 		m.WaitingWriters += lm.WaitingWriters
+		m.TotalWaitDurationNanos += lm.WaitDurationNanos
 		m.addToTopKLocksByWaiters(lm)
+		m.addToTopKLocksByWaitDuration(lm)
 	}
 }
 
@@ -79,18 +103,31 @@ func (m *LockTableMetrics) addLockMetrics(lm LockMetrics) {
 // TopKLocksByWaiters list. If two LockMetrics structs have the same number
 // of waiters, the first one added will be ordered first in the ordering.
 func (m *LockTableMetrics) addToTopKLocksByWaiters(lm LockMetrics) {
-	m.addToTopK(lm, func(cmp LockMetrics) int64 { return cmp.Waiters })
+	addToTopK(m.TopKLocksByWaiters[:], lm, func(cmp LockMetrics) int64 { return cmp.Waiters })
 }
 
-func (m *LockTableMetrics) addToTopK(lm LockMetrics, cmp func(LockMetrics) int64) {
+// addToTopKLocksByHoldDuration adds the provided LockMetrics to the receiver's
+// TopKLocksByHoldDuration list. They are ordered by decreasing hold duration.
+func (m *LockTableMetrics) addToTopKLocksByHoldDuration(lm LockMetrics) {
+	addToTopK(m.TopKLocksByHoldDuration[:], lm, func(cmp LockMetrics) int64 { return cmp.HoldDurationNanos })
+}
+
+// addToTopKLocksByWaitDuration adds the provided LockMetrics to the receiver's
+// TopKLocksByWaitDuration list. The LockMetrics are ordered by the maximum
+// wait duration across all waiters on each lock, in decreasing order.
+func (m *LockTableMetrics) addToTopKLocksByWaitDuration(lm LockMetrics) {
+	addToTopK(m.TopKLocksByWaitDuration[:], lm, func(cmp LockMetrics) int64 { return cmp.MaxWaitDurationNanos })
+}
+
+func addToTopK(topK []LockMetrics, lm LockMetrics, cmp func(LockMetrics) int64) {
 	cpy := false
-	for i, cur := range m.TopKLocksByWaiters {
+	for i, cur := range topK {
 		if cur.Key == nil {
-			m.TopKLocksByWaiters[i] = lm
+			topK[i] = lm
 			break
 		}
 		if cpy || cmp(lm) > cmp(cur) {
-			m.TopKLocksByWaiters[i] = lm
+			topK[i] = lm
 			lm = cur
 			cpy = true
 		}

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -49,6 +49,10 @@ global: num=2
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
+# 200ms passes between req1 and req2
+time-tick ms=200
+----
+
 # req2 is also for txn1 and will not wait for locks that are held by self.
 
 new-request r=req2 txn=txn1 ts=10,2 spans=w@b,d+r@d,g
@@ -80,6 +84,11 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
+# 1s passes before txn2 begins
+time-tick s=1
+----
+
+
 # txn1 holds locks on b, c, e.
 # txn2 has a smaller timestamp than txn1.
 new-txn txn=txn2 ts=8,12 epoch=0
@@ -104,6 +113,11 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
+# 200ms passes between req3 and req4
+time-tick ms=200
+----
+
+
 # req4 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
 # not conflict with lock on e since wants to read there and the read is at a lower timestamp
 # than the lock.
@@ -117,6 +131,11 @@ start-waiting: true
 guard-state r=req4
 ----
 new: state=waitForDistinguished txn=txn1 key="b" held=true guard-access=write
+
+# 3s passes while req4 is waiting on locks on b,c
+time-tick s=3
+----
+
 
 # Release lock on b since epoch of txn1 has changed.
 update txn=txn1 ts=11,1 epoch=1 span=b
@@ -135,6 +154,10 @@ local: num=0
 guard-state r=req4
 ----
 new: state=waitForDistinguished txn=txn1 key="c" held=true guard-access=write
+
+# 1s passes while req4 continues to wait on c (and only has reservation on b)
+time-tick s=1
+----
 
 # Release lock on c since epoch of txn1 has changed.
 update txn=txn1 ts=11,1 epoch=1 span=c,e
@@ -209,6 +232,11 @@ scan r=req4
 ----
 start-waiting: true
 
+# 2s passes while req4 continues to wait on a, f after rescanning/enqueueing
+time-tick s=2
+----
+
+
 # req4 from txn2 has a reservation on b, c with ts=8,12. And txn1 has a lock on e with ts=10,1
 # which does not conflict. And txn3 with ts=6 has locks on a, f that do conflict. This is better
 # viewed as:
@@ -248,28 +276,98 @@ metrics
 ----
 locks: 5
 locksheld: 3
+totallockholddurationnanos: 11400000000
 lockswithreservation: 2
 lockswithwaitqueues: 1
 waiters: 1
 waitingreaders: 0
 waitingwriters: 1
+totalwaitdurationnanos: 2000000000
 topklocksbywaiters:
 - key:
   - 97
   held: true
+  holddurationnanos: 2000000000
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 2000000000
+  maxwaitdurationnanos: 2000000000
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 7400000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 97
+  held: true
+  holddurationnanos: 2000000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2000000000
+  maxwaitdurationnanos: 2000000000
+- key:
+  - 102
+  held: true
+  holddurationnanos: 2000000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 97
+  held: true
+  holddurationnanos: 2000000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2000000000
+  maxwaitdurationnanos: 2000000000
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+
+# 300ms passes before req5
+time-tick ms=300
+----
+
 
 # req5 is again from transaction 1. Since it is reading from b, c, and even though txn1
 # conflicts with the reservation holder since txn1.ts > txn2.ts, reads don't wait for
@@ -298,6 +396,11 @@ global: num=5
  lock: "f"
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0, seqs: [0]
 local: num=0
+
+# 100ms passes between req5 and req6
+time-tick ms=100
+----
+
 
 # req6 from txn1 conflicts with lock at f, and reservations at b, c.
 
@@ -348,33 +451,104 @@ metrics
 ----
 locks: 5
 locksheld: 3
+totallockholddurationnanos: 12600000000
 lockswithreservation: 2
 lockswithwaitqueues: 2
 waiters: 2
 waitingreaders: 0
 waitingwriters: 2
+totalwaitdurationnanos: 2400000000
 topklocksbywaiters:
 - key:
   - 97
   held: true
+  holddurationnanos: 2400000000
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 2400000000
+  maxwaitdurationnanos: 2400000000
 - key:
   - 98
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 7800000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 97
+  held: true
+  holddurationnanos: 2400000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2400000000
+  maxwaitdurationnanos: 2400000000
+- key:
+  - 102
+  held: true
+  holddurationnanos: 2400000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 97
+  held: true
+  holddurationnanos: 2400000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2400000000
+  maxwaitdurationnanos: 2400000000
+- key:
+  - 98
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 guard-state r=req6
 ----
 new: state=waitForDistinguished txn=txn2 key="b" held=false guard-access=write
+
+# 250ms passes between req6 and req7
+time-tick ms=250
+----
+
 
 # req7 from txn3 only wants to write to c
 
@@ -433,30 +607,102 @@ metrics
 ----
 locks: 5
 locksheld: 3
+totallockholddurationnanos: 13350000000
 lockswithreservation: 2
 lockswithwaitqueues: 3
 waiters: 3
 waitingreaders: 0
 waitingwriters: 3
+totalwaitdurationnanos: 2900000000
 topklocksbywaiters:
 - key:
   - 97
   held: true
+  holddurationnanos: 2650000000
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 2650000000
+  maxwaitdurationnanos: 2650000000
 - key:
   - 98
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 250000000
+  maxwaitdurationnanos: 250000000
 - key:
   - 99
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 8050000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 97
+  held: true
+  holddurationnanos: 2650000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2650000000
+  maxwaitdurationnanos: 2650000000
+- key:
+  - 102
+  held: true
+  holddurationnanos: 2650000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 97
+  held: true
+  holddurationnanos: 2650000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2650000000
+  maxwaitdurationnanos: 2650000000
+- key:
+  - 98
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 250000000
+  maxwaitdurationnanos: 250000000
+- key:
+  - 99
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+
+# 100ms passes between before releasing a
+time-tick ms=100
+----
+
 
 # Release a. req4 waits at f.
 release txn=txn3 span=a
@@ -516,30 +762,101 @@ metrics
 ----
 locks: 5
 locksheld: 2
+totallockholddurationnanos: 10900000000
 lockswithreservation: 3
 lockswithwaitqueues: 3
 waiters: 3
 waitingreaders: 1
 waitingwriters: 2
+totalwaitdurationnanos: 450000000
 topklocksbywaiters:
 - key:
   - 98
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 350000000
+  maxwaitdurationnanos: 350000000
 - key:
   - 99
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 100000000
+  maxwaitdurationnanos: 100000000
 - key:
   - 102
   held: true
+  holddurationnanos: 2750000000
   waiters: 1
   waitingreaders: 1
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 8150000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 102
+  held: true
+  holddurationnanos: 2750000000
+  waiters: 1
+  waitingreaders: 1
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 98
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 350000000
+  maxwaitdurationnanos: 350000000
+- key:
+  - 99
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 100000000
+  maxwaitdurationnanos: 100000000
+- key:
+  - 102
+  held: true
+  holddurationnanos: 2750000000
+  waiters: 1
+  waitingreaders: 1
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+
+# 500ms passes between before releasing f
+time-tick ms=500
+----
+
 
 # Release f. This will cause req4 to be done waiting.
 
@@ -655,29 +972,95 @@ metrics
 ----
 locks: 4
 locksheld: 3
+totallockholddurationnanos: 8650000000
 lockswithreservation: 1
 lockswithwaitqueues: 2
 waiters: 2
 waitingreaders: 0
 waitingwriters: 2
+totalwaitdurationnanos: 1450000000
 topklocksbywaiters:
 - key:
   - 98
   held: true
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 850000000
+  maxwaitdurationnanos: 850000000
 - key:
   - 99
   held: true
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 600000000
+  maxwaitdurationnanos: 600000000
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 8650000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 98
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 850000000
+  maxwaitdurationnanos: 850000000
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 600000000
+  maxwaitdurationnanos: 600000000
+topklocksbywaitduration:
+- key:
+  - 98
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 850000000
+  maxwaitdurationnanos: 850000000
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 600000000
+  maxwaitdurationnanos: 600000000
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 dequeue r=req4
 ----
@@ -708,6 +1091,11 @@ local: num=0
 #  req7                  w*
 #   txn3
 #   6
+
+# 2s passes between before releasing c
+time-tick s=2
+----
+
 
 # Release the lock at c. The lock at e is not held by txn2 so will be ignored.
 # req7 will get the reservation at c and will become doneWaiting.
@@ -751,28 +1139,97 @@ metrics
 ----
 locks: 3
 locksheld: 2
+totallockholddurationnanos: 12650000000
 lockswithreservation: 1
 lockswithwaitqueues: 1
 waiters: 1
 waitingreaders: 0
 waitingwriters: 1
+totalwaitdurationnanos: 2850000000
 topklocksbywaiters:
 - key:
   - 98
   held: true
+  holddurationnanos: 2000000000
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 2850000000
+  maxwaitdurationnanos: 2850000000
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 10650000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 98
+  held: true
+  holddurationnanos: 2000000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2850000000
+  maxwaitdurationnanos: 2850000000
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 98
+  held: true
+  holddurationnanos: 2000000000
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2850000000
+  maxwaitdurationnanos: 2850000000
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+
+# 40ms passes between before releasing b
+time-tick ms=40
+----
+
 
 # Now before req7 can scan again, release the lock at b. This will cause req6 to break the
 # reservation of req7 at c and become doneWaiting too.
@@ -829,28 +1286,91 @@ metrics
 ----
 locks: 3
 locksheld: 1
+totallockholddurationnanos: 10690000000
 lockswithreservation: 2
 lockswithwaitqueues: 1
 waiters: 1
 waitingreaders: 0
 waitingwriters: 1
+totalwaitdurationnanos: 2640000000
 topklocksbywaiters:
 - key:
   - 99
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 2640000000
+  maxwaitdurationnanos: 2640000000
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 101
+  held: true
+  holddurationnanos: 10690000000
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 99
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 2640000000
+  maxwaitdurationnanos: 2640000000
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 scan r=req7
 ----
@@ -891,6 +1411,11 @@ local: num=0
 
 # e is still locked
 
+# 15s passes between before req8
+time-tick s=15
+----
+
+
 new-request r=req8 txn=txn3 ts=6 spans=w@e
 ----
 
@@ -909,6 +1434,11 @@ global: num=1
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
+# 100ms passes between before releasing c-f
+time-tick ms=100
+----
+
+
 release txn=txn1 span=c,f
 ----
 global: num=0
@@ -923,27 +1453,88 @@ metrics
 ----
 locks: 0
 locksheld: 0
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 0
 waiters: 0
 waitingreaders: 0
 waitingwriters: 0
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 # All requests have been retired and the lock table is empty.
 # The following tests multiple requests from the same transaction.
@@ -980,27 +1571,89 @@ metrics
 ----
 locks: 1
 locksheld: 1
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 0
 waiters: 0
 waitingreaders: 0
 waitingwriters: 0
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 new-request r=req10 txn=txn2 ts=8,12 spans=w@c
 ----
@@ -1051,28 +1704,91 @@ metrics
 ----
 locks: 1
 locksheld: 1
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 1
 waiters: 3
 waitingreaders: 0
 waitingwriters: 3
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 99
   held: true
+  holddurationnanos: 0
   waiters: 3
   waitingreaders: 0
   waitingwriters: 3
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 3
+  waitingreaders: 0
+  waitingwriters: 3
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 3
+  waitingreaders: 0
+  waitingwriters: 3
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 release txn=txn1 span=c
 ----
@@ -1116,28 +1832,90 @@ metrics
 ----
 locks: 1
 locksheld: 0
+totallockholddurationnanos: 0
 lockswithreservation: 1
 lockswithwaitqueues: 1
 waiters: 2
 waitingreaders: 0
 waitingwriters: 2
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 99
   held: false
+  holddurationnanos: 0
   waiters: 2
   waitingreaders: 0
   waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 99
+  held: false
+  holddurationnanos: 0
+  waiters: 2
+  waitingreaders: 0
+  waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 acquire r=req10 k=c durability=u
 ----
@@ -1172,28 +1950,91 @@ metrics
 ----
 locks: 1
 locksheld: 1
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 1
 waiters: 1
 waitingreaders: 0
 waitingwriters: 1
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 99
   held: true
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 dequeue r=req10
 ----
@@ -1251,27 +2092,88 @@ metrics
 ----
 locks: 1
 locksheld: 0
+totallockholddurationnanos: 0
 lockswithreservation: 1
 lockswithwaitqueues: 0
 waiters: 0
 waitingreaders: 0
 waitingwriters: 0
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 dequeue r=req11
 ----
@@ -1349,27 +2251,88 @@ metrics
 ----
 locks: 0
 locksheld: 0
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 0
 waiters: 0
 waitingreaders: 0
 waitingwriters: 0
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 # Test with distinguished waiter being a later request from the same
 # transaction that eventually grabs a reservation. Triggered a bug
@@ -1440,29 +2403,94 @@ metrics
 ----
 locks: 2
 locksheld: 2
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 2
 waiters: 2
 waitingreaders: 0
 waitingwriters: 2
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 99
   held: true
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key:
   - 100
   held: true
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 100
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 100
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 release txn=txn1 span=c
 ----
@@ -1497,28 +2525,91 @@ metrics
 ----
 locks: 2
 locksheld: 1
+totallockholddurationnanos: 0
 lockswithreservation: 1
 lockswithwaitqueues: 1
 waiters: 2
 waitingreaders: 0
 waitingwriters: 2
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 100
   held: true
+  holddurationnanos: 0
   waiters: 2
   waitingreaders: 0
   waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 100
+  held: true
+  holddurationnanos: 0
+  waiters: 2
+  waitingreaders: 0
+  waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 100
+  held: true
+  holddurationnanos: 0
+  waiters: 2
+  waitingreaders: 0
+  waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 release txn=txn1 span=d
 ----
@@ -1643,28 +2734,92 @@ metrics
 ----
 locks: 2
 locksheld: 2
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 1
 waiters: 1
 waitingreaders: 0
 waitingwriters: 1
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 99
   held: true
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key:
+  - 100
+  held: true
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 99
+  held: true
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 new-request r=req23 txn=txn3 ts=10 spans=w@d
 ----
@@ -1726,28 +2881,90 @@ metrics
 ----
 locks: 2
 locksheld: 0
+totallockholddurationnanos: 0
 lockswithreservation: 2
 lockswithwaitqueues: 1
 waiters: 1
 waitingreaders: 0
 waitingwriters: 1
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 100
   held: false
+  holddurationnanos: 0
   waiters: 1
   waitingreaders: 0
   waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 100
+  held: false
+  holddurationnanos: 0
+  waiters: 1
+  waitingreaders: 0
+  waitingwriters: 1
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 acquire r=req23 k=d durability=u
 ----
@@ -1788,24 +3005,85 @@ metrics
 ----
 locks: 0
 locksheld: 0
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 0
 waiters: 0
 waitingreaders: 0
 waitingwriters: 0
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -109,28 +109,91 @@ metrics
 ----
 locks: 1
 locksheld: 1
+totallockholddurationnanos: 0
 lockswithreservation: 0
 lockswithwaitqueues: 1
 waiters: 4
 waitingreaders: 2
 waitingwriters: 2
+totalwaitdurationnanos: 0
 topklocksbywaiters:
 - key:
   - 97
   held: true
+  holddurationnanos: 0
   waiters: 4
   waitingreaders: 2
   waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 - key: []
   held: false
+  holddurationnanos: 0
   waiters: 0
   waitingreaders: 0
   waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbyholdduration:
+- key:
+  - 97
+  held: true
+  holddurationnanos: 0
+  waiters: 4
+  waitingreaders: 2
+  waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+topklocksbywaitduration:
+- key:
+  - 97
+  held: true
+  holddurationnanos: 0
+  waiters: 4
+  waitingreaders: 2
+  waitingwriters: 2
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
+- key: []
+  held: false
+  holddurationnanos: 0
+  waiters: 0
+  waitingreaders: 0
+  waitingwriters: 0
+  waitdurationnanos: 0
+  maxwaitdurationnanos: 0
 
 # -------------------------------------------------------------
 # Update lock timestamp to 11,1 - nothing moves

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1220,6 +1220,20 @@ throttled they do count towards 'delay.total' and 'delay.enginebackpressure'.
 		Measurement: "Locks",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaConcurrencyAverageLockHoldDurationNanos = metric.Metadata{
+		Name: "kv.concurrency.avg_lock_hold_duration_nanos",
+		Help: "Average lock hold duration across locks currently held in lock tables. " +
+			"Does not include replicated locks (intents) that are not held in memory",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaConcurrencyMaxLockHoldDurationNanos = metric.Metadata{
+		Name: "kv.concurrency.max_lock_hold_duration_nanos",
+		Help: "Maximum length of time any lock in a lock table is held. " +
+			"Does not include replicated locks (intents) that are not held in memory",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaConcurrencyLocksWithWaitQueues = metric.Metadata{
 		Name:        "kv.concurrency.locks_with_wait_queues",
 		Help:        "Number of active locks held in lock tables with active wait-queues",
@@ -1231,6 +1245,18 @@ throttled they do count towards 'delay.total' and 'delay.enginebackpressure'.
 		Help:        "Number of requests actively waiting in a lock wait-queue",
 		Measurement: "Lock-Queue Waiters",
 		Unit:        metric.Unit_COUNT,
+	}
+	metaConcurrencyAverageLockWaitDurationNanos = metric.Metadata{
+		Name:        "kv.concurrency.avg_lock_wait_duration_nanos",
+		Help:        "Average lock wait duration across requests currently waiting in lock wait-queues",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaConcurrencyMaxLockWaitDurationNanos = metric.Metadata{
+		Name:        "kv.concurrency.max_lock_wait_duration_nanos",
+		Help:        "Maximum lock wait duration across requests currently waiting in lock wait-queues",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	metaConcurrencyMaxLockWaitQueueWaitersForLock = metric.Metadata{
 		Name:        "kv.concurrency.max_lock_wait_queue_waiters_for_lock",
@@ -1484,8 +1510,12 @@ type StoreMetrics struct {
 
 	// Concurrency control metrics.
 	Locks                          *metric.Gauge
+	AverageLockHoldDurationNanos   *metric.Gauge
+	MaxLockHoldDurationNanos       *metric.Gauge
 	LocksWithWaitQueues            *metric.Gauge
 	LockWaitQueueWaiters           *metric.Gauge
+	AverageLockWaitDurationNanos   *metric.Gauge
+	MaxLockWaitDurationNanos       *metric.Gauge
 	MaxLockWaitQueueWaitersForLock *metric.Gauge
 
 	// Closed timestamp metrics.
@@ -1926,8 +1956,12 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 
 		// Concurrency control metrics.
 		Locks:                          metric.NewGauge(metaConcurrencyLocks),
+		AverageLockHoldDurationNanos:   metric.NewGauge(metaConcurrencyAverageLockHoldDurationNanos),
+		MaxLockHoldDurationNanos:       metric.NewGauge(metaConcurrencyMaxLockHoldDurationNanos),
 		LocksWithWaitQueues:            metric.NewGauge(metaConcurrencyLocksWithWaitQueues),
 		LockWaitQueueWaiters:           metric.NewGauge(metaConcurrencyLockWaitQueueWaiters),
+		AverageLockWaitDurationNanos:   metric.NewGauge(metaConcurrencyAverageLockWaitDurationNanos),
+		MaxLockWaitDurationNanos:       metric.NewGauge(metaConcurrencyMaxLockWaitDurationNanos),
 		MaxLockWaitQueueWaitersForLock: metric.NewGauge(metaConcurrencyMaxLockWaitQueueWaitersForLock),
 
 		// Closed timestamp metrics.

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1004,10 +1004,24 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Lock Hold Durations",
+				Metrics: []string{
+					"kv.concurrency.avg_lock_hold_duration_nanos",
+					"kv.concurrency.max_lock_hold_duration_nanos",
+				},
+			},
+			{
 				Title: "Waiters",
 				Metrics: []string{
 					"kv.concurrency.lock_wait_queue_waiters",
 					"kv.concurrency.max_lock_wait_queue_waiters_for_lock",
+				},
+			},
+			{
+				Title: "Lock Wait Durations",
+				Metrics: []string{
+					"kv.concurrency.avg_lock_wait_duration_nanos",
+					"kv.concurrency.max_lock_wait_duration_nanos",
 				},
 			},
 		},


### PR DESCRIPTION
This change adds tracking on the lock acquisition time in the lock
table as well as the lock wait start time in the reader/writer wait
queues, and exposes the average and maximum durations of lock hold and
lock wait via the KV concurrency metrics.  The new metrics are:
```
kv_concurrency_avg_lock_hold_duration_nanos
kv_concurrency_max_lock_hold_duration_nanos
kv_concurrency_avg_lock_wait_duration_nanos
kv_concurrency_max_lock_wait_duration_nanos
```

Resovles #67619

Release note: None