### PR TITLE
util/tracing: enable the trace registry beyond tests

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -164,7 +164,7 @@ var ZipkinCollector = settings.RegisterValidatedStringSetting(
 
 // enableTracingByDefault controls whether Tracers configured with
 // WithTracingMode(TracingModeFromEnv) generally create spans or not.
-var enableTracingByDefault = envutil.EnvOrDefaultBool("COCKROACH_REAL_SPANS", false) || buildutil.CrdbTestBuild
+var enableTracingByDefault = envutil.EnvOrDefaultBool("COCKROACH_REAL_SPANS", true)
 
 // panicOnUseAfterFinish, if set, causes use of a span after Finish() to panic
 // if detected.
@@ -182,8 +182,7 @@ var debugUseAfterFinish = envutil.EnvOrDefaultBool("COCKROACH_DEBUG_SPAN_USE_AFT
 // the span mutexes end up being reused and locked repeatedly in random order on
 // the same goroutine. This erroneously looks like a potential deadlock to the
 // detector.
-var reuseSpans = (buildutil.CrdbTestBuild && !syncutil.DeadlockEnabled) ||
-	envutil.EnvOrDefaultBool("COCKROACH_REUSE_TRACING_SPANS", false)
+var reuseSpans = !syncutil.DeadlockEnabled && envutil.EnvOrDefaultBool("COCKROACH_REUSE_TRACING_SPANS", true)
 
 // detectSpanRefLeaks enables the detection of Span reference leaks - i.e.
 // failures to decrement a Span's reference count. If detection is enabled, such


### PR DESCRIPTION
This patch defaults the COCKROACH_REAL_SPANS and
COCKROACH_REUSE_TRACING_SPANS env vars to true. This causes tracing
spans to be created even for operations that are not explicitly traced
(i.e. operations for which a "trace recording" has not been requested).
This was already the case in unit tests. Creating the tracing spans is
nice because, which a span is alive, it is present in the active spans
registry which can be queried in various ways (e.g. through the
crdb_internal.node_inflight_trace_spans virtual table, and through the
/debug/tracez console page). I've got big plans for exposing this
registry.

I believe this change to have almost no measurable performance impact.
Some unittest benchmarks:
```
make bench PKG=./pkg/sql/tests BENCHES='BenchmarkKV///rows=1$$'

name                        old time/op  new time/op  delta
KV/Insert/Native/rows=1-32  92.2µs ±11%  88.0µs ± 6%    ~     (p=0.421 n=5+5)
KV/Insert/SQL/rows=1-32      322µs ± 6%   312µs ± 4%    ~     (p=0.151 n=5+5)
KV/Update/Native/rows=1-32   114µs ± 0%   118µs ± 3%  +3.64%  (p=0.016 n=4+5)
KV/Update/SQL/rows=1-32      398µs ± 2%   402µs ± 5%    ~     (p=0.690 n=5+5)
KV/Delete/Native/rows=1-32  94.3µs ± 2%  91.0µs ± 5%    ~     (p=0.056 n=5+5)
KV/Delete/SQL/rows=1-32      266µs ±10%   260µs ±17%    ~     (p=0.690 n=5+5)
KV/Scan/Native/rows=1-32    19.4µs ± 3%  21.0µs ± 5%  +8.01%  (p=0.008 n=5+5)
KV/Scan/SQL/rows=1-32        194µs ± 8%   201µs ± 5%    ~     (p=0.421 n=5+5)
```

And 30 runs of kv95 and kv0 roachtests with results processed through benchstat:
```
kv95:
name                    old ops/sec  new ops/sec  delta
kv95/enc=false/nodes=3   29.6k ± 4%   29.2k ± 8%  -1.33%  (p=0.018 n=30+30)

kv0:
name                   old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=3   13.6k ± 4%   13.5k ± 3%    ~     (p=0.217 n=30+27)
```

This measurements were taken with https://github.com/cockroachdb/cockroach/pull/76199 - a last pending performance
optimization for the tracing library in a long chain of them.

It's possible that this changes causes some roachtests to fail with span
use-after-finish assertions; roachtests are configured to crash on these
assertions, unlike production. But I don't expect that to happen (at
least, not too much), since unit tests have been running like this for a
while. I've also kick off a roachtest run; it's far from done, but so
far everything looks good.

Release note: The crdb_internal.node_inflight_trace_spans virtual table
will now present traces for all operations ongoing on the respective
node. Before, the table was reflecting a small percentage of ongoing
operations unless tracing was explicitly enabled.