### PR TITLE
release-21.2: backupccl: allow user to specify separate path for incremental backups

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2111,6 +2111,7 @@ restore_options ::=
 	| 'DETACHED'
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
+	| 'INCREMENTAL_STORAGE' '=' string_or_placeholder_opt_list
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -931,6 +931,7 @@ unreserved_keyword ::=
 	| 'INCLUDING'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
+	| 'INCREMENTAL_STORAGE'
 	| 'INDEXES'
 	| 'INHERITS'
 	| 'INJECT'
@@ -1858,6 +1859,7 @@ backup_options ::=
 	| 'DETACHED'
 	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'INCLUDE_DEPRECATED_INTERLEAVES'
+	| 'INCREMENTAL_STORAGE' '=' string_or_placeholder_opt_list
 
 c_expr ::=
 	d_expr

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -931,7 +931,7 @@ unreserved_keyword ::=
 	| 'INCLUDING'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
-	| 'INCREMENTAL_STORAGE'
+	| 'INCREMENTAL_LOCATION'
 	| 'INDEXES'
 	| 'INHERITS'
 	| 'INJECT'
@@ -1859,7 +1859,7 @@ backup_options ::=
 	| 'DETACHED'
 	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'INCLUDE_DEPRECATED_INTERLEAVES'
-	| 'INCREMENTAL_STORAGE' '=' string_or_placeholder_opt_list
+	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 
 c_expr ::=
 	d_expr
@@ -2111,7 +2111,7 @@ restore_options ::=
 	| 'DETACHED'
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
-	| 'INCREMENTAL_STORAGE' '=' string_or_placeholder_opt_list
+	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 
 scrub_option_list ::=
 	( scrub_option ) ( ( ',' scrub_option ) )*

--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -281,9 +281,9 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 			// - BACKUP INTO collection
 			// - BACKUP INTO LATEST IN collection
 			// - BACKUP INTO full1 IN collection
-			// - BACKUP INTO full1 IN collection, incremental_storage = inc_storage_path
-			// - BACKUP INTO full1 IN collection, incremental_storage = inc_storage_path
-			// - BACKUP INTO LATEST IN collection, incremental_storage = inc_storage_path
+			// - BACKUP INTO full1 IN collection, incremental_location = inc_storage_path
+			// - BACKUP INTO full1 IN collection, incremental_location = inc_storage_path
+			// - BACKUP INTO LATEST IN collection, incremental_location = inc_storage_path
 			t.Run("collection", func(t *testing.T) {
 				collectionLoc := fmt.Sprintf("nodelocal://1/%s/?AUTH=implicit", t.Name())
 				collectionTo := localizeURI(t, collectionLoc, localities)
@@ -439,7 +439,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					writeManifest(t, expectedDefault)
 				}
 
-				// A remote incremental into the first full: BACKUP INTO full1 IN collection, incremental_storage = inc_storage_path
+				// A remote incremental into the first full: BACKUP INTO full1 IN collection, incremental_location = inc_storage_path
 				{
 					expectedSuffix := "/2020/12/25-060000.00"
 					expectedIncDir := "/20201225/090000.00"
@@ -457,7 +457,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					firstRemoteBackupChain = append(firstRemoteBackupChain, expectedDefault)
 				}
 
-				// Another remote incremental into the first full: BACKUP INTO full1 IN collection, incremental_storage = inc_storage_path
+				// Another remote incremental into the first full: BACKUP INTO full1 IN collection, incremental_location = inc_storage_path
 				{
 					expectedSuffix := "/2020/12/25-060000.00"
 					expectedIncDir := "/20201225/093000.00"
@@ -474,7 +474,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 				}
 
 				// A remote incremental into the second full backup: BACKUP INTO LATEST IN collection,
-				//incremental_storage = inc_storage_path
+				//incremental_location = inc_storage_path
 				{
 					expectedSuffix := "/2020/12/25-073000.00"
 					expectedIncDir := "/20201225/100000.00"

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -61,7 +61,7 @@ const (
 	backupOptWithPrivileges     = "privileges"
 	backupOptAsJSON             = "as_json"
 	backupOptWithDebugIDs       = "debug_ids"
-	backupOptIncStorage         = "incremental_storage"
+	backupOptIncStorage         = "incremental_location"
 	localityURLParam            = "COCKROACH_LOCALITY"
 	defaultLocalityValue        = "default"
 )
@@ -703,7 +703,7 @@ func backupPlanHook(
 			return err
 		}
 		if !backupStmt.Nested && len(incrementalStorage) > 0 {
-			return errors.New("incremental_storage option not supported with `BACKUP TO` syntax")
+			return errors.New("incremental_location option not supported with `BACKUP TO` syntax")
 		}
 
 		endTime := p.ExecCfg().Clock.Now()

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -61,6 +61,7 @@ const (
 	backupOptWithPrivileges     = "privileges"
 	backupOptAsJSON             = "as_json"
 	backupOptWithDebugIDs       = "debug_ids"
+	backupOptIncStorage         = "incremental_storage"
 	localityURLParam            = "COCKROACH_LOCALITY"
 	defaultLocalityValue        = "default"
 )

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -334,6 +334,7 @@ func resolveOptionsForBackupJobDescription(
 	}
 
 	var err error
+	// TODO(msbutler): use cloud.RedactKMSURI(uri) here instead?
 	newOpts.EncryptionKMSURI, err = sanitizeURIList(kmsURIs)
 	if err != nil {
 		return tree.BackupOptions{}, err

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -852,7 +852,8 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	_, _, sqlDB, tmpDir, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	const c1, c2, c3 = `nodelocal://0/`, `nodelocal://1/`, `nodelocal://2/`
+	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
+	const i1, i2, i3 = `nodelocal://0/inc/`, `nodelocal://1/inc/`, `nodelocal://2/inc/`
 
 	const localFoo1, localFoo2, localFoo3 = LocalFoo + "/1", LocalFoo + "/2", LocalFoo + "/3"
 	backups := []interface{}{
@@ -867,19 +868,27 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", c3, url.QueryEscape("dc=dc2")),
 	}
 
+	incrementals := []interface{}{
+		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", i1, url.QueryEscape("default")),
+		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", i2, url.QueryEscape("dc=dc1")),
+		fmt.Sprintf("%s?COCKROACH_LOCALITY=%s", i3, url.QueryEscape("dc=dc2")),
+	}
+
 	sqlDB.Exec(t, "BACKUP TO ($1, $2, $3)", backups...)
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO LATEST IN ($1, $2, $3)", collections...)
 	sqlDB.Exec(t, "BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
+	sqlDB.Exec(t, "BACKUP INTO LATEST IN $4 WITH incremental_storage = ($1, $2, $3)",
+		append(incrementals, collections[0])...)
 
 	// Find the subdirectory created by the full BACKUP INTO statement.
-	matches, err := filepath.Glob(path.Join(tmpDir, "*/*/*/"+backupManifestName))
+	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupManifestName))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
 	for i := range matches {
 		matches[i] = strings.TrimPrefix(filepath.Dir(matches[i]), tmpDir)
 	}
-	full1 := matches[0]
+	full1 := strings.TrimPrefix(matches[0], "/full")
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS]",
 		[][]string{
@@ -887,10 +896,13 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 				backups[2].(string))},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1, collections[0],
 				collections[1], collections[2])},
-			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", strings.TrimPrefix(full1, "/"),
+			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", full1,
 				collections[0], collections[1], collections[2])},
 			{fmt.Sprintf("BACKUP INTO '%s' IN ('%s', '%s', '%s')", "/subdir",
 				collections[0], collections[1], collections[2])},
+			{fmt.Sprintf("BACKUP INTO '%s' IN '%s' WITH incremental_storage = ('%s', '%s', '%s')",
+				"/subdir", collections[0], incrementals[0],
+				incrementals[1], incrementals[2])},
 		},
 	)
 
@@ -906,12 +918,17 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, $3)", collections...)
 
+	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
+	sqlDB.Exec(t, "RESTORE DATABASE data FROM LATEST IN ($1, $2, "+
+		"$3) WITH incremental_storage = ($4, $5, $6)",
+		append(collections, incrementals[0], incrementals[1], incrementals[2])...)
+
 	// The flavors of BACKUP and RESTORE which automatically resolve the right
 	// directory to read/write data to, have URIs with the resolved path written
 	// to the job description.
-	getResolvedCollectionURIs := func(subdir string) []string {
-		resolvedCollectionURIs := make([]string, len(collections))
-		for i, collection := range collections {
+	getResolvedCollectionURIs := func(prefixes []interface{}, subdir string) []string {
+		resolvedCollectionURIs := make([]string, len(prefixes))
+		for i, collection := range prefixes {
 			parsed, err := url.Parse(collection.(string))
 			require.NoError(t, err)
 			parsed.Path = path.Join(parsed.Path, subdir)
@@ -921,8 +938,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		return resolvedCollectionURIs
 	}
 
-	resolvedCollectionURIs := getResolvedCollectionURIs(full1)
-	resolvedSubdirURIs := getResolvedCollectionURIs("subdir")
+	resolvedCollectionURIs := getResolvedCollectionURIs(collections, full1)
+	resolvedSubdirURIs := getResolvedCollectionURIs(collections, "subdir")
+	resolvedIncURIs := getResolvedCollectionURIs(incrementals, "subdir")
 
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS] WHERE job_type='RESTORE'",
@@ -939,6 +957,9 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s')",
 				resolvedSubdirURIs[0], resolvedSubdirURIs[1],
 				resolvedSubdirURIs[2])},
+			{fmt.Sprintf("RESTORE DATABASE data FROM ('%s', '%s', '%s') WITH incremental_storage = ('%s', '%s', '%s')",
+				resolvedSubdirURIs[0], resolvedSubdirURIs[1], resolvedSubdirURIs[2],
+				resolvedIncURIs[0], resolvedIncURIs[1], resolvedIncURIs[2])},
 		},
 	)
 }
@@ -9071,4 +9092,83 @@ func TestRestoreSyntheticPublicSchemaNamespaceEntryCleanupOnFail(t *testing.T) {
 	// We should have no non-system database with a public schema name space
 	// entry with id 29.
 	sqlDB.CheckQueryResults(t, `SELECT id FROM system.namespace WHERE name = 'public' AND id=29 AND "parentID"!=1`, [][]string{})
+}
+
+// TestBackupRestoreSeperateIncrementalPrefix tests that a backup/restore round
+// trip using the 'incremental_storage' parameter restores the same db as a BR
+// round trip without the parameter.
+func TestBackupRestoreSeparateIncrementalPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	_, _, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, MultiNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
+	const i1, i2, i3 = `nodelocal://0/inc/`, `nodelocal://1/inc/`, `nodelocal://2/inc/`
+
+	collections := []string{
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c1, url.QueryEscape("default")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c2, url.QueryEscape("dc=dc1")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c3, url.QueryEscape("dc=dc2")),
+	}
+
+	incrementals := []string{
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i1, url.QueryEscape("default")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i2, url.QueryEscape("dc=dc1")),
+		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", i3, url.QueryEscape("dc=dc2")),
+	}
+	tests := []struct {
+		dest []string
+		inc  []string
+	}{{dest: []string{collections[0]}, inc: []string{incrementals[0]}},
+		{dest: collections, inc: incrementals}}
+
+	for _, br := range tests {
+
+		dest := strings.Join(br.dest, ", ")
+		inc := strings.Join(br.inc, ", ")
+
+		if len(br.dest) > 1 {
+			dest = "(" + dest + ")"
+			inc = "(" + inc + ")"
+		}
+		// create db
+		sqlDB.Exec(t, `CREATE DATABASE fkdb`)
+		sqlDB.Exec(t, `CREATE TABLE fkdb.fk (ind INT)`)
+
+		for i := 0; i < 10; i++ {
+			sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, i)
+		}
+		fb := fmt.Sprintf("BACKUP DATABASE fkdb INTO %s", dest)
+		sqlDB.Exec(t, fb)
+
+		sqlDB.Exec(t, `INSERT INTO fkdb.fk (ind) VALUES ($1)`, 200)
+
+		// The ALTER DATABASE statements had to be added because the new_db_name
+		// RESTORE parameter is unavailable on 21.2.
+		//  - the restored db with incremental_storage should be called "inc_fkdb"
+		//  - the restored db without it should be called "trad_fkdb
+		sqlDB.Exec(t, "ALTER DATABASE fkdb RENAME TO inc_fkdb")
+		sib := fmt.Sprintf("BACKUP DATABASE inc_fkdb INTO LATEST IN %s WITH incremental_storage = %s", dest, inc)
+		sqlDB.Exec(t, sib)
+
+		sqlDB.Exec(t, "ALTER DATABASE inc_fkdb RENAME TO orig_fkdb")
+		sir := fmt.Sprintf("RESTORE DATABASE inc_fkdb FROM LATEST IN %s WITH incremental_storage = %s", dest, inc)
+		sqlDB.Exec(t, sir)
+
+		sqlDB.Exec(t, "ALTER DATABASE orig_fkdb RENAME TO trad_fkdb")
+		ib := fmt.Sprintf("BACKUP DATABASE trad_fkdb INTO LATEST IN %s", dest)
+		sqlDB.Exec(t, ib)
+		sqlDB.Exec(t, "ALTER DATABASE trad_fkdb RENAME TO orig_fkdb")
+		ir := fmt.Sprintf("RESTORE DATABASE trad_fkdb FROM LATEST IN %s", dest)
+		sqlDB.Exec(t, ir)
+
+		sqlDB.CheckQueryResults(t, `SELECT * FROM trad_fkdb.fk`, sqlDB.QueryStr(t, `SELECT * FROM inc_fkdb.fk`))
+
+		sqlDB.Exec(t, "DROP DATABASE orig_fkdb")
+		sqlDB.Exec(t, "DROP DATABASE trad_fkdb;")
+		sqlDB.Exec(t, "DROP DATABASE inc_fkdb;")
+	}
 }

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -1009,6 +1009,18 @@ func (m ScheduledBackupExecutionArgs) MarshalJSONPB(x *jsonpb.Marshaler) ([]byte
 		backup.IncrementalFrom[i] = tree.NewDString(clean)
 	}
 
+	for i := range backup.Options.IncrementalStorage {
+		raw, ok := backup.Options.IncrementalStorage[i].(*tree.StrVal)
+		if !ok {
+			return nil, errors.Errorf("unexpected %T arg in backup schedule: %v", raw, raw)
+		}
+		clean, err := cloud.SanitizeExternalStorageURI(raw.RawString(), nil /* extraParams */)
+		if err != nil {
+			return nil, err
+		}
+		backup.Options.IncrementalStorage[i] = tree.NewDString(clean)
+	}
+
 	for i := range backup.Options.EncryptionKMSURI {
 		raw, ok := backup.Options.EncryptionKMSURI[i].(*tree.StrVal)
 		if !ok {

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -432,6 +432,25 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			},
 		},
 		{
+			name:  "full-cluster-remote-incremental-storage",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH incremental_storage = 'nodelocal://1/incremental' RECURRING '@hourly'",
+			user:  enterpriseUser,
+			expectedSchedules: []expectedSchedule{
+				{
+					nameRe:     "BACKUP .*",
+					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached, incremental_storage = 'nodelocal://1/incremental'",
+					period:     time.Hour,
+					paused:     true,
+				},
+				{
+					nameRe:     "BACKUP .+",
+					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					period:     24 * time.Hour,
+					runsNow:    true,
+				},
+			},
+		},
+		{
 			name: "multiple-tables-with-revision-history",
 			user: enterpriseUser,
 			query: `

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -432,13 +432,13 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			},
 		},
 		{
-			name:  "full-cluster-remote-incremental-storage",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH incremental_storage = 'nodelocal://1/incremental' RECURRING '@hourly'",
+			name:  "full-cluster-remote-incremental-location",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH incremental_location = 'nodelocal://1/incremental' RECURRING '@hourly'",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .*",
-					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached, incremental_storage = 'nodelocal://1/incremental'",
+					backupStmt: "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached, incremental_location = 'nodelocal://1/incremental'",
 					period:     time.Hour,
 					paused:     true,
 				},

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -76,11 +76,15 @@ const (
 	// storing incremental backups for auto-appendable backups.
 	// It is exported for testing backup inspection tooling.
 	DateBasedIncFolderName = "/20060102/150405.00"
+
 	// DateBasedIntoFolderName is the date format used when creating sub-directories
 	// for storing backups in a collection.
 	// Also exported for testing backup inspection tooling.
 	DateBasedIntoFolderName = "/2006/01/02-150405.00"
-	latestFileName          = "LATEST"
+
+	// latestFileName is the name of a file in the collection which contains the
+	// path of the most recently taken full backup in the backup collection.
+	latestFileName = "LATEST"
 )
 
 // isGZipped detects whether the given bytes represent GZipped data. This check

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1532,7 +1532,7 @@ func restorePlanHook(
 	var incStorageFn func() ([]string, error)
 	if restoreStmt.Options.IncrementalStorage != nil {
 		if restoreStmt.Subdir == nil {
-			err = errors.New("incremental_storage can only be used with the following" +
+			err = errors.New("incremental_location can only be used with the following" +
 				" syntax: 'RESTORE [target] FROM [subdirectory] IN [destination]'")
 			return nil, nil, nil, false, err
 		}
@@ -1604,7 +1604,7 @@ func restorePlanHook(
 
 		// incFrom will contain the directory URIs for incremental backups (i.e.
 		// <prefix>/<subdir>) iff len(From)==1, regardless of the
-		// 'incremental_storage' param. len(From)=1 implies that the user has not
+		// 'incremental_location' param. len(From)=1 implies that the user has not
 		// explicitly passed incremental backups, so we'll have to look for any in
 		// <prefix>/<subdir>. len(incFrom)>1 implies the incremental backups are
 		// locality aware.

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -292,8 +292,14 @@ func (e *scheduledBackupExecutor) GetCreateScheduleStatement(
 		kmsURIs = append(kmsURIs, kmsURI.RawString())
 	}
 
-	redactedBackupNode, err := GetRedactedBackupNode(backupNode.Backup, destinations,
-		nil /* incrementalFrom */, kmsURIs, "", false /* hasBeenPlanned */)
+	redactedBackupNode, err := GetRedactedBackupNode(
+		backupNode.Backup,
+		destinations,
+		nil, /* incrementalFrom */
+		kmsURIs,
+		"",
+		nil,
+		false /* hasBeenPlanned */)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -424,8 +424,8 @@ func TestShowBackups(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP data.bank INTO $1`, full)
 	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1`, full)
 	// Make 2 remote incremental backups, chaining to the third full backup
-	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_storage = $2`, full, remoteInc)
-	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_storage = $2`, full, remoteInc)
+	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_location = $2`, full, remoteInc)
+	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_location = $2`, full, remoteInc)
 
 	rows := sqlDBRestore.QueryStr(t, `SHOW BACKUPS IN $1`, full)
 
@@ -445,7 +445,7 @@ func TestShowBackups(t *testing.T) {
 
 	// check that full and remote incremental backups appear
 	b3 := sqlDBRestore.QueryStr(t,
-		`SELECT * FROM [SHOW BACKUP LATEST IN $1 WITH incremental_storage= 'nodelocal://0/foo/inc'] WHERE object_type='table'`, full)
+		`SELECT * FROM [SHOW BACKUP LATEST IN $1 WITH incremental_location= 'nodelocal://0/foo/inc'] WHERE object_type='table'`, full)
 	require.Equal(t, 3, len(b3))
 
 }

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -408,6 +408,7 @@ func TestShowBackups(t *testing.T) {
 	defer cleanupEmptyCluster()
 
 	const full = LocalFoo + "/full"
+	const remoteInc = LocalFoo + "/inc"
 
 	// Make an initial backup.
 	sqlDB.Exec(t, `BACKUP data.bank INTO $1`, full)
@@ -422,6 +423,9 @@ func TestShowBackups(t *testing.T) {
 	// Make a third full backup, add changes to it.
 	sqlDB.Exec(t, `BACKUP data.bank INTO $1`, full)
 	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1`, full)
+	// Make 2 remote incremental backups, chaining to the third full backup
+	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_storage = $2`, full, remoteInc)
+	sqlDB.Exec(t, `BACKUP data.bank INTO LATEST IN $1 WITH incremental_storage = $2`, full, remoteInc)
 
 	rows := sqlDBRestore.QueryStr(t, `SHOW BACKUPS IN $1`, full)
 
@@ -438,6 +442,12 @@ func TestShowBackups(t *testing.T) {
 		sqlDBRestore.QueryStr(t, `SHOW BACKUP $1 IN $2`, rows[2][0], full),
 		sqlDBRestore.QueryStr(t, `SHOW BACKUP LATEST IN $1`, full),
 	)
+
+	// check that full and remote incremental backups appear
+	b3 := sqlDBRestore.QueryStr(t,
+		`SELECT * FROM [SHOW BACKUP LATEST IN $1 WITH incremental_storage= 'nodelocal://0/foo/inc'] WHERE object_type='table'`, full)
+	require.Equal(t, 3, len(b3))
+
 }
 
 func TestShowBackupTenants(t *testing.T) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -790,7 +790,7 @@ func (u *sqlSymUnion) setVar() *tree.SetVar {
 
 %token <str> IDENTITY
 %token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPORT IN INCLUDE
-%token <str> INCLUDE_DEPRECATED_INTERLEAVES INCLUDING INCREMENT INCREMENTAL INCREMENTAL_STORAGE
+%token <str> INCLUDE_DEPRECATED_INTERLEAVES INCLUDING INCREMENT INCREMENTAL INCREMENTAL_LOCATION
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INTERLEAVE INITIALLY
 %token <str> INNER INSERT INT INTEGER
@@ -2598,7 +2598,7 @@ opt_clear_data:
 //    kms="[kms_provider]://[kms_host]/[master_key_identifier]?[parameters]" : encrypt backups using KMS
 //    detached: execute backup job asynchronously, without waiting for its completion
 //    include_deprecated_interleaves: allow backing up interleaved tables, even if future versions will be unable to restore.
-//    incremental_storage: specify a different path to store the incremental backup
+//    incremental_location: specify a different path to store the incremental backup
 //
 // %SeeAlso: RESTORE, WEBDOCS/backup.html
 backup_stmt:
@@ -2708,7 +2708,7 @@ backup_options:
   {
     $$.val = &tree.BackupOptions{IncludeDeprecatedInterleaves: true}
   }
-| INCREMENTAL_STORAGE '=' string_or_placeholder_opt_list
+| INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
   {
   $$.val = &tree.BackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
   }
@@ -3044,7 +3044,7 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{DebugPauseOn: $3.expr()}
   }
-| INCREMENTAL_STORAGE '=' string_or_placeholder_opt_list
+| INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
 	{
 		$$.val = &tree.RestoreOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
 	}
@@ -13235,7 +13235,7 @@ unreserved_keyword:
 | INCLUDING
 | INCREMENT
 | INCREMENTAL
-| INCREMENTAL_STORAGE
+| INCREMENTAL_LOCATION
 | INDEXES
 | INHERITS
 | INJECT

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3044,7 +3044,10 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{DebugPauseOn: $3.expr()}
   }
-
+| INCREMENTAL_STORAGE '=' string_or_placeholder_opt_list
+	{
+		$$.val = &tree.RestoreOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
+	}
 import_format:
   name
   {

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -487,6 +487,14 @@ RESTORE DATABASE foo, baz FROM '_' -- literals removed
 RESTORE DATABASE _, _ FROM 'bar' -- identifiers removed
 
 parse
+RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_storage = 'baz'
+----
+RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH incremental_storage = 'baz' -- normalized!
+RESTORE DATABASE foo FROM ('bar') IN ('latest') WITH incremental_storage = ('baz') -- fully parenthesized
+RESTORE DATABASE foo FROM '_' IN '_' WITH incremental_storage = '_' -- literals removed
+RESTORE DATABASE _ FROM 'bar' IN 'latest' WITH incremental_storage = 'baz' -- identifiers removed
+
+parse
 RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'
 ----
 RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -47,6 +47,14 @@ BACKUP TABLE foo INTO LATEST IN '_' -- literals removed
 BACKUP TABLE _ INTO LATEST IN 'bar' -- identifiers removed
 
 parse
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_storage = 'baz'
+----
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_storage = 'baz'
+BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH incremental_storage = ('baz') -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '_' WITH incremental_storage = '_' -- literals removed
+BACKUP TABLE _ INTO LATEST IN 'bar' WITH incremental_storage = 'baz' -- identifiers removed
+
+parse
 BACKUP TABLE foo INTO 'subdir' IN 'bar'
 ----
 BACKUP TABLE foo INTO 'subdir' IN 'bar'

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -47,12 +47,12 @@ BACKUP TABLE foo INTO LATEST IN '_' -- literals removed
 BACKUP TABLE _ INTO LATEST IN 'bar' -- identifiers removed
 
 parse
-BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_storage = 'baz'
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_location = 'baz'
 ----
-BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_storage = 'baz'
-BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH incremental_storage = ('baz') -- fully parenthesized
-BACKUP TABLE foo INTO LATEST IN '_' WITH incremental_storage = '_' -- literals removed
-BACKUP TABLE _ INTO LATEST IN 'bar' WITH incremental_storage = 'baz' -- identifiers removed
+BACKUP TABLE foo INTO LATEST IN 'bar' WITH incremental_location = 'baz'
+BACKUP TABLE (foo) INTO LATEST IN ('bar') WITH incremental_location = ('baz') -- fully parenthesized
+BACKUP TABLE foo INTO LATEST IN '_' WITH incremental_location = '_' -- literals removed
+BACKUP TABLE _ INTO LATEST IN 'bar' WITH incremental_location = 'baz' -- identifiers removed
 
 parse
 BACKUP TABLE foo INTO 'subdir' IN 'bar'
@@ -487,12 +487,12 @@ RESTORE DATABASE foo, baz FROM '_' -- literals removed
 RESTORE DATABASE _, _ FROM 'bar' -- identifiers removed
 
 parse
-RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_storage = 'baz'
+RESTORE DATABASE foo FROM 'bar' IN LATEST WITH incremental_location = 'baz'
 ----
-RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH incremental_storage = 'baz' -- normalized!
-RESTORE DATABASE foo FROM ('bar') IN ('latest') WITH incremental_storage = ('baz') -- fully parenthesized
-RESTORE DATABASE foo FROM '_' IN '_' WITH incremental_storage = '_' -- literals removed
-RESTORE DATABASE _ FROM 'bar' IN 'latest' WITH incremental_storage = 'baz' -- identifiers removed
+RESTORE DATABASE foo FROM 'bar' IN 'latest' WITH incremental_location = 'baz' -- normalized!
+RESTORE DATABASE foo FROM ('bar') IN ('latest') WITH incremental_location = ('baz') -- fully parenthesized
+RESTORE DATABASE foo FROM '_' IN '_' WITH incremental_location = '_' -- literals removed
+RESTORE DATABASE _ FROM 'bar' IN 'latest' WITH incremental_location = 'baz' -- identifiers removed
 
 parse
 RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -272,7 +272,7 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 
 	if o.IncrementalStorage != nil {
 		maybeAddSep()
-		ctx.WriteString("incremental_storage = ")
+		ctx.WriteString("incremental_location = ")
 		ctx.FormatNode(&o.IncrementalStorage)
 	}
 }
@@ -311,7 +311,7 @@ func (o *BackupOptions) CombineWith(other *BackupOptions) error {
 	if o.IncrementalStorage == nil {
 		o.IncrementalStorage = other.IncrementalStorage
 	} else if other.IncrementalStorage != nil {
-		return errors.New("incremental_storage option specified multiple times")
+		return errors.New("incremental_location option specified multiple times")
 	}
 
 	if o.IncludeDeprecatedInterleaves {
@@ -399,7 +399,7 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 
 	if o.IncrementalStorage != nil {
 		maybeAddSep()
-		ctx.WriteString("incremental_storage = ")
+		ctx.WriteString("incremental_location = ")
 		ctx.FormatNode(&o.IncrementalStorage)
 	}
 }
@@ -482,7 +482,7 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 	if o.IncrementalStorage == nil {
 		o.IncrementalStorage = other.IncrementalStorage
 	} else if other.IncrementalStorage != nil {
-		return errors.New("incremental_storage option specified multiple times")
+		return errors.New("incremental_location option specified multiple times")
 	}
 
 	return nil

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -41,23 +41,37 @@ type BackupOptions struct {
 	Detached                     bool
 	EncryptionKMSURI             StringOrPlaceholderOptList
 	IncludeDeprecatedInterleaves bool
+	IncrementalStorage           StringOrPlaceholderOptList
 }
 
 var _ NodeFormatter = &BackupOptions{}
 
 // Backup represents a BACKUP statement.
 type Backup struct {
-	Targets         *TargetList
-	To              StringOrPlaceholderOptList
+	Targets *TargetList
+
+	// To is set to the root directory of the backup (called the <destination> in
+	// the docs).
+	To StringOrPlaceholderOptList
+
+	// IncrementalFrom is only set for the old 'BACKUP .... TO ...' syntax.
 	IncrementalFrom Exprs
-	AsOf            AsOfClause
-	Options         BackupOptions
-	Nested          bool
-	AppendToLatest  bool
-	// Subdir may be set by the parser when the SQL query is of the form
-	// `BACKUP INTO 'subdir' IN...`. Alternatively, if Nested is true but a subdir
-	// was not explicitly specified by the user, then this will be set during
-	// BACKUP planning once the destination has been resolved.
+
+	AsOf    AsOfClause
+	Options BackupOptions
+
+	// Nested is set to true when the user creates a backup with
+	//`BACKUP ... INTO... ` syntax.
+	Nested bool
+
+	// AppendToLatest is set to true if the user creates a backup with
+	//`BACKUP...INTO LATEST...`
+	AppendToLatest bool
+
+	// Subdir may be set by the parser when the SQL query is of the form `BACKUP
+	// INTO 'subdir' IN...`. Alternatively, if Nested is true but a subdir was not
+	// explicitly specified by the user, then this will be set during BACKUP
+	// planning once the destination has been resolved.
 	Subdir Expr
 }
 
@@ -242,6 +256,12 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 		maybeAddSep()
 		ctx.WriteString("include_deprecated_interleaves")
 	}
+
+	if o.IncrementalStorage != nil {
+		maybeAddSep()
+		ctx.WriteString("incremental_storage = ")
+		ctx.FormatNode(&o.IncrementalStorage)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -275,6 +295,12 @@ func (o *BackupOptions) CombineWith(other *BackupOptions) error {
 		return errors.New("kms specified multiple times")
 	}
 
+	if o.IncrementalStorage == nil {
+		o.IncrementalStorage = other.IncrementalStorage
+	} else if other.IncrementalStorage != nil {
+		return errors.New("incremental_storage option specified multiple times")
+	}
+
 	if o.IncludeDeprecatedInterleaves {
 		if other.IncludeDeprecatedInterleaves {
 			return errors.New("include_deprecated_interleaves option specified multiple times")
@@ -291,7 +317,8 @@ func (o BackupOptions) IsDefault() bool {
 	options := BackupOptions{}
 	return o.CaptureRevisionHistory == options.CaptureRevisionHistory &&
 		o.Detached == options.Detached && cmp.Equal(o.EncryptionKMSURI, options.EncryptionKMSURI) &&
-		o.EncryptionPassphrase == options.EncryptionPassphrase
+		o.EncryptionPassphrase == options.EncryptionPassphrase &&
+		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage)
 }
 
 // Format implements the NodeFormatter interface.


### PR DESCRIPTION
Backport 5/5 commits from #72713 , #73357, #73744, #76416, #76274 

/cc @cockroachdb/release

Release justification: customers urgently want to create separate directories for incremental backups and full backups.