### PR TITLE
cli,sql: do not exit interactive shells with Ctrl+C

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -34,12 +34,12 @@ func TestCLITimeout(t *testing.T) {
 	// the timeout a chance to have an effect. We specify --all to include some
 	// slower to access virtual tables in the query.
 	testutils.SucceedsSoon(t, func() error {
-		out, err := c.RunWithCapture("node status 1 --all --timeout 1ns")
+		out, err := c.RunWithCapture("node status 1 --all --timeout 1ms")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		const exp = `node status 1 --all --timeout 1ns
+		const exp = `node status 1 --all --timeout 1ms
 ERROR: query execution canceled due to statement timeout
 SQLSTATE: 57014
 `

--- a/pkg/cli/clierror/syntax_error_test.go
+++ b/pkg/cli/clierror/syntax_error_test.go
@@ -11,6 +11,7 @@
 package clierror_test
 
 import (
+	"context"
 	"io/ioutil"
 	"net/url"
 	"testing"
@@ -44,7 +45,7 @@ func TestIsSQLSyntaxError(t *testing.T) {
 		}
 	}()
 
-	_, err := conn.QueryRow(`INVALID SYNTAX`, nil)
+	_, err := conn.QueryRow(context.Background(), `INVALID SYNTAX`)
 	if !clierror.IsSQLSyntaxError(err) {
 		t.Fatalf("expected error to be recognized as syntax error: %+v", err)
 	}

--- a/pkg/cli/clisqlcfg/context.go
+++ b/pkg/cli/clisqlcfg/context.go
@@ -13,6 +13,7 @@
 package clisqlcfg
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -213,7 +214,8 @@ func (c *Context) maybeSetSafeUpdates(conn clisqlclient.Conn) {
 		safeUpdates = c.CliCtx.IsInteractive
 	}
 	if safeUpdates {
-		if err := conn.Exec("SET sql_safe_updates = TRUE", nil); err != nil {
+		if err := conn.Exec(context.Background(),
+			"SET sql_safe_updates = TRUE"); err != nil {
 			// We only enable the setting in interactive sessions. Ignoring
 			// the error with a warning is acceptable, because the user is
 			// there to decide what they want to do if it doesn't work.
@@ -228,5 +230,6 @@ func (c *Context) maybeSetReadOnly(conn clisqlclient.Conn) error {
 	if !c.ReadOnly {
 		return nil
 	}
-	return conn.Exec("SET default_transaction_read_only = TRUE", nil)
+	return conn.Exec(context.Background(),
+		"SET default_transaction_read_only = TRUE")
 }

--- a/pkg/cli/clisqlclient/txn_shim.go
+++ b/pkg/cli/clisqlclient/txn_shim.go
@@ -30,17 +30,17 @@ type sqlTxnShim struct {
 
 var _ crdb.Tx = sqlTxnShim{}
 
-func (t sqlTxnShim) Commit(context.Context) error {
-	return t.conn.Exec(`COMMIT`, nil)
+func (t sqlTxnShim) Commit(ctx context.Context) error {
+	return t.conn.Exec(ctx, `COMMIT`)
 }
 
-func (t sqlTxnShim) Rollback(context.Context) error {
-	return t.conn.Exec(`ROLLBACK`, nil)
+func (t sqlTxnShim) Rollback(ctx context.Context) error {
+	return t.conn.Exec(ctx, `ROLLBACK`)
 }
 
-func (t sqlTxnShim) Exec(_ context.Context, query string, values ...interface{}) error {
+func (t sqlTxnShim) Exec(ctx context.Context, query string, values ...interface{}) error {
 	if len(values) != 0 {
 		panic("sqlTxnShim.ExecContext must not be called with values")
 	}
-	return t.conn.Exec(query, nil)
+	return t.conn.Exec(ctx, query)
 }

--- a/pkg/cli/clisqlexec/run_query_test.go
+++ b/pkg/cli/clisqlexec/run_query_test.go
@@ -12,6 +12,7 @@ package clisqlexec_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -38,7 +39,9 @@ func makeSQLConn(url string) clisqlclient.Conn {
 func runQueryAndFormatResults(
 	conn clisqlclient.Conn, w io.Writer, fn clisqlclient.QueryFn,
 ) (err error) {
-	return testExecCtx.RunQueryAndFormatResults(conn, w, ioutil.Discard, fn)
+	return testExecCtx.RunQueryAndFormatResults(
+		context.Background(),
+		conn, w, ioutil.Discard, fn)
 }
 
 func TestRunQuery(t *testing.T) {
@@ -74,7 +77,9 @@ SET
 	b.Reset()
 
 	// Use system database for sample query/output as they are fairly fixed.
-	cols, rows, err := testExecCtx.RunQuery(conn, clisqlclient.MakeQuery(`SHOW COLUMNS FROM system.namespace`), false)
+	cols, rows, err := testExecCtx.RunQuery(
+		context.Background(),
+		conn, clisqlclient.MakeQuery(`SHOW COLUMNS FROM system.namespace`), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -834,7 +834,9 @@ func (c *cliState) doRefreshPrompts(nextState cliStateEnum) cliStateEnum {
 func (c *cliState) refreshTransactionStatus() {
 	c.lastKnownTxnStatus = unknownTxnStatus
 
-	dbVal, dbColType, hasVal := c.conn.GetServerValue("transaction status", `SHOW TRANSACTION STATUS`)
+	dbVal, dbColType, hasVal := c.conn.GetServerValue(
+		context.Background(),
+		"transaction status", `SHOW TRANSACTION STATUS`)
 	if !hasVal {
 		return
 	}
@@ -867,7 +869,9 @@ func (c *cliState) refreshDatabaseName() string {
 		return unknownDbName
 	}
 
-	dbVal, dbColType, hasVal := c.conn.GetServerValue("database name", `SHOW DATABASE`)
+	dbVal, dbColType, hasVal := c.conn.GetServerValue(
+		context.Background(),
+		"database name", `SHOW DATABASE`)
 	if !hasVal {
 		return unknownDbName
 	}
@@ -1586,7 +1590,9 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 	if c.iCtx.autoTrace != "" {
 		// Clear the trace by disabling tracing, then restart tracing
 		// with the specified options.
-		c.exitErr = c.conn.Exec("SET tracing = off; SET tracing = "+c.iCtx.autoTrace, nil)
+		c.exitErr = c.conn.Exec(
+			context.Background(),
+			"SET tracing = off; SET tracing = "+c.iCtx.autoTrace)
 		if c.exitErr != nil {
 			if !c.singleStatement {
 				clierror.OutputError(c.iCtx.stderr, c.exitErr, true /*showSeverity*/, false /*verbose*/)
@@ -1599,7 +1605,9 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 	}
 
 	// Now run the statement/query.
-	c.exitErr = c.sqlExecCtx.RunQueryAndFormatResults(c.conn, c.iCtx.stdout, c.iCtx.stderr,
+	c.exitErr = c.sqlExecCtx.RunQueryAndFormatResults(
+		context.Background(),
+		c.conn, c.iCtx.stdout, c.iCtx.stderr,
 		clisqlclient.MakeQuery(c.concatLines))
 	if c.exitErr != nil {
 		if !c.singleStatement {
@@ -1611,7 +1619,8 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 	// this even if there was an error: a trace on errors is useful.
 	if c.iCtx.autoTrace != "" {
 		// First, disable tracing.
-		if err := c.conn.Exec("SET tracing = off", nil); err != nil {
+		if err := c.conn.Exec(context.Background(),
+			"SET tracing = off"); err != nil {
 			// Print the error for the SET tracing statement. This will
 			// appear below the error for the main query above, if any,
 			clierror.OutputError(c.iCtx.stderr, err, true /*showSeverity*/, false /*verbose*/)
@@ -1629,7 +1638,9 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 			if strings.Contains(c.iCtx.autoTrace, "kv") {
 				traceType = "kv"
 			}
-			if err := c.sqlExecCtx.RunQueryAndFormatResults(c.conn, c.iCtx.stdout, c.iCtx.stderr,
+			if err := c.sqlExecCtx.RunQueryAndFormatResults(
+				context.Background(),
+				c.conn, c.iCtx.stdout, c.iCtx.stderr,
 				clisqlclient.MakeQuery(fmt.Sprintf("SHOW %s TRACE FOR SESSION", traceType))); err != nil {
 				clierror.OutputError(c.iCtx.stderr, err, true /*showSeverity*/, false /*verbose*/)
 				if c.exitErr == nil {
@@ -1915,7 +1926,9 @@ func (c *cliState) runStatements(stmts []string) error {
 // decomposition in the first return value. If it is not, the function
 // extracts a help string if available.
 func (c *cliState) serverSideParse(sql string) (helpText string, err error) {
-	cols, rows, err := c.sqlExecCtx.RunQuery(c.conn,
+	cols, rows, err := c.sqlExecCtx.RunQuery(
+		context.Background(),
+		c.conn,
 		clisqlclient.MakeQuery("SHOW SYNTAX "+lexbase.EscapeSQLString(sql)),
 		true)
 	if err != nil {

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1021,9 +1021,11 @@ func (c *cliState) doReadLine(nextState cliStateEnum) cliStateEnum {
 			return cliStartLine
 		}
 
-		// Otherwise, also terminate with an interrupt error.
-		c.exitErr = err
-		return cliStop
+		// If a human is looking, tell them that quitting is done in another way.
+		if c.sqlExecCtx.TerminalOutput {
+			fmt.Fprintf(c.iCtx.stdout, "^C\nUse \\q or terminate input to exit.\n")
+		}
+		return cliStartLine
 
 	case errors.Is(err, io.EOF):
 		c.atEOF = true

--- a/pkg/cli/clisqlshell/statement_diag.go
+++ b/pkg/cli/clisqlshell/statement_diag.go
@@ -12,6 +12,7 @@ package clisqlshell
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"text/tabwriter"
@@ -54,7 +55,8 @@ func (c *cliState) handleStatementDiag(
 		} else {
 			filename = fmt.Sprintf("stmt-bundle-%d.zip", id)
 		}
-		cmdErr = clisqlclient.StmtDiagDownloadBundle(c.conn, id, filename)
+		cmdErr = clisqlclient.StmtDiagDownloadBundle(
+			context.Background(), c.conn, id, filename)
 		if cmdErr == nil {
 			fmt.Fprintf(c.iCtx.stdout, "Bundle saved to %q\n", filename)
 		}
@@ -75,7 +77,7 @@ func (c *cliState) statementDiagList() error {
 	const timeFmt = "2006-01-02 15:04:05 MST"
 
 	// -- List bundles --
-	bundles, err := clisqlclient.StmtDiagListBundles(c.conn)
+	bundles, err := clisqlclient.StmtDiagListBundles(context.Background(), c.conn)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_job_trace.go
+++ b/pkg/cli/debug_job_trace.go
@@ -51,7 +51,8 @@ func runDebugJobTrace(_ *cobra.Command, args []string) (resErr error) {
 
 func getJobTraceID(sqlConn clisqlclient.Conn, jobID int64) (int64, error) {
 	var traceID int64
-	rows, err := sqlConn.Query(`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`, []driver.Value{jobID})
+	rows, err := sqlConn.Query(context.Background(),
+		`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`, jobID)
 	if err != nil {
 		return traceID, err
 	}
@@ -80,17 +81,10 @@ func getJobTraceID(sqlConn clisqlclient.Conn, jobID int64) (int64, error) {
 }
 
 func constructJobTraceZipBundle(ctx context.Context, sqlConn clisqlclient.Conn, jobID int64) error {
-	maybePrint := func(stmt string) string {
-		if debugCtx.verbose {
-			fmt.Println("querying " + stmt)
-		}
-		return stmt
-	}
-
 	// Check if a timeout has been set for this command.
 	if cliCtx.cmdTimeout != 0 {
-		stmt := fmt.Sprintf(`SET statement_timeout = '%s'`, cliCtx.cmdTimeout)
-		if err := sqlConn.Exec(maybePrint(stmt), nil); err != nil {
+		if err := sqlConn.Exec(context.Background(),
+			`SET statement_timeout = $1`, cliCtx.cmdTimeout.String()); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -237,6 +237,7 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 			startTime := timeutil.Now()
 			sqlExecCtx := clisqlexec.Context{}
 			_, _, err = sqlExecCtx.RunQuery(
+				context.Background(),
 				conn,
 				clisqlclient.MakeQuery(`SHOW ALL CLUSTER QUERIES`),
 				false,
@@ -326,6 +327,6 @@ func TestTransientClusterMultitenant(t *testing.T) {
 		}()
 
 		// Create a table on each tenant to make sure that the tenants are separate.
-		require.NoError(t, conn.Exec("CREATE TABLE a (a int PRIMARY KEY)", nil))
+		require.NoError(t, conn.Exec(context.Background(), "CREATE TABLE a (a int PRIMARY KEY)"))
 	}
 }

--- a/pkg/cli/interactive_tests/test_audit_log.tcl
+++ b/pkg/cli/interactive_tests/test_audit_log.tcl
@@ -58,7 +58,7 @@ eexpect root@
 system "grep -q 'sensitive_table_access.*ALTER TABLE.*helloworld.*SET OFF.*AccessMode\":\"rw\"' $logfile"
 end_test
 
-interrupt
+send_eof
 eexpect eof
 
 stop_server $argv
@@ -81,7 +81,7 @@ eexpect "ALTER TABLE"
 eexpect root@
 send "select x from d.helloworld;\r"
 eexpect root@
-interrupt
+send_eof
 eexpect eof
 
 # Check the file was created and populated properly.

--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -52,7 +52,7 @@ send "commit;\r"
 eexpect "ROLLBACK"
 eexpect root@
 
-interrupt
+send_eof
 eexpect eof
 end_test
 

--- a/pkg/cli/interactive_tests/test_contextual_help.tcl
+++ b/pkg/cli/interactive_tests/test_contextual_help.tcl
@@ -128,7 +128,7 @@ eexpect root@
 end_test
 
 # Finally terminate with Ctrl+C.
-interrupt
+send_eof
 eexpect eof
 
 start_test "Check that the hint for a single ? is also printed in non-interactive sessions."

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -35,7 +35,7 @@ eexpect "brief introduction"
 eexpect root@
 # Ensure db is movr.
 eexpect "movr>"
-interrupt
+send_eof
 eexpect eof
 end_test
 
@@ -68,7 +68,7 @@ eexpect ":26257"
 eexpect "sslmode=disable"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 
 # With command-line override.
@@ -88,7 +88,7 @@ eexpect "(sql/unix)"
 eexpect "root:unused@"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 
 end_test
@@ -125,7 +125,7 @@ eexpect ":26257"
 eexpect "sslmode=require"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 
 # With command-line override.
@@ -146,7 +146,7 @@ eexpect "(sql/unix)"
 eexpect "demo:"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 
 end_test
@@ -213,7 +213,7 @@ eexpect "http://"
 eexpect ":8005"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 
 spawn $argv demo --no-example-database --nodes 3 --sql-port 23000
@@ -249,7 +249,7 @@ eexpect "(sql)"
 eexpect ":23002"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 
 
@@ -264,7 +264,7 @@ eexpect "defaultdb>"
 # Check the URL is valid. If the connection fails, the system command will fail too.
 system "$argv sql --url `cat test.url` -e 'select 1'"
 
-interrupt
+send_eof
 eexpect eof
 
 # Ditto, insecure
@@ -275,7 +275,7 @@ eexpect "defaultdb>"
 # Check the URL is valid. If the connection fails, the system command will fail too.
 system "$argv sql --url `cat test.url` -e 'select 1'"
 
-interrupt
+send_eof
 eexpect eof
 
 

--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -28,6 +28,6 @@ send "\\demo shutdown 3\r"
 eexpect "shutting down nodes is not supported in --global configurations"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 end_test

--- a/pkg/cli/interactive_tests/test_demo_multitenant.tcl
+++ b/pkg/cli/interactive_tests/test_demo_multitenant.tcl
@@ -25,6 +25,6 @@ send "SELECT gateway_region();\n"
 eexpect "us-east1"
 eexpect "defaultdb>"
 
-interrupt
+send_eof
 eexpect eof
 end_test

--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -13,10 +13,12 @@ eexpect "movr>"
 # Wrong number of args
 send "\\demo node\r"
 eexpect "invalid syntax: \\\\demo node. Try \\\\? for help."
+eexpect "movr>"
 
 # Cannot shutdown node 1
 send "\\demo shutdown 1\r"
 eexpect "cannot shutdown node 1"
+eexpect "movr>"
 
 # Cannot operate on a node which does not exist.
 send "\\demo shutdown 8\r"
@@ -27,14 +29,17 @@ send "\\demo decommission 8\r"
 eexpect "node 8 does not exist"
 send "\\demo recommission 8\r"
 eexpect "node 8 does not exist"
+eexpect "movr>"
 
 # Cannot restart a node that is not shut down.
 send "\\demo restart 2\r"
 eexpect "node 2 is already running"
+eexpect "movr>"
 
 # Shut down a separate node.
 send "\\demo shutdown 3\r"
 eexpect "node 3 has been shutdown"
+eexpect "movr>"
 
 send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
 eexpect "1 |  false   |      false      | active"
@@ -42,10 +47,12 @@ eexpect "2 |  false   |      false      | active"
 eexpect "3 |   true   |      false      | active"
 eexpect "4 |  false   |      false      | active"
 eexpect "5 |  false   |      false      | active"
+eexpect "movr>"
 
 # Cannot shut it down again.
 send "\\demo shutdown 3\r"
 eexpect "node 3 is already shut down"
+eexpect "movr>"
 
 # Expect queries to still work with just one node down.
 send "SELECT count(*) FROM movr.rides;\r"
@@ -55,6 +62,7 @@ eexpect "movr>"
 # Now restart the node.
 send "\\demo restart 3\r"
 eexpect "node 3 has been restarted"
+eexpect "movr>"
 
 send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
 eexpect "1 |  false   |      false      | active"
@@ -62,10 +70,12 @@ eexpect "2 |  false   |      false      | active"
 eexpect "3 |  false   |      false      | active"
 eexpect "4 |  false   |      false      | active"
 eexpect "5 |  false   |      false      | active"
+eexpect "movr>"
 
 # Try commissioning commands
 send "\\demo decommission 4\r"
 eexpect "node 4 has been decommissioned"
+eexpect "movr>"
 
 send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
 eexpect "1 |  false   |      false      | active"
@@ -73,20 +83,25 @@ eexpect "2 |  false   |      false      | active"
 eexpect "3 |  false   |      false      | active"
 eexpect "4 |  false   |      true       | decommissioned"
 eexpect "5 |  false   |      false      | active"
+eexpect "movr>"
 
 send "\\demo recommission 4\r"
 eexpect "can only recommission a decommissioning node"
+eexpect "movr>"
 
 send "\\demo add blah\r"
 eexpect "internal server error: tier must be in the form \"key=value\" not \"blah\""
+eexpect "movr>"
 
 send "\\demo add region=ca-central,zone=a\r"
 eexpect "node 6 has been added with locality \"region=ca-central,zone=a\""
+eexpect "movr>"
 
 send "show regions from cluster;\r"
 eexpect "ca-central | \{a\}"
 eexpect "us-east1   | \{b,c,d\}"
 eexpect "us-west1   | \{b\}"
+eexpect "movr>"
 
 # We use kv_node_status here because gossip_liveness is timing dependant.
 # Node 4's status entry should have been removed by now.
@@ -96,10 +111,12 @@ eexpect "2 | region=us-east1,az=c"
 eexpect "3 | region=us-east1,az=d"
 eexpect "5 | region=us-west1,az=b"
 eexpect "6 | region=ca-central,zone=a"
+eexpect "movr>"
 
 # Shut down the newly created node.
 send "\\demo shutdown 6\r"
 eexpect "node 6 has been shutdown"
+eexpect "movr>"
 
 # By now the node should have stabilized in gossip which allows us to query the more detailed information there.
 send "select node_id, draining, decommissioning, membership from crdb_internal.gossip_liveness ORDER BY node_id;\r"
@@ -109,7 +126,8 @@ eexpect "3 |  false   |      false      | active"
 eexpect "4 |  false   |      true       | decommissioned"
 eexpect "5 |  false   |      false      | active"
 eexpect "6 |   true   |      false      | active"
+eexpect "movr>"
 
-interrupt
+send_eof
 eexpect eof
 end_test

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -95,7 +95,7 @@ eexpect "8"
 eexpect "(1 row)"
 eexpect "movr>"
 
-interrupt
+send_eof
 eexpect $prompt
 end_test
 
@@ -119,7 +119,7 @@ eexpect "  survival_goal"
 eexpect "zone"
 eexpect "movr>"
 
-interrupt
+send_eof
 eexpect $prompt
 
 send "$argv demo movr --geo-partitioned-replicas --multi-region --survive=region\r"
@@ -131,7 +131,7 @@ eexpect "  survival_goal"
 eexpect "region"
 eexpect "movr>"
 
-interrupt
+send_eof
 eexpect $prompt
 
 end_test

--- a/pkg/cli/interactive_tests/test_demo_telemetry.tcl
+++ b/pkg/cli/interactive_tests/test_demo_telemetry.tcl
@@ -18,7 +18,7 @@ send "alter table vehicles partition by list (city) (partition p1 values in ('ny
 # expect that it failed, as no license was requested.
 eexpect "use of partitions requires an enterprise license"
 # clean up after the test
-interrupt
+send_eof
 eexpect eof
 
 end_test

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -30,8 +30,9 @@ if {!$workloadRunning} {
   report "Workload is not running"
   exit 1
 }
+eexpect "movr>"
 
-interrupt
+send_eof
 eexpect eof
 end_test
 
@@ -48,7 +49,8 @@ eexpect "movr>"
 send "SELECT count(*) FROM \[SHOW RANGES FROM TABLE USERS\];\r"
 eexpect "6"
 eexpect "(1 row)"
+eexpect "movr>"
 
-interrupt
+send_eof
 eexpect eof
 end_test

--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -37,7 +37,7 @@ send "\r"
 eexpect root@
 
 # Finish the test.
-interrupt
+send_eof
 eexpect ":/# "
 end_test
 

--- a/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
@@ -42,7 +42,7 @@ eexpect "Bundle saved to"
 
 file_exists "stmt-bundle-$id.zip"
 
-interrupt
+send_eof
 eexpect eof
 
 end_test
@@ -81,7 +81,7 @@ eexpect "Bundle saved to"
 
 file_exists "stmt-bundle-$id.zip"
 
-interrupt
+send_eof
 eexpect eof
 
 stop_tenant 5 $argv

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -89,7 +89,7 @@ eexpect "cli.demo.explicitflags.logtostderr"
 eexpect "cli.demo.explicitflags.no-example-database"
 eexpect "cli.demo.runs"
 eexpect "defaultdb>"
-interrupt
+send_eof
 eexpect ":/# "
 end_test
 
@@ -112,7 +112,7 @@ eexpect "cli.start-single-node.explicitflags.listening-url-file"
 eexpect "cli.start-single-node.explicitflags.max-sql-memory"
 eexpect "cli.start-single-node.runs"
 eexpect "defaultdb>"
-interrupt
+send_eof
 eexpect ":/# "
 end_test
 
@@ -121,7 +121,7 @@ send "export COCKROACH_URL=`cat server_url`;\r"
 eexpect ":/# "
 send "$argv sql\r"
 eexpect "defaultdb>"
-interrupt
+send_eof
 eexpect ":/# "
 end_test
 

--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -81,8 +81,8 @@ eexpect "1 row"
 eexpect root@
 end_test
 
-# Finally terminate with Ctrl+C
-interrupt
+# Finally terminate with Ctrl+D
+send_eof
 eexpect eof
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_init_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_command.tcl
@@ -61,7 +61,7 @@ expect {
 }
 
 interrupt
-interrupt
+send_eof
 eexpect eof
 
 end_test

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -266,8 +266,8 @@ eexpect Description
 eexpect root@
 end_test
 
-# Finally terminate with Ctrl+C.
-interrupt
+# Finally terminate with Ctrl+D.
+send_eof
 eexpect eof
 
 spawn /bin/bash
@@ -301,7 +301,7 @@ eexpect "errexit,false"
 eexpect "prompt1,%n@"
 eexpect "show_times,true"
 eexpect root@
-interrupt
+send_eof
 eexpect ":/# "
 
 # Then verify that the defaults can be overridden.
@@ -316,7 +316,7 @@ eexpect "errexit,true"
 eexpect "prompt1,%n@haa"
 eexpect "show_times,false"
 eexpect root@
-interrupt
+send_eof
 eexpect ":/# "
 
 end_test

--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -75,6 +75,7 @@ eexpect " ->"
 send "\\p\r"
 eexpect "select\r\n*->"
 interrupt
+eexpect root@
 end_test
 
 start_test "Test that a dangling table creation can be committed, and that other non-DDL, non-DML statements can be issued in the same txn. (#15283)"
@@ -111,7 +112,7 @@ end_test
 
 
 
-interrupt
+send_eof
 eexpect eof
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -26,6 +26,6 @@ eexpect "NOTICE: hello"
 eexpect "NOTICE: world"
 eexpect "WARNING: stay indoors"
 eexpect root@
-interrupt
+send_eof
 eexpect eof
 end_test

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -98,11 +98,10 @@ eexpect "Failed running \"sql\""
 # Check that history is scrubbed.
 send "$argv sql --certs-dir=$certs_dir\r"
 eexpect "root@"
-interrupt
 end_test
 
-# Terminate the shell with Ctrl+C.
-interrupt
+# Terminate the shell with Ctrl+D.
+send_eof
 eexpect $prompt
 
 start_test "Check that an auth cookie cannot be created for a user that does not exist."
@@ -119,12 +118,12 @@ send "$argv sql --url 'postgres://eisen@?host=$mywd&port=26257'\r"
 eexpect "Enter password:"
 send "hunter2\r"
 eexpect "eisen@"
-interrupt
+send_eof
 eexpect $prompt
 
 send "$argv sql --url 'postgres://eisen:hunter2@?host=$mywd&port=26257'\r"
 eexpect "eisen@"
-interrupt
+send_eof
 eexpect $prompt
 
 end_test

--- a/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
@@ -17,7 +17,7 @@ send "\\demo shutdown 2\n"
 eexpect "\\demo can only be run with cockroach demo"
 
 # Exit the shell.
-interrupt
+send_eof
 eexpect eof
 
 # Have good manners and clean up.

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -117,7 +117,7 @@ eexpect "1 row"
 eexpect root@
 end_test
 
-interrupt
+send_eof
 eexpect eof
 
 set spawn_id $shell_spawn_id

--- a/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
@@ -62,7 +62,7 @@ eexpect "New ID:"
 eexpect root@
 end_test
 
-interrupt
+send_eof
 eexpect eof
 
 stop_server $argv
@@ -80,7 +80,7 @@ eexpect "warning: server version older than client"
 eexpect root@
 end_test
 
-interrupt
+send_eof
 eexpect eof
 
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_style_enabled.tcl
+++ b/pkg/cli/interactive_tests/test_style_enabled.tcl
@@ -13,7 +13,7 @@ eexpect root@
 send "SET CLUSTER SETTING sql.defaults.datestyle.enabled = true;\r"
 eexpect "SET CLUSTER SETTING"
 eexpect root@
-interrupt
+send_eof
 eexpect eof
 
 
@@ -24,7 +24,7 @@ eexpect root@
 send "SHOW intervalstyle;\r"
 eexpect "iso_8601"
 eexpect root@
-interrupt
+send_eof
 eexpect eof
 
 # TODO(#72065): uncomment

--- a/pkg/cli/nodelocal.go
+++ b/pkg/cli/nodelocal.go
@@ -131,7 +131,7 @@ func uploadFile(
 		return err
 	}
 
-	nodeID, _, _, err := conn.GetServerMetadata()
+	nodeID, _, _, err := conn.GetServerMetadata(ctx)
 	if err != nil {
 		return errors.Wrap(err, "unable to get node id")
 	}

--- a/pkg/cli/statement_diag.go
+++ b/pkg/cli/statement_diag.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"text/tabwriter"
@@ -49,8 +50,10 @@ func runStmtDiagList(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	ctx := context.Background()
+
 	// -- List bundles --
-	bundles, err := clisqlclient.StmtDiagListBundles(conn)
+	bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -71,7 +74,7 @@ func runStmtDiagList(cmd *cobra.Command, args []string) (resErr error) {
 	}
 
 	// -- List outstanding activation requests --
-	reqs, err := clisqlclient.StmtDiagListOutstandingRequests(conn)
+	reqs, err := clisqlclient.StmtDiagListOutstandingRequests(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -131,7 +134,8 @@ func runStmtDiagDownload(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
-	if err := clisqlclient.StmtDiagDownloadBundle(conn, id, filename); err != nil {
+	if err := clisqlclient.StmtDiagDownloadBundle(
+		context.Background(), conn, id, filename); err != nil {
 		return err
 	}
 	fmt.Printf("Bundle saved to %q\n", filename)
@@ -154,11 +158,13 @@ func runStmtDiagDelete(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	ctx := context.Background()
+
 	if stmtDiagCtx.all {
 		if len(args) > 0 {
 			return errors.New("extra arguments with --all")
 		}
-		return clisqlclient.StmtDiagDeleteAllBundles(conn)
+		return clisqlclient.StmtDiagDeleteAllBundles(ctx, conn)
 	}
 	if len(args) != 1 {
 		return fmt.Errorf("accepts 1 arg, received %d", len(args))
@@ -169,7 +175,7 @@ func runStmtDiagDelete(cmd *cobra.Command, args []string) (resErr error) {
 		return errors.New("invalid ID")
 	}
 
-	return clisqlclient.StmtDiagDeleteBundle(conn, id)
+	return clisqlclient.StmtDiagDeleteBundle(ctx, conn, id)
 }
 
 var stmtDiagCancelCmd = &cobra.Command{
@@ -188,11 +194,13 @@ func runStmtDiagCancel(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	ctx := context.Background()
+
 	if stmtDiagCtx.all {
 		if len(args) > 0 {
 			return errors.New("extra arguments with --all")
 		}
-		return clisqlclient.StmtDiagCancelAllOutstandingRequests(conn)
+		return clisqlclient.StmtDiagCancelAllOutstandingRequests(ctx, conn)
 	}
 	if len(args) != 1 {
 		return fmt.Errorf("accepts 1 arg, received %d", len(args))
@@ -203,7 +211,7 @@ func runStmtDiagCancel(cmd *cobra.Command, args []string) (resErr error) {
 		return errors.New("invalid ID")
 	}
 
-	return clisqlclient.StmtDiagCancelOutstandingRequest(conn, id)
+	return clisqlclient.StmtDiagCancelOutstandingRequest(ctx, conn, id)
 }
 
 var stmtDiagCmds = []*cobra.Command{

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -815,11 +815,11 @@ func TestUsernameUserfileInteraction(t *testing.T) {
 			},
 		} {
 			createUserQuery := fmt.Sprintf(`CREATE USER "%s" WITH PASSWORD 'a'`, tc.username)
-			err = conn.Exec(createUserQuery, nil)
+			err = conn.Exec(ctx, createUserQuery)
 			require.NoError(t, err)
 
 			privsUserQuery := fmt.Sprintf(`GRANT CREATE ON DATABASE defaultdb TO "%s"`, tc.username)
-			err = conn.Exec(privsUserQuery, nil)
+			err = conn.Exec(ctx, privsUserQuery)
 			require.NoError(t, err)
 
 			userURL, cleanup2 := sqlutils.PGUrlWithOptionalClientCerts(t, c.ServingSQLAddr(), t.Name(),


### PR DESCRIPTION
First commit from #76434.
Needed for #76433.

This change is a preface to making the interactive shell support
Ctrl+C to cancel a currently executing query.

When that happens, we need to ensure that Ctrl+C *only* cancels the
current query, and not the entire shell. This is because there is no
deterministic boundary in time for a user to decide whether the key
press will cancel only the query, or stop the shell. If they care
about keeping their shell alive, they would never "dare" to press
Ctrl+C while a query is executing.

Incidentally, this is also what `psql` does, for pretty much the same
reason.

Note that the new behavior is restricted to *interactive* shells, when
stdin is a terminal. The behavior for non-interactive shells remains
unchanged, where Ctrl+C will terminate everything. This is also what
other SQL shells do.

Release note (cli change): `cockroach sql` (and `demo`) now continue
to accept user input when Ctrl+C is pressed at the interactive prompt
and the current input line is empty. Previously, it would terminate
the shell.  To terminate the shell, the client-side command `\q` is
still supported. The user can also terminate the input altogether via
EOF (Ctrl+D).
The behavior in non-interactive use remains unchanged.