### PR TITLE
kv: disallow GC requests that bump GC threshold and GC expired versions

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/errors"
 )
 
 func init() {
@@ -62,6 +63,33 @@ func GC(
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.GCRequest)
 	h := cArgs.Header
+
+	// We do not allow GC requests to bump the GC threshold at the same time that
+	// they GC individual keys. This is because performing both of these actions
+	// at the same time could lead to a race where a read request is allowed to
+	// evaluate without error while also failing to see MVCC versions that were
+	// concurrently GCed, which would be a form of data corruption.
+	//
+	// This race is possible because foreground traffic consults the in-memory
+	// version of the GC threshold (r.mu.state.GCThreshold), which is updated
+	// after (in handleGCThresholdResult), not atomically with, the application of
+	// the GC request's WriteBatch to the LSM (in ApplyToStateMachine). This
+	// allows a read request to see the effect of a GC on MVCC state without
+	// seeing its effect on the in-memory GC threshold.
+	//
+	// The latching above looks like it will help here, but in practice it does
+	// not for two reasons:
+	// 1. the latches do not protect timestamps below the GC request's batch
+	//    timestamp. This means that they only conflict with concurrent writes,
+	//    but not all concurrent reads.
+	// 2. the read could be served off a follower, which could be applying the
+	//    GC request's effect from the raft log. Latches held on the leaseholder
+	//    would have no impact on a follower read.
+	if !args.Threshold.IsEmpty() && len(args.Keys) != 0 &&
+		!cArgs.EvalCtx.EvalKnobs().AllowGCWithNewThresholdAndKeys {
+		return result.Result{}, errors.AssertionFailedf(
+			"GC request can set threshold or it can GC keys, but it is unsafe for it to do both")
+	}
 
 	// All keys must be inside the current replica range. Keys outside
 	// of this range in the GC request are dropped silently, which is

--- a/pkg/kv/kvserver/kvserverbase/knobs.go
+++ b/pkg/kv/kvserver/kvserverbase/knobs.go
@@ -32,6 +32,12 @@ type BatchEvalTestingKnobs struct {
 	// the chance that conflicting transactions will prevent parallel commit
 	// attempts from succeeding.
 	RecoverIndeterminateCommitsOnFailedPushes bool
+
+	// AllowGCWithNewThresholdAndKeys configures whether GC requests are allowed
+	// to increase the GC threshold and to GC individual keys at the same time. By
+	// default, this is not allowed because it is unsafe. See cmd_gc.go for an
+	// explanation of why.
+	AllowGCWithNewThresholdAndKeys bool
 }
 
 // IntentResolverTestingKnobs contains testing helpers that are used during


### PR DESCRIPTION
Related to #55293.

This commit adds a safeguard to GC requests that prevents them from
bumping the GC threshold at the same time that they GC individual MVCC
versions. This was found to be unsafe in #55293 because performing both
of these actions at the same time could lead to a race where a read
request is allowed to evaluate without error while also failing to see
MVCC versions that are concurrently GCed.

This race is possible because foreground traffic consults the in-memory
version of the GC threshold (`r.mu.state.GCThreshold`), which is updated
after (in `handleGCThresholdResult`), not atomically with, the application
of the GC request's WriteBatch to the LSM (in `ApplyToStateMachine`). This
allows a read request to see the effect of a GC on MVCC state without seeing
its effect on the in-memory GC threshold.

The latches acquired by GC quests look like it will help with this race,
but in practice they do not for two reasons:
1. the latches do not protect timestamps below the GC request's batch
   timestamp. This means that they only conflict with concurrent writes,
   but not all concurrent reads.
2. the read could be served off a follower, which could be applying the
   GC request's effect from the raft log. Latches held on the leaseholder
   would have no impact on a follower read.

Thankfully, the GC queue has split these two steps for the past few
releases, at least since 87e85eb, so we do not have a bug today.

The commit also adds a test that reliably exercises the bug with a few
well-placed calls to `time.Sleep`. The test contains a variant where the
read is performed on the leaseholder and a variant where it is performed
on a follower. Both fail by default. If we switch the GC request to
acquire non-MVCC latches then the leaseholder variant passes, but the
follower read variant still fails.