### PR TITLE
ci,dev: allow injecting cockroach binary into `compose` tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/compose.sh
+++ b/build/teamcity/cockroach/nightlies/compose.sh
@@ -10,9 +10,16 @@ tc_start_block "Run compose tests"
 bazel build //pkg/cmd/bazci --config=ci
 BAZCI=$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci
 
-$BAZCI run --config=crosslinux --config=test --config=with_ui --artifacts_dir=$PWD/artifacts \
+bazel build //pkg/cmd/cockroach //pkg/compose/compare/compare:compare_test --config=ci --config=crosslinux --config=test --config=with_ui
+CROSSBIN=$(bazel info bazel-bin --config=ci --config=crosslinux --config=test --config=with_ui)
+COCKROACH=$CROSSBIN/pkg/cmd/cockroach/cockroach_/cockroach
+COMPAREBIN=$(bazel run //pkg/compose/compare/compare:compare_test --config=ci --config=crosslinux --config=test --config=with_ui --run_under=realpath | grep '^/' | tail -n1)
+
+$BAZCI run --config=ci --config=test --artifacts_dir=$PWD/artifacts \
        //pkg/compose:compose_test -- \
        --test_env=GO_TEST_WRAP_TESTV=1 \
+       --test_arg -cockroach --test_arg $COCKROACH \
+       --test_arg -compare --test_arg $COMPAREBIN \
        --test_timeout=1800
 
 tc_end_block "Run compose tests"

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -292,7 +292,7 @@ func (d *dev) getBasicBuildArgs(
 				typ := fields[0]
 				args = append(args, fullTargetName)
 				buildTargets = append(buildTargets, buildTarget{fullName: fullTargetName, kind: typ})
-				if typ == "go_test" {
+				if typ == "go_test" || typ == "go_transition_test" {
 					shouldBuildWithTestConfig = true
 				}
 			}

--- a/pkg/cmd/dev/testdata/datadriven/compose
+++ b/pkg/cmd/dev/testdata/datadriven/compose
@@ -1,9 +1,0 @@
-exec
-dev compose
-----
-bazel run //pkg/compose:compose_test --config=test
-
-exec
-dev compose --cpus 12 --short --timeout 1m -f TestComposeCompare
-----
-bazel run //pkg/compose:compose_test --config=test --local_cpu_resources=12 --test_filter=TestComposeCompare --test_arg -test.short --test_timeout=60


### PR DESCRIPTION
Same sort of thing we do in `acceptance`: build the `cockroach` and
`compare_test` binaries ahead of time and pass the locations to the
binaries as flags.

Release note: None