### PR TITLE
sql: add option to enable/disable txn id cache 

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -77,7 +77,7 @@ server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number o
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted
 server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_sessions older than this duration are periodically purged
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
-sql.contention.txn_id_cache.max_size	byte size	64 MiB	the maximum byte size TxnID cache will use
+sql.contention.txn_id_cache.max_size	byte size	64 MiB	the maximum byte size TxnID cache will use (set to 0 to disable)
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed
 sql.cross_db_sequence_references.enabled	boolean	false	if true, sequences referenced by tables from other databases are allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -88,7 +88,7 @@
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>
 <tr><td><code>server.web_session.purge.ttl</code></td><td>duration</td><td><code>1h0m0s</code></td><td>if nonzero, entries in system.web_sessions older than this duration are periodically purged</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
-<tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the maximum byte size TxnID cache will use</td></tr>
+<tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the maximum byte size TxnID cache will use (set to 0 to disable)</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_references.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, sequences referenced by tables from other databases are allowed</td></tr>

--- a/pkg/sql/contention/txnidcache/cluster_settings.go
+++ b/pkg/sql/contention/txnidcache/cluster_settings.go
@@ -16,6 +16,6 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 var MaxSize = settings.RegisterByteSizeSetting(
 	settings.TenantWritable,
 	`sql.contention.txn_id_cache.max_size`,
-	"the maximum byte size TxnID cache will use",
+	"the maximum byte size TxnID cache will use (set to 0 to disable)",
 	64*1024*1024, // 64 MB
 ).WithPublic()

--- a/pkg/sql/contention/txnidcache/fifo_cache.go
+++ b/pkg/sql/contention/txnidcache/fifo_cache.go
@@ -26,8 +26,7 @@ var nodePool = &sync.Pool{
 }
 
 type fifoCache struct {
-	blockPool *sync.Pool
-	capacity  contentionutils.CapacityLimiter
+	capacity contentionutils.CapacityLimiter
 
 	mu struct {
 		syncutil.RWMutex
@@ -54,10 +53,9 @@ type blockList struct {
 	tailIdx int
 }
 
-func newFIFOCache(pool *sync.Pool, capacity contentionutils.CapacityLimiter) *fifoCache {
+func newFIFOCache(capacity contentionutils.CapacityLimiter) *fifoCache {
 	c := &fifoCache{
-		blockPool: pool,
-		capacity:  capacity,
+		capacity: capacity,
 	}
 
 	c.mu.data = make(map[uuid.UUID]roachpb.TransactionFingerprintID)
@@ -85,7 +83,7 @@ func (c *fifoCache) add(b *block) {
 
 	// Zeros out the block and put it back into the blockPool.
 	*b = block{}
-	c.blockPool.Put(b)
+	blockPool.Put(b)
 
 	c.maybeEvictLocked()
 }

--- a/pkg/sql/contention/txnidcache/fifo_cache_test.go
+++ b/pkg/sql/contention/txnidcache/fifo_cache_test.go
@@ -13,7 +13,6 @@ package txnidcache
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -22,12 +21,7 @@ import (
 )
 
 func TestFIFOCache(t *testing.T) {
-	pool := &sync.Pool{
-		New: func() interface{} {
-			return &block{}
-		},
-	}
-	cache := newFIFOCache(pool, func() int64 { return 2 * blockSize } /* capacity */)
+	cache := newFIFOCache(func() int64 { return 2 * blockSize } /* capacity */)
 
 	// Fill the first eviction block in cache to 1/4 capacity.
 	input1, expected1 := generateInputBlock(blockSize * 1 / 4 /* size */)

--- a/pkg/sql/contention/txnidcache/txn_id_cache.go
+++ b/pkg/sql/contention/txnidcache/txn_id_cache.go
@@ -145,7 +145,7 @@ func NewTxnIDCache(st *cluster.Settings, metrics *Metrics) *Cache {
 		return MaxSize.Get(&st.SV) / entrySize
 	} /* capacity */)
 
-	t.writer = newWriter(t)
+	t.writer = newWriter(st, t)
 	return t
 }
 

--- a/pkg/sql/contention/txnidcache/writer.go
+++ b/pkg/sql/contention/txnidcache/writer.go
@@ -11,8 +11,6 @@
 package txnidcache
 
 import (
-	"sync"
-
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -24,20 +22,18 @@ const shardCount = 16
 type writer struct {
 	shards [shardCount]*concurrentWriteBuffer
 
-	sink      blockSink
-	blockPool *sync.Pool
+	sink blockSink
 }
 
 var _ Writer = &writer{}
 
-func newWriter(sink blockSink, blockPool *sync.Pool) *writer {
+func newWriter(sink blockSink) *writer {
 	w := &writer{
-		sink:      sink,
-		blockPool: blockPool,
+		sink: sink,
 	}
 
 	for shardIdx := 0; shardIdx < shardCount; shardIdx++ {
-		w.shards[shardIdx] = newConcurrentWriteBuffer(sink, blockPool)
+		w.shards[shardIdx] = newConcurrentWriteBuffer(sink)
 	}
 
 	return w

--- a/pkg/sql/contention/txnidcache/writer.go
+++ b/pkg/sql/contention/txnidcache/writer.go
@@ -11,6 +11,7 @@
 package txnidcache
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -20,6 +21,8 @@ import (
 const shardCount = 16
 
 type writer struct {
+	st *cluster.Settings
+
 	shards [shardCount]*concurrentWriteBuffer
 
 	sink blockSink
@@ -27,8 +30,9 @@ type writer struct {
 
 var _ Writer = &writer{}
 
-func newWriter(sink blockSink) *writer {
+func newWriter(st *cluster.Settings, sink blockSink) *writer {
 	w := &writer{
+		st:   st,
 		sink: sink,
 	}
 
@@ -41,6 +45,9 @@ func newWriter(sink blockSink) *writer {
 
 // Record implements the Writer interface.
 func (w *writer) Record(resolvedTxnID ResolvedTxnID) {
+	if MaxSize.Get(&w.st.SV) == 0 {
+		return
+	}
 	shardIdx := hashTxnID(resolvedTxnID.TxnID)
 	buffer := w.shards[shardIdx]
 	buffer.Record(resolvedTxnID)

--- a/pkg/sql/contention/txnidcache/writer_test.go
+++ b/pkg/sql/contention/txnidcache/writer_test.go
@@ -27,18 +27,15 @@ import (
 )
 
 type blackHoleSink struct {
-	pool *sync.Pool
-
 	// Simulate a real sink.
 	ch chan *block
 }
 
 var _ blockSink = &blackHoleSink{}
 
-func newBlackHoleSink(pool *sync.Pool, chanSize int) *blackHoleSink {
+func newBlackHoleSink(chanSize int) *blackHoleSink {
 	return &blackHoleSink{
-		pool: pool,
-		ch:   make(chan *block, chanSize),
+		ch: make(chan *block, chanSize),
 	}
 }
 
@@ -46,7 +43,7 @@ func (b *blackHoleSink) start() {
 	go func() {
 		for incomingBlock := range b.ch {
 			*incomingBlock = block{}
-			b.pool.Put(incomingBlock)
+			blockPool.Put(incomingBlock)
 		}
 	}()
 }
@@ -75,10 +72,10 @@ func BenchmarkWriter(b *testing.B) {
 
 	ctx := context.Background()
 
-	run := func(b *testing.B, sink blockSink, blockPool *sync.Pool, numOfConcurrentWriter int) {
+	run := func(b *testing.B, sink blockSink, numOfConcurrentWriter int) {
 		starter := make(chan struct{})
 
-		w := newWriter(sink, blockPool)
+		w := newWriter(sink)
 
 		b.ResetTimer()
 		b.SetBytes(blockSize * entrySize)
@@ -109,28 +106,22 @@ func BenchmarkWriter(b *testing.B) {
 
 	type testSinkType struct {
 		name string
-		new  func() (_ blockSink, _ *sync.Pool, cleanup func())
+		new  func() (_ blockSink, cleanup func())
 	}
 
 	sinkTypes := []testSinkType{
 		{
 			name: "blackHole",
-			new: func() (_ blockSink, _ *sync.Pool, cleanup func()) {
-				blockPool := &sync.Pool{
-					New: func() interface{} {
-						return &block{}
-					},
-				}
-
-				blackHole := newBlackHoleSink(blockPool, channelSize)
+			new: func() (_ blockSink, cleanup func()) {
+				blackHole := newBlackHoleSink(channelSize)
 				blackHole.start()
 
-				return blackHole, blockPool, blackHole.stop
+				return blackHole, blackHole.stop
 			},
 		},
 		{
 			name: "real",
-			new: func() (_ blockSink, _ *sync.Pool, cleanup func()) {
+			new: func() (_ blockSink, cleanup func()) {
 				st := cluster.MakeTestingClusterSettings()
 				metrics := NewMetrics()
 				realSink := NewTxnIDCache(st, &metrics)
@@ -138,7 +129,7 @@ func BenchmarkWriter(b *testing.B) {
 				stopper := stop.NewStopper()
 				realSink.Start(ctx, stopper)
 
-				return realSink, realSink.blockPool, func() {
+				return realSink, func() {
 					stopper.Stop(ctx)
 				}
 			},
@@ -149,10 +140,10 @@ func BenchmarkWriter(b *testing.B) {
 		b.Run(fmt.Sprintf("sinkType=%s", sinkType.name), func(b *testing.B) {
 			for _, numOfConcurrentWriter := range []int{1, 24, 48, 64, 92, 128} {
 				b.Run(fmt.Sprintf("concurrentWriter=%d", numOfConcurrentWriter), func(b *testing.B) {
-					sink, blockPool, cleanup := sinkType.new()
+					sink, cleanup := sinkType.new()
 					defer cleanup()
 
-					run(b, sink, blockPool, numOfConcurrentWriter)
+					run(b, sink, numOfConcurrentWriter)
 				})
 			}
 		})

--- a/pkg/sql/contention/txnidcache/writer_test.go
+++ b/pkg/sql/contention/txnidcache/writer_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 type blackHoleSink struct {
@@ -71,11 +72,12 @@ func BenchmarkWriter(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
 	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 
 	run := func(b *testing.B, sink blockSink, numOfConcurrentWriter int) {
 		starter := make(chan struct{})
 
-		w := newWriter(sink)
+		w := newWriter(st, sink)
 
 		b.ResetTimer()
 		b.SetBytes(blockSize * entrySize)
@@ -148,4 +150,51 @@ func BenchmarkWriter(b *testing.B) {
 			}
 		})
 	}
+}
+
+type counterSink struct {
+	numOfRecord int
+}
+
+var _ blockSink = &counterSink{}
+
+func (c *counterSink) push(block *block) {
+	for i := 0; i < blockSize; i++ {
+		if !block[i].valid() {
+			break
+		}
+		c.numOfRecord++
+	}
+}
+
+func TestTxnIDCacheCanBeDisabledViaClusterSetting(t *testing.T) {
+	st := cluster.MakeTestingClusterSettings()
+	ctx := context.Background()
+
+	sink := &counterSink{}
+	w := newWriter(st, sink)
+	w.Record(ResolvedTxnID{
+		TxnID: uuid.FastMakeV4(),
+	})
+
+	w.Flush()
+	require.Equal(t, 1, sink.numOfRecord)
+
+	// This should disable txn id cache.
+	MaxSize.Override(ctx, &st.SV, 0)
+
+	w.Record(ResolvedTxnID{
+		TxnID: uuid.FastMakeV4(),
+	})
+	w.Flush()
+	require.Equal(t, 1, sink.numOfRecord)
+
+	// This should re-enable txn id cache.
+	MaxSize.Override(ctx, &st.SV, MaxSize.Default())
+
+	w.Record(ResolvedTxnID{
+		TxnID: uuid.FastMakeV4(),
+	})
+	w.Flush()
+	require.Equal(t, 2, sink.numOfRecord)
 }


### PR DESCRIPTION
Reviewer note: only last commit is relevant

---

Resolves #76329

Release note (sql change): when `sql.contention.txn_id_cache.max_size`
is set to 0, it would effectively turn off transaction ID cache.