### PR TITLE
workload/schemachanger: fixes to get the workload stable

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -15,7 +15,6 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -22,7 +22,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -35,9 +34,6 @@ import (
 func TestWorkload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer utilccl.TestingEnableEnterprise()()
-
-	skip.WithIssue(t, 63226, "flaky test")
-	skip.UnderStressRace(t, "times out")
 
 	dir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err)

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -110,4 +110,5 @@ func TestWorkload(t *testing.T) {
 		g.Go(workerFn(gCtx, ql.WorkerFns[i]))
 	}
 	require.NoError(t, g.Wait())
+	ql.Close(ctx)
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -768,23 +768,54 @@ CREATE TABLE crdb_internal.jobs (
 
 		// We'll reuse this container on each loop.
 		container := make(tree.Datums, 0, 21)
+		sessionJobs := make([]*jobs.Record, 0, len(p.extendedEvalCtx.SchemaChangeJobRecords))
+		uniqueJobs := make(map[*jobs.Record]struct{})
+		for _, job := range p.extendedEvalCtx.SchemaChangeJobRecords {
+			if _, ok := uniqueJobs[job]; ok {
+				continue
+			}
+			sessionJobs = append(sessionJobs, job)
+			uniqueJobs[job] = struct{}{}
+		}
 		return func() (datums tree.Datums, e error) {
 			// Loop while we need to skip a row.
 			for {
 				ok, err := it.Next(ctx)
-				if !ok {
+				if err != nil {
 					return nil, err
 				}
-				r := it.Cur()
-				id, status, created, payloadBytes, progressBytes, sessionIDBytes, instanceID :=
-					r[0], r[1], r[2], r[3], r[4], r[5], r[6]
+				var id, status, created, payloadBytes, progressBytes, sessionIDBytes,
+					instanceID tree.Datum
+				lastRun, nextRun, numRuns := tree.DNull, tree.DNull, tree.DNull
+				if ok {
+					r := it.Cur()
+					id, status, created, payloadBytes, progressBytes, sessionIDBytes, instanceID =
+						r[0], r[1], r[2], r[3], r[4], r[5], r[6]
+					lastRun, numRuns, nextRun = r[7], r[8], r[9]
+				} else if !ok {
+					if len(sessionJobs) == 0 {
+						return nil, nil
+					}
+					job := sessionJobs[len(sessionJobs)-1]
+					sessionJobs = sessionJobs[:len(sessionJobs)-1]
+					// Convert the job into datums, where protobufs will be intentionally,
+					// marshalled.
+					id = tree.NewDInt(tree.DInt(job.JobID))
+					status = tree.NewDString(string(jobs.StatusPending))
+					created = tree.TimestampToInexactDTimestamp(p.txn.ReadTimestamp())
+					progressBytes, payloadBytes, err = getPayloadAndProgressFromJobsRecord(p, job)
+					if err != nil {
+						return nil, err
+					}
+					sessionIDBytes = tree.NewDBytes(tree.DBytes(p.extendedEvalCtx.SessionID.GetBytes()))
+					instanceID = tree.NewDInt(tree.DInt(p.extendedEvalCtx.ExecCfg.JobRegistry.ID()))
+				}
 
 				var jobType, description, statement, username, descriptorIDs, started, runningStatus,
 					finished, modified, fractionCompleted, highWaterTimestamp, errorStr, coordinatorID,
-					traceID, lastRun, nextRun, numRuns, executionErrors, executionEvents = tree.DNull, tree.DNull, tree.DNull,
+					traceID, executionErrors, executionEvents = tree.DNull, tree.DNull, tree.DNull,
 					tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull,
-					tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull,
-					tree.DNull, tree.DNull
+					tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull, tree.DNull
 
 				// Extract data from the payload.
 				payload, err := jobs.UnmarshalPayload(payloadBytes)
@@ -880,8 +911,6 @@ CREATE TABLE crdb_internal.jobs (
 						traceID = tree.NewDInt(tree.DInt(progress.TraceID))
 					}
 				}
-
-				lastRun, numRuns, nextRun = r[7], r[8], r[9]
 				if payload != nil {
 					executionErrors = jobs.FormatRetriableExecutionErrorLogToStringArray(
 						ctx, payload.RetriableExecutionFailureLog,
@@ -4459,6 +4488,32 @@ func (m marshaledJobMetadataMap) GetJobMetadata(
 	return md, nil
 }
 
+func getPayloadAndProgressFromJobsRecord(
+	p *planner, job *jobs.Record,
+) (progressBytes *tree.DBytes, payloadBytes *tree.DBytes, err error) {
+	progressMarshalled, err := protoutil.Marshal(&jobspb.Progress{
+		ModifiedMicros: p.txn.ReadTimestamp().GoTime().UnixMicro(),
+		Details:        jobspb.WrapProgressDetails(job.Progress),
+		RunningStatus:  string(job.RunningStatus),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	progressBytes = tree.NewDBytes(tree.DBytes(progressMarshalled))
+	payloadMarshalled, err := protoutil.Marshal(&jobspb.Payload{
+		Description:   job.Description,
+		Statement:     job.Statements,
+		UsernameProto: job.Username.EncodeProto(),
+		Details:       jobspb.WrapPayloadDetails(job.Details),
+		Noncancelable: job.NonCancelable,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	payloadBytes = tree.NewDBytes(tree.DBytes(payloadMarshalled))
+	return progressBytes, payloadBytes, nil
+}
+
 func collectMarshaledJobMetadataMap(
 	ctx context.Context, p *planner, acct *mon.BoundAccount, descs []catalog.Descriptor,
 ) (marshaledJobMetadataMap, error) {
@@ -4512,6 +4567,18 @@ func collectMarshaledJobMetadataMap(
 	}
 	if err := it.Close(); err != nil {
 		return nil, err
+	}
+	for _, record := range p.ExtendedEvalContext().SchemaChangeJobRecords {
+		progressBytes, payloadBytes, err := getPayloadAndProgressFromJobsRecord(p, record)
+		if err != nil {
+			return nil, err
+		}
+		mj := marshaledJobMetadata{
+			status:        tree.NewDString(string(record.RunningStatus)),
+			payloadBytes:  payloadBytes,
+			progressBytes: progressBytes,
+		}
+		m[record.JobID] = mj
 	}
 	return m, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -721,6 +721,12 @@ CREATE UNIQUE INDEX i_idx ON customers (i)
 statement ok
 CREATE UNIQUE INDEX n_idx ON customers (n)
 
+# Validate that pending jobs show within a transactions before its committed.
+query TTT
+SELECT status, started, job_type FROM crdb_internal.jobs WHERE status='pending'
+----
+pending    NULL                                    SCHEMA CHANGE
+
 statement error pgcode XXA00 violates unique constraint
 COMMIT
 

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -179,7 +179,7 @@ func RandColumnTypes(rng *rand.Rand, numCols int) []*types.T {
 // RandSortingType returns a column type which can be key-encoded.
 func RandSortingType(rng *rand.Rand) *types.T {
 	typ := RandType(rng)
-	for colinfo.MustBeValueEncoded(typ) {
+	for colinfo.MustBeValueEncoded(typ) || typ == types.Void {
 		typ = RandType(rng)
 	}
 	return typ

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/encoding",
-        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload",

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/encoding",
+        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload",

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -952,6 +952,16 @@ SELECT
 	)
 }
 
+// databaseHasMultiRegion determines whether the database is multi-region
+// enabled.
+func databaseIsMultiRegion(ctx context.Context, tx pgx.Tx) (bool, error) {
+	return scanBool(
+		ctx,
+		tx,
+		`SELECT EXISTS (SELECT * FROM [SHOW REGIONS FROM DATABASE])`,
+	)
+}
+
 // databaseHasRegionChange determines whether the database is currently undergoing
 // a region change.
 func databaseHasRegionChange(ctx context.Context, tx pgx.Tx) (bool, error) {

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -163,7 +163,7 @@ func colIsPrimaryKey(
 		FROM (
 			SELECT DISTINCT column_name
 				FROM information_schema.statistics
-			WHERE index_name = 'primary'
+			WHERE (index_name = 'primary' OR index_name LIKE '%pkey%')
 				AND table_schema = $1
 				AND table_name = $2
 				AND storing = 'NO'

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -807,15 +807,21 @@ func tableHasOngoingSchemaChanges(
 		ctx,
 		tx,
 		`
-		SELECT json_array_length(
-        crdb_internal.pb_to_json(
-            'cockroach.sql.sqlbase.Descriptor',
-            descriptor
-        )->'table'->'mutations'
-       )
-       > 0
-		FROM system.descriptor
-	  WHERE id = $1::REGCLASS
+SELECT
+	json_array_length(
+		COALESCE(
+			crdb_internal.pb_to_json(
+				'cockroach.sql.sqlbase.Descriptor',
+				descriptor
+			)->'table'->'mutations',
+			'[]'
+		)
+	)
+	> 0
+FROM
+	system.descriptor
+WHERE
+	id = $1::REGCLASS;
 		`,
 		tableName.String(),
 	)

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -271,6 +271,54 @@ func (og *operationGenerator) violatesUniqueConstraints(
 	return false, nil
 }
 
+// ErrSchemaChangesDisallowedDueToPkSwap is generated when schema changes are
+// disallowed on a table because PK swap is already in progress.
+var ErrSchemaChangesDisallowedDueToPkSwap = errors.New("not schema changes allowed on selected table due to PK swap")
+
+func (og *operationGenerator) tableHasPrimaryKeySwapActive(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) error {
+
+	indexName, err := og.scanStringArray(
+		ctx,
+		tx,
+		fmt.Sprintf(`
+SELECT array_agg(index_name)
+  FROM (
+		SELECT index_name
+		  FROM [SHOW INDEXES FROM %s]
+		 WHERE index_name LIKE '%%_pkey%%'
+		 LIMIT 1
+       );
+	`, tableName.String()),
+	)
+	if err != nil {
+		return err
+	}
+
+	allowed, err := og.scanBool(
+		ctx,
+		tx,
+		`
+SELECT count(*) > 0
+  FROM crdb_internal.schema_changes
+ WHERE type = 'INDEX'
+       AND table_id = $1::REGCLASS
+       AND  target_name = $2
+       AND direction = 'DROP';
+`,
+		tableName.String(),
+		indexName[0],
+	)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrSchemaChangesDisallowedDueToPkSwap
+	}
+	return nil
+}
+
 func (og *operationGenerator) violatesUniqueConstraintsHelper(
 	ctx context.Context,
 	tx pgx.Tx,

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -20,8 +20,10 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-func tableExists(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (bool, error) {
-	return scanBool(ctx, tx, `SELECT EXISTS (
+func (og *operationGenerator) tableExists(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
 	SELECT table_name
     FROM information_schema.tables 
    WHERE table_schema = $1
@@ -29,8 +31,10 @@ func tableExists(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (boo
    )`, tableName.Schema(), tableName.Object())
 }
 
-func viewExists(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (bool, error) {
-	return scanBool(ctx, tx, `SELECT EXISTS (
+func (og *operationGenerator) viewExists(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
 	SELECT table_name
     FROM information_schema.views 
    WHERE table_schema = $1
@@ -38,8 +42,10 @@ func viewExists(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (bool
    )`, tableName.Schema(), tableName.Object())
 }
 
-func sequenceExists(ctx context.Context, tx pgx.Tx, seqName *tree.TableName) (bool, error) {
-	return scanBool(ctx, tx, `SELECT EXISTS (
+func (og *operationGenerator) sequenceExists(
+	ctx context.Context, tx pgx.Tx, seqName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
 	SELECT sequence_name
     FROM information_schema.sequences
    WHERE sequence_schema = $1
@@ -47,10 +53,10 @@ func sequenceExists(ctx context.Context, tx pgx.Tx, seqName *tree.TableName) (bo
    )`, seqName.Schema(), seqName.Object())
 }
 
-func columnExistsOnTable(
+func (og *operationGenerator) columnExistsOnTable(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, `SELECT EXISTS (
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
 	SELECT column_name
     FROM information_schema.columns 
    WHERE table_schema = $1
@@ -59,14 +65,22 @@ func columnExistsOnTable(
    )`, tableName.Schema(), tableName.Object(), columnName)
 }
 
-func tableHasRows(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (bool, error) {
-	return scanBool(ctx, tx, fmt.Sprintf(`SELECT EXISTS (SELECT * FROM %s)`, tableName.String()))
+func (og *operationGenerator) tableHasRows(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, fmt.Sprintf(`SELECT EXISTS (SELECT * FROM %s)`, tableName.String()))
 }
 
-func scanBool(
+func (og *operationGenerator) scanBool(
 	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
 ) (b bool, err error) {
 	err = tx.QueryRow(ctx, query, args...).Scan(&b)
+	if err == nil {
+		og.LogQueryResults(
+			fmt.Sprintf("%q %q", query, args),
+			fmt.Sprintf("%t", b),
+		)
+	}
 	return b, errors.Wrapf(err, "scanBool: %q %q", query, args)
 }
 
@@ -77,16 +91,20 @@ func scanString(
 	return s, errors.Wrapf(err, "scanString: %q %q", query, args)
 }
 
-func schemaExists(ctx context.Context, tx pgx.Tx, schemaName string) (bool, error) {
-	return scanBool(ctx, tx, `SELECT EXISTS (
+func (og *operationGenerator) schemaExists(
+	ctx context.Context, tx pgx.Tx, schemaName string,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
 	SELECT schema_name
 		FROM information_schema.schemata
    WHERE schema_name = $1
 	)`, schemaName)
 }
 
-func tableHasDependencies(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (bool, error) {
-	return scanBool(ctx, tx, `
+func (og *operationGenerator) tableHasDependencies(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `
 	SELECT EXISTS(
         SELECT fd.descriptor_name
           FROM crdb_internal.forward_dependencies AS fd
@@ -104,7 +122,7 @@ func tableHasDependencies(ctx context.Context, tx pgx.Tx, tableName *tree.TableN
 	`, tableName.Object(), tableName.Schema())
 }
 
-func columnIsDependedOn(
+func (og *operationGenerator) columnIsDependedOn(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
 	// To see if a column is depended on, the ordinal_position of the column is looked up in
@@ -116,7 +134,7 @@ func columnIsDependedOn(
 	// stored as a list of numbers in a string, so SQL functions are used to parse these values
 	// into arrays. unnest is used to flatten rows with this column of array type into multiple rows,
 	// so performing unions and joins is easier.
-	return scanBool(ctx, tx, `SELECT EXISTS(
+	return og.scanBool(ctx, tx, `SELECT EXISTS(
 		SELECT source.column_id
 			FROM (
 			   SELECT DISTINCT column_id
@@ -155,10 +173,10 @@ func columnIsDependedOn(
 )`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
 }
 
-func colIsPrimaryKey(
+func (og *operationGenerator) colIsPrimaryKey(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
-	primaryColumns, err := scanStringArray(ctx, tx,
+	primaryColumns, err := og.scanStringArray(ctx, tx,
 		`SELECT array_agg(column_name)
 		FROM (
 			SELECT DISTINCT column_name
@@ -183,7 +201,7 @@ func colIsPrimaryKey(
 
 // valuesViolateUniqueConstraints determines if any unique constraints (including primary constraints)
 // will be violated upon inserting the specified rows into the specified table.
-func violatesUniqueConstraints(
+func (og *operationGenerator) violatesUniqueConstraints(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columns []string, rows [][]string,
 ) (bool, error) {
 
@@ -238,7 +256,7 @@ func violatesUniqueConstraints(
 		// will be inserted into the database.
 		previousRows := map[string]bool{}
 		for _, row := range rows {
-			violation, err := violatesUniqueConstraintsHelper(
+			violation, err := og.violatesUniqueConstraintsHelper(
 				ctx, tx, tableName, columns, constraint, row, previousRows,
 			)
 			if err != nil {
@@ -253,7 +271,7 @@ func violatesUniqueConstraints(
 	return false, nil
 }
 
-func violatesUniqueConstraintsHelper(
+func (og *operationGenerator) violatesUniqueConstraintsHelper(
 	ctx context.Context,
 	tx pgx.Tx,
 	tableName *tree.TableName,
@@ -309,7 +327,7 @@ func violatesUniqueConstraintsHelper(
 	previousRows[queryString] = true
 
 	// Check for uniqueness against rows in the database.
-	exists, err := scanBool(ctx, tx, queryString)
+	exists, err := og.scanBool(ctx, tx, queryString)
 	if err != nil {
 		return false, err
 	}
@@ -342,10 +360,10 @@ func scanStringArrayRows(
 	return results, nil
 }
 
-func indexExists(
+func (og *operationGenerator) indexExists(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, indexName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, `SELECT EXISTS(
+	return og.scanBool(ctx, tx, `SELECT EXISTS(
 			SELECT *
 			  FROM information_schema.statistics
 			 WHERE table_schema = $1
@@ -354,16 +372,22 @@ func indexExists(
   )`, tableName.Schema(), tableName.Object(), indexName)
 }
 
-func scanStringArray(
+func (og *operationGenerator) scanStringArray(
 	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
 ) (b []string, err error) {
 	err = tx.QueryRow(ctx, query, args...).Scan(&b)
+	if err == nil {
+		og.LogQueryResultArray(
+			fmt.Sprintf("%q %q", query, args),
+			b,
+		)
+	}
 	return b, errors.Wrapf(err, "scanStringArray %q %q", query, args)
 }
 
 // canApplyUniqueConstraint checks if the rows in a table are unique with respect
 // to the specified columns such that a unique constraint can successfully be applied.
-func canApplyUniqueConstraint(
+func (og *operationGenerator) canApplyUniqueConstraint(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columns []string,
 ) (bool, error) {
 	columnNames := strings.Join(columns, ", ")
@@ -382,7 +406,7 @@ func canApplyUniqueConstraint(
 		}
 	}
 
-	return scanBool(ctx, tx,
+	return og.scanBool(ctx, tx,
 		fmt.Sprintf(`
 		SELECT (
 	       SELECT count(*)
@@ -401,20 +425,20 @@ func canApplyUniqueConstraint(
 
 }
 
-func columnContainsNull(
+func (og *operationGenerator) columnContainsNull(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, fmt.Sprintf(`SELECT EXISTS (
+	return og.scanBool(ctx, tx, fmt.Sprintf(`SELECT EXISTS (
 		SELECT %s
 		  FROM %s
 	   WHERE %s IS NULL
 	)`, columnName, tableName.String(), columnName))
 }
 
-func constraintIsPrimary(
+func (og *operationGenerator) constraintIsPrimary(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, constraintName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, fmt.Sprintf(`
+	return og.scanBool(ctx, tx, fmt.Sprintf(`
 	SELECT EXISTS(
 	        SELECT *
 	          FROM pg_catalog.pg_constraint
@@ -426,10 +450,10 @@ func constraintIsPrimary(
 }
 
 // Checks if a column has a single unique constraint.
-func columnHasSingleUniqueConstraint(
+func (og *operationGenerator) columnHasSingleUniqueConstraint(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
 	SELECT EXISTS(
 	        SELECT column_name
 	          FROM (
@@ -450,10 +474,10 @@ func columnHasSingleUniqueConstraint(
 	       )
 	`, tableName.Schema(), tableName.Object(), columnName)
 }
-func constraintIsUnique(
+func (og *operationGenerator) constraintIsUnique(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, constraintName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, fmt.Sprintf(`
+	return og.scanBool(ctx, tx, fmt.Sprintf(`
 	SELECT EXISTS(
 	        SELECT *
 	          FROM pg_catalog.pg_constraint
@@ -464,11 +488,11 @@ func constraintIsUnique(
 	`, tableName.String(), constraintName))
 }
 
-func columnIsStoredComputed(
+func (og *operationGenerator) columnIsStoredComputed(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
 	// Note that we COALESCE because the column may not exist.
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
 SELECT COALESCE(
         (
             SELECT attgenerated
@@ -481,11 +505,11 @@ SELECT COALESCE(
 `, tableName.String(), columnName)
 }
 
-func columnIsComputed(
+func (og *operationGenerator) columnIsComputed(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
 	// Note that we COALESCE because the column may not exist.
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
 SELECT COALESCE(
         (
             SELECT attgenerated
@@ -498,8 +522,10 @@ SELECT COALESCE(
 `, tableName.String(), columnName)
 }
 
-func constraintExists(ctx context.Context, tx pgx.Tx, constraintName string) (bool, error) {
-	return scanBool(ctx, tx, fmt.Sprintf(`
+func (og *operationGenerator) constraintExists(
+	ctx context.Context, tx pgx.Tx, constraintName string,
+) (bool, error) {
+	return og.scanBool(ctx, tx, fmt.Sprintf(`
 	SELECT EXISTS(
 	        SELECT *
 	          FROM pg_catalog.pg_constraint
@@ -508,7 +534,7 @@ func constraintExists(ctx context.Context, tx pgx.Tx, constraintName string) (bo
 	`, constraintName))
 }
 
-func rowsSatisfyFkConstraint(
+func (og *operationGenerator) rowsSatisfyFkConstraint(
 	ctx context.Context,
 	tx pgx.Tx,
 	parentTable *tree.TableName,
@@ -520,7 +546,7 @@ func rowsSatisfyFkConstraint(
 	if parentTable.Schema() == childTable.Schema() && parentTable.Object() == childTable.Object() && parentColumn.name == childColumn.name {
 		return true, nil
 	}
-	return scanBool(ctx, tx, fmt.Sprintf(`
+	return og.scanBool(ctx, tx, fmt.Sprintf(`
 	SELECT NOT EXISTS(
 	  SELECT *
 	    FROM %s as t1
@@ -531,7 +557,7 @@ func rowsSatisfyFkConstraint(
 }
 
 // violatesFkConstraints checks if the rows to be inserted will result in a foreign key violation.
-func violatesFkConstraints(
+func (og *operationGenerator) violatesFkConstraints(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columns []string, rows [][]string,
 ) (bool, error) {
 	fkConstraints, err := scanStringArrayRows(ctx, tx, fmt.Sprintf(`
@@ -585,7 +611,7 @@ func violatesFkConstraints(
 				continue
 			}
 
-			violation, err := violatesFkConstraintsHelper(
+			violation, err := og.violatesFkConstraintsHelper(
 				ctx, tx, columnNameToIndexMap, parentTableSchema, parentTableName, parentColumnName, childColumnName, row,
 			)
 			if err != nil {
@@ -603,7 +629,7 @@ func violatesFkConstraints(
 
 // violatesFkConstraintsHelper checks if a single row will violate a foreign key constraint
 // between the childColumn and parentColumn.
-func violatesFkConstraintsHelper(
+func (og *operationGenerator) violatesFkConstraintsHelper(
 	ctx context.Context,
 	tx pgx.Tx,
 	columnNameToIndexMap map[string]int,
@@ -617,7 +643,7 @@ func violatesFkConstraintsHelper(
 		return false, nil
 	}
 
-	return scanBool(ctx, tx, fmt.Sprintf(`
+	return og.scanBool(ctx, tx, fmt.Sprintf(`
 	SELECT NOT EXISTS (
 	    SELECT * from %s.%s
 	    WHERE %s = %s
@@ -625,10 +651,10 @@ func violatesFkConstraintsHelper(
 	`, parentTableSchema, parentTableName, parentColumn, childValue))
 }
 
-func columnIsInDroppingIndex(
+func (og *operationGenerator) columnIsInDroppingIndex(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
 SELECT EXISTS(
         SELECT index_id
           FROM (
@@ -665,11 +691,11 @@ const descriptorsAndConstraintMutationsCTE = `descriptors AS (
                                  WHERE (mut->'constraint') IS NOT NULL
                             )`
 
-func constraintInDroppingState(
+func (og *operationGenerator) constraintInDroppingState(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, constraintName string,
 ) (bool, error) {
 	// TODO(ajwerner): Figure out how to plumb the column name into this query.
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
   WITH `+descriptorsAndConstraintMutationsCTE+`
 SELECT true
        IN (
@@ -682,10 +708,10 @@ SELECT true
 `, tableName.String(), constraintName)
 }
 
-func columnNotNullConstraintInMutation(
+func (og *operationGenerator) columnNotNullConstraintInMutation(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
   WITH `+descriptorsAndConstraintMutationsCTE+`,
        col AS (
             SELECT (c->>'id')::INT8 AS id
@@ -704,10 +730,10 @@ SELECT EXISTS(
 `, tableName.String(), columnName)
 }
 
-func schemaContainsTypesWithCrossSchemaReferences(
+func (og *operationGenerator) schemaContainsTypesWithCrossSchemaReferences(
 	ctx context.Context, tx pgx.Tx, schemaName string,
 ) (bool, error) {
-	return scanBool(ctx, tx, `
+	return og.scanBool(ctx, tx, `
   WITH database_id AS (
                     SELECT id
                       FROM system.namespace
@@ -771,8 +797,10 @@ SELECT EXISTS(
 
 // enumMemberPresent determines whether val is a member of the enum.
 // This includes non-public members.
-func enumMemberPresent(ctx context.Context, tx pgx.Tx, enum string, val string) (bool, error) {
-	return scanBool(ctx, tx, `
+func (og *operationGenerator) enumMemberPresent(
+	ctx context.Context, tx pgx.Tx, enum string, val string,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `
 WITH enum_members AS (
 	SELECT
 				json_array_elements(
@@ -800,10 +828,10 @@ SELECT
 }
 
 // tableHasOngoingSchemaChanges returns whether the table has any mutations lined up.
-func tableHasOngoingSchemaChanges(
+func (og *operationGenerator) tableHasOngoingSchemaChanges(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
 ) (bool, error) {
-	return scanBool(
+	return og.scanBool(
 		ctx,
 		tx,
 		`
@@ -829,10 +857,10 @@ WHERE
 
 // tableHasOngoingAlterPKSchemaChanges checks whether a given table has an ALTER
 // PRIMARY KEY related change in progress.
-func tableHasOngoingAlterPKSchemaChanges(
+func (og *operationGenerator) tableHasOngoingAlterPKSchemaChanges(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
 ) (bool, error) {
-	return scanBool(
+	return og.scanBool(
 		ctx,
 		tx,
 		`
@@ -874,8 +902,10 @@ SELECT
 // table. This column is either the tree.RegionalByRowRegionDefaultCol column,
 // or the column specified in the AS clause. This function asserts if the
 // supplied table is not REGIONAL BY ROW.
-func getRegionColumn(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (string, error) {
-	isTableRegionalByRow, err := tableIsRegionalByRow(ctx, tx, tableName)
+func (og *operationGenerator) getRegionColumn(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (string, error) {
+	isTableRegionalByRow, err := og.tableIsRegionalByRow(ctx, tx, tableName)
 	if err != nil {
 		return "", err
 	}
@@ -919,8 +949,10 @@ FROM
 }
 
 // tableIsRegionalByRow checks whether the given table is a REGIONAL BY ROW table.
-func tableIsRegionalByRow(ctx context.Context, tx pgx.Tx, tableName *tree.TableName) (bool, error) {
-	return scanBool(
+func (og *operationGenerator) tableIsRegionalByRow(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(
 		ctx,
 		tx,
 		`
@@ -954,8 +986,8 @@ SELECT
 
 // databaseHasMultiRegion determines whether the database is multi-region
 // enabled.
-func databaseIsMultiRegion(ctx context.Context, tx pgx.Tx) (bool, error) {
-	return scanBool(
+func (og *operationGenerator) databaseIsMultiRegion(ctx context.Context, tx pgx.Tx) (bool, error) {
+	return og.scanBool(
 		ctx,
 		tx,
 		`SELECT EXISTS (SELECT * FROM [SHOW REGIONS FROM DATABASE])`,
@@ -964,8 +996,10 @@ func databaseIsMultiRegion(ctx context.Context, tx pgx.Tx) (bool, error) {
 
 // databaseHasRegionChange determines whether the database is currently undergoing
 // a region change.
-func databaseHasRegionChange(ctx context.Context, tx pgx.Tx) (bool, error) {
-	isMultiRegion, err := scanBool(
+func (og *operationGenerator) databaseHasRegionChange(
+	ctx context.Context, tx pgx.Tx,
+) (bool, error) {
+	isMultiRegion, err := og.scanBool(
 		ctx,
 		tx,
 		`SELECT EXISTS (SELECT * FROM [SHOW REGIONS FROM DATABASE])`,
@@ -973,7 +1007,7 @@ func databaseHasRegionChange(ctx context.Context, tx pgx.Tx) (bool, error) {
 	if err != nil || !isMultiRegion {
 		return false, err
 	}
-	return scanBool(
+	return og.scanBool(
 		ctx,
 		tx,
 		`
@@ -1002,8 +1036,10 @@ SELECT EXISTS (
 // databaseHasRegionalByRowChange checks whether a given database has any tables
 // which are currently undergoing a change to or from REGIONAL BY ROW, or
 // REGIONAL BY ROW tables with schema changes on it.
-func databaseHasRegionalByRowChange(ctx context.Context, tx pgx.Tx) (bool, error) {
-	return scanBool(
+func (og *operationGenerator) databaseHasRegionalByRowChange(
+	ctx context.Context, tx pgx.Tx,
+) (bool, error) {
+	return og.scanBool(
 		ctx,
 		tx,
 		`

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -869,7 +869,6 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 	duplicateRegionColumn := false
 	nonIndexableType := false
 	def.Columns = make(tree.IndexElemList, 1+og.randIntn(len(columnNames)))
-	implicitlyIndex := false
 	for i := range def.Columns {
 		def.Columns[i].Column = tree.Name(columnNames[i].name)
 		def.Columns[i].Direction = tree.Direction(og.randIntn(1 + int(tree.Descending)))
@@ -893,14 +892,6 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 			if !colinfo.ColumnTypeIsIndexable(columnNames[i].typ) {
 				nonIndexableType = true
 			}
-		}
-
-		colUsedInPrimaryIdx, err := og.colIsPrimaryKey(ctx, tx, tableName, columnNames[i].name)
-		if err != nil {
-			return "", err
-		}
-		if colUsedInPrimaryIdx {
-			implicitlyIndex = true
 		}
 	}
 
@@ -991,7 +982,6 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 			{code: pgcode.FeatureNotSupported, condition: duplicateRegionColumn},
 			{code: pgcode.Uncategorized, condition: virtualComputedStored},
 			{code: pgcode.FeatureNotSupported, condition: hasAlterPKSchemaChange},
-			{code: pgcode.DuplicateColumn, condition: implicitlyIndex},
 		}.add(og.expectedExecErrors)
 	}
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -240,7 +240,6 @@ func (og *operationGenerator) randOp(ctx context.Context, tx pgx.Tx) (stmt strin
 			if errors.Is(err, pgx.ErrNoRows) {
 				continue
 			}
-
 			return "", err
 		}
 		// Screen for schema change after write in the same transaction.
@@ -829,6 +828,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 	duplicateRegionColumn := false
 	nonIndexableType := false
 	def.Columns = make(tree.IndexElemList, 1+og.randIntn(len(columnNames)))
+	implicitlyIndex := false
 	for i := range def.Columns {
 		def.Columns[i].Column = tree.Name(columnNames[i].name)
 		def.Columns[i].Direction = tree.Direction(og.randIntn(1 + int(tree.Descending)))
@@ -852,6 +852,14 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 			if !colinfo.ColumnTypeIsIndexable(columnNames[i].typ) {
 				nonIndexableType = true
 			}
+		}
+
+		colUsedInPrimaryIdx, err := colIsPrimaryKey(ctx, tx, tableName, columnNames[i].name)
+		if err != nil {
+			return "", err
+		}
+		if colUsedInPrimaryIdx {
+			implicitlyIndex = true
 		}
 	}
 
@@ -942,6 +950,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 			{code: pgcode.FeatureNotSupported, condition: duplicateRegionColumn},
 			{code: pgcode.Uncategorized, condition: virtualComputedStored},
 			{code: pgcode.FeatureNotSupported, condition: hasAlterPKSchemaChange},
+			{code: pgcode.DuplicateColumn, condition: implicitlyIndex},
 		}.add(og.expectedExecErrors)
 	}
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -453,7 +453,11 @@ func (og *operationGenerator) alterTableLocality(ctx context.Context, tx pgx.Tx)
 	if err != nil {
 		return "", err
 	}
-	if hasSchemaChange || databaseHasRegionChange {
+	databaseHasMultiRegion, err := databaseIsMultiRegion(ctx, tx)
+	if err != nil {
+		return "", err
+	}
+	if hasSchemaChange || databaseHasRegionChange || !databaseHasMultiRegion {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return `ALTER TABLE invalid_table SET LOCALITY REGIONAL BY ROW`, nil
 	}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -267,6 +267,11 @@ func (og *operationGenerator) randOp(ctx context.Context, tx pgx.Tx) (stmt strin
 			if errors.Is(err, pgx.ErrNoRows) {
 				continue
 			}
+			// Table select had a primary key swap, so no statement
+			// generated.
+			if errors.Is(err, ErrSchemaChangesDisallowedDueToPkSwap) {
+				continue
+			}
 			return "", err
 		}
 		// Screen for schema change after write in the same transaction.
@@ -314,6 +319,10 @@ func (og *operationGenerator) addColumn(ctx context.Context, tx pgx.Tx) (string,
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s ADD COLUMN IrrelevantColumnName string`, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	columnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(false))
@@ -396,6 +405,10 @@ func (og *operationGenerator) addUniqueConstraint(ctx context.Context, tx pgx.Tx
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s ADD CONSTRAINT IrrelevantConstraintName UNIQUE (IrrelevantColumnName)`, tableName), nil
 	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
+	}
 
 	columnForConstraint, err := og.randColumnWithMeta(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
@@ -462,6 +475,10 @@ func (og *operationGenerator) alterTableLocality(ctx context.Context, tx pgx.Tx)
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s SET LOCALITY REGIONAL BY ROW`, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	databaseRegionNames, err := og.getDatabaseRegionNames(ctx, tx)
@@ -828,6 +845,10 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (strin
 			},
 		}
 		return tree.Serialize(def), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	columnNames, err := og.getTableColumns(ctx, tx, tableName.String(), true)
@@ -1374,6 +1395,10 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (string
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s DROP COLUMN "IrrelevantColumnName"`, tableName), nil
 	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
+	}
 
 	columnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
@@ -1424,6 +1449,10 @@ func (og *operationGenerator) dropColumnDefault(ctx context.Context, tx pgx.Tx) 
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "IrrelevantColumnName" DROP DEFAULT`, tableName), nil
 	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
+	}
 	columnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
 		return "", err
@@ -1450,6 +1479,10 @@ func (og *operationGenerator) dropColumnNotNull(ctx context.Context, tx pgx.Tx) 
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "IrrelevantColumnName" DROP NOT NULL`, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 	columnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
@@ -1495,6 +1528,10 @@ func (og *operationGenerator) dropColumnStored(ctx context.Context, tx pgx.Tx) (
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN IrrelevantColumnName DROP STORED`, tableName), nil
 	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
+	}
 
 	columnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
@@ -1531,6 +1568,10 @@ func (og *operationGenerator) dropConstraint(ctx context.Context, tx pgx.Tx) (st
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s DROP CONSTRAINT IrrelevantConstraintName`, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	constraintName, err := og.randConstraint(ctx, tx, tableName.String())
@@ -1583,6 +1624,10 @@ func (og *operationGenerator) dropIndex(ctx context.Context, tx pgx.Tx) (string,
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`DROP INDEX %s@"IrrelevantIndexName"`, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	indexName, err := og.randIndex(ctx, tx, *tableName, og.pctExisting(true))
@@ -1718,6 +1763,10 @@ func (og *operationGenerator) renameColumn(ctx context.Context, tx pgx.Tx) (stri
 		return fmt.Sprintf(`ALTER TABLE %s RENAME COLUMN "IrrelevantColumnName" TO "OtherIrrelevantName"`,
 			tableName), nil
 	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
+	}
 
 	srcColumnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
@@ -1766,6 +1815,10 @@ func (og *operationGenerator) renameIndex(ctx context.Context, tx pgx.Tx) (strin
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER INDEX %s@"IrrelevantConstraintName" RENAME TO "OtherConstraintName"`,
 			tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	srcIndexName, err := og.randIndex(ctx, tx, *tableName, og.pctExisting(true))
@@ -1859,6 +1912,12 @@ func (og *operationGenerator) renameTable(ctx context.Context, tx pgx.Tx) (strin
 	if err != nil {
 		return "", err
 	}
+	if srcTableExists {
+		err = og.tableHasPrimaryKeySwapActive(ctx, tx, srcTableName)
+		if err != nil {
+			return "", err
+		}
+	}
 
 	destSchemaExists, err := og.schemaExists(ctx, tx, destTableName.Schema())
 	if err != nil {
@@ -1951,6 +2010,10 @@ func (og *operationGenerator) setColumnDefault(ctx context.Context, tx pgx.Tx) (
 		return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN IrrelevantColumnName SET DEFAULT "IrrelevantValue"`,
 			tableName), nil
 	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
+	}
 
 	columnForDefault, err := og.randColumnWithMeta(ctx, tx, *tableName, og.pctExisting(true))
 	if err != nil {
@@ -2007,6 +2070,10 @@ func (og *operationGenerator) setColumnNotNull(ctx context.Context, tx pgx.Tx) (
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN IrrelevantColumnName SET NOT NULL`, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	columnName, err := og.randColumn(ctx, tx, *tableName, og.pctExisting(true))
@@ -2066,6 +2133,10 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (str
 	if !tableExists {
 		og.expectedExecErrors.add(pgcode.UndefinedTable)
 		return fmt.Sprintf(`%s ALTER TABLE %s ALTER COLUMN IrrelevantColumnName SET DATA TYPE IrrelevantDataType`, setSessionVariableString, tableName), nil
+	}
+	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
+	if err != nil {
+		return "", err
 	}
 
 	columnForTypeChange, err := og.randColumnWithMeta(ctx, tx, *tableName, og.pctExisting(true))

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -218,6 +218,9 @@ func (s *schemaChange) Ops(
 		s.workers = append(s.workers, w)
 
 		ql.WorkerFns = append(ql.WorkerFns, w.run)
+		ql.Close = func(ctx2 context.Context) {
+			pool.Close()
+		}
 	}
 	return ql, nil
 }


### PR DESCRIPTION
This pull request contains a number of fixes to get the schemachanger workload more stable

1. Fixes for various error conditions, where the schema changer workload was either expecting or not expecting correct errors
2. Additional logging for the schema changer workload to root cause errors
3. Removal of bad validation logic inside the schemachanger, which could lead to failures


Release justification: Low risk since we are only enabling a test again, which will find existing issues not create new ones.