### PR TITLE
kvserver: add load-based rebalancing metrics to the allocator

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/etcd/raft/v3"
@@ -361,6 +362,118 @@ func rangeUsageInfoForRepl(repl *Replica) RangeUsageInfo {
 	return info
 }
 
+var (
+	// Load-based lease transfers.
+	metaLBLeaseTransferCannotFindBetterCandidate = metric.Metadata{
+		Name: "kv.allocator.load_based_lease_transfers.cannot_find_better_candidate",
+		Help: "The number times the allocator determined that the lease was on the best" +
+			" possible replica",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBLeaseTransferExistingNotOverfull = metric.Metadata{
+		Name: "kv.allocator.load_based_lease_transfers.existing_not_overfull",
+		Help: "The number times the allocator determined that the lease was not on an" +
+			" overfull store",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBLeaseTransferDeltaNotSignificant = metric.Metadata{
+		Name: "kv.allocator.load_based_lease_transfers.delta_not_significant",
+		Help: "The number times the allocator determined that the delta between the existing" +
+			" store and the best candidate was not significant",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBLeaseTransferMissingStatsForExistingStore = metric.Metadata{
+		Name:        "kv.allocator.load_based_lease_transfers.missing_stats_for_existing_stores",
+		Help:        "The number times the allocator was missing qps stats for the leaseholder",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBLeaseTransferSignificantlySwitchesRelativeDisposition = metric.Metadata{
+		Name: "kv.allocator.load_based_lease_transfers.significantly_switches_relative_disposition",
+		Help: "The number times the allocator decided to not transfer the lease because" +
+			" it would invert the dispositions of the sending and the receiving stores",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBLeaseTransferShouldTransfer = metric.Metadata{
+		Name: "kv.allocator.load_based_lease_transfers.should_transfer",
+		Help: "The number times the allocator determined that the lease should be" +
+			" transferred to another replica for better load distribution",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	// Load-based replica rebalances.
+	metaLBReplicaRebalancingCannotFindBetterCandidate = metric.Metadata{
+		Name: "kv.allocator.load_based_replica_rebalancing.cannot_find_better_candidate",
+		Help: "The number times the allocator determined that the range was on the best" +
+			" possible stores",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBReplicaRebalancingExistingNotOverfull = metric.Metadata{
+		Name: "kv.allocator.load_based_replica_rebalancing.existing_not_overfull",
+		Help: "The number times the allocator determined that none of the range's replicas" +
+			" were on overfull stores",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBReplicaRebalancingDeltaNotSignificant = metric.Metadata{
+		Name: "kv.allocator.load_based_replica_rebalancing.delta_not_significant",
+		Help: "The number times the allocator determined that the delta between an" +
+			" existing store and the best replacement candidate was not high enough",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBReplicaRebalancingMissingStatsForExistingStore = metric.Metadata{
+		Name:        "kv.allocator.load_based_replica_rebalancing.missing_stats_for_existing_store",
+		Help:        "The number times the allocator was missing the qps stats for the existing store",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBReplicaRebalancingSignificantlySwitchesRelativeDisposition = metric.Metadata{
+		Name: "kv.allocator.load_based_replica_rebalancing.significantly_switches_relative_disposition",
+		Help: "The number times the allocator decided to not rebalance the replica" +
+			" because it would invert the dispositions of the sending and the receiving stores",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLBReplicaRebalancingShouldTransfer = metric.Metadata{
+		Name: "kv.allocator.load_based_replica_rebalancing.should_transfer",
+		Help: "The number times the allocator determined that the replica should be" +
+			" rebalanced to another store for better load distribution",
+		Measurement: "Attempts",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+type loadBasedLeaseTransferMetrics struct {
+	CannotFindBetterCandidate                *metric.Counter
+	ExistingNotOverfull                      *metric.Counter
+	DeltaNotSignificant                      *metric.Counter
+	MissingStatsForExistingStore             *metric.Counter
+	SignificantlySwitchesRelativeDisposition *metric.Counter
+	ShouldTransfer                           *metric.Counter
+}
+
+type loadBasedReplicaRebalanceMetrics struct {
+	CannotFindBetterCandidate                *metric.Counter
+	ExistingNotOverfull                      *metric.Counter
+	DeltaNotSignificant                      *metric.Counter
+	MissingStatsForExistingStore             *metric.Counter
+	SignificantlySwitchesRelativeDisposition *metric.Counter
+	ShouldRebalance                          *metric.Counter
+}
+
+// AllocatorMetrics capture metrics about the allocator's decisions.
+type AllocatorMetrics struct {
+	loadBasedLeaseTransferMetrics
+	loadBasedReplicaRebalanceMetrics
+}
+
 // Allocator tries to spread replicas as evenly as possible across the stores
 // in the cluster.
 type Allocator struct {
@@ -369,7 +482,30 @@ type Allocator struct {
 	// TODO(aayush): Let's replace this with a *rand.Rand that has a rand.Source
 	// wrapped inside a mutex, to avoid misuse.
 	randGen allocatorRand
-	knobs   *AllocatorTestingKnobs
+	metrics AllocatorMetrics
+
+	knobs *AllocatorTestingKnobs
+}
+
+func makeAllocatorMetrics() AllocatorMetrics {
+	return AllocatorMetrics{
+		loadBasedLeaseTransferMetrics: loadBasedLeaseTransferMetrics{
+			CannotFindBetterCandidate:                metric.NewCounter(metaLBLeaseTransferCannotFindBetterCandidate),
+			ExistingNotOverfull:                      metric.NewCounter(metaLBLeaseTransferExistingNotOverfull),
+			DeltaNotSignificant:                      metric.NewCounter(metaLBLeaseTransferDeltaNotSignificant),
+			MissingStatsForExistingStore:             metric.NewCounter(metaLBLeaseTransferMissingStatsForExistingStore),
+			SignificantlySwitchesRelativeDisposition: metric.NewCounter(metaLBLeaseTransferSignificantlySwitchesRelativeDisposition),
+			ShouldTransfer:                           metric.NewCounter(metaLBLeaseTransferShouldTransfer),
+		},
+		loadBasedReplicaRebalanceMetrics: loadBasedReplicaRebalanceMetrics{
+			CannotFindBetterCandidate:                metric.NewCounter(metaLBReplicaRebalancingCannotFindBetterCandidate),
+			ExistingNotOverfull:                      metric.NewCounter(metaLBReplicaRebalancingExistingNotOverfull),
+			DeltaNotSignificant:                      metric.NewCounter(metaLBReplicaRebalancingDeltaNotSignificant),
+			MissingStatsForExistingStore:             metric.NewCounter(metaLBReplicaRebalancingMissingStatsForExistingStore),
+			SignificantlySwitchesRelativeDisposition: metric.NewCounter(metaLBReplicaRebalancingSignificantlySwitchesRelativeDisposition),
+			ShouldRebalance:                          metric.NewCounter(metaLBReplicaRebalancingShouldTransfer),
+		},
+	}
 }
 
 // MakeAllocator creates a new allocator using the specified StorePool.
@@ -377,6 +513,7 @@ func MakeAllocator(
 	storePool *StorePool,
 	nodeLatencyFn func(addr string) (time.Duration, bool),
 	knobs *AllocatorTestingKnobs,
+	storeMetrics *StoreMetrics,
 ) Allocator {
 	var randSource rand.Source
 	// There are number of test cases that make a test store but don't add
@@ -387,12 +524,18 @@ func MakeAllocator(
 	} else {
 		randSource = rand.NewSource(rand.Int63())
 	}
-	return Allocator{
+	allocator := Allocator{
 		storePool:     storePool,
 		nodeLatencyFn: nodeLatencyFn,
 		randGen:       makeAllocatorRand(randSource),
+		metrics:       makeAllocatorMetrics(),
 		knobs:         knobs,
 	}
+	if storeMetrics != nil {
+		storeMetrics.registry.AddMetricStruct(allocator.metrics.loadBasedLeaseTransferMetrics)
+		storeMetrics.registry.AddMetricStruct(allocator.metrics.loadBasedReplicaRebalanceMetrics)
+	}
+	return allocator
 }
 
 // GetNeededVoters calculates the number of voters a range should have given its
@@ -1133,6 +1276,7 @@ func (a Allocator) rebalanceTarget(
 		a.storePool.getLocalitiesByStore(replicaSetForDiversityCalc),
 		a.storePool.isStoreReadyForRoutineReplicaTransfer,
 		options,
+		a.metrics,
 	)
 
 	if len(results) == 0 {
@@ -1533,15 +1677,18 @@ func (a *Allocator) TransferLeaseTarget(
 
 		switch noRebalanceReason {
 		case noBetterCandidate:
+			a.metrics.loadBasedLeaseTransferMetrics.CannotFindBetterCandidate.Inc(1)
 			log.VEventf(ctx, 5, "r%d: could not find a better target for lease", leaseRepl.GetRangeID())
 			return roachpb.ReplicaDescriptor{}
 		case existingNotOverfull:
+			a.metrics.loadBasedLeaseTransferMetrics.ExistingNotOverfull.Inc(1)
 			log.VEventf(
 				ctx, 5, "r%d: existing leaseholder s%d is not overfull",
 				leaseRepl.GetRangeID(), leaseRepl.StoreID(),
 			)
 			return roachpb.ReplicaDescriptor{}
 		case deltaNotSignificant:
+			a.metrics.loadBasedLeaseTransferMetrics.DeltaNotSignificant.Inc(1)
 			log.VEventf(
 				ctx, 5,
 				"r%d: delta between s%d and the coldest follower (ignoring r%d's lease) is not large enough",
@@ -1549,17 +1696,20 @@ func (a *Allocator) TransferLeaseTarget(
 			)
 			return roachpb.ReplicaDescriptor{}
 		case significantlySwitchesRelativeDisposition:
+			a.metrics.loadBasedLeaseTransferMetrics.SignificantlySwitchesRelativeDisposition.Inc(1)
 			log.VEventf(ctx, 5,
 				"r%d: lease transfer away from s%d would make it hotter than the coldest follower",
 				leaseRepl.GetRangeID(), leaseRepl.StoreID())
 			return roachpb.ReplicaDescriptor{}
 		case missingStatsForExistingStore:
+			a.metrics.loadBasedLeaseTransferMetrics.MissingStatsForExistingStore.Inc(1)
 			log.VEventf(
 				ctx, 5, "r%d: missing stats for leaseholder s%d",
 				leaseRepl.GetRangeID(), leaseRepl.StoreID(),
 			)
 			return roachpb.ReplicaDescriptor{}
 		case shouldRebalance:
+			a.metrics.loadBasedLeaseTransferMetrics.ShouldTransfer.Inc(1)
 			log.VEventf(
 				ctx,
 				5,

--- a/pkg/kv/kvserver/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator_scorer_test.go
@@ -1205,6 +1205,7 @@ func TestShouldRebalanceDiversity(t *testing.T) {
 			existingStoreLocalities,
 			func(context.Context, roachpb.StoreID) bool { return true },
 			options,
+			AllocatorMetrics{},
 		)
 		actual := len(targets) > 0
 		if actual != tc.expected {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1156,13 +1156,13 @@ func NewStore(
 			cfg.StorePool,
 			cfg.RPCContext.RemoteClocks.Latency,
 			cfg.TestingKnobs.AllocatorKnobs,
+			s.metrics,
 		)
 	} else {
 		s.allocator = MakeAllocator(
 			cfg.StorePool, func(string) (time.Duration, bool) {
 				return 0, false
-			},
-			cfg.TestingKnobs.AllocatorKnobs,
+			}, cfg.TestingKnobs.AllocatorKnobs, s.metrics,
 		)
 	}
 	s.replRankings = newReplicaRankings()

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -643,6 +643,44 @@ var charts = []sectionDescription{
 	},
 	{
 		Organization: [][]string{
+			{DistributionLayer, "Rebalancing"},
+			{ReplicationLayer, "Leases"},
+		},
+		Charts: []chartDescription{
+			{
+				Title: "Allocator Load-Based Lease Transfer Decisions",
+				Metrics: []string{
+					"kv.allocator.load_based_lease_transfers.should_transfer",
+					"kv.allocator.load_based_lease_transfers.significantly_switches_relative_disposition",
+					"kv.allocator.load_based_lease_transfers.missing_stats_for_existing_stores",
+					"kv.allocator.load_based_lease_transfers.delta_not_significant",
+					"kv.allocator.load_based_lease_transfers.existing_not_overfull",
+					"kv.allocator.load_based_lease_transfers.cannot_find_better_candidate",
+				},
+			},
+		},
+	},
+	{
+		Organization: [][]string{
+			{DistributionLayer, "Rebalancing"},
+			{ReplicationLayer, "Replicas"},
+		},
+		Charts: []chartDescription{
+			{
+				Title: "Allocator Load-Based Lease Transfer Decisions",
+				Metrics: []string{
+					"kv.allocator.load_based_replica_rebalancing.should_transfer",
+					"kv.allocator.load_based_replica_rebalancing.significantly_switches_relative_disposition",
+					"kv.allocator.load_based_replica_rebalancing.missing_stats_for_existing_store",
+					"kv.allocator.load_based_replica_rebalancing.delta_not_significant",
+					"kv.allocator.load_based_replica_rebalancing.existing_not_overfull",
+					"kv.allocator.load_based_replica_rebalancing.cannot_find_better_candidate",
+				},
+			},
+		},
+	},
+	{
+		Organization: [][]string{
 			{DistributionLayer, "Split Queue"},
 			{ReplicationLayer, "Split Queue"},
 		},


### PR DESCRIPTION
This commit adds some sorely needed metrics around the allocator's load-based rebalancing decisions that will hopefully help us diagnose potential issues without having to resort to enabling vmodules.

Release note: None
