### PR TITLE
sql/pgwire: add metrics for pgwire cancel requests

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -74,6 +74,8 @@ go_library(
         "@com_github_lib_pq//oid",
         "@com_github_xdg_go_scram//:scram",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2209,6 +2209,15 @@ var charts = []sectionDescription{
 				},
 				AxisLabel: "Latency",
 			},
+			{
+				Title: "Cancel Requests (Postgres Protocol)",
+				Metrics: []string{
+					"sql.pgwire_cancel.total",
+					"sql.pgwire_cancel.ignored",
+					"sql.pgwire_cancel.successful",
+				},
+				AxisLabel: "Count",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76332

Release note (general change): The following metrics were added for
observability of cancellation requests made using the Postgres wire
protocol:
- sql.pgwire_cancel.total
- sql.pgwire_cancel.ignored
- sql.pgwire_cancel.successful

The metrics are all counters. The "ignored" counter is incremented if a
cancel request was ignored due to exceeding the per-node rate limit of
cancel requests.