### PR TITLE
sql: migrate prepared statements during session migration

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2614,6 +2614,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		SchemaChangeJobRecords: ex.extraTxnState.schemaChangeJobRecords,
 		statsProvider:          ex.server.sqlStats,
 		indexUsageStats:        ex.indexUsageStats,
+		statementPreparer:      ex,
 	}
 	evalCtx.copyFromExecCfg(ex.server.cfg)
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1538,10 +1538,25 @@ type prepStmtNamespace struct {
 	portals map[string]PreparedPortal
 }
 
-// HasPrepared returns true if there are prepared statements or portals
-// in the session.
-func (ns prepStmtNamespace) HasPrepared() bool {
-	return len(ns.prepStmts) > 0 || len(ns.portals) > 0
+// HasActivePortals returns true if there are portals in the session.
+func (ns prepStmtNamespace) HasActivePortals() bool {
+	return len(ns.portals) > 0
+}
+
+// MigratablePreparedStatements returns a mapping of all prepared statements.
+func (ns prepStmtNamespace) MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement {
+	ret := make([]sessiondatapb.MigratableSession_PreparedStatement, 0, len(ns.prepStmts))
+	for name, stmt := range ns.prepStmts {
+		ret = append(
+			ret,
+			sessiondatapb.MigratableSession_PreparedStatement{
+				Name:                 name,
+				PlaceholderTypeHints: stmt.InferredTypes,
+				SQL:                  stmt.SQL,
+			},
+		)
+	}
+	return ret
 }
 
 func (ns prepStmtNamespace) String() string {

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -60,7 +60,7 @@ func (ex *connExecutor) execPrepare(
 	}
 
 	stmt := makeStatement(parseCmd.Statement, ex.generateID())
-	ps, err := ex.addPreparedStmt(
+	_, err := ex.addPreparedStmt(
 		ctx,
 		parseCmd.Name,
 		stmt,
@@ -72,28 +72,6 @@ func (ex *connExecutor) execPrepare(
 		return retErr(err)
 	}
 
-	// Convert the inferred SQL types back to an array of pgwire Oids.
-	if len(ps.TypeHints) > pgwirebase.MaxPreparedStatementArgs {
-		return retErr(
-			pgwirebase.NewProtocolViolationErrorf(
-				"more than %d arguments to prepared statement: %d",
-				pgwirebase.MaxPreparedStatementArgs, len(ps.TypeHints)))
-	}
-	inferredTypes := make([]oid.Oid, len(ps.Types))
-	copy(inferredTypes, parseCmd.RawTypeHints)
-
-	for i := range ps.Types {
-		// OID to Datum is not a 1-1 mapping (for example, int4 and int8
-		// both map to TypeInt), so we need to maintain the types sent by
-		// the client.
-		if inferredTypes[i] == 0 || inferredTypes[i] == oid.T_unknown {
-			t, _ := ps.ValueType(tree.PlaceholderIdx(i))
-			inferredTypes[i] = t.Oid()
-		}
-	}
-	// Remember the inferred placeholder types so they can be reported on
-	// Describe.
-	ps.InferredTypes = inferredTypes
 	return nil, nil
 }
 
@@ -114,7 +92,10 @@ func (ex *connExecutor) addPreparedStmt(
 	origin PreparedStatementOrigin,
 ) (*PreparedStatement, error) {
 	if _, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts[name]; ok {
-		panic(errors.AssertionFailedf("prepared statement already exists: %q", name))
+		return nil, pgerror.Newf(
+			pgcode.DuplicatePreparedStatement,
+			"prepared statement %q already exists", name,
+		)
 	}
 
 	// Prepare the query. This completes the typing of placeholders.
@@ -123,10 +104,29 @@ func (ex *connExecutor) addPreparedStmt(
 		return nil, err
 	}
 
+	if len(prepared.TypeHints) > pgwirebase.MaxPreparedStatementArgs {
+		return nil, pgwirebase.NewProtocolViolationErrorf(
+			"more than %d arguments to prepared statement: %d",
+			pgwirebase.MaxPreparedStatementArgs, len(prepared.TypeHints))
+	}
+
 	if err := prepared.memAcc.Grow(ctx, int64(len(name))); err != nil {
 		return nil, err
 	}
 	ex.extraTxnState.prepStmtsNamespace.prepStmts[name] = prepared
+
+	// Remember the inferred placeholder types so they can be reported on
+	// Describe. First, try to preserve the hints sent by the client.
+	prepared.InferredTypes = make([]oid.Oid, len(prepared.Types))
+	copy(prepared.InferredTypes, rawTypeHints)
+	for i, it := range prepared.InferredTypes {
+		// If the client did not provide an OID type hint, then infer the OID.
+		if it == 0 || it == oid.T_unknown {
+			t, _ := prepared.ValueType(tree.PlaceholderIdx(i))
+			prepared.InferredTypes[i] = t.Oid()
+		}
+	}
+
 	return prepared, nil
 }
 
@@ -163,13 +163,12 @@ func (ex *connExecutor) prepare(
 	var flags planFlags
 	prepare := func(ctx context.Context, txn *kv.Txn) (err error) {
 		p := &ex.planner
-		if origin != PreparedStatementOriginSQL {
-			// If the PREPARE command was issued as a SQL statement, then we
-			// have already reset the planner at the very beginning of the
-			// execution (in execStmtInOpenState). We might have also
-			// instrumented the planner to collect execution statistics, and
-			// resetting the planner here would break the assumptions of the
-			// instrumentation.
+		if origin == PreparedStatementOriginWire {
+			// If the PREPARE command was issued as a SQL statement or through
+			// deserialize_session, then we have already reset the planner at the very
+			// beginning of the execution (in execStmtInOpenState). We might have also
+			// instrumented the planner to collect execution statistics, and resetting
+			// the planner here would break the assumptions of the instrumentation.
 			ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime())
 		}

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/roleoption",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -216,13 +216,6 @@ func (ep *DummyEvalPlanner) UserHasAdminRole(
 	return false, errors.WithStack(errEvalPlanner)
 }
 
-// CheckCanBecomeUser is part of the EvalPlanner interface.
-func (ep *DummyEvalPlanner) CheckCanBecomeUser(
-	ctx context.Context, becomeUser security.SQLUsername,
-) error {
-	return errors.WithStack(errEvalPlanner)
-}
-
 // MemberOfWithAdminOption is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
 	ctx context.Context, member security.SQLUsername,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
@@ -510,7 +511,12 @@ type DummyPreparedStatementState struct{}
 
 var _ tree.PreparedStatementState = (*DummyPreparedStatementState)(nil)
 
-// HasPrepared is part of the tree.PreparedStatementState interface.
-func (ps *DummyPreparedStatementState) HasPrepared() bool {
+// HasActivePortals is part of the tree.PreparedStatementState interface.
+func (ps *DummyPreparedStatementState) HasActivePortals() bool {
 	return false
+}
+
+// MigratablePreparedStatements is part of the tree.PreparedStatementState interface.
+func (ps *DummyPreparedStatementState) MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement {
+	return nil
 }

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -34,6 +34,9 @@ const (
 	// PreparedStatementOriginSQL signifies the prepared statement was made
 	// over a parsed SQL query.
 	PreparedStatementOriginSQL
+	// PreparedStatementOriginSessionMigration signifies that the prepared
+	// statement came from a call to crdb_internal.deserialize_session.
+	PreparedStatementOriginSessionMigration
 )
 
 // PreparedStatement is a SQL statement that has been parsed and the types

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6349,7 +6349,7 @@ table's zone configuration this will return NULL.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				state := tree.MustBeDBytes(args[0])
-				return evalCtx.Planner.DeserializeSessionState(&state)
+				return evalCtx.Planner.DeserializeSessionState(tree.NewDBytes(state))
 			},
 			Info:       `This function deserializes the serialized variables into the current session.`,
 			Volatility: tree.VolatilityVolatile,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3250,10 +3250,6 @@ type EvalPlanner interface {
 	// the `system.users` table
 	UserHasAdminRole(ctx context.Context, user security.SQLUsername) (bool, error)
 
-	// CheckCanBecomeUser returns an error if the SessionUser cannot become the
-	// becomeUser.
-	CheckCanBecomeUser(ctx context.Context, becomeUser security.SQLUsername) error
-
 	// MemberOfWithAdminOption is used to collect a list of roles (direct and
 	// indirect) that the member is part of. See the comment on the planner
 	// implementation in authorization.go

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -3391,7 +3392,8 @@ type EvalSessionAccessor interface {
 // PreparedStatementState is a limited interface that exposes metadata about
 // prepared statements.
 type PreparedStatementState interface {
-	HasPrepared() bool
+	HasActivePortals() bool
+	MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement
 }
 
 // ClientNoticeSender is a limited interface to send notices to the

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -109,7 +109,7 @@ func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, erro
 			"can only deserialize matching session users",
 		)
 	}
-	if err := evalCtx.Planner.CheckCanBecomeUser(evalCtx.Context, sd.User()); err != nil {
+	if err := p.checkCanBecomeUser(evalCtx.Context, sd.User()); err != nil {
 		return nil, err
 	}
 	*evalCtx.SessionData() = *sd

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -11,13 +11,16 @@
 package sql
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 // SerializeSessionState is a wrapper for serializeSessionState, and uses the
@@ -45,10 +48,10 @@ func serializeSessionState(
 		)
 	}
 
-	if prepStmtsState.HasPrepared() {
+	if prepStmtsState.HasActivePortals() {
 		return nil, pgerror.Newf(
 			pgcode.InvalidTransactionState,
-			"cannot serialize a session which has portals or prepared statements",
+			"cannot serialize a session which has active portals",
 		)
 	}
 
@@ -70,6 +73,7 @@ func serializeSessionState(
 	m.SessionData = sd.SessionData
 	sessiondata.MarshalNonLocal(sd, &m.SessionData)
 	m.LocalOnlySessionData = sd.LocalOnlySessionData
+	m.PreparedStatements = prepStmtsState.MigratablePreparedStatements()
 
 	b, err := protoutil.Marshal(&m)
 	if err != nil {
@@ -81,7 +85,7 @@ func serializeSessionState(
 
 // DeserializeSessionState deserializes the given state into the current session.
 func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, error) {
-	evalCtx := p.EvalContext()
+	evalCtx := p.ExtendedEvalContext()
 	if !evalCtx.TxnImplicit {
 		return nil, pgerror.Newf(
 			pgcode.InvalidTransactionState,
@@ -91,10 +95,7 @@ func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, erro
 
 	var m sessiondatapb.MigratableSession
 	if err := protoutil.Unmarshal([]byte(*state), &m); err != nil {
-		return nil, pgerror.WithCandidateCode(
-			errors.Wrapf(err, "error deserializing session"),
-			pgcode.InvalidParameterValue,
-		)
+		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "error deserializing session")
 	}
 	sd, err := sessiondata.UnmarshalNonLocal(m.SessionData)
 	if err != nil {
@@ -112,6 +113,50 @@ func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, erro
 	if err := p.checkCanBecomeUser(evalCtx.Context, sd.User()); err != nil {
 		return nil, err
 	}
-	*evalCtx.SessionData() = *sd
+
+	for _, prepStmt := range m.PreparedStatements {
+		parserStmt, err := parser.ParseOneWithInt(
+			prepStmt.SQL,
+			parser.NakedIntTypeFromDefaultIntSize(sd.DefaultIntSize),
+		)
+		if err != nil {
+			return nil, err
+		}
+		id := GenerateClusterWideID(evalCtx.ExecCfg.Clock.Now(), evalCtx.ExecCfg.NodeID.SQLInstanceID())
+		stmt := makeStatement(parserStmt, id)
+
+		var placeholderTypes tree.PlaceholderTypes
+		if len(prepStmt.PlaceholderTypeHints) > 0 {
+			// Prepare the mapping of SQL placeholder names to types. Pre-populate it
+			// with the type hints that were serialized.
+			placeholderTypes = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
+			for i, t := range prepStmt.PlaceholderTypeHints {
+				// If the OID is user defined or unknown, then skip it and let the
+				// statementPreparer resolve the type.
+				if t == 0 || t == oid.T_unknown || types.IsOIDUserDefinedType(t) {
+					placeholderTypes[i] = nil
+					continue
+				}
+				v, ok := types.OidToType[t]
+				if !ok {
+					err := pgwirebase.NewProtocolViolationErrorf("unknown oid type: %v", t)
+					return nil, err
+				}
+				placeholderTypes[i] = v
+			}
+		}
+
+		_, err = evalCtx.statementPreparer.addPreparedStmt(
+			evalCtx.Context,
+			prepStmt.Name, stmt, placeholderTypes, prepStmt.PlaceholderTypeHints,
+			PreparedStatementOriginSessionMigration,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	*p.SessionData() = *sd
+
 	return tree.MakeDBool(true), nil
 }

--- a/pkg/sql/sessiondatapb/BUILD.bazel
+++ b/pkg/sql/sessiondatapb/BUILD.bazel
@@ -12,7 +12,10 @@ go_library(
     embed = [":sessiondatapb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/security"],
+    deps = [
+        "//pkg/security",
+        "@com_github_lib_pq//oid",  # keep
+    ],
 )
 
 proto_library(

--- a/pkg/sql/sessiondatapb/session_migration.proto
+++ b/pkg/sql/sessiondatapb/session_migration.proto
@@ -21,4 +21,15 @@ import "sql/sessiondatapb/local_only_session_data.proto";
 message MigratableSession {
   cockroach.sql.sessiondatapb.SessionData session_data = 1 [(gogoproto.nullable)=false];
   cockroach.sql.sessiondatapb.LocalOnlySessionData local_only_session_data = 2 [(gogoproto.nullable)=false];
+
+  // PreparedStatement represents a prepared statement in a migratable session.
+  message PreparedStatement {
+    string name = 1;
+    repeated uint32 placeholder_type_hints = 2 [
+      (gogoproto.customtype)="github.com/lib/pq/oid.Oid"
+    ];
+    string sql = 3 [(gogoproto.customname)="SQL"];
+  }
+  repeated PreparedStatement prepared_statements = 3 [(gogoproto.nullable)=false];
+
 }

--- a/pkg/sql/testdata/session_migration/errors
+++ b/pkg/sql/testdata/session_migration/errors
@@ -3,7 +3,7 @@
 exec
 SELECT crdb_internal.deserialize_session('invalid proto')
 ----
-pq: crdb_internal.deserialize_session(): error deserializing session: unexpected EOF
+ERROR: crdb_internal.deserialize_session(): error deserializing session: unexpected EOF (SQLSTATE 22023)
 
 exec
 SET experimental_enable_temp_tables = true;
@@ -13,7 +13,7 @@ CREATE TEMP TABLE temp_tbl()
 query
 SELECT crdb_internal.serialize_session()
 ----
-pq: crdb_internal.serialize_session(): cannot serialize session with temporary schemas
+ERROR: crdb_internal.serialize_session(): cannot serialize session with temporary schemas (SQLSTATE 25000)
 
 reset
 ----
@@ -25,7 +25,7 @@ BEGIN
 query
 SELECT crdb_internal.serialize_session()
 ----
-pq: crdb_internal.serialize_session(): cannot serialize a session which is inside a transaction
+ERROR: crdb_internal.serialize_session(): cannot serialize a session which is inside a transaction (SQLSTATE 25000)
 
 reset
 ----
@@ -41,7 +41,7 @@ BEGIN
 exec
 SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
 ----
-pq: crdb_internal.deserialize_session(): cannot deserialize a session whilst inside a transaction
+ERROR: crdb_internal.deserialize_session(): cannot deserialize a session whilst inside a transaction (SQLSTATE 25000)
 
 reset
 ----
@@ -55,7 +55,7 @@ SELECT crdb_internal.deserialize_session(
   )
 )
 ----
-pq: crdb_internal.deserialize_session(): can only deserialize matching session users
+ERROR: crdb_internal.deserialize_session(): can only deserialize matching session users (SQLSTATE 42501)
 
 # We cannot deserialize a different session_user, even if current_user matches.
 exec
@@ -66,7 +66,7 @@ SELECT crdb_internal.deserialize_session(
   )
 )
 ----
-pq: crdb_internal.deserialize_session(): can only deserialize matching session users
+ERROR: crdb_internal.deserialize_session(): can only deserialize matching session users (SQLSTATE 42501)
 
 # We cannot deserialize into a current_user we do not match.
 user
@@ -84,4 +84,4 @@ SELECT crdb_internal.deserialize_session(
   )
 )
 ----
-pq: crdb_internal.deserialize_session(): only root can become root
+ERROR: crdb_internal.deserialize_session(): only root can become root (SQLSTATE 42501)

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -1,0 +1,67 @@
+# This file contains tests for migrating prepared statements.
+
+wire_prepare s1
+SELECT 1
+----
+
+query
+EXECUTE s1
+----
+1
+
+exec
+CREATE TABLE t(a INT4, b TEXT, c DATE)
+----
+
+wire_prepare s2
+INSERT INTO t VALUES($1, $2, $3)
+----
+
+let $x
+SELECT encode(crdb_internal.serialize_session(), 'hex')
+----
+
+# Instead of closing the session, just tell the server to remove the prepared
+# statements. This way the client still keeps all the prepared statement
+# metadata.
+exec
+DEALLOCATE ALL
+----
+
+query
+EXECUTE s1
+----
+ERROR: prepared statement "s1" does not exist (SQLSTATE 26000)
+
+exec
+SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
+----
+
+wire_query s1
+----
+1
+
+query
+EXECUTE s1
+----
+1
+
+wire_exec s2 1 cat 2022-02-10
+----
+
+query
+SELECT * FROM t
+----
+1 cat 2022-02-10 00:00:00 +0000 UTC
+
+reset
+----
+
+wire_prepare s2
+SELECT 1
+----
+
+exec
+SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
+----
+ERROR: crdb_internal.deserialize_session(): prepared statement "s2" already exists (SQLSTATE 42P05)

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -17,6 +17,34 @@ wire_prepare s2
 INSERT INTO t VALUES($1, $2, $3)
 ----
 
+exec
+ALTER TABLE t RENAME TO t2
+----
+
+wire_prepare s3
+INSERT INTO t2 VALUES($1, $2, $3)
+----
+
+exec
+ALTER TABLE t2 DROP COLUMN c
+----
+
+wire_prepare s4
+INSERT INTO t2 VALUES($1, $2)
+----
+
+wire_exec s2 1 cat 2022-02-10
+----
+ERROR: relation "t" does not exist (SQLSTATE 42P01)
+
+wire_exec s3 1 cat 2022-02-10
+----
+ERROR: INSERT has more expressions than target columns, 3 expressions for 2 targets (SQLSTATE 42601)
+
+query
+SELECT * FROM t2
+----
+
 let $x
 SELECT encode(crdb_internal.serialize_session(), 'hex')
 ----
@@ -46,13 +74,23 @@ EXECUTE s1
 ----
 1
 
+# The s2 and s3 statements should experience the same errors that they did
+# before the session migration.
 wire_exec s2 1 cat 2022-02-10
+----
+ERROR: relation "t" does not exist (SQLSTATE 42P01)
+
+wire_exec s3 1 cat 2022-02-10
+----
+ERROR: INSERT has more expressions than target columns, 3 expressions for 2 targets (SQLSTATE 42601)
+
+wire_exec s4 1 cat
 ----
 
 query
-SELECT * FROM t
+SELECT * FROM t2
 ----
-1 cat 2022-02-10 00:00:00 +0000 UTC
+1 cat
 
 reset
 ----

--- a/pkg/sql/testdata/session_migration/session_migration
+++ b/pkg/sql/testdata/session_migration/session_migration
@@ -48,15 +48,23 @@ new_state
 reset
 ----
 
-reset
-----
-
-# We cannot serialized prepared statements
+# Test serializing prepared statements.
 exec
 PREPARE stmt AS SELECT 1
 ----
 
-exec
-SELECT crdb_internal.serialize_session()
+let $x
+SELECT encode(crdb_internal.serialize_session(), 'hex')
 ----
-pq: crdb_internal.serialize_session(): cannot serialize a session which has portals or prepared statements
+
+reset
+----
+
+exec
+SELECT crdb_internal.deserialize_session( decode('$x', 'hex') )
+----
+
+query
+EXECUTE stmt
+----
+1

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -528,7 +528,7 @@ func (p *planner) setRole(ctx context.Context, local bool, s security.SQLUsernam
 		}
 	}
 
-	if err := p.CheckCanBecomeUser(ctx, becomeUser); err != nil {
+	if err := p.checkCanBecomeUser(ctx, becomeUser); err != nil {
 		return err
 	}
 
@@ -573,8 +573,9 @@ func (p *planner) setRole(ctx context.Context, local bool, s security.SQLUsernam
 
 }
 
-// CheckCanBecomeUser implements the EvalPlanner interface.
-func (p *planner) CheckCanBecomeUser(ctx context.Context, becomeUser security.SQLUsername) error {
+// checkCanBecomeUser returns an error if the SessionUser cannot become the
+// becomeUser.
+func (p *planner) checkCanBecomeUser(ctx context.Context, becomeUser security.SQLUsername) error {
 	sessionUser := p.SessionData().SessionUser()
 
 	// Switching to None can always succeed.

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/sqlutils/rows.go
+++ b/pkg/testutils/sqlutils/rows.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/jackc/pgx/v4"
 )
 
 // RowsToDataDrivenOutput converts a gosql.Rows object into an appropriate
@@ -25,6 +27,50 @@ func RowsToDataDrivenOutput(rows *gosql.Rows) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Allocate a buffer of *interface{} to write results into.
+	elemsI := make([]interface{}, len(cols))
+	for i := range elemsI {
+		elemsI[i] = new(interface{})
+	}
+	elems := make([]string, len(cols))
+
+	// Build string output of the row data.
+	var output strings.Builder
+	for rows.Next() {
+		if err := rows.Scan(elemsI...); err != nil {
+			return "", err
+		}
+		for i, elem := range elemsI {
+			val := *(elem.(*interface{}))
+			switch t := val.(type) {
+			case []byte:
+				// The postgres wire protocol does not distinguish between
+				// strings and byte arrays, but our tests do. In order to do
+				// The Right Thing™, we replace byte arrays which are valid
+				// UTF-8 with strings. This allows byte arrays which are not
+				// valid UTF-8 to print as a list of bytes (e.g. `[124 107]`)
+				// while printing valid strings naturally.
+				if str := string(t); utf8.ValidString(str) {
+					elems[i] = str
+				}
+			default:
+				elems[i] = fmt.Sprintf("%v", val)
+			}
+		}
+		output.WriteString(strings.Join(elems, " "))
+		output.WriteString("\n")
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+// PGXRowsToDataDrivenOutput converts a pgx.Rows object into an appropriate
+// string for usage in data driven tests.
+func PGXRowsToDataDrivenOutput(rows pgx.Rows) (string, error) {
+	// Find out how many output columns there are.
+	cols := rows.FieldDescriptions()
 	// Allocate a buffer of *interface{} to write results into.
 	elemsI := make([]interface{}, len(cols))
 	for i := range elemsI {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76398

See individual commits. The last one contains the business logic changes,
and the rest are just refactors.

Release note (sql change): The crdb_internal.serialize_session and
crdb_internal.deserialize_session now can handle prepared statements.
When deserializing, any prepared statements that existed when the
session was serialized are re-prepared. It is an error to re-prepare a
statement if the current session already has a statement with that name.