### PR TITLE
sql: enable sqllogictest bigtest select5.test

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3701,9 +3701,7 @@ func RunSQLLiteLogicTest(t *testing.T, configOverride string) {
 		"/test/select2.test",
 		"/test/select3.test",
 		"/test/select4.test",
-
-		// TODO(andyk): No support for join ordering yet, so this takes too long.
-		// "/test/select5.test",
+		"/test/select5.test",
 
 		// TODO(pmattis): Incompatibilities in numeric types.
 		// For instance, we type SUM(int) as a decimal since all of our ints are


### PR DESCRIPTION
Previously, we were not running this test since our join reordering
capabilities were insufficient and it was too slow. We have suppported
improved join reording for a while now, so we should run this test to
improve our test coverage.

Release note: None