### PR TITLE
opt: fix bug in histogram estimation code for multi-column spans

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2222,3 +2222,58 @@ select
  │              └── fd: (2)-->(5)
  └── filters
       └── st_coveredby(geom:1, '0101000000000000000000F03F000000000000F03F') [type=bool, outer=(1), immutable, constraints=(/1: (/NULL - ])]
+
+# Regression test for #76485. Ensure that we do not estimate 0 rows
+# when filtering a histogram with a multi-column span.
+
+exec-ddl
+CREATE TABLE t76485 (
+  a INT,
+  b INT,
+  c STRING,
+  INDEX (a, c),
+  INDEX (a, b, c)
+)
+----
+
+exec-ddl
+ALTER TABLE t76485 INJECT STATISTICS '[
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2022-02-12 23:43:16.318153",
+        "distinct_count": 10,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 0,
+                "num_range": 0,
+                "upper_bound": "10"
+            },
+            {
+                "distinct_range": 9,
+                "num_eq": 10000,
+                "num_range": 9,
+                "upper_bound": "20"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 1,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 10009
+    }
+]'
+----
+
+opt
+SELECT * FROM t76485 WHERE a = 20 AND b = 30 AND c < 'foo';
+----
+scan t76485@t76485_a_b_c_idx
+ ├── columns: a:1(int!null) b:2(int!null) c:3(string!null)
+ ├── constraint: /1/2/3/4: (/20/30/NULL - /20/30/'foo')
+ ├── stats: [rows=9.310865, distinct(1)=1, null(1)=0, avgsize(1)=4, distinct(2)=1, null(2)=0, avgsize(2)=4, distinct(3)=9.31087, null(3)=0, avgsize(3)=4, distinct(1,2)=1, null(1,2)=0, avgsize(1,2)=8, distinct(1-3)=9.31087, null(1-3)=0, avgsize(1-3)=12]
+ │   histogram(1)=  0 9.3109
+ │                <---- 20 -
+ └── fd: ()-->(1,2)

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -603,12 +603,18 @@ func getFilteredBucket(
 
 	// Determine whether this span includes the original upper bound of the
 	// bucket.
-	isSpanEndBoundaryInclusive := filteredSpan.EndBoundary() == constraint.IncludeBoundary
-	includesOriginalUpperBound := isSpanEndBoundaryInclusive && cmpSpanEndBucketEnd == 0
-	if iter.desc {
-		isSpanStartBoundaryInclusive := filteredSpan.StartBoundary() == constraint.IncludeBoundary
-		includesOriginalUpperBound = isSpanStartBoundaryInclusive && cmpSpanStartBucketStart == 0
+	var keyLength, cmp int
+	var keyBoundaryInclusive bool
+	if !iter.desc {
+		keyLength = filteredSpan.EndKey().Length()
+		keyBoundaryInclusive = filteredSpan.EndBoundary() == constraint.IncludeBoundary
+		cmp = cmpSpanEndBucketEnd
+	} else {
+		keyLength = filteredSpan.StartKey().Length()
+		keyBoundaryInclusive = filteredSpan.StartBoundary() == constraint.IncludeBoundary
+		cmp = cmpSpanStartBucketStart
 	}
+	includesOriginalUpperBound := cmp == 0 && ((colOffset < keyLength-1) || keyBoundaryInclusive)
 
 	// Calculate the new value for numEq.
 	var numEq float64


### PR DESCRIPTION
This commit fixes a bug in the histogram estimation code, which could
cause the optimizer to think that an index scan produced 0 rows, when
in fact it produced a large number. This was due to an inaccurate assumption
in the histogram filtering code that if a span had an exclusive boundary,
the upper bound of the span was excluded from the histogram. However, this
failed to account for the fact that we support constraining a histogram with
multi-column spans, and we can select different column offsets to use to
constrain the histogram. The assumption above is only valid if the column
offset corresponds to the last column in the span key. This logic has now
been fixed.

Fixes #76485

Release note (performance improvement): Fixed a bug in the histogram estimation
code that could cause the optimizer to think a scan of a multi-column index
would produce 0 rows, when in fact it would produce many rows. This could cause
the optimizer to choose a suboptimal plan. This bug has now been fixed, making
it less likely for the optimizer to choose a suboptimal plan when multiple
multi-column indexes are available.