### PR TITLE
release-21.2: roachtest: try to stabilize ORM nightlies

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -25,7 +25,7 @@ import (
 var activerecordResultRegex = regexp.MustCompile(`^(?P<test>[^\s]+#[^\s]+) = (?P<timing>\d+\.\d+ s) = (?P<result>.)$`)
 var railsReleaseTagRegex = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)\.?(?P<subpoint>\d*)$`)
 var supportedRailsVersion = "6.1"
-var activerecordAdapterVersion = "v6.1.3"
+var activerecordAdapterVersion = "v6.1.5"
 
 // This test runs activerecord's full test suite against a single cockroach node.
 


### PR DESCRIPTION
Backport 1/1 commits from #76442.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/70008

Release note: None
