### PR TITLE
pkg/cmd/github-post: revert pebble metamorphic repro command

### DIFF
--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -540,10 +540,8 @@ func formatPebbleMetamorphicIssue(
 			s := f.testMessage[i+len(seedHeader):]
 			s = strings.TrimSpace(s)
 			s = strings.TrimSpace(s[:strings.Index(s, "\n")])
-
-			repro = fmt.Sprintf("dev test @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test "+
-				"-f TestMeta --stress --stress-args='-p 1' -- --define gotags=bazel,invariants --test_timeout=11000 "+
-				`--test_arg -seed --test_arg %s --test_arg -ops --test_arg "uniform:5000-25000"`, s)
+			repro = fmt.Sprintf("go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' "+
+				`-timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed %s -ops "uniform:5000-25000"`, s)
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -235,7 +235,7 @@ TestXXA - 1.00s
 					testName: "TestMeta",
 					title:    "internal/metamorphic: TestMeta failed",
 					message:  "panic: induced panic",
-					expRepro: `dev test @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test -f TestMeta --stress --stress-args='-p 1' -- --define gotags=bazel,invariants --test_timeout=11000 --test_arg -seed --test_arg 1600209371838097000 --test_arg -ops --test_arg "uniform:5000-25000"`,
+					expRepro: `go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-25000"`,
 				},
 			},
 			formatter: formatPebbleMetamorphicIssue,


### PR DESCRIPTION
Revert to using the command as it is run relative to the Pebble repo
root.

Release note: None