### PR TITLE
dev: stop messing with PATH

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=16
+DEV_VERSION=17
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/main.go
+++ b/pkg/cmd/dev/main.go
@@ -27,10 +27,6 @@ func main() {
 
 	dev := makeDevCmd()
 
-	if err := setupPath(dev); err != nil {
-		log.Fatalf("Failed to setup PATH: %v", err)
-	}
-
 	if err := dev.cli.Execute(); err != nil {
 		log.Printf("ERROR: %v", err)
 		os.Exit(1)

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -15,9 +15,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alessio/shellescape"
@@ -111,68 +109,6 @@ func addCommonTestFlags(cmd *cobra.Command) {
 func (d *dev) ensureBinaryInPath(bin string) error {
 	if _, err := d.exec.LookPath(bin); err != nil {
 		return fmt.Errorf("could not find %s in PATH", bin)
-	}
-	return nil
-}
-
-// setupPath removes the ccache directory from PATH to prevent it writing files
-// outside of the bazel sandbox. This function is called only once to prevent
-// multiple unnecessary calls.
-func setupPath(dev *dev) error {
-	var once sync.Once
-	var err error
-	once.Do(func() {
-		err = setupPathReal(dev)
-	})
-	return err
-}
-
-// setupPathReal uses a list of known compiler names to check if they are
-// symlinks to `ccache`.
-func setupPathReal(dev *dev) error {
-	knownCompilers := []string{"cc", "gcc", "c++", "g++", "clang", "clang++"}
-	// datadriven uses Fprintln() to construct commands, adding '\n' to the end.
-	// Trim the output here and in other places that don't expect the extra new line
-	// at the end.
-	origPath := strings.TrimSuffix(dev.os.Getenv("PATH"), "\n")
-	pathEntries := strings.Split(origPath, string(os.PathListSeparator))
-	for i, entry := range pathEntries {
-		pathEntries[i] = filepath.Clean(entry)
-	}
-	for _, compiler := range knownCompilers {
-		compilerPath, err := dev.exec.LookPath(compiler)
-		if err != nil {
-			continue
-		}
-		compilerPath = strings.TrimSuffix(compilerPath, "\n")
-		compilerDir, _ := filepath.Split(compilerPath)
-		compilerDir = filepath.Clean(compilerDir)
-		compilerResolvedPath, err := dev.os.Readlink(compilerPath)
-		if err != nil {
-			// Skip broken symlinks and real binaries
-			continue
-		}
-		compilerResolvedPath = strings.TrimSuffix(compilerResolvedPath, "\n")
-		_, file := filepath.Split(filepath.Clean(compilerResolvedPath))
-		if file != "ccache" {
-			continue
-		}
-		// The compiler points to ccache, remove it from PATH
-		var newPathEntries []string
-		for _, dir := range pathEntries {
-			if compilerDir != dir {
-				newPathEntries = append(newPathEntries, dir)
-			}
-		}
-		newPath := strings.Join(newPathEntries, string(os.PathListSeparator))
-		if origPath == newPath {
-			log.Printf("WARNING: PATH did not change: %s", origPath)
-		}
-		if err := dev.os.Setenv("PATH", newPath); err != nil {
-			return fmt.Errorf("failed to set PATH to %s, %w", newPath, err)
-		}
-		// All done, return early without trying other known compilers
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
Effectively reverts #68405. Messing with the PATH here can lead to
thrashing the build cache/discarding the analysis cache when switching
between `dev` and `bazel`, something folks do. The reasons for this PATH
munging no longer hold (#71941), bazel builds don't interop with
ccache if using one of the provided toolchains.

Release note: None