### PR TITLE
opt: fixes top k xform rules when an ordering column only has one value

### DIFF
--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -233,6 +233,12 @@ func (c *CustomFuncs) GenerateLimitedTopKScans(
 	grp memo.RelExpr, sp *memo.ScanPrivate, tp *memo.TopKPrivate,
 ) {
 	required := tp.Ordering
+	// If the ordering was already optimized out (e.g., there is only one possible
+	// value for what would have been the required ordering), then there is no
+	// benefit to exploring limited top K.
+	if len(required.Columns) == 0 {
+		return
+	}
 	// Iterate over all non-inverted and non-partial secondary indexes.
 	var pkCols opt.ColSet
 	var iter scanIndexIter

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2093,3 +2093,30 @@ top-k
  ├── ordering: +2
  └── scan defg
       └── columns: d:1 e:2 f:3 g:4
+
+# Regression testing for #76102.
+exec-ddl
+CREATE TABLE tab_76102 (
+ a INT2 NULL,
+ b INT2 NULL AS (a + NULL) STORED,
+ UNIQUE (a DESC)
+)
+----
+
+# The GROUP BY column can only have one value (NULL), so  we do not benefit from
+# limited TopK, and trying to apply the rule may lead to errors since the
+# required ordering is optimized away in this case.
+opt expect-not=GenerateLimitedTopKScans
+SELECT b FROM tab_76102@tab_76102_a_key GROUP BY b LIMIT 5
+----
+index-join tab_76102
+ ├── columns: b:2
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── scan tab_76102@tab_76102_a_key
+      ├── columns: rowid:3!null
+      ├── limit: 1
+      ├── flags: force-index=tab_76102_a_key
+      ├── key: ()
+      └── fd: ()-->(3)


### PR DESCRIPTION
When a column can only have one possible value, the optimizer may
omit it from required orderings. This caused an error in the xform rules
`GenerateLimitedTopKScans`, which previously assumed there would always
be at least one column in its required ordering in order to identify
relevant secondary indexes. In this change, we skip the rule if there
are no required columns, since it's not beneficial to use a limited Top
K if there is only one possible value to order by anyway.

Fixes: #76102

Release note: None