### PR TITLE
bazel: upgrade to bazel 5.0.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
-build --symlink_prefix=_bazel/ --experimental_no_product_name_out_symlink
+build --symlink_prefix=_bazel/
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build:with_ui --define cockroach_with_ui=y
 build:test --define crdb_test=y

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/4.2.1
+cockroachdb/5.0.0


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/75796.

Release note: None