### PR TITLE
spanconfig: teach the KVAccessor about system span configurations

### DIFF
--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
@@ -34,20 +34,25 @@ import (
 // 		span [a,e)
 // 		span [a,b)
 // 		span [b,c)
+//		system-target {source=1,target=20}
+//		system-target {source=1,target=1}
+//		system-target {source=20,target=20}
 //      ----
 //
 // 		kvaccessor-update
 // 		delete [c,e)
 // 		upsert [c,d):C
 // 		upsert [d,e):D
+// 		delete {source=1,target=1}
+// 		upsert {source=1,target=1}:A
 //      ----
 //
 // They tie into GetSpanConfigRecords and UpdateSpanConfigRecords
-// respectively. For kvaccessor-get, each listed span is added to the set of
-// spans being read. For kvaccessor-update, the lines prefixed with "delete"
-// count towards the spans being deleted, and for "upsert" they correspond to
+// respectively. For kvaccessor-get, each listed target is added to the set of
+// targets being read. For kvaccessor-update, the lines prefixed with "delete"
+// count towards the targets being deleted, and for "upsert" they correspond to
 // the span config entries being upserted. See
-// spanconfigtestutils.Parse{Span,Config,SpanConfigEntry} for more details.
+// spanconfigtestutils.Parse{Span,Config,SpanConfigRecord} for more details.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -77,7 +82,9 @@ func TestDataDriven(t *testing.T) {
 
 				var output strings.Builder
 				for _, record := range records {
-					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigRecord(record)))
+					output.WriteString(fmt.Sprintf(
+						"%s\n", spanconfigtestutils.PrintSpanConfigRecord(t, record),
+					))
 				}
 				return output.String()
 			case "kvaccessor-update":

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
@@ -1,0 +1,97 @@
+# Walk through a full set of scenarios pertaining to system span configs.
+
+# Test with an empty slate.
+kvaccessor-get
+system-target {cluster}
+system-target {source=1,target=1}
+system-target {source=1,target=10}
+system-target {source=20,target=20}
+----
+
+# Try deleting a system span configuration that doesn't exist.
+kvaccessor-update
+delete {cluster}
+----
+err: expected to delete 1 row(s), deleted 0
+
+# Basic tests that set all possible combinations of system targets.
+kvaccessor-update
+upsert {cluster}:A
+upsert {source=1,target=1}:B
+upsert {source=1,target=10}:C
+upsert {source=20,target=20}:D
+----
+ok
+
+kvaccessor-get
+system-target {cluster}
+system-target {source=1,target=1}
+system-target {source=1,target=10}
+system-target {source=20,target=20}
+----
+{cluster}:A
+{source=1,target=1}:B
+{source=1,target=10}:C
+{source=20,target=20}:D
+
+# Update some of the span configurations that we added and ensure that works.
+kvaccessor-update
+upsert {cluster}:F
+upsert {source=1,target=1}:G
+upsert {source=1,target=10}:H
+upsert {source=20,target=20}:I
+----
+ok
+
+kvaccessor-get
+system-target {cluster}
+system-target {source=1,target=1}
+system-target {source=1,target=10}
+system-target {source=20,target=20}
+----
+{cluster}:F
+{source=1,target=1}:G
+{source=1,target=10}:H
+{source=20,target=20}:I
+
+# Delete all the system span configurations that we just added and ensure
+# they take effect.
+kvaccessor-update
+delete {cluster}
+delete {source=1,target=1}
+delete {source=1,target=10}
+delete {source=20,target=20}
+----
+ok
+
+kvaccessor-get
+system-target {cluster}
+system-target {source=1,target=1}
+system-target {source=1,target=10}
+system-target {source=20,target=20}
+----
+
+# Lastly, try adding multiple system targets set by the host tenant that apply
+# to distinct secondary tenants. We also add a system span configuration set by
+# one of these secondary tenant's on itself for kicks.
+kvaccessor-update
+upsert {cluster}:Z
+upsert {source=1,target=10}:A
+upsert {source=1,target=20}:B
+upsert {source=1,target=30}:C
+upsert {source=10,target=10}:G
+----
+ok
+
+kvaccessor-get
+system-target {cluster}
+system-target {source=1,target=10}
+system-target {source=1,target=20}
+system-target {source=1,target=30}
+system-target {source=10,target=10}
+----
+{cluster}:Z
+{source=1,target=10}:A
+{source=1,target=20}:B
+{source=1,target=30}:C
+{source=10,target=10}:G

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -181,7 +181,7 @@ func TestDataDriven(t *testing.T) {
 
 				var output strings.Builder
 				for _, record := range records {
-					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigRecord(record)))
+					output.WriteString(fmt.Sprintf("%s\n", spanconfigtestutils.PrintSpanConfigRecord(t, record)))
 				}
 				return output.String()
 

--- a/pkg/spanconfig/spanconfigstore/spanconfigstore_test.go
+++ b/pkg/spanconfig/spanconfigstore/spanconfigstore_test.go
@@ -127,7 +127,7 @@ func TestRandomized(t *testing.T) {
 		_ = store.forEachOverlapping(testSpan,
 			func(entry spanConfigEntry) error {
 				t.Fatalf("found unexpected entry: %s",
-					spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
+					spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
 						Target: spanconfig.MakeTargetFromSpan(entry.span),
 						Config: entry.config,
 					}))
@@ -140,7 +140,7 @@ func TestRandomized(t *testing.T) {
 			func(entry spanConfigEntry) error {
 				if !foundEntry.isEmpty() {
 					t.Fatalf("expected single overlapping entry, found second: %s",
-						spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
+						spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
 							Target: spanconfig.MakeTargetFromSpan(entry.span),
 							Config: entry.config,
 						}))

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -98,10 +98,10 @@ func TestDataDriven(t *testing.T) {
 
 				var b strings.Builder
 				for _, target := range deleted {
-					b.WriteString(fmt.Sprintf("deleted %s\n", spanconfigtestutils.PrintTarget(target)))
+					b.WriteString(fmt.Sprintf("deleted %s\n", spanconfigtestutils.PrintTarget(t, target)))
 				}
 				for _, ent := range added {
-					b.WriteString(fmt.Sprintf("added %s\n", spanconfigtestutils.PrintSpanConfigRecord(ent)))
+					b.WriteString(fmt.Sprintf("added %s\n", spanconfigtestutils.PrintSpanConfigRecord(t, ent)))
 				}
 				return b.String()
 
@@ -133,7 +133,7 @@ func TestDataDriven(t *testing.T) {
 				_ = store.TestingSpanConfigStoreForEachOverlapping(span,
 					func(entry spanConfigEntry) error {
 						results = append(results,
-							spanconfigtestutils.PrintSpanConfigRecord(spanconfig.Record{
+							spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
 								Target: spanconfig.MakeTargetFromSpan(entry.span),
 								Config: entry.config,
 							}),

--- a/pkg/spanconfig/systemtarget.go
+++ b/pkg/spanconfig/systemtarget.go
@@ -90,11 +90,11 @@ func (st SystemTarget) encode() roachpb.Span {
 		k = keys.SystemSpanConfigEntireKeyspace
 	} else if st.SourceTenantID == roachpb.SystemTenantID {
 		k = encoding.EncodeUvarintAscending(
-			keys.SystemSpanConfigHostOnTenantKeyspace, st.TargetTenantID.InternalValue,
+			keys.SystemSpanConfigHostOnTenantKeyspace, st.TargetTenantID.ToUint64(),
 		)
 	} else {
 		k = encoding.EncodeUvarintAscending(
-			keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace, st.SourceTenantID.InternalValue,
+			keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace, st.SourceTenantID.ToUint64(),
 		)
 	}
 	return roachpb.Span{Key: k, EndKey: k.PrefixEnd()}
@@ -143,7 +143,7 @@ func (st SystemTarget) less(ot SystemTarget) bool {
 			return false
 		}
 
-		return st.TargetTenantID.InternalValue < ot.TargetTenantID.InternalValue
+		return st.TargetTenantID.ToUint64() < ot.TargetTenantID.ToUint64()
 	}
 
 	if st.SourceTenantID == roachpb.SystemTenantID {
@@ -152,7 +152,7 @@ func (st SystemTarget) less(ot SystemTarget) bool {
 		return false
 	}
 
-	return st.SourceTenantID.InternalValue < ot.SourceTenantID.InternalValue
+	return st.SourceTenantID.ToUint64() < ot.SourceTenantID.ToUint64()
 }
 
 // equal returns true iff the receiver is equal to the supplied system target.

--- a/pkg/spanconfig/systemtarget.go
+++ b/pkg/spanconfig/systemtarget.go
@@ -41,15 +41,37 @@ type SystemTarget struct {
 	TargetTenantID *roachpb.TenantID
 }
 
-// MakeSystemTarget constructs, validates, and returns a new SystemTarget.
-func MakeSystemTarget(
-	sourceTenantID roachpb.TenantID, targetTenantID *roachpb.TenantID,
+// MakeTenantTarget constructs, validates, and returns a new SystemTarget that
+// targets the physical keyspace of the targetTenantID.
+func MakeTenantTarget(
+	sourceTenantID roachpb.TenantID, targetTenantID roachpb.TenantID,
 ) (SystemTarget, error) {
 	t := SystemTarget{
 		SourceTenantID: sourceTenantID,
-		TargetTenantID: targetTenantID,
+		TargetTenantID: &targetTenantID,
 	}
 	return t, t.validate()
+}
+
+// MakeSystemTargetFromProto constructs a SystemTarget from a
+// roachpb.SystemSpanConfigTarget and validates it.
+func MakeSystemTargetFromProto(proto *roachpb.SystemSpanConfigTarget) (SystemTarget, error) {
+	if proto.SourceTenantID == roachpb.SystemTenantID && proto.TargetTenantID == nil {
+		return MakeClusterTarget(), nil
+	} else if proto.TargetTenantID == nil {
+		return SystemTarget{},
+			errors.Newf("secondary tenant %s cannot target the entire cluster", proto.SourceTenantID)
+	}
+
+	return MakeTenantTarget(proto.SourceTenantID, *proto.TargetTenantID)
+}
+
+// MakeClusterTarget returns a new system target that targets the entire cluster.
+// Only the host tenant is allowed to target the entire cluster.
+func MakeClusterTarget() SystemTarget {
+	return SystemTarget{
+		SourceTenantID: roachpb.SystemTenantID,
+	}
 }
 
 // targetsEntireCluster returns true if the target applies to all ranges in the
@@ -135,12 +157,19 @@ func (st SystemTarget) less(ot SystemTarget) bool {
 
 // equal returns true iff the receiver is equal to the supplied system target.
 func (st SystemTarget) equal(ot SystemTarget) bool {
-	return st.SourceTenantID == ot.SourceTenantID && st.TargetTenantID == ot.TargetTenantID
+	return st.SourceTenantID.Equal(ot.SourceTenantID) && st.TargetTenantID.Equal(ot.TargetTenantID)
 }
 
 // String returns a pretty printed version of a system target.
 func (st SystemTarget) String() string {
-	return fmt.Sprintf("{system target source: %s target: %s}", st.SourceTenantID, st.TargetTenantID)
+	if st.targetsEntireCluster() {
+		return "{cluster}"
+	}
+	return fmt.Sprintf(
+		"{source=%d,target=%d}",
+		st.SourceTenantID.ToUint64(),
+		st.TargetTenantID.ToUint64(),
+	)
 }
 
 // decodeSystemTarget converts the given span into a SystemTarget. An error is
@@ -153,7 +182,7 @@ func decodeSystemTarget(span roachpb.Span) (SystemTarget, error) {
 	}
 	switch {
 	case bytes.Equal(span.Key, keys.SystemSpanConfigEntireKeyspace):
-		return MakeSystemTarget(roachpb.SystemTenantID, nil /* targetTenantID */)
+		return MakeClusterTarget(), nil
 	case bytes.HasPrefix(span.Key, keys.SystemSpanConfigHostOnTenantKeyspace):
 		// System span config was applied by the host tenant over a secondary
 		// tenant's entire keyspace.
@@ -163,7 +192,7 @@ func decodeSystemTarget(span roachpb.Span) (SystemTarget, error) {
 			return SystemTarget{}, err
 		}
 		tenID := roachpb.MakeTenantID(tenIDRaw)
-		return MakeSystemTarget(roachpb.SystemTenantID, &tenID)
+		return MakeTenantTarget(roachpb.SystemTenantID, tenID)
 	case bytes.HasPrefix(span.Key, keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace):
 		// System span config was applied by a secondary tenant over its entire
 		// keyspace.
@@ -173,7 +202,7 @@ func decodeSystemTarget(span roachpb.Span) (SystemTarget, error) {
 			return SystemTarget{}, err
 		}
 		tenID := roachpb.MakeTenantID(tenIDRaw)
-		return MakeSystemTarget(tenID, &tenID)
+		return MakeTenantTarget(tenID, tenID)
 	default:
 		return SystemTarget{},
 			errors.AssertionFailedf("span %s did not conform to SystemTarget encoding", span)

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -27,8 +27,12 @@ func MakeTarget(t roachpb.SpanConfigTarget) (Target, error) {
 	switch t.Union.(type) {
 	case *roachpb.SpanConfigTarget_Span:
 		return MakeTargetFromSpan(*t.GetSpan()), nil
-		// TODO(arul): Add a case here for SpanConfigTarget_SystemTarget once we've
-		// taught and tested the KVAccessor to work with system targets.
+	case *roachpb.SpanConfigTarget_SystemSpanConfigTarget:
+		systemTarget, err := MakeSystemTargetFromProto(t.GetSystemSpanConfigTarget())
+		if err != nil {
+			return Target{}, err
+		}
+		return MakeTargetFromSystemTarget(systemTarget), nil
 	default:
 		return Target{}, errors.AssertionFailedf("unknown type of system target %v", t)
 	}


### PR DESCRIPTION
First 3 commits are from https://github.com/cockroachdb/cockroach/pull/76219, this one's quite small -- mostly just tests. 

----

This patch teaches the KVAccessor to update and get system span
configurations.

Release note: None