### PR TITLE
kvnemesis: update table ID

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/liveness",
         "//pkg/roachpb",
+        "//pkg/sql/catalog/bootstrap",
         "//pkg/storage",
         "//pkg/util/bufalloc",
         "//pkg/util/ctxgroup",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -379,7 +379,7 @@ func updateZoneConfig(zone *zonepb.ZoneConfig, change ChangeZoneType) {
 }
 
 func updateZoneConfigInEnv(ctx context.Context, env *Env, change ChangeZoneType) error {
-	return env.UpdateZoneConfig(ctx, GeneratorDataTableID, func(zone *zonepb.ZoneConfig) {
+	return env.UpdateZoneConfig(ctx, int(GeneratorDataTableID), func(zone *zonepb.ZoneConfig) {
 		updateZoneConfig(zone, change)
 	})
 }

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -250,7 +251,8 @@ func NewDefaultConfig() GeneratorConfig {
 }
 
 // GeneratorDataTableID is the table ID that corresponds to GeneratorDataSpan.
-const GeneratorDataTableID = 50
+// This must be a table ID that is not used in a new cluster.
+var GeneratorDataTableID = bootstrap.TestingMinUserDescID()
 
 // GeneratorDataSpan returns a span that contains all of the operations created
 // by this Generator.

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -486,9 +487,10 @@ func TestZoneChecker(t *testing.T) {
 		newZoneKey     ZoneKey
 	}
 	// NB: IDs need to be beyond MaxSystemConfigDescID, otherwise special logic
-	// kicks in for mapping keys to zones.
-	dbID := 50
-	t1ID := 51
+	// kicks in for mapping keys to zones. They also need to not overlap with any
+	// system table IDs.
+	dbID := int(bootstrap.TestingMinUserDescID())
+	t1ID := dbID + 1
 	t1 := table{name: "t1",
 		partitions: []partition{
 			{


### PR DESCRIPTION
These tests hardcode a table ID of 50. This now overlaps with the
tenant_settings table. Updating to 100, which is now the first
user-created ID in a new cluster.

Release note: None