### PR TITLE
ccl/sqlproxyccl: add connector component and support for session revival token

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "authentication.go",
         "backend_dialer.go",
+        "connector.go",
         "error.go",
         "frontend_admitter.go",
         "metrics.go",
@@ -48,6 +49,7 @@ go_test(
     size = "small",
     srcs = [
         "authentication_test.go",
+        "connector_test.go",
         "frontend_admitter_test.go",
         "main_test.go",
         "proxy_handler_test.go",
@@ -59,7 +61,6 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/sqlproxyccl/denylist",
-        "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/sqlproxyccl/throttler",
         "//pkg/ccl/utilccl",

--- a/pkg/ccl/sqlproxyccl/backend_dialer.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer.go
@@ -24,13 +24,15 @@ import (
 //
 // BackendDial uses a dial timeout of 5 seconds to mitigate network black
 // holes.
+//
+// TODO(jaylim-crl): Move dialer into connector in the future.
 var BackendDial = func(
-	msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
+	msg *pgproto3.StartupMessage, serverAddress string, tlsConfig *tls.Config,
 ) (net.Conn, error) {
 	// TODO this behavior may need to change once multi-region multi-tenant
 	// clusters are supported. The fixed timeout may need to be replaced by an
 	// adaptive timeout or the timeout could be replaced by speculative retries.
-	conn, err := net.DialTimeout("tcp", outgoingAddress, time.Second*5)
+	conn, err := net.DialTimeout("tcp", serverAddress, time.Second*5)
 	if err != nil {
 		return nil, newErrorf(
 			codeBackendDown, "unable to reach backend SQL server: %v", err,
@@ -44,7 +46,7 @@ var BackendDial = func(
 	if err != nil {
 		return nil, newErrorf(
 			codeBackendDown, "relaying StartupMessage to target server %v: %v",
-			outgoingAddress, err)
+			serverAddress, err)
 	}
 	return conn, nil
 }

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -1,0 +1,387 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors"
+	pgproto3 "github.com/jackc/pgproto3/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// sessionRevivalTokenStartupParam indicates the name of the parameter that
+// will activate token-based authentication if present in the startup message.
+const sessionRevivalTokenStartupParam = "crdb:session_revival_token_base64"
+
+// TenantResolver is an interface for the tenant directory. Currently only
+// tenant.Directory implements it.
+//
+// TODO(jaylim-crl): Rename this to Directory, and the current tenant.Directory
+// to tenant.directory. This needs to be moved into the tenant package as well.
+// This is added here to aid testing.
+type TenantResolver interface {
+	// EnsureTenantAddr returns an IP address of one of the given tenant's SQL
+	// processes based on the tenantID and clusterName fields. This should block
+	// until the process associated with the IP is ready.
+	//
+	// If no matching pods are found (e.g. cluster name mismatch, or tenant was
+	// deleted), this will return a GRPC NotFound error.
+	EnsureTenantAddr(
+		ctx context.Context,
+		tenantID roachpb.TenantID,
+		clusterName string,
+	) (string, error)
+
+	// LookupTenantAddrs returns the IP addresses for all available SQL
+	// processes for the given tenant. It returns a GRPC NotFound error if the
+	// tenant does not exist.
+	//
+	// Unlike EnsureTenantAddr which blocks until there is an associated
+	// process, LookupTenantAddrs will just return an empty set if no processes
+	// are available for the tenant.
+	LookupTenantAddrs(ctx context.Context, tenantID roachpb.TenantID) ([]string, error)
+
+	// ReportFailure is used to indicate to the resolver that a connection
+	// attempt to connect to a particular SQL tenant pod have failed.
+	ReportFailure(ctx context.Context, tenantID roachpb.TenantID, addr string) error
+}
+
+// connector is a per-session tenant-associated component that can be used to
+// obtain a connection to the tenant cluster. This will also handle the
+// authentication phase. All connections returned by the connector should
+// already be ready to accept regular pgwire messages (e.g. SQL queries).
+type connector struct {
+	// ClusterName and TenantID corresponds to the tenant identifiers associated
+	// with this connector.
+	//
+	// NOTE: These fields are required.
+	ClusterName string
+	TenantID    roachpb.TenantID
+
+	// Directory corresponds to the tenant directory, which will be used to
+	// resolve tenants to their corresponding IP addresses. If this isn't set,
+	// we will fallback to use RoutingRule.
+	//
+	// TODO(jaylim-crl): Replace this with a Directory interface, and remove
+	// the RoutingRule field. RoutingRule should not be in here.
+	//
+	// NOTE: This field is optional.
+	Directory TenantResolver
+
+	// RoutingRule refers to the static rule that will be used when resolving
+	// tenants. This will be used directly whenever the Directory field isn't
+	// specified, or as a fallback if one was specified.
+	//
+	// The literal "{{clusterName}}" will be replaced with ClusterName within
+	// the RoutingRule string.
+	//
+	// NOTE: This field is optional, if Directory isn't set.
+	RoutingRule string
+
+	// StartupMsg represents the startup message associated with the client.
+	// This will be used when establishing a pgwire connection with the SQL pod.
+	//
+	// NOTE: This field is required.
+	StartupMsg *pgproto3.StartupMessage
+
+	// TLSConfig represents the client TLS config used by the connector when
+	// connecting with the SQL pod. If the ServerName field is set, this will
+	// be overridden during connection establishment. Set to nil if we are
+	// connecting to an insecure cluster.
+	//
+	// NOTE: This field is optional.
+	TLSConfig *tls.Config
+
+	// IdleMonitorWrapperFn is used to wrap the connection to the SQL pod with
+	// an idle monitor. If not specified, the raw connection to the SQL pod
+	// will be returned.
+	//
+	// In the case of connecting with an authentication phase, the connection
+	// will be wrapped before starting the authentication.
+	//
+	// NOTE: This field is optional.
+	IdleMonitorWrapperFn func(serverConn net.Conn) net.Conn
+
+	// Testing knobs for internal connector calls. If specified, these will
+	// be called instead of the actual logic.
+	testingKnobs struct {
+		dialTenantCluster func(ctx context.Context) (net.Conn, error)
+		lookupAddr        func(ctx context.Context) (string, error)
+		dialSQLServer     func(serverAddr string) (net.Conn, error)
+	}
+}
+
+// OpenTenantConnWithToken opens a connection to the tenant cluster using the
+// token-based authentication.
+func (c *connector) OpenTenantConnWithToken(ctx context.Context, token string) (net.Conn, error) {
+	c.StartupMsg.Parameters[sessionRevivalTokenStartupParam] = token
+	defer func() {
+		// Delete token after return.
+		delete(c.StartupMsg.Parameters, sessionRevivalTokenStartupParam)
+	}()
+
+	serverConn, err := c.dialTenantCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if c.IdleMonitorWrapperFn != nil {
+		serverConn = c.IdleMonitorWrapperFn(serverConn)
+	}
+	return serverConn, nil
+}
+
+// OpenTenantConnWithAuth opens a connection to the tenant cluster using
+// normal authentication methods (e.g. password, etc.). Once a connection to
+// one of the tenant's SQL pod has been established, we will transfer
+// request/response flow between clientConn and the new connection to the
+// authenticator, which implies that this will be blocked until authentication
+// succeeds, or when an error is returned.
+//
+// sentToClient will be set to true if an error occurred during the
+// authenticator phase since errors would have already been sent to the client.
+func (c *connector) OpenTenantConnWithAuth(
+	ctx context.Context, clientConn net.Conn, throttleHook func(throttler.AttemptStatus) error,
+) (retServerConn net.Conn, sentToClient bool, retErr error) {
+	// Just a safety check, but this shouldn't happen since we will block the
+	// startup param in the frontend admitter. The only case where we actually
+	// need to delete this param is if OpenTenantConnWithToken was called
+	// previously, but that wouldn't happen based on the current proxy logic.
+	delete(c.StartupMsg.Parameters, sessionRevivalTokenStartupParam)
+
+	serverConn, err := c.dialTenantCluster(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() {
+		if retErr != nil {
+			serverConn.Close()
+		}
+	}()
+
+	if c.IdleMonitorWrapperFn != nil {
+		serverConn = c.IdleMonitorWrapperFn(serverConn)
+	}
+
+	// Perform user authentication for non-token-based auth methods. This will
+	// block until the server has authenticated the client.
+	if err := authenticate(clientConn, serverConn, throttleHook); err != nil {
+		return nil, true, err
+	}
+	return serverConn, false, nil
+}
+
+// dialTenantCluster returns a connection to the tenant cluster associated
+// with the connector. Once a connection has been established, the pgwire
+// startup message will be relayed to the server.
+func (c *connector) dialTenantCluster(ctx context.Context) (net.Conn, error) {
+	if c.testingKnobs.dialTenantCluster != nil {
+		return c.testingKnobs.dialTenantCluster(ctx)
+	}
+
+	// Repeatedly try to make a connection until context is canceled, or until
+	// we get a non-retriable error. This is preferable to terminating client
+	// connections, because in most cases those connections will simply be
+	// retried, further increasing load on the system.
+	retryOpts := retry.Options{
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     5 * time.Second,
+	}
+
+	lookupAddrErr := log.Every(time.Minute)
+	dialSQLServerErr := log.Every(time.Minute)
+	reportFailureErr := log.Every(time.Minute)
+	var lookupAddrErrs, dialSQLServerErrs, reportFailureErrs int
+	var crdbConn net.Conn
+	var serverAddr string
+	var err error
+
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		// Retrieve a SQL pod address to connect to.
+		serverAddr, err = c.lookupAddr(ctx)
+		if err != nil {
+			if isRetriableConnectorError(err) {
+				lookupAddrErrs++
+				if lookupAddrErr.ShouldLog() {
+					log.Ops.Errorf(ctx, "lookup address (%d errors skipped): %v",
+						lookupAddrErrs, err)
+					lookupAddrErrs = 0
+				}
+				continue
+			}
+			return nil, err
+		}
+		// Make a connection to the SQL pod.
+		crdbConn, err = c.dialSQLServer(serverAddr)
+		if err != nil {
+			if isRetriableConnectorError(err) {
+				dialSQLServerErrs++
+				if dialSQLServerErr.ShouldLog() {
+					log.Ops.Errorf(ctx, "dial SQL server (%d errors skipped): %v",
+						dialSQLServerErrs, err)
+					dialSQLServerErrs = 0
+				}
+
+				// Report the failure to the directory so that it can refresh
+				// any stale information that may have caused the problem.
+				if c.Directory != nil {
+					if err = reportFailureToDirectory(
+						ctx, c.TenantID, serverAddr, c.Directory,
+					); err != nil {
+						reportFailureErrs++
+						if reportFailureErr.ShouldLog() {
+							log.Ops.Errorf(ctx,
+								"report failure (%d errors skipped): %v",
+								reportFailureErrs,
+								err,
+							)
+							reportFailureErrs = 0
+						}
+					}
+				}
+				continue
+			}
+			return nil, err
+		}
+		return crdbConn, nil
+	}
+
+	// err will never be nil here regardless of whether we retry infinitely or
+	// a bounded number of times. In our case, since we retry infinitely, the
+	// only possibility is when ctx's Done channel is closed (which implies that
+	// ctx.Err() != nil.
+	//
+	// If the error is already marked, just return that.
+	if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+		return nil, err
+	}
+	// Otherwise, mark the error, and return that.
+	return nil, errors.Mark(err, ctx.Err())
+}
+
+// resolveTCPAddr indirection to allow test hooks.
+var resolveTCPAddr = net.ResolveTCPAddr
+
+// lookupAddr returns an address (that must include both host and port)
+// pointing to one of the SQL pods for the tenant associated with this
+// connector.
+//
+// This will be called within an infinite backoff loop. If an error is
+// transient, this will return an error that has been marked with
+// errRetryConnectorSentinel (i.e. markAsRetriableConnectorError).
+func (c *connector) lookupAddr(ctx context.Context) (string, error) {
+	if c.testingKnobs.lookupAddr != nil {
+		return c.testingKnobs.lookupAddr(ctx)
+	}
+
+	// First try to lookup tenant in the directory (if available).
+	if c.Directory != nil {
+		addr, err := c.Directory.EnsureTenantAddr(ctx, c.TenantID, c.ClusterName)
+		if err != nil {
+			if status.Code(err) != codes.NotFound {
+				return "", markAsRetriableConnectorError(err)
+			}
+			// Fallback to old resolution rule.
+		} else {
+			return addr, nil
+		}
+	}
+
+	// Derive DNS address and then try to resolve it. If it does not exist, then
+	// map to a GRPC NotFound error.
+	//
+	// TODO(jaylim-crl): This code is temporary. Remove this once we have fully
+	// replaced this with a Directory interface. This fallback does not need
+	// to exist.
+	addr := strings.ReplaceAll(
+		c.RoutingRule, "{{clusterName}}",
+		fmt.Sprintf("%s-%d", c.ClusterName, c.TenantID.ToUint64()),
+	)
+	if _, err := resolveTCPAddr("tcp", addr); err != nil {
+		log.Errorf(ctx, "could not retrieve SQL server address: %v", err.Error())
+		return "", newErrorf(codeParamsRoutingFailed,
+			"cluster %s-%d not found", c.ClusterName, c.TenantID.ToUint64())
+	}
+	return addr, nil
+}
+
+// dialSQLServer dials the given address for the SQL pod, and forwards the
+// startup message to it. If the connector specifies a TLS connection, it will
+// also attempt to upgrade the PG connection to use TLS.
+//
+// This will be called within an infinite backoff loop. If an error is
+// transient, this will return an error that has been marked with
+// errRetryConnectorSentinel (i.e. markAsRetriableConnectorError).
+func (c *connector) dialSQLServer(serverAddr string) (net.Conn, error) {
+	if c.testingKnobs.dialSQLServer != nil {
+		return c.testingKnobs.dialSQLServer(serverAddr)
+	}
+
+	// Use a TLS config if one was provided. If TLSConfig is nil, Clone will
+	// return nil.
+	tlsConf := c.TLSConfig.Clone()
+	if tlsConf != nil {
+		// serverAddr will always have a port. We use an empty string as the
+		// default port as we only care about extracting the host.
+		outgoingHost, _, err := addr.SplitHostPort(serverAddr, "" /* defaultPort */)
+		if err != nil {
+			return nil, err
+		}
+		// Always set ServerName. If InsecureSkipVerify is true, this will
+		// be ignored.
+		tlsConf.ServerName = outgoingHost
+	}
+
+	conn, err := BackendDial(c.StartupMsg, serverAddr, tlsConf)
+	if err != nil {
+		var codeErr *codeError
+		if errors.As(err, &codeErr) && codeErr.code == codeBackendDown {
+			return nil, markAsRetriableConnectorError(err)
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+// errRetryConnectorSentinel exists to allow more robust retection of retry
+// errors even if they are wrapped.
+var errRetryConnectorSentinel = errors.New("retry connector error")
+
+// markAsRetriableConnectorError marks the given error with
+// errRetryConnectorSentinel, which will trigger the connector to retry if such
+// error returns.
+func markAsRetriableConnectorError(err error) error {
+	return errors.Mark(err, errRetryConnectorSentinel)
+}
+
+// isRetriableConnectorError checks whether a given error is retriable. This
+// should be called on errors which are transient so that the connector can
+// retry on such errors.
+func isRetriableConnectorError(err error) bool {
+	return errors.Is(err, errRetryConnectorSentinel)
+}
+
+// reportFailureToDirectory is a hookable function that calls the given tenant
+// directory's ReportFailure method.
+var reportFailureToDirectory = func(
+	ctx context.Context, tenantID roachpb.TenantID, addr string, directory TenantResolver,
+) error {
+	return directory.ReportFailure(ctx, tenantID, addr)
+}

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -1,0 +1,674 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestConnector_OpenTenantConnWithToken(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const token = "foobarbaz"
+	ctx := context.Background()
+
+	t.Run("error", func(t *testing.T) {
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: make(map[string]string),
+			},
+		}
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			return nil, errors.New("foo")
+		}
+
+		crdbConn, err := c.OpenTenantConnWithToken(ctx, token)
+		require.EqualError(t, err, "foo")
+		require.Nil(t, crdbConn)
+
+		// Ensure that token is deleted.
+		str, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+		require.False(t, ok)
+		require.Equal(t, "", str)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: make(map[string]string),
+			},
+		}
+		conn, _ := net.Pipe()
+		defer conn.Close()
+
+		var openCalled bool
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			openCalled = true
+
+			// Validate that token is set.
+			str, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+			require.True(t, ok)
+			require.Equal(t, token, str)
+
+			return conn, nil
+		}
+
+		crdbConn, err := c.OpenTenantConnWithToken(ctx, token)
+		require.True(t, openCalled)
+		require.NoError(t, err)
+		require.Equal(t, conn, crdbConn)
+
+		// Ensure that token is deleted.
+		_, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+		require.False(t, ok)
+	})
+
+	t.Run("idle monitor wrapper is called", func(t *testing.T) {
+		var wrapperCalled bool
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: make(map[string]string),
+			},
+			IdleMonitorWrapperFn: func(crdbConn net.Conn) net.Conn {
+				wrapperCalled = true
+				return crdbConn
+			},
+		}
+
+		conn, _ := net.Pipe()
+		defer conn.Close()
+
+		var openCalled bool
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			openCalled = true
+
+			// Validate that token is set.
+			str, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+			require.True(t, ok)
+			require.Equal(t, token, str)
+
+			return conn, nil
+		}
+
+		crdbConn, err := c.OpenTenantConnWithToken(ctx, token)
+		require.True(t, wrapperCalled)
+		require.True(t, openCalled)
+		require.NoError(t, err)
+		require.Equal(t, conn, crdbConn)
+
+		// Ensure that token is deleted.
+		_, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+		require.False(t, ok)
+	})
+}
+
+func TestConnector_OpenTenantConnWithAuth(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	dummyHook := func(throttler.AttemptStatus) error {
+		return nil
+	}
+
+	t.Run("error during open", func(t *testing.T) {
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: make(map[string]string),
+			},
+		}
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			return nil, errors.New("foo")
+		}
+
+		crdbConn, sentToClient, err := c.OpenTenantConnWithAuth(ctx,
+			nil /* clientConn */, nil /* throttleHook */)
+		require.EqualError(t, err, "foo")
+		require.False(t, sentToClient)
+		require.Nil(t, crdbConn)
+	})
+
+	t.Run("error during auth", func(t *testing.T) {
+		conn, _ := net.Pipe()
+		defer conn.Close()
+
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: make(map[string]string),
+			},
+		}
+
+		var openCalled bool
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			openCalled = true
+			return conn, nil
+		}
+
+		defer testutils.TestingHook(
+			&authenticate,
+			func(
+				clientConn net.Conn,
+				crdbConn net.Conn,
+				throttleHook func(status throttler.AttemptStatus) error,
+			) error {
+				return errors.New("bar")
+			},
+		)()
+
+		crdbConn, sentToClient, err := c.OpenTenantConnWithAuth(ctx,
+			nil /* clientConn */, nil /* throttleHook */)
+		require.True(t, openCalled)
+		require.EqualError(t, err, "bar")
+		require.True(t, sentToClient)
+		require.Nil(t, crdbConn)
+
+		// Connection should be closed.
+		_, err = conn.Write([]byte("foo"))
+		require.Regexp(t, "closed pipe", err)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		clientConn, _ := net.Pipe()
+		defer clientConn.Close()
+
+		serverConn, _ := net.Pipe()
+		defer serverConn.Close()
+
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: map[string]string{
+					// Passing in a token should have no effect.
+					sessionRevivalTokenStartupParam: "foo",
+				},
+			},
+		}
+
+		var openCalled bool
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			openCalled = true
+
+			// Validate that token is not set.
+			_, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+			require.False(t, ok)
+
+			return serverConn, nil
+		}
+
+		var authCalled bool
+		defer testutils.TestingHook(
+			&authenticate,
+			func(
+				client net.Conn,
+				server net.Conn,
+				throttleHook func(status throttler.AttemptStatus) error,
+			) error {
+				authCalled = true
+				require.Equal(t, clientConn, client)
+				require.NotNil(t, server)
+				require.Equal(t, reflect.ValueOf(dummyHook).Pointer(),
+					reflect.ValueOf(throttleHook).Pointer())
+				return nil
+			},
+		)()
+
+		crdbConn, sentToClient, err := c.OpenTenantConnWithAuth(ctx, clientConn, dummyHook)
+		require.True(t, openCalled)
+		require.True(t, authCalled)
+		require.NoError(t, err)
+		require.False(t, sentToClient)
+		require.Equal(t, serverConn, crdbConn)
+	})
+
+	t.Run("idle monitor wrapper is called", func(t *testing.T) {
+		clientConn, _ := net.Pipe()
+		defer clientConn.Close()
+
+		serverConn, _ := net.Pipe()
+		defer serverConn.Close()
+
+		var wrapperCalled bool
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: map[string]string{
+					// Passing in a token should have no effect.
+					sessionRevivalTokenStartupParam: "foo",
+				},
+			},
+			IdleMonitorWrapperFn: func(crdbConn net.Conn) net.Conn {
+				wrapperCalled = true
+				return crdbConn
+			},
+		}
+
+		var openCalled bool
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			openCalled = true
+
+			// Validate that token is not set.
+			_, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+			require.False(t, ok)
+
+			return serverConn, nil
+		}
+
+		var authCalled bool
+		defer testutils.TestingHook(
+			&authenticate,
+			func(
+				client net.Conn,
+				server net.Conn,
+				throttleHook func(status throttler.AttemptStatus) error,
+			) error {
+				authCalled = true
+				require.Equal(t, clientConn, client)
+				require.NotNil(t, server)
+				require.Equal(t, reflect.ValueOf(dummyHook).Pointer(),
+					reflect.ValueOf(throttleHook).Pointer())
+				return nil
+			},
+		)()
+
+		crdbConn, sentToClient, err := c.OpenTenantConnWithAuth(ctx, clientConn, dummyHook)
+		require.True(t, openCalled)
+		require.True(t, wrapperCalled)
+		require.True(t, authCalled)
+		require.NoError(t, err)
+		require.False(t, sentToClient)
+		require.Equal(t, serverConn, crdbConn)
+	})
+}
+
+func TestConnector_dialTenantCluster(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	bgCtx := context.Background()
+
+	t.Run("context canceled at boundary", func(t *testing.T) {
+		// This is a short test, and is expected to finish within ms.
+		ctx, cancel := context.WithTimeout(bgCtx, 2*time.Second)
+		defer cancel()
+
+		c := &connector{}
+		var lookupAddrCount int
+		c.testingKnobs.lookupAddr = func(ctx context.Context) (string, error) {
+			lookupAddrCount++
+			if lookupAddrCount >= 2 {
+				// Cancel context to trigger loop exit on next retry.
+				cancel()
+			}
+			return "", markAsRetriableConnectorError(errors.New("baz"))
+		}
+
+		conn, err := c.dialTenantCluster(ctx)
+		require.EqualError(t, err, "baz")
+		require.True(t, errors.Is(err, context.Canceled))
+		require.Nil(t, conn)
+
+		require.Equal(t, 2, lookupAddrCount)
+	})
+
+	t.Run("context canceled within loop", func(t *testing.T) {
+		// This is a short test, and is expected to finish within ms.
+		ctx, cancel := context.WithTimeout(bgCtx, 2*time.Second)
+		defer cancel()
+
+		c := &connector{}
+		c.testingKnobs.lookupAddr = func(ctx context.Context) (string, error) {
+			return "", errors.Wrap(context.Canceled, "foobar")
+		}
+
+		conn, err := c.dialTenantCluster(ctx)
+		require.EqualError(t, err, "foobar: context canceled")
+		require.True(t, errors.Is(err, context.Canceled))
+		require.Nil(t, conn)
+	})
+
+	t.Run("non-transient error", func(t *testing.T) {
+		// This is a short test, and is expected to finish within ms.
+		ctx, cancel := context.WithTimeout(bgCtx, 2*time.Second)
+		defer cancel()
+
+		c := &connector{}
+		c.testingKnobs.lookupAddr = func(ctx context.Context) (string, error) {
+			return "", errors.New("baz")
+		}
+
+		conn, err := c.dialTenantCluster(ctx)
+		require.EqualError(t, err, "baz")
+		require.Nil(t, conn)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		// This should not take more than 5 seconds.
+		ctx, cancel := context.WithTimeout(bgCtx, 5*time.Second)
+		defer cancel()
+
+		crdbConn, _ := net.Pipe()
+		defer crdbConn.Close()
+
+		var reportFailureFnCount int
+		c := &connector{
+			TenantID: roachpb.MakeTenantID(42),
+		}
+		c.Directory = &testTenantResolver{
+			reportFailureFn: func(fnCtx context.Context, tenantID roachpb.TenantID, addr string) error {
+				reportFailureFnCount++
+				require.Equal(t, ctx, fnCtx)
+				require.Equal(t, c.TenantID, tenantID)
+				require.Equal(t, "127.0.0.10:42", addr)
+				return nil
+			},
+		}
+
+		// We will exercise the following events:
+		// 1. retriable error on lookupAddr.
+		// 2. retriable error on dialSQLServer.
+		var addrLookupFnCount, dialSQLServerCount int
+		c.testingKnobs.lookupAddr = func(ctx context.Context) (string, error) {
+			addrLookupFnCount++
+			if addrLookupFnCount == 1 {
+				return "", markAsRetriableConnectorError(errors.New("foo"))
+			}
+			return "127.0.0.10:42", nil
+		}
+		c.testingKnobs.dialSQLServer = func(serverAddr string) (net.Conn, error) {
+			require.Equal(t, serverAddr, "127.0.0.10:42")
+			dialSQLServerCount++
+			if dialSQLServerCount == 1 {
+				return nil, markAsRetriableConnectorError(errors.New("bar"))
+			}
+			return crdbConn, nil
+		}
+		conn, err := c.dialTenantCluster(ctx)
+		require.NoError(t, err)
+		require.Equal(t, crdbConn, conn)
+
+		// Assert existing calls.
+		require.Equal(t, 3, addrLookupFnCount)
+		require.Equal(t, 2, dialSQLServerCount)
+		require.Equal(t, 1, reportFailureFnCount)
+	})
+}
+
+func TestConnector_lookupAddr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("only routing rule", func(t *testing.T) {
+		c := &connector{
+			ClusterName: "foo-bar-baz",
+			TenantID:    roachpb.MakeTenantID(10),
+			RoutingRule: `{{clusterName}}.foo`,
+		}
+
+		var resolveTCPAddrCalled bool
+		defer testutils.TestingHook(
+			&resolveTCPAddr,
+			func(network, addr string) (*net.TCPAddr, error) {
+				resolveTCPAddrCalled = true
+				require.Equal(t, "tcp", network)
+				require.Equal(t, "foo-bar-baz-10.foo", addr)
+				return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 26257}, nil
+			},
+		)()
+
+		addr, err := c.lookupAddr(ctx)
+		require.True(t, resolveTCPAddrCalled)
+		require.NoError(t, err)
+		require.Equal(t, "foo-bar-baz-10.foo", addr)
+	})
+
+	t.Run("error for only routing rule", func(t *testing.T) {
+		c := &connector{
+			ClusterName: "cluster-name",
+			TenantID:    roachpb.MakeTenantID(10),
+			RoutingRule: "foo-bar-baz",
+		}
+
+		var resolveTCPAddrCalled bool
+		defer testutils.TestingHook(
+			&resolveTCPAddr,
+			func(network, addr string) (*net.TCPAddr, error) {
+				resolveTCPAddrCalled = true
+				require.Equal(t, "tcp", network)
+				require.Equal(t, "foo-bar-baz", addr)
+				return nil, errors.New("foo")
+			},
+		)()
+
+		addr, err := c.lookupAddr(ctx)
+		require.True(t, resolveTCPAddrCalled)
+		require.EqualError(t, err, "codeParamsRoutingFailed: cluster cluster-name-10 not found")
+		require.Equal(t, "", addr)
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		var ensureTenantAddrFnCount int
+		c := &connector{
+			ClusterName: "my-foo",
+			TenantID:    roachpb.MakeTenantID(10),
+		}
+		c.Directory = &testTenantResolver{
+			ensureTenantAddrFn: func(fnCtx context.Context, tenantID roachpb.TenantID, clusterName string) (string, error) {
+				ensureTenantAddrFnCount++
+				require.Equal(t, ctx, fnCtx)
+				require.Equal(t, c.TenantID, tenantID)
+				require.Equal(t, c.ClusterName, clusterName)
+				return "127.0.0.10:80", nil
+			},
+		}
+
+		addr, err := c.lookupAddr(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "127.0.0.10:80", addr)
+		require.Equal(t, 1, ensureTenantAddrFnCount)
+	})
+
+	t.Run("routing rule fallback with directory", func(t *testing.T) {
+		var ensureTenantAddrFnCount int
+		c := &connector{
+			ClusterName: "my-foo",
+			TenantID:    roachpb.MakeTenantID(10),
+			RoutingRule: "foo.bar",
+		}
+		c.Directory = &testTenantResolver{
+			ensureTenantAddrFn: func(fnCtx context.Context, tenantID roachpb.TenantID, clusterName string) (string, error) {
+				ensureTenantAddrFnCount++
+				require.Equal(t, ctx, fnCtx)
+				require.Equal(t, c.TenantID, tenantID)
+				require.Equal(t, c.ClusterName, clusterName)
+				return "", status.Errorf(codes.NotFound, "foo")
+			},
+		}
+
+		var resolveTCPAddrCalled bool
+		defer testutils.TestingHook(
+			&resolveTCPAddr,
+			func(network, addr string) (*net.TCPAddr, error) {
+				resolveTCPAddrCalled = true
+				require.Equal(t, "tcp", network)
+				require.Equal(t, "foo.bar", addr)
+				return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 26257}, nil
+			},
+		)()
+
+		addr, err := c.lookupAddr(ctx)
+		require.True(t, resolveTCPAddrCalled)
+		require.NoError(t, err)
+		require.Equal(t, "foo.bar", addr)
+		require.Equal(t, 1, ensureTenantAddrFnCount)
+	})
+
+	t.Run("directory with retriable error", func(t *testing.T) {
+		var ensureTenantAddrFnCount int
+		c := &connector{
+			ClusterName: "my-foo",
+			TenantID:    roachpb.MakeTenantID(10),
+			RoutingRule: "foo.bar",
+		}
+		c.Directory = &testTenantResolver{
+			ensureTenantAddrFn: func(fnCtx context.Context, tenantID roachpb.TenantID, clusterName string) (string, error) {
+				ensureTenantAddrFnCount++
+				require.Equal(t, ctx, fnCtx)
+				require.Equal(t, c.TenantID, tenantID)
+				require.Equal(t, c.ClusterName, clusterName)
+				return "", errors.New("foo")
+			},
+		}
+
+		addr, err := c.lookupAddr(ctx)
+		require.EqualError(t, err, "foo")
+		require.Equal(t, "", addr)
+		require.Equal(t, 1, ensureTenantAddrFnCount)
+	})
+}
+
+func TestConnector_dialSQLServer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("with tlsConfig", func(t *testing.T) {
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{},
+			TLSConfig:  &tls.Config{InsecureSkipVerify: true},
+		}
+		crdbConn, _ := net.Pipe()
+		defer crdbConn.Close()
+
+		defer testutils.TestingHook(&BackendDial,
+			func(msg *pgproto3.StartupMessage, serverAddress string,
+				tlsConfig *tls.Config) (net.Conn, error) {
+				require.Equal(t, c.StartupMsg, msg)
+				require.Equal(t, "10.11.12.13:80", serverAddress)
+				require.Equal(t, "10.11.12.13", tlsConfig.ServerName)
+				return crdbConn, nil
+			},
+		)()
+		conn, err := c.dialSQLServer("10.11.12.13:80")
+		require.NoError(t, err)
+		require.Equal(t, crdbConn, conn)
+	})
+
+	t.Run("invalid serverAddr with tlsConfig", func(t *testing.T) {
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{},
+			TLSConfig:  &tls.Config{InsecureSkipVerify: true},
+		}
+		conn, err := c.dialSQLServer("!@#$::")
+		require.Error(t, err)
+		require.Regexp(t, "invalid address format", err)
+		require.False(t, isRetriableConnectorError(err))
+		require.Nil(t, conn)
+	})
+
+	t.Run("without tlsConfig", func(t *testing.T) {
+		c := &connector{StartupMsg: &pgproto3.StartupMessage{}}
+		crdbConn, _ := net.Pipe()
+		defer crdbConn.Close()
+
+		defer testutils.TestingHook(&BackendDial,
+			func(msg *pgproto3.StartupMessage, serverAddress string,
+				tlsConfig *tls.Config) (net.Conn, error) {
+				require.Equal(t, c.StartupMsg, msg)
+				require.Equal(t, "10.11.12.13:1234", serverAddress)
+				require.Nil(t, tlsConfig)
+				return crdbConn, nil
+			},
+		)()
+		conn, err := c.dialSQLServer("10.11.12.13:1234")
+		require.NoError(t, err)
+		require.Equal(t, crdbConn, conn)
+	})
+
+	t.Run("failed to dial with non-transient error", func(t *testing.T) {
+		c := &connector{StartupMsg: &pgproto3.StartupMessage{}}
+		defer testutils.TestingHook(&BackendDial,
+			func(msg *pgproto3.StartupMessage, serverAddress string,
+				tlsConfig *tls.Config) (net.Conn, error) {
+				require.Equal(t, c.StartupMsg, msg)
+				require.Equal(t, "127.0.0.1:1234", serverAddress)
+				require.Nil(t, tlsConfig)
+				return nil, errors.New("foo")
+			},
+		)()
+		conn, err := c.dialSQLServer("127.0.0.1:1234")
+		require.EqualError(t, err, "foo")
+		require.False(t, isRetriableConnectorError(err))
+		require.Nil(t, conn)
+	})
+
+	t.Run("failed to dial with transient error", func(t *testing.T) {
+		c := &connector{StartupMsg: &pgproto3.StartupMessage{}}
+		defer testutils.TestingHook(&BackendDial,
+			func(msg *pgproto3.StartupMessage, serverAddress string,
+				tlsConfig *tls.Config) (net.Conn, error) {
+				require.Equal(t, c.StartupMsg, msg)
+				require.Equal(t, "127.0.0.2:4567", serverAddress)
+				require.Nil(t, tlsConfig)
+				return nil, newErrorf(codeBackendDown, "bar")
+			},
+		)()
+		conn, err := c.dialSQLServer("127.0.0.2:4567")
+		require.EqualError(t, err, "codeBackendDown: bar")
+		require.True(t, isRetriableConnectorError(err))
+		require.Nil(t, conn)
+	})
+}
+
+func TestRetriableConnectorError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	err := errors.New("foobar")
+	require.False(t, isRetriableConnectorError(err))
+	err = markAsRetriableConnectorError(err)
+	require.True(t, isRetriableConnectorError(err))
+}
+
+var _ TenantResolver = &testTenantResolver{}
+
+// testTenantResolver is a test implementation of the tenant resolver.
+type testTenantResolver struct {
+	ensureTenantAddrFn  func(ctx context.Context, tenantID roachpb.TenantID, clusterName string) (string, error)
+	lookupTenantAddrsFn func(ctx context.Context, tenantID roachpb.TenantID) ([]string, error)
+	reportFailureFn     func(ctx context.Context, tenantID roachpb.TenantID, addr string) error
+}
+
+// EnsureTenantAddr implements the TenantResolver interface.
+func (r *testTenantResolver) EnsureTenantAddr(
+	ctx context.Context, tenantID roachpb.TenantID, clusterName string,
+) (string, error) {
+	return r.ensureTenantAddrFn(ctx, tenantID, clusterName)
+}
+
+// LookupTenantAddrs implements the TenantResolver interface.
+func (r *testTenantResolver) LookupTenantAddrs(
+	ctx context.Context, tenantID roachpb.TenantID,
+) ([]string, error) {
+	return r.lookupTenantAddrsFn(ctx, tenantID)
+}
+
+// ReportFailure implements the TenantResolver interface.
+func (r *testTenantResolver) ReportFailure(
+	ctx context.Context, tenantID roachpb.TenantID, addr string,
+) error {
+	return r.reportFailureFn(ctx, tenantID, addr)
+}

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/denylist"
-	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -670,7 +669,7 @@ func TestDirectoryConnect(t *testing.T) {
 		// Ensure that Directory.ReportFailure is being called correctly.
 		countReports := 0
 		defer testutils.TestingHook(&reportFailureToDirectory, func(
-			ctx context.Context, tenantID roachpb.TenantID, addr string, directory *tenant.Directory,
+			ctx context.Context, tenantID roachpb.TenantID, addr string, directory TenantResolver,
 		) error {
 			require.Equal(t, roachpb.MakeTenantID(28), tenantID)
 			addrs, err := directory.LookupTenantAddrs(ctx, tenantID)


### PR DESCRIPTION
Informs #76000.

Previously, all the connection establishment logic is coupled with the handler
function within proxy_handler.go. This makes connecting to a new SQL pod during
connection migration difficult. This commit refactors all of those connection
logic out of the proxy handler into a connector component, as described in the
connection migration RFC. At the same time, we also add support for the session
revival token within this connector component.

Note that the overall behavior of the SQL proxy should be unchanged with this
commit.

Release note: None