### PR TITLE
kvserver: emit MVCC range tombstones over rangefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -118,6 +118,20 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 				// expect SST ingestion into spans with active changefeeds.
 				return errors.Errorf("unexpected SST ingestion: %v", t)
 
+			case *roachpb.RangeFeedDeleteRange:
+				// For now, we just error on MVCC range tombstones. These are currently
+				// only expected to be used by schema GC and IMPORT INTO, and such spans
+				// should not have active changefeeds across them.
+				//
+				// TODO(erikgrinaker): Write an end-to-end test which verifies that an
+				// IMPORT INTO which gets rolled back using MVCC range tombstones will
+				// not be visible to a changefeed, neither when started before the
+				// import or when resuming from a timestamp before the import. The table
+				// decriptor should be marked as offline during the import, and catchup
+				// scans should detect this and prevent reading anything in that
+				// timespan.
+				return errors.Errorf("unexpected MVCC range deletion: %v", t)
+
 			default:
 				return errors.Errorf("unexpected RangeFeedEvent variant %v", t)
 			}

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -386,6 +386,7 @@ func (s *eventStream) streamLoop(ctx context.Context, frontier *span.Frontier) e
 				}
 			default:
 				// TODO(yevgeniy): Handle SSTs.
+				// TODO(erikgrinaker): Handle DeleteRange events (MVCC range tombstones).
 				return errors.AssertionFailedf("unexpected event")
 			}
 		}

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -41,6 +41,7 @@ type config struct {
 	onCheckpoint         OnCheckpoint
 	onFrontierAdvance    OnFrontierAdvance
 	onSSTable            OnSSTable
+	onDeleteRange        OnDeleteRange
 	extraPProfLabels     []string
 }
 
@@ -175,6 +176,25 @@ type OnSSTable func(ctx context.Context, sst *roachpb.RangeFeedSSTable)
 func WithOnSSTable(f OnSSTable) Option {
 	return optionFunc(func(c *config) {
 		c.onSSTable = f
+	})
+}
+
+// OnDeleteRange is called when an MVCC range tombstone is written (e.g. when
+// DeleteRange is called with UseExperimentalRangeTombstone, but not when the
+// range is deleted using point tombstones). If this callback is not provided,
+// such range tombstones will be ignored.
+//
+// MVCC range tombstones are currently experimental, and disabled by default.
+// They are only written when storage.CanUseExperimentalMVCCRangeTombstones() is
+// true, and are only expected during certain operations like schema GC and
+// IMPORT INTO (i.e. not across live tables).
+type OnDeleteRange func(ctx context.Context, value *roachpb.RangeFeedDeleteRange)
+
+// WithOnDeleteRange sets up a callback that's invoked whenever a MVCC range
+// deletion tombstone is written.
+func WithOnDeleteRange(f OnDeleteRange) Option {
+	return optionFunc(func(c *config) {
+		c.onDeleteRange = f
 	})
 }
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -349,6 +349,10 @@ func (f *RangeFeed) processEvents(
 						"received unexpected rangefeed SST event with no OnSSTable handler")
 				}
 				f.onSSTable(ctx, ev.SST)
+			case ev.DelRange != nil:
+				if f.onDeleteRange != nil {
+					f.onDeleteRange(ctx, ev.DelRange)
+				}
 			case ev.Error != nil:
 				// Intentionally do nothing, we'll get an error returned from the
 				// call to RangeFeed.

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -188,7 +188,7 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 	opts.FS = vfs.Default
 	opts.LBaseMaxBytes = lBaseMaxBytes
 	opts.ReadOnly = readOnly
-	opts.FormatMajorVersion = pebble.FormatBlockPropertyCollector
+	opts.FormatMajorVersion = pebble.FormatRangeKeys
 	peb, err := storage.NewPebble(
 		context.Background(),
 		storage.PebbleConfig{

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -629,6 +629,10 @@ func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLo
 			// Publish the new value directly.
 			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue)
 
+		case *enginepb.MVCCDeleteRangeOp:
+			// Publish the range deletion directly.
+			p.publishDeleteRange(ctx, t.StartKey, t.EndKey, t.Timestamp)
+
 		case *enginepb.MVCCWriteIntentOp:
 			// No updates to publish.
 
@@ -696,6 +700,22 @@ func (p *Processor) publishValue(
 		PrevValue: prevVal,
 	})
 	p.reg.PublishToOverlapping(roachpb.Span{Key: key}, &event)
+}
+
+func (p *Processor) publishDeleteRange(
+	ctx context.Context, startKey, endKey roachpb.Key, timestamp hlc.Timestamp,
+) {
+	span := roachpb.Span{Key: startKey, EndKey: endKey}
+	if !p.Span.ContainsKeyRange(roachpb.RKey(startKey), roachpb.RKey(endKey)) {
+		log.Fatalf(ctx, "span %s not in Processor's key range %v", span, p.Span)
+	}
+
+	var event roachpb.RangeFeedEvent
+	event.MustSetValue(&roachpb.RangeFeedDeleteRange{
+		Span:      span,
+		Timestamp: timestamp,
+	})
+	p.reg.PublishToOverlapping(span, &event)
 }
 
 func (p *Processor) publishSSTable(

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -169,6 +169,13 @@ func (r *registration) validateEvent(event *roachpb.RangeFeedEvent) {
 		if t.WriteTS.IsEmpty() {
 			panic(fmt.Sprintf("unexpected empty RangeFeedSSTable.Timestamp: %v", t))
 		}
+	case *roachpb.RangeFeedDeleteRange:
+		if len(t.Span.Key) == 0 || len(t.Span.EndKey) == 0 {
+			panic(fmt.Sprintf("unexpected empty key in RangeFeedDeleteRange.Span: %v", t))
+		}
+		if t.Timestamp.IsEmpty() {
+			panic(fmt.Sprintf("unexpected empty RangeFeedDeleteRange.Timestamp: %v", t))
+		}
 	default:
 		panic(fmt.Sprintf("unexpected RangeFeedEvent variant: %v", t))
 	}
@@ -215,6 +222,13 @@ func (r *registration) maybeStripEvent(event *roachpb.RangeFeedEvent) *roachpb.R
 			t = copyOnWrite().(*roachpb.RangeFeedCheckpoint)
 			t.Span = r.span
 		}
+	case *roachpb.RangeFeedDeleteRange:
+		// Truncate the range tombstone to the registration bounds.
+		if i := t.Span.Intersect(r.span); !i.Equal(t.Span) {
+			t = copyOnWrite().(*roachpb.RangeFeedDeleteRange)
+			t.Span = i.Clone()
+		}
+
 	case *roachpb.RangeFeedSSTable:
 		// SSTs are always sent in their entirety, it is up to the caller to
 		// filter out irrelevant entries.
@@ -389,6 +403,8 @@ func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.Rang
 		minTS = t.Value.Timestamp
 	case *roachpb.RangeFeedSSTable:
 		minTS = t.WriteTS
+	case *roachpb.RangeFeedDeleteRange:
+		minTS = t.Timestamp
 	case *roachpb.RangeFeedCheckpoint:
 		// Always publish checkpoint notifications, regardless of a registration's
 		// starting timestamp.

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -142,6 +142,10 @@ func (rts *resolvedTimestamp) consumeLogicalOp(op enginepb.MVCCLogicalOp) bool {
 		rts.assertOpAboveRTS(op, t.Timestamp)
 		return false
 
+	case *enginepb.MVCCDeleteRangeOp:
+		rts.assertOpAboveRTS(op, t.Timestamp)
+		return false
+
 	case *enginepb.MVCCWriteIntentOp:
 		rts.assertOpAboveRTS(op, t.Timestamp)
 		return rts.intentQ.IncRef(t.TxnID, t.TxnKey, t.TxnMinTimestamp, t.Timestamp)

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -520,7 +520,8 @@ func (r *Replica) populatePrevValsInLogicalOpLogRaftMuLocked(
 		case *enginepb.MVCCWriteIntentOp,
 			*enginepb.MVCCUpdateIntentOp,
 			*enginepb.MVCCAbortIntentOp,
-			*enginepb.MVCCAbortTxnOp:
+			*enginepb.MVCCAbortTxnOp,
+			*enginepb.MVCCDeleteRangeOp:
 			// Nothing to do.
 			continue
 		default:
@@ -594,7 +595,8 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 		case *enginepb.MVCCWriteIntentOp,
 			*enginepb.MVCCUpdateIntentOp,
 			*enginepb.MVCCAbortIntentOp,
-			*enginepb.MVCCAbortTxnOp:
+			*enginepb.MVCCAbortTxnOp,
+			*enginepb.MVCCDeleteRangeOp:
 			// Nothing to do.
 			continue
 		default:

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1480,6 +1480,9 @@ func (e *RangeFeedEvent) ShallowCopy() *RangeFeedEvent {
 	case *RangeFeedSSTable:
 		cpySST := *t
 		cpy.MustSetValue(&cpySST)
+	case *RangeFeedDeleteRange:
+		cpyDelRange := *t
+		cpy.MustSetValue(&cpyDelRange)
 	case *RangeFeedError:
 		cpyErr := *t
 		cpy.MustSetValue(&cpyErr)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2660,15 +2660,24 @@ message RangeFeedSSTable {
   util.hlc.Timestamp write_ts = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "WriteTS"];
 }
 
+// RangeFeedDeleteRange is a variant of RangeFeedEvent that represents a
+// deletion of the specified key range at the given timestamp using an MVCC
+// range tombstone.
+message RangeFeedDeleteRange {
+  Span               span        = 1 [(gogoproto.nullable) = false];
+  util.hlc.Timestamp timestamp   = 2 [(gogoproto.nullable) = false];
+}
+
 // RangeFeedEvent is a union of all event types that may be returned on a
 // RangeFeed response stream.
 message RangeFeedEvent {
   option (gogoproto.onlyone) = true;
 
-  RangeFeedValue      val        = 1;
-  RangeFeedCheckpoint checkpoint = 2;
-  RangeFeedError      error      = 3;
-  RangeFeedSSTable    sst        = 4 [(gogoproto.customname) = "SST"];
+  RangeFeedValue       val        = 1;
+  RangeFeedCheckpoint  checkpoint = 2;
+  RangeFeedError       error      = 3;
+  RangeFeedSSTable     sst        = 4 [(gogoproto.customname) = "SST"];
+  RangeFeedDeleteRange del_range  = 5;
 }
 
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -2073,6 +2073,11 @@ func (u *LockUpdate) SetTxn(txn *Transaction) {
 	u.IgnoredSeqNums = txn.IgnoredSeqNums
 }
 
+// Clone returns a copy of the span.
+func (s Span) Clone() Span {
+	return Span{Key: s.Key.Clone(), EndKey: s.EndKey.Clone()}
+}
+
 // EqualValue is Equal.
 //
 // TODO(tbg): remove this passthrough.

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -303,6 +303,15 @@ message MVCCAbortTxnOp {
     (gogoproto.nullable) = false];
 }
 
+// MVCCDeleteRangeOp corresponds to a range deletion using an MVCC range
+// tombstone.
+message MVCCDeleteRangeOp {
+  bytes              start_key = 1;
+  bytes              end_key   = 2;
+  util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+}
+
+
 // MVCCLogicalOp is a union of all logical MVCC operation types.
 message MVCCLogicalOp {
   option (gogoproto.onlyone) = true;
@@ -313,4 +322,5 @@ message MVCCLogicalOp {
   MVCCCommitIntentOp commit_intent = 4;
   MVCCAbortIntentOp  abort_intent  = 5;
   MVCCAbortTxnOp     abort_txn     = 6;
+  MVCCDeleteRangeOp  delete_range  = 7;
 }

--- a/pkg/storage/mvcc_logical_ops.go
+++ b/pkg/storage/mvcc_logical_ops.go
@@ -44,6 +44,8 @@ const (
 	MVCCCommitIntentOpType
 	// MVCCAbortIntentOpType corresponds to the MVCCAbortIntentOp variant.
 	MVCCAbortIntentOpType
+	// MVCCDeleteRangeOpType corresponds to the MVCCDeleteRangeOp variant.
+	MVCCDeleteRangeOpType
 )
 
 // MVCCLogicalOpDetails contains details about the occurrence of an MVCC logical
@@ -51,6 +53,7 @@ const (
 type MVCCLogicalOpDetails struct {
 	Txn       enginepb.TxnMeta
 	Key       roachpb.Key
+	EndKey    roachpb.Key // only set for MVCCDeleteRangeOpType
 	Timestamp hlc.Timestamp
 
 	// Safe indicates that the values in this struct will never be invalidated
@@ -132,6 +135,16 @@ func (ol *OpLoggerBatch) logLogicalOp(op MVCCLogicalOpType, details MVCCLogicalO
 	case MVCCAbortIntentOpType:
 		ol.recordOp(&enginepb.MVCCAbortIntentOp{
 			TxnID: details.Txn.ID,
+		})
+	case MVCCDeleteRangeOpType:
+		if !details.Safe {
+			ol.opsAlloc, details.Key = ol.opsAlloc.Copy(details.Key, 0)
+			ol.opsAlloc, details.EndKey = ol.opsAlloc.Copy(details.EndKey, 0)
+		}
+		ol.recordOp(&enginepb.MVCCDeleteRangeOp{
+			StartKey:  details.Key,
+			EndKey:    details.EndKey,
+			Timestamp: details.Timestamp,
 		})
 	default:
 		panic(fmt.Sprintf("unexpected op type %v", op))

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -207,6 +207,10 @@ func (p *pebbleBatch) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) M
 		return iter
 	}
 
+	if opts.KeyTypes != IterKeyTypePointsOnly && p.db.FormatMajorVersion() < pebble.FormatRangeKeys {
+		opts.KeyTypes = IterKeyTypePointsOnly
+	}
+
 	if !opts.MinTimestampHint.IsEmpty() {
 		// MVCCIterators that specify timestamp bounds cannot be cached.
 		iter := MVCCIterator(newPebbleIterator(p.batch, nil, opts))
@@ -256,6 +260,10 @@ func (p *pebbleBatch) NewEngineIterator(opts IterOptions) EngineIterator {
 
 	if p.writeOnly {
 		panic("write-only batch")
+	}
+
+	if opts.KeyTypes != IterKeyTypePointsOnly {
+		panic("range keys are not supported for engine iterators, only MVCC")
 	}
 
 	iter := &p.normalEngineIter


### PR DESCRIPTION
**storage: disable range keys in iterators when unsupported**

This patch falls back to `IterKeyTypePointsOnly` if the Pebble database
is not at `FormatRangeKeys` yet, to avoid a Pebble panic. These
databases can't contain range keys by definition, so this has no
practical effect.

Release note: None

**kvserver: emit MVCC range tombstones over rangefeeds**

This patch adds MVCC range tombstone support to range feeds. Whenever a
`DeleteRange` request with `UseExperimentalRangeTombstone` succeeds, a new
`MVCCDeleteRangeOp` logical op type is recorded and emitted across the
range feed as an `RangeFeedDeleteRange` event.

MVCC range tombstones are under active development, and highly
experimental. They will only be used (and emitted) after checking
`storage.CanUseExperimentalMVCCRangeTombstones`, which requires a
version gate and environment variable to be enabled.

Changefeeds will emit an error for these events. We do not expect to see
these in online spans with changefeeds, since they are initially only
planned for use with schema GC and import rollbacks.

The rangefeed client library has been extended with support for these
events, but no existing callers handle them for the same reason as
changefeeds. Initial scans do not emit regular tombstones, and thus not
range tombstones either, but catchup scans will emit them if
encountered.

This only has rudimentary integration testing, as MVCC range tombstones
are still experimental and lack e.g. persistence and replication -- more
comprehensive tests will be implemented later.

Resolves #70433.

Release note: None