### PR TITLE
kvserver: make it clear that rebalancing snapshots block all log truncation

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1553,15 +1553,26 @@ func (r *Replica) initializeRaftLearners(
 	default:
 		log.Fatalf(ctx, "unexpected replicaType %s", replicaType)
 	}
-	// Lock learner snapshots even before we run the ConfChange txn to add them
-	// to prevent a race with the raft snapshot queue trying to send it first.
+	// Before we run the ConfChange:
 	//
-	// Also note that the lock only prevents the raft snapshot queue from sending
-	// snapshots to learners and non-voters, it will still send them to voters.
-	// There are more details about this locking in
+	// 1. Lock log truncation so that we don't truncate above the index the snapshot
+	// is being generated off of. If we were to truncate above the snapshot's index,
+	// the replica would need another fresh snapshot anyway.
+	//
+	// 2. Lock learner snapshots to prevent a race with the raft snapshot queue
+	// trying to send it first. Also note that the lock only prevents the raft
+	// snapshot queue from sending snapshots to learners and non-voters, it will
+	// still send them to voters. There are more details about this locking in
 	_ = (*raftSnapshotQueue)(nil).processRaftSnapshot
 	// as well as a TODO about fixing all this to be less subtle and brittle.
-	releaseSnapshotLockFn := r.lockLearnerSnapshot(ctx, targets)
+	//
+	// This is all done before we even add the learner because as of
+	// https://github.com/etcd-io/etcd/pull/11037, the Raft leader will proactively
+	// probe newly added follower replicas which can in-turn trigger a "Raft
+	// snapshot" from the raftSnapshotQueue. If the raftSnapshotQueue wins this
+	// race, this `ChangeReplicas` call will fail and we will end up repeating the
+	// work of adding / upreplicating a new learner.
+	releaseSnapshotLockFn := r.lockLogTruncationAndLearnerSnaps(ctx, targets)
 	defer releaseSnapshotLockFn()
 
 	// If we fail to add or send a snapshot to the learners we're adding, roll
@@ -1672,7 +1683,7 @@ func (r *Replica) initializeRaftLearners(
 		// or non-voter replica if its store is already sending a snapshot to that
 		// replica. That would race with this snapshot, except that we've put a
 		// (best effort) lock on it before the conf change txn was run (see call to
-		// `lockLearnerSnapshot` above). This is best effort because the lock can
+		// `lockLogTruncationAndLearnerSnaps` above). This is best effort because the lock can
 		// time out and the lock is local to this node, while the raft leader could
 		// be on another node entirely (they're usually co-located but this is not
 		// guaranteed).
@@ -1691,12 +1702,16 @@ func (r *Replica) initializeRaftLearners(
 	return desc, nil
 }
 
-// lockLearnerSnapshot stops the raft snapshot queue from sending snapshots to
-// the soon-to-be added learner replicas to prevent duplicate snapshots from
-// being sent. This lock is best effort because it times out and it is a node
-// local lock while the raft snapshot queue might be running on a different
-// node. An idempotent unlock function is returned.
-func (r *Replica) lockLearnerSnapshot(
+// lockLogTruncationAndLearnerSnaps stops all[1] log truncation so that we don't
+// truncate above the snapshot and stops the raft snapshot queue from sending
+// snapshots to the soon-to-be added learner replicas to prevent duplicate
+// snapshots from being sent. This lock is best effort because it times out and
+// it is a node local lock while the raft snapshot queue might be running on a
+// different node. An idempotent unlock function is returned.
+//
+// [1] We even disallow log truncations that are truncating below the index of
+// an in-flight snapshot.
+func (r *Replica) lockLogTruncationAndLearnerSnaps(
 	ctx context.Context, additions []roachpb.ReplicationTarget,
 ) (unlock func()) {
 	// TODO(dan): The way this works is hacky, but it was added at the last minute

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -379,7 +379,7 @@ func TestNonVoterCatchesUpViaRaftSnapshotQueue(t *testing.T) {
 		return atomic.LoadInt64(&skipInitialSnapshot) == 1
 	}
 	// Synchronize with the removal of the "best effort" lock on log truncation.
-	// See (*Replica).lockLearnerSnapshot for details.
+	// See (*Replica).lockLogTruncationAndLearnerSnaps for details.
 	nonVoterSnapLockRemoved := make(chan struct{}, 1)
 	ltk.storeKnobs.NonVoterAfterInitialization = func() {
 		nonVoterSnapLockRemoved <- struct{}{}


### PR DESCRIPTION
The previous naming of this method and its comment weren't capturing the fact
that it also placed a best effort lock on log truncation. This was likely
intentional as the `(*Replica).GetSnapshot` method also places the same (but
more precise) lock for the same reason. The difference is that the lock on log
truncations that we place during rebalancing is a lot more wide is it blocks
_all_ log truncations (even the ones that are truncating below the index of an
in-flight snapshot).

We might rationalize this or remove this entirely in the future, but this
commit makes this a bit clearer.

Release note: None