### PR TITLE
util/tracing: eliminate allocation for WithParent(<empty>)

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -432,6 +432,7 @@ go_test(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
         "@org_golang_x_crypto//bcrypt",
     ],

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -254,8 +254,8 @@ type remoteParent SpanMeta
 // WithRemoteParentFromTraceInfo will not allocate (whereas
 // WithRemoteParentFromSpanMeta allocates).
 func WithRemoteParentFromSpanMeta(parent SpanMeta) SpanOption {
-	if parent.sterile {
-		return remoteParent{}
+	if parent.Empty() || parent.sterile {
+		return nil
 	}
 	return (remoteParent)(parent)
 }


### PR DESCRIPTION
This patch makes WithRemoteParent(SpanMeta{}) not allocate a useless
no-op span creation option. WithRemoteParent(SpanMeta{}) is superflous,
but the call can happen when the caller that doesn't know whether
there's a parent or not. I don't think the case is very common, but the
optimization is very natural.
This patch makes the no-op option be a represented as `nil`, as opposed
to a heap-allocated empty struct.

BenchmarkSetupSpanForIncomingRPC is enhanced to cover more code paths.
The delta in the "/no_parent" case captures the improvement here - one
allocation saved per not-traced RPC when tracing is generally enabled.

```
name                                  old time/op    new time/op    delta
SetupSpanForIncomingRPC/traceInfo-32     434ns ± 2%     445ns ± 1%   +2.68%  (p=0.008 n=5+5)
SetupSpanForIncomingRPC/grpcMeta-32     1.22µs ± 3%    1.23µs ± 2%     ~     (p=1.000 n=5+5)
SetupSpanForIncomingRPC/no_parent-32     439ns ± 2%     312ns ± 1%  -28.90%  (p=0.008 n=5+5)

name                                  old alloc/op   new alloc/op   delta
SetupSpanForIncomingRPC/traceInfo-32      144B ± 0%      144B ± 0%     ~     (all equal)
SetupSpanForIncomingRPC/grpcMeta-32       544B ± 0%      544B ± 0%     ~     (all equal)
SetupSpanForIncomingRPC/no_parent-32      144B ± 0%       48B ± 0%  -66.67%  (p=0.008 n=5+5)

name                                  old allocs/op  new allocs/op  delta
SetupSpanForIncomingRPC/traceInfo-32      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
SetupSpanForIncomingRPC/grpcMeta-32       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
SetupSpanForIncomingRPC/no_parent-32      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.008 n=5+5)
```

Release note: None