### PR TITLE
kvserver: print attempts on slow lease

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1275,8 +1275,8 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 					return nil
 				case <-slowTimer.C:
 					slowTimer.Read = true
-					log.Warningf(ctx, "have been waiting %s attempting to acquire lease",
-						base.SlowRequestThreshold)
+					log.Warningf(ctx, "have been waiting %s attempting to acquire lease (%d attempts)",
+						base.SlowRequestThreshold, attempt)
 					r.store.metrics.SlowLeaseRequests.Inc(1)
 					defer func() {
 						r.store.metrics.SlowLeaseRequests.Dec(1)


### PR DESCRIPTION
It's usually 1, but it can't hurt to detect cases in which we're looping
around. This came up when writing tests for #33007.

Release note: None
