### PR TITLE
coldata: prohibit Vec.Append from a vector into itself

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -309,6 +309,9 @@ func (b *Bytes) CopySlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
 // AppendSlice appends srcStartIdx inclusive and srcEndIdx exclusive []byte
 // values from src into the receiver starting at destIdx.
 func (b *Bytes) AppendSlice(src *Bytes, destIdx, srcStartIdx, srcEndIdx int) {
+	if b == src && srcStartIdx != srcEndIdx {
+		panic("AppendSlice when b == src is only supported when srcStartIdx == srcEndIdx")
+	}
 	if b.isWindow {
 		panic("AppendSlice is called on a window into Bytes")
 	}

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -117,6 +117,12 @@ func applyMethodsAndVerify(
 			}
 			continue
 		case copySlice, appendSlice:
+			if m == appendSlice && selfReferencingSources {
+				// AppendSlice with selfReferencingSources is only supported
+				// when srcStartIdx == srcEndIdx, so we skip this method to
+				// avoid whittling down our destination slice.
+				continue
+			}
 			// Generate a length-inclusive destIdx.
 			destIdx := rng.Intn(n + 1)
 			srcStartIdx := rng.Intn(sourceN)
@@ -136,10 +142,6 @@ func applyMethodsAndVerify(
 			} else {
 				b1.AppendSlice(b1Source, destIdx, srcStartIdx, srcEndIdx)
 				b2 = append(b2[:destIdx], b2Source[srcStartIdx:srcEndIdx]...)
-				if selfReferencingSources {
-					b1Source = b1
-					b2Source = b2
-				}
 				numNewVals = srcEndIdx - srcStartIdx
 			}
 			// Deep copy the copied/appended byte slices.

--- a/pkg/col/coldata/vec.go
+++ b/pkg/col/coldata/vec.go
@@ -95,9 +95,8 @@ type Vec interface {
 	// Vec.
 	// Refer to the SliceArgs comment for specifics and TestAppend for examples.
 	//
-	// NOTE: Append does *not* support the case of appending 0 values (i.e.
-	// the behavior of Append when args.SrcStartIdx == args.SrcEndIdx is
-	// undefined).
+	// Note: Append()'ing from a Vector into itself is only supported when
+	// args.SrcStartIdx == args.SrcEndIdx.
 	Append(SliceArgs)
 
 	// Copy uses SliceArgs to copy elements of a source Vec into this Vec. It is


### PR DESCRIPTION
Currently, `Vec.Append` works in cases when the destination and the
source vectors are the same; this, however, is not necessary since the
only production use of that method is in
`colexecutils.AppendOnlyBufferedBatch.AppendTuples`, and there we're
appending values from an input batch into the append-only batch. We also
have linters in place that prohibit the usage of `Vec.Append` in
production code outside of that single spot, so it's safe to prohibit
the self-referencing `Vec.Append`.

Release note: None