### PR TITLE
[CRDB-9550] kv: adjust number of voters needed calculation when determining replication status

### DIFF
--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -59,14 +59,14 @@ func TestConformanceReport(t *testing.T) {
 		{
 			name: "simple no violations",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name:   "db1",
 						tables: []table{{name: "t1"}, {name: "t2"}},
 						// The database has a zone requesting everything to be on SSDs.
 						zone: &zone{
-							replicas:    3,
+							voters:      3,
 							constraints: "[+ssd]",
 						},
 					},
@@ -106,27 +106,27 @@ func TestConformanceReport(t *testing.T) {
 			name: "violations at multiple levels",
 			// Test zone constraints inheritance at all levels.
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3, constraints: "[+default]"},
+				defaultZone: zone{voters: 3, constraints: "[+default]"},
 				schema: []database{
 					{
 						name: "db1",
 						// All the objects will have zones asking for different tags.
 						zone: &zone{
-							replicas:    3,
+							voters:      3,
 							constraints: "[+db1]",
 						},
 						tables: []table{
 							{
 								name: "t1",
 								zone: &zone{
-									replicas:    3,
+									voters:      3,
 									constraints: "[+t1]",
 								},
 							},
 							{
 								name: "t2",
 								zone: &zone{
-									replicas:    3,
+									voters:      3,
 									constraints: "[+t2]",
 								},
 							},
@@ -225,14 +225,14 @@ func TestConformanceReport(t *testing.T) {
 			// violation, and another entry for "dc1" with one violation.
 			name: "constraint conjunctions",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name:   "db1",
 						tables: []table{{name: "t1"}, {name: "t2"}},
 						// The database has a zone requesting everything to be on SSDs.
 						zone: &zone{
-							replicas: 2,
+							voters: 2,
 							// The first conjunction will be satisfied; the second won't.
 							constraints: `{"+region=us,+dc=dc1":1,"+region=us,+dc=dc2":1}`,
 						},
@@ -308,16 +308,21 @@ func runConformanceReportTest(t *testing.T, tc conformanceConstraintTestCase) {
 }
 
 type zone struct {
-	// 0 means unset.
-	replicas int32
+	// indicates the number of replicas that
+	// are voters. 0 means unset.
+	voters int32
+	// indicates the number of replicas that
+	// are non-voting.
+	nonVoters int32
 	// "" means unset. "[]" means empty.
 	constraints string
 }
 
 func (z zone) toZoneConfig() zonepb.ZoneConfig {
 	cfg := zonepb.NewZoneConfig()
-	if z.replicas != 0 {
-		cfg.NumReplicas = proto.Int32(z.replicas)
+	cfg.NumReplicas = proto.Int32(z.voters + z.nonVoters)
+	if z.nonVoters != 0 && z.voters != 0 {
+		cfg.NumVoters = proto.Int32(z.voters)
 	}
 	if z.constraints != "" {
 		var constraintsList zonepb.ConstraintsList

--- a/pkg/kv/kvserver/reports/critical_localities_report_test.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report_test.go
@@ -56,13 +56,13 @@ func TestCriticalLocalitiesReport(t *testing.T) {
 		{
 			name: "simple",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name: "db1",
-						zone: &zone{replicas: 3},
+						zone: &zone{voters: 3},
 						tables: []table{
-							{name: "t1", zone: &zone{replicas: 3}},
+							{name: "t1", zone: &zone{voters: 3}},
 							// Critical localities for t2 are counted towards db1's zone,
 							// since t2 doesn't define a zone.
 							{name: "t2"},
@@ -80,7 +80,7 @@ func TestCriticalLocalitiesReport(t *testing.T) {
 							// qualifying zone.
 							{name: "t4"},
 							{name: "t5"},
-							{name: "t6", zone: &zone{replicas: 3}},
+							{name: "t6", zone: &zone{voters: 3}},
 						},
 					},
 				},

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -255,11 +255,11 @@ type replicationStatsVisitor struct {
 	report   RangeReport
 	visitErr bool
 
-	// prevZoneKey and prevNumReplicas maintain state from one range to the next.
+	// prevZoneKey and prevNumVoters maintain state from one range to the next.
 	// This state can be reused when a range is covered by the same zone config as
 	// the previous one. Reusing it speeds up the report generation.
-	prevZoneKey     ZoneKey
-	prevNumReplicas int
+	prevZoneKey   ZoneKey
+	prevNumVoters int
 }
 
 var _ rangeVisitor = &replicationStatsVisitor{}
@@ -289,10 +289,10 @@ func (v *replicationStatsVisitor) Report() RangeReport {
 // reset is part of the rangeVisitor interface.
 func (v *replicationStatsVisitor) reset(ctx context.Context) {
 	*v = replicationStatsVisitor{
-		cfg:             v.cfg,
-		nodeChecker:     v.nodeChecker,
-		prevNumReplicas: -1,
-		report:          make(RangeReport, len(v.report)),
+		cfg:           v.cfg,
+		nodeChecker:   v.nodeChecker,
+		prevNumVoters: -1,
+		report:        make(RangeReport, len(v.report)),
 	}
 
 	// Iterate through all the zone configs to create report entries for all the
@@ -335,14 +335,19 @@ func (v *replicationStatsVisitor) visitNewZone(
 	}()
 	var zKey ZoneKey
 	var zConfig *zonepb.ZoneConfig
-	var numReplicas int
+	// NumReplicas and NumVoters are not necessarily set in tandem so
+	// if NumVoters is not found there should be continual traversal to
+	// find it and otherwise defer to NumReplicas.
+	// Based on the above, desiredNumVoters is set to NumVoters or NumReplicas
+	// if NumVoters is not set.
+	var desiredNumVoters int
 
 	// Figure out the zone config for whose report the current range is to be
 	// counted. This is the lowest-level zone config covering the range that
 	// changes replication settings. We also need to figure out the replication
 	// factor this zone is configured with; the replication factor might be
 	// inherited from a higher-level zone config.
-	found, err := visitZones(ctx, r, v.cfg, ignoreSubzonePlaceholders,
+	_, err := visitZones(ctx, r, v.cfg, ignoreSubzonePlaceholders,
 		func(_ context.Context, zone *zonepb.ZoneConfig, key ZoneKey) bool {
 			if zConfig == nil {
 				if !zoneChangesReplication(zone) {
@@ -350,38 +355,45 @@ func (v *replicationStatsVisitor) visitNewZone(
 				}
 				zKey = key
 				zConfig = zone
-				if zone.NumReplicas != nil {
-					numReplicas = int(*zone.NumReplicas)
+				if zone.NumVoters != nil {
+					desiredNumVoters = int(*zone.NumVoters)
 					return true
 				}
-				// We need to continue upwards in search for the NumReplicas.
+				if zone.NumReplicas != nil && desiredNumVoters == 0 {
+					desiredNumVoters = int(*zone.NumReplicas)
+				}
+				// We need to continue upwards in search for NumVoters
+				// and, if the previous is not found, NumReplicas.
 				return false
 			}
-			// We had already found the zone to report to, but we're haven't found
-			// its NumReplicas yet.
-			if zone.NumReplicas != nil {
-				numReplicas = int(*zone.NumReplicas)
+			if zone.NumVoters != nil {
+				desiredNumVoters = int(*zone.NumVoters)
 				return true
 			}
+			if *zone.NumReplicas != 0 && desiredNumVoters == 0 {
+				desiredNumVoters = int(*zone.NumReplicas)
+			}
+			// We had already found the zone to report to, but we're haven't found
+			// its NumVoters and NumReplicas yet.
 			return false
 		})
 	if err != nil {
 		return errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error visiting zones for range %s", r)
 	}
-	v.prevZoneKey = zKey
-	v.prevNumReplicas = numReplicas
-	if !found {
+	if desiredNumVoters == 0 {
 		return errors.AssertionFailedf(
 			"no zone config with replication attributes found for range: %s", r)
 	}
+	v.prevZoneKey = zKey
+	v.prevNumVoters = desiredNumVoters
 
-	v.countRange(ctx, zKey, numReplicas, r)
+	v.countRange(ctx, zKey, desiredNumVoters, r)
 	return nil
 }
 
 // visitSameZone is part of the rangeVisitor interface.
 func (v *replicationStatsVisitor) visitSameZone(ctx context.Context, r *roachpb.RangeDescriptor) {
-	v.countRange(ctx, v.prevZoneKey, v.prevNumReplicas, r)
+	v.countRange(ctx, v.prevZoneKey, v.prevNumVoters, r)
 }
 
 func (v *replicationStatsVisitor) countRange(
@@ -404,5 +416,6 @@ func (v *replicationStatsVisitor) countRange(
 // the lowest ancestor for which this method returns true.
 func zoneChangesReplication(zone *zonepb.ZoneConfig) bool {
 	return (zone.NumReplicas != nil && *zone.NumReplicas != 0) ||
+		(zone.NumVoters != nil && *zone.NumVoters != 0) ||
 		zone.Constraints != nil
 }

--- a/pkg/kv/kvserver/reports/replication_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report_test.go
@@ -245,7 +245,7 @@ func TestReplicationStatsReport(t *testing.T) {
 		{
 			name: "simple no violations",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name: "db1",
@@ -262,7 +262,7 @@ func TestReplicationStatsReport(t *testing.T) {
 						},
 						zone: &zone{
 							// Change replication options so that db1 gets a report entry.
-							replicas: 3,
+							voters: 3,
 						},
 					},
 					{
@@ -326,7 +326,7 @@ func TestReplicationStatsReport(t *testing.T) {
 		{
 			name: "simple violations",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name: "db1",
@@ -381,7 +381,7 @@ func TestReplicationStatsReport(t *testing.T) {
 		{
 			name: "joint consensus",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name: "db1",

--- a/pkg/kv/kvserver/reports/replication_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report_test.go
@@ -429,7 +429,138 @@ func TestReplicationStatsReport(t *testing.T) {
 					},
 				},
 			},
-		}}
+		},
+		{
+			name: "simple no violations with non-voters",
+			baseReportTestCase: baseReportTestCase{
+				defaultZone: zone{voters: 1, nonVoters: 2},
+				schema: []database{
+					{
+						name: "db1",
+						tables: []table{
+							{name: "t1",
+								partitions: []partition{{
+									name:  "p1",
+									start: []int{100},
+									end:   []int{200},
+									zone:  &zone{constraints: "[+p1]"},
+								}},
+							},
+							{name: "t2"},
+						},
+						zone: &zone{
+							// Change replication options so that db1 gets a report entry.
+							nonVoters: 3,
+						},
+					},
+				},
+				splits: []split{
+					{key: "/Table/t1", stores: "1 2 3"},
+					{key: "/Table/t1/pk", stores: "1 2 3"},
+					{key: "/Table/t1/pk/1", stores: "1 2 3"},
+					{key: "/Table/t1/pk/2", stores: "1 2 3"},
+					{key: "/Table/t1/pk/3", stores: "1 2 3"},
+					{key: "/Table/t1/pk/100", stores: "1 2 3"},
+					{key: "/Table/t1/pk/150", stores: "1 2 3"},
+					{key: "/Table/t1/pk/200", stores: "1 2 3"},
+					{key: "/Table/t2", stores: "1 2 3"},
+					{key: "/Table/t2/pk", stores: "1 2 3"},
+				},
+				nodes: []node{
+					{id: 1, stores: []store{{id: 1}}},
+					{id: 2, stores: []store{{id: 2}}},
+					{id: 3, stores: []store{{id: 3}}},
+				},
+			},
+			exp: []replicationStatsEntry{
+				{
+					object: "db1",
+					zoneRangeStatus: zoneRangeStatus{
+						numRanges:       8,
+						unavailable:     0,
+						underReplicated: 0,
+						// All ranges are over-replicated because they have
+						// too many voters.
+						overReplicated: 8,
+					},
+				},
+				{
+					object: "t1.p1",
+					zoneRangeStatus: zoneRangeStatus{
+						numRanges:       2,
+						unavailable:     0,
+						underReplicated: 0,
+						overReplicated:  2,
+					},
+				},
+			},
+		},
+		{
+			name: "voters inherited and overwriting lower level num replicas",
+			baseReportTestCase: baseReportTestCase{
+				defaultZone: zone{voters: 3, nonVoters: 1},
+				schema: []database{
+					{
+						name: "db1",
+						tables: []table{
+							{name: "t1",
+								partitions: []partition{{
+									name:  "p1",
+									start: []int{100},
+									end:   []int{200},
+									zone:  &zone{constraints: "[+p1]"},
+								}},
+							},
+							{name: "t2"},
+						},
+						zone: &zone{
+							// Change replication options so that db1 gets a report entry.
+							nonVoters: 2,
+						},
+					},
+				},
+				splits: []split{
+					{key: "/Table/t1", stores: "1 2 3"},
+					{key: "/Table/t1/pk", stores: "1 2 3"},
+					{key: "/Table/t1/pk/1", stores: "1 2 3"},
+					{key: "/Table/t1/pk/2", stores: "1 2 3"},
+					{key: "/Table/t1/pk/3", stores: "1 2 3"},
+					{key: "/Table/t1/pk/100", stores: "1 2 3"},
+					{key: "/Table/t1/pk/150", stores: "1 2 3"},
+					{key: "/Table/t1/pk/200", stores: "1 2 3"},
+					{key: "/Table/t2", stores: "1 2 3"},
+					{key: "/Table/t2/pk", stores: "1 2 3"},
+				},
+				nodes: []node{
+					{id: 1, stores: []store{{id: 1}}},
+					{id: 2, stores: []store{{id: 2}}},
+					{id: 3, stores: []store{{id: 3}}},
+				},
+			},
+			exp: []replicationStatsEntry{
+				{
+					object: "db1",
+					zoneRangeStatus: zoneRangeStatus{
+						// no ranges are over-replicated because voters is inherited
+						// from the higher level
+						numRanges:       8,
+						unavailable:     0,
+						underReplicated: 0,
+						overReplicated:  0,
+					},
+				},
+				{
+					object: "t1.p1",
+					zoneRangeStatus: zoneRangeStatus{
+						numRanges:       2,
+						unavailable:     0,
+						underReplicated: 0,
+						overReplicated:  0,
+					},
+				},
+			},
+		},
+	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			runReplicationStatsTest(t, tc)

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -590,7 +590,7 @@ func TestRangeIteration(t *testing.T) {
 		schema: []database{{
 			name: "db1",
 			zone: &zone{
-				replicas: 3,
+				voters: 3,
 			},
 			tables: []table{
 				{


### PR DESCRIPTION
Currently, when a range has non-voting replicas and it is queried through replication
stats, it will be reported as underreplicated. This is because in the case where a
zone is configured to have non-voting replicas, for the over/under replicated counts,
we compare the number of current voters to the total number of replicas which is
erroneus. Instead, we will compare current number of voters to the total number of
voters if voters has been set and otherwise will defer to the total number of replicas.
This patch ignores the desired non-voters count for the purposes of this report, for
better or worse. Resolves #69335.

Release justification: low risk bug fix

Release note (bug fix): use total number of voters if set when determining replication
status

Before change:
![Screen Shot 2022-02-11 at 10 03 57 AM](https://user-images.githubusercontent.com/17861665/153615571-85163409-5bac-40f4-9669-20dce77185cf.png)

After change:
![Screen Shot 2022-02-11 at 9 53 04 AM](https://user-images.githubusercontent.com/17861665/153615316-785b156b-bd23-4cfa-a76d-7c9fa47fbf1e.png)