### PR TITLE
cli: modernize the SQL API calls

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -34,12 +34,12 @@ func TestCLITimeout(t *testing.T) {
 	// the timeout a chance to have an effect. We specify --all to include some
 	// slower to access virtual tables in the query.
 	testutils.SucceedsSoon(t, func() error {
-		out, err := c.RunWithCapture("node status 1 --all --timeout 1ns")
+		out, err := c.RunWithCapture("node status 1 --all --timeout 1ms")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		const exp = `node status 1 --all --timeout 1ns
+		const exp = `node status 1 --all --timeout 1ms
 ERROR: query execution canceled due to statement timeout
 SQLSTATE: 57014
 `

--- a/pkg/cli/clierror/syntax_error_test.go
+++ b/pkg/cli/clierror/syntax_error_test.go
@@ -11,6 +11,7 @@
 package clierror_test
 
 import (
+	"context"
 	"io/ioutil"
 	"net/url"
 	"testing"
@@ -44,7 +45,7 @@ func TestIsSQLSyntaxError(t *testing.T) {
 		}
 	}()
 
-	_, err := conn.QueryRow(`INVALID SYNTAX`, nil)
+	_, err := conn.QueryRow(context.Background(), `INVALID SYNTAX`)
 	if !clierror.IsSQLSyntaxError(err) {
 		t.Fatalf("expected error to be recognized as syntax error: %+v", err)
 	}

--- a/pkg/cli/clisqlcfg/context.go
+++ b/pkg/cli/clisqlcfg/context.go
@@ -13,6 +13,7 @@
 package clisqlcfg
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -213,7 +214,8 @@ func (c *Context) maybeSetSafeUpdates(conn clisqlclient.Conn) {
 		safeUpdates = c.CliCtx.IsInteractive
 	}
 	if safeUpdates {
-		if err := conn.Exec("SET sql_safe_updates = TRUE", nil); err != nil {
+		if err := conn.Exec(context.Background(),
+			"SET sql_safe_updates = TRUE"); err != nil {
 			// We only enable the setting in interactive sessions. Ignoring
 			// the error with a warning is acceptable, because the user is
 			// there to decide what they want to do if it doesn't work.
@@ -228,5 +230,6 @@ func (c *Context) maybeSetReadOnly(conn clisqlclient.Conn) error {
 	if !c.ReadOnly {
 		return nil
 	}
-	return conn.Exec("SET default_transaction_read_only = TRUE", nil)
+	return conn.Exec(context.Background(),
+		"SET default_transaction_read_only = TRUE")
 }

--- a/pkg/cli/clisqlclient/txn_shim.go
+++ b/pkg/cli/clisqlclient/txn_shim.go
@@ -30,17 +30,17 @@ type sqlTxnShim struct {
 
 var _ crdb.Tx = sqlTxnShim{}
 
-func (t sqlTxnShim) Commit(context.Context) error {
-	return t.conn.Exec(`COMMIT`, nil)
+func (t sqlTxnShim) Commit(ctx context.Context) error {
+	return t.conn.Exec(ctx, `COMMIT`)
 }
 
-func (t sqlTxnShim) Rollback(context.Context) error {
-	return t.conn.Exec(`ROLLBACK`, nil)
+func (t sqlTxnShim) Rollback(ctx context.Context) error {
+	return t.conn.Exec(ctx, `ROLLBACK`)
 }
 
-func (t sqlTxnShim) Exec(_ context.Context, query string, values ...interface{}) error {
+func (t sqlTxnShim) Exec(ctx context.Context, query string, values ...interface{}) error {
 	if len(values) != 0 {
 		panic("sqlTxnShim.ExecContext must not be called with values")
 	}
-	return t.conn.Exec(query, nil)
+	return t.conn.Exec(ctx, query)
 }

--- a/pkg/cli/clisqlexec/run_query_test.go
+++ b/pkg/cli/clisqlexec/run_query_test.go
@@ -12,6 +12,7 @@ package clisqlexec_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"net/url"
@@ -38,7 +39,9 @@ func makeSQLConn(url string) clisqlclient.Conn {
 func runQueryAndFormatResults(
 	conn clisqlclient.Conn, w io.Writer, fn clisqlclient.QueryFn,
 ) (err error) {
-	return testExecCtx.RunQueryAndFormatResults(conn, w, ioutil.Discard, fn)
+	return testExecCtx.RunQueryAndFormatResults(
+		context.Background(),
+		conn, w, ioutil.Discard, fn)
 }
 
 func TestRunQuery(t *testing.T) {
@@ -74,7 +77,9 @@ SET
 	b.Reset()
 
 	// Use system database for sample query/output as they are fairly fixed.
-	cols, rows, err := testExecCtx.RunQuery(conn, clisqlclient.MakeQuery(`SHOW COLUMNS FROM system.namespace`), false)
+	cols, rows, err := testExecCtx.RunQuery(
+		context.Background(),
+		conn, clisqlclient.MakeQuery(`SHOW COLUMNS FROM system.namespace`), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -834,7 +834,9 @@ func (c *cliState) doRefreshPrompts(nextState cliStateEnum) cliStateEnum {
 func (c *cliState) refreshTransactionStatus() {
 	c.lastKnownTxnStatus = unknownTxnStatus
 
-	dbVal, dbColType, hasVal := c.conn.GetServerValue("transaction status", `SHOW TRANSACTION STATUS`)
+	dbVal, dbColType, hasVal := c.conn.GetServerValue(
+		context.Background(),
+		"transaction status", `SHOW TRANSACTION STATUS`)
 	if !hasVal {
 		return
 	}
@@ -867,7 +869,9 @@ func (c *cliState) refreshDatabaseName() string {
 		return unknownDbName
 	}
 
-	dbVal, dbColType, hasVal := c.conn.GetServerValue("database name", `SHOW DATABASE`)
+	dbVal, dbColType, hasVal := c.conn.GetServerValue(
+		context.Background(),
+		"database name", `SHOW DATABASE`)
 	if !hasVal {
 		return unknownDbName
 	}
@@ -1586,7 +1590,9 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 	if c.iCtx.autoTrace != "" {
 		// Clear the trace by disabling tracing, then restart tracing
 		// with the specified options.
-		c.exitErr = c.conn.Exec("SET tracing = off; SET tracing = "+c.iCtx.autoTrace, nil)
+		c.exitErr = c.conn.Exec(
+			context.Background(),
+			"SET tracing = off; SET tracing = "+c.iCtx.autoTrace)
 		if c.exitErr != nil {
 			if !c.singleStatement {
 				clierror.OutputError(c.iCtx.stderr, c.exitErr, true /*showSeverity*/, false /*verbose*/)
@@ -1599,7 +1605,9 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 	}
 
 	// Now run the statement/query.
-	c.exitErr = c.sqlExecCtx.RunQueryAndFormatResults(c.conn, c.iCtx.stdout, c.iCtx.stderr,
+	c.exitErr = c.sqlExecCtx.RunQueryAndFormatResults(
+		context.Background(),
+		c.conn, c.iCtx.stdout, c.iCtx.stderr,
 		clisqlclient.MakeQuery(c.concatLines))
 	if c.exitErr != nil {
 		if !c.singleStatement {
@@ -1611,7 +1619,8 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 	// this even if there was an error: a trace on errors is useful.
 	if c.iCtx.autoTrace != "" {
 		// First, disable tracing.
-		if err := c.conn.Exec("SET tracing = off", nil); err != nil {
+		if err := c.conn.Exec(context.Background(),
+			"SET tracing = off"); err != nil {
 			// Print the error for the SET tracing statement. This will
 			// appear below the error for the main query above, if any,
 			clierror.OutputError(c.iCtx.stderr, err, true /*showSeverity*/, false /*verbose*/)
@@ -1629,7 +1638,9 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 			if strings.Contains(c.iCtx.autoTrace, "kv") {
 				traceType = "kv"
 			}
-			if err := c.sqlExecCtx.RunQueryAndFormatResults(c.conn, c.iCtx.stdout, c.iCtx.stderr,
+			if err := c.sqlExecCtx.RunQueryAndFormatResults(
+				context.Background(),
+				c.conn, c.iCtx.stdout, c.iCtx.stderr,
 				clisqlclient.MakeQuery(fmt.Sprintf("SHOW %s TRACE FOR SESSION", traceType))); err != nil {
 				clierror.OutputError(c.iCtx.stderr, err, true /*showSeverity*/, false /*verbose*/)
 				if c.exitErr == nil {
@@ -1915,7 +1926,9 @@ func (c *cliState) runStatements(stmts []string) error {
 // decomposition in the first return value. If it is not, the function
 // extracts a help string if available.
 func (c *cliState) serverSideParse(sql string) (helpText string, err error) {
-	cols, rows, err := c.sqlExecCtx.RunQuery(c.conn,
+	cols, rows, err := c.sqlExecCtx.RunQuery(
+		context.Background(),
+		c.conn,
 		clisqlclient.MakeQuery("SHOW SYNTAX "+lexbase.EscapeSQLString(sql)),
 		true)
 	if err != nil {

--- a/pkg/cli/clisqlshell/statement_diag.go
+++ b/pkg/cli/clisqlshell/statement_diag.go
@@ -12,6 +12,7 @@ package clisqlshell
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"text/tabwriter"
@@ -54,7 +55,8 @@ func (c *cliState) handleStatementDiag(
 		} else {
 			filename = fmt.Sprintf("stmt-bundle-%d.zip", id)
 		}
-		cmdErr = clisqlclient.StmtDiagDownloadBundle(c.conn, id, filename)
+		cmdErr = clisqlclient.StmtDiagDownloadBundle(
+			context.Background(), c.conn, id, filename)
 		if cmdErr == nil {
 			fmt.Fprintf(c.iCtx.stdout, "Bundle saved to %q\n", filename)
 		}
@@ -75,7 +77,7 @@ func (c *cliState) statementDiagList() error {
 	const timeFmt = "2006-01-02 15:04:05 MST"
 
 	// -- List bundles --
-	bundles, err := clisqlclient.StmtDiagListBundles(c.conn)
+	bundles, err := clisqlclient.StmtDiagListBundles(context.Background(), c.conn)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_job_trace.go
+++ b/pkg/cli/debug_job_trace.go
@@ -51,7 +51,8 @@ func runDebugJobTrace(_ *cobra.Command, args []string) (resErr error) {
 
 func getJobTraceID(sqlConn clisqlclient.Conn, jobID int64) (int64, error) {
 	var traceID int64
-	rows, err := sqlConn.Query(`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`, []driver.Value{jobID})
+	rows, err := sqlConn.Query(context.Background(),
+		`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`, jobID)
 	if err != nil {
 		return traceID, err
 	}
@@ -80,17 +81,10 @@ func getJobTraceID(sqlConn clisqlclient.Conn, jobID int64) (int64, error) {
 }
 
 func constructJobTraceZipBundle(ctx context.Context, sqlConn clisqlclient.Conn, jobID int64) error {
-	maybePrint := func(stmt string) string {
-		if debugCtx.verbose {
-			fmt.Println("querying " + stmt)
-		}
-		return stmt
-	}
-
 	// Check if a timeout has been set for this command.
 	if cliCtx.cmdTimeout != 0 {
-		stmt := fmt.Sprintf(`SET statement_timeout = '%s'`, cliCtx.cmdTimeout)
-		if err := sqlConn.Exec(maybePrint(stmt), nil); err != nil {
+		if err := sqlConn.Exec(context.Background(),
+			`SET statement_timeout = $1`, cliCtx.cmdTimeout.String()); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -237,6 +237,7 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 			startTime := timeutil.Now()
 			sqlExecCtx := clisqlexec.Context{}
 			_, _, err = sqlExecCtx.RunQuery(
+				context.Background(),
 				conn,
 				clisqlclient.MakeQuery(`SHOW ALL CLUSTER QUERIES`),
 				false,
@@ -326,6 +327,6 @@ func TestTransientClusterMultitenant(t *testing.T) {
 		}()
 
 		// Create a table on each tenant to make sure that the tenants are separate.
-		require.NoError(t, conn.Exec("CREATE TABLE a (a int PRIMARY KEY)", nil))
+		require.NoError(t, conn.Exec(context.Background(), "CREATE TABLE a (a int PRIMARY KEY)"))
 	}
 }

--- a/pkg/cli/nodelocal.go
+++ b/pkg/cli/nodelocal.go
@@ -131,7 +131,7 @@ func uploadFile(
 		return err
 	}
 
-	nodeID, _, _, err := conn.GetServerMetadata()
+	nodeID, _, _, err := conn.GetServerMetadata(ctx)
 	if err != nil {
 		return errors.Wrap(err, "unable to get node id")
 	}

--- a/pkg/cli/statement_diag.go
+++ b/pkg/cli/statement_diag.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"text/tabwriter"
@@ -49,8 +50,10 @@ func runStmtDiagList(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	ctx := context.Background()
+
 	// -- List bundles --
-	bundles, err := clisqlclient.StmtDiagListBundles(conn)
+	bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -71,7 +74,7 @@ func runStmtDiagList(cmd *cobra.Command, args []string) (resErr error) {
 	}
 
 	// -- List outstanding activation requests --
-	reqs, err := clisqlclient.StmtDiagListOutstandingRequests(conn)
+	reqs, err := clisqlclient.StmtDiagListOutstandingRequests(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -131,7 +134,8 @@ func runStmtDiagDownload(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
-	if err := clisqlclient.StmtDiagDownloadBundle(conn, id, filename); err != nil {
+	if err := clisqlclient.StmtDiagDownloadBundle(
+		context.Background(), conn, id, filename); err != nil {
 		return err
 	}
 	fmt.Printf("Bundle saved to %q\n", filename)
@@ -154,11 +158,13 @@ func runStmtDiagDelete(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	ctx := context.Background()
+
 	if stmtDiagCtx.all {
 		if len(args) > 0 {
 			return errors.New("extra arguments with --all")
 		}
-		return clisqlclient.StmtDiagDeleteAllBundles(conn)
+		return clisqlclient.StmtDiagDeleteAllBundles(ctx, conn)
 	}
 	if len(args) != 1 {
 		return fmt.Errorf("accepts 1 arg, received %d", len(args))
@@ -169,7 +175,7 @@ func runStmtDiagDelete(cmd *cobra.Command, args []string) (resErr error) {
 		return errors.New("invalid ID")
 	}
 
-	return clisqlclient.StmtDiagDeleteBundle(conn, id)
+	return clisqlclient.StmtDiagDeleteBundle(ctx, conn, id)
 }
 
 var stmtDiagCancelCmd = &cobra.Command{
@@ -188,11 +194,13 @@ func runStmtDiagCancel(cmd *cobra.Command, args []string) (resErr error) {
 	}
 	defer func() { resErr = errors.CombineErrors(resErr, conn.Close()) }()
 
+	ctx := context.Background()
+
 	if stmtDiagCtx.all {
 		if len(args) > 0 {
 			return errors.New("extra arguments with --all")
 		}
-		return clisqlclient.StmtDiagCancelAllOutstandingRequests(conn)
+		return clisqlclient.StmtDiagCancelAllOutstandingRequests(ctx, conn)
 	}
 	if len(args) != 1 {
 		return fmt.Errorf("accepts 1 arg, received %d", len(args))
@@ -203,7 +211,7 @@ func runStmtDiagCancel(cmd *cobra.Command, args []string) (resErr error) {
 		return errors.New("invalid ID")
 	}
 
-	return clisqlclient.StmtDiagCancelOutstandingRequest(conn, id)
+	return clisqlclient.StmtDiagCancelOutstandingRequest(ctx, conn, id)
 }
 
 var stmtDiagCmds = []*cobra.Command{

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -815,11 +815,11 @@ func TestUsernameUserfileInteraction(t *testing.T) {
 			},
 		} {
 			createUserQuery := fmt.Sprintf(`CREATE USER "%s" WITH PASSWORD 'a'`, tc.username)
-			err = conn.Exec(createUserQuery, nil)
+			err = conn.Exec(ctx, createUserQuery)
 			require.NoError(t, err)
 
 			privsUserQuery := fmt.Sprintf(`GRANT CREATE ON DATABASE defaultdb TO "%s"`, tc.username)
-			err = conn.Exec(privsUserQuery, nil)
+			err = conn.Exec(ctx, privsUserQuery)
 			require.NoError(t, err)
 
 			userURL, cleanup2 := sqlutils.PGUrlWithOptionalClientCerts(t, c.ServingSQLAddr(), t.Name(),


### PR DESCRIPTION
Needed for #76433.

This brings the cli (sub-)packages kicking and screaming into the
post-go1.8 era, by adding the missing context arguments.

Also,
Fixes #76432.

Release note (bug fix): Some of the `cockroach node` subcommands did
not handle `--timeout` properly. This is now fixed.