### PR TITLE
clisqlshell: handle interactive query cancellation

### DIFF
--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/scanner",
         "//pkg/sql/sqlfsm",
         "//pkg/util/envutil",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_knz_go_libedit//:go-libedit",
     ],

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	democlusterapi "github.com/cockroachdb/cockroach/pkg/cli/democluster/api"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // Context represents the external configuration of the interactive
@@ -71,4 +72,11 @@ type internalContext struct {
 
 	// current database name, if known. This is maintained on a best-effort basis.
 	dbName string
+
+	// state about the current query.
+	mu struct {
+		syncutil.Mutex
+		cancelFn func()
+		doneCh   chan struct{}
+	}
 }

--- a/pkg/cli/interactive_tests/test_interrupt.tcl
+++ b/pkg/cli/interactive_tests/test_interrupt.tcl
@@ -1,0 +1,108 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect "defaultdb>"
+
+start_test "Check that interrupt with a partial line clears the line."
+send "asasaa"
+interrupt
+eexpect "defaultdb>"
+end_test
+
+start_test "Check that interrupt with a multiline clears the current line."
+send "select\r"
+eexpect " -> "
+send "'XXX'"
+interrupt
+send "'YYY';\r"
+eexpect "column"
+eexpect "YYY"
+eexpect "defaultdb>"
+end_test
+
+start_test "Check that interrupt with an empty line prints an information message."
+interrupt
+eexpect "terminate input to exit"
+eexpect "defaultdb>"
+end_test
+
+start_test "Check that interrupt can cancel a query."
+send "select pg_sleep(1000000);\r"
+eexpect "\r\n"
+sleep 0.4
+interrupt
+eexpect "query execution canceled"
+eexpect "57014"
+
+# TODO(knz): we currently need to trigger a reconnection
+# before we get a healthy prompt. This will be fixed
+# in a later version.
+send "\r"
+eexpect "defaultdb>"
+end_test
+
+# Quit the SQL client, and open a unix shell.
+send_eof
+eexpect eof
+spawn /bin/bash
+set shell2_spawn_id $spawn_id
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Check that interactive, non-terminal queries are cancellable without terminating the shell."
+send "$argv sql >/dev/null\r"
+eexpect "\r\n"
+sleep 0.4
+send "select 'A'+3;\r"
+eexpect "\r\n"
+# Sanity check: we can still process _some_ SQL.
+# stderr is not redirected so we still see errors.
+eexpect "unsupported binary operator"
+
+# Now on to check cancellation.
+send "select pg_sleep(10000);\r"
+sleep 0.4
+interrupt
+eexpect "query execution canceled"
+eexpect "57014"
+
+# TODO(knz): we currently need to trigger a reconnection
+# before we get a healthy prompt. This will be fixed
+# in a later version.
+send "\rselect 1;\r"
+
+# Send another query, expect an error. The shell should
+# not have terminated by this point.
+send "select 'A'+3;\r"
+eexpect "\r\n"
+eexpect "unsupported binary operator"
+
+# Terminate SQL shell, expect unix shell.
+send_eof
+eexpect ":/# "
+
+start_test "Check that non-interactive interrupts terminate the SQL shell."
+send "cat | $argv sql\r"
+eexpect "\r\n"
+sleep 0.4
+# Sanity check.
+send "select 'XX'||'YY';\r"
+eexpect "XXYY"
+
+# Check what interrupt does.
+send "select pg_sleep(10000);\r"
+sleep 0.4
+interrupt
+# This exits the SQL shell directly. expect unix shell.
+eexpect ":/# "
+
+end_test
+
+send "exit 0\r"
+eexpect eof
+
+stop_server $argv


### PR DESCRIPTION
Fixes #76433. 

As of this PR, there's a bug in lib/pq which forces the session to
terminate when any query gets cancelled. We find this unacceptable
and we plan to fix it later.

Release note (cli change): The interactive SQL shell (`cockroach sql`,
`cockroach demo`) now supports interrupting a currently running
query with Ctrl+C, without losing access to the shell.