### PR TITLE
descmetadata: remove bogus target in BUILD.bazel

### DIFF
--- a/pkg/sql/descmetadata/BUILD.bazel
+++ b/pkg/sql/descmetadata/BUILD.bazel
@@ -1,28 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "commenter",
-    srcs = [
-        "comment_updater.go",
-        "comment_updater_factory.go",
-    ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/commenter",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/keys",
-        "//pkg/kv",
-        "//pkg/security",
-        "//pkg/sql/catalog",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/schemachanger/scexec",
-        "//pkg/sql/schemachanger/scpb",
-        "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondata",
-        "//pkg/sql/sqlutil",
-    ],
-)
-
-go_library(
     name = "descmetadata",
     srcs = [
         "metadata_updater.go",


### PR DESCRIPTION
This can break `...` builds.

Release note: None