### PR TITLE
cmd/reduce: add -tlp option

### DIFF
--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -55,6 +55,7 @@ var (
 	unknown         = flags.Bool("unknown", false, "print unknown types during walk")
 	workers         = flags.Int("goroutines", goroutines, "number of worker goroutines (defaults to NumCPU/3")
 	chunkReductions = flags.Int("chunk", 0, "number of consecutive chunk reduction failures allowed before halting chunk reduction (default 0)")
+	tlp             = flags.Bool("tlp", false, "last two non-empty lines in file are equivalent queries returning different results")
 )
 
 const description = `
@@ -62,6 +63,10 @@ The reduce utility attempts to simplify SQL that produces an error in
 CockroachDB. The problematic SQL, specified via -file flag, is
 repeatedly reduced as long as it produces an error in the CockroachDB
 demo that matches the provided -contains regex.
+
+An alternative mode of operation is enabled by specifying -tlp option:
+in such case the last two queries in the file must be equivalent and
+produce different results.
 
 The following options are available:
 
@@ -83,12 +88,12 @@ func main() {
 		fmt.Printf("%s: -file must be provided\n\n", os.Args[0])
 		usage()
 	}
-	if *contains == "" {
-		fmt.Printf("%s: -contains must be provided\n\n", os.Args[0])
+	if *contains == "" && !*tlp {
+		fmt.Printf("%s: either -contains must be provided or -tlp flag specified\n\n", os.Args[0])
 		usage()
 	}
 	reducesql.LogUnknown = *unknown
-	out, err := reduceSQL(*binary, *contains, file, *workers, *verbose, *chunkReductions)
+	out, err := reduceSQL(*binary, *contains, file, *workers, *verbose, *chunkReductions, *tlp)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -96,8 +101,12 @@ func main() {
 }
 
 func reduceSQL(
-	binary, contains string, file *string, workers int, verbose bool, chunkReductions int,
+	binary, contains string, file *string, workers int, verbose bool, chunkReductions int, tlp bool,
 ) (string, error) {
+	const tlpFailureError = "TLP_FAILURE"
+	if tlp {
+		contains = tlpFailureError
+	}
 	containsRE, err := regexp.Compile(contains)
 	if err != nil {
 		return "", err
@@ -107,8 +116,57 @@ func reduceSQL(
 		return "", err
 	}
 
+	inputString := string(input)
+	var tlpCheck string
+
+	// If TLP check is requested, then we remove the last two queries from the
+	// input (each query is expected to be delimited by empty lines) which we
+	// use then to construct a special TLP check query that results in an error
+	// if two removed queries return different results.
+	//
+	// We do not just include the TLP check query into the input string because
+	// the reducer would then reduce the check query itself, making the
+	// reduction meaningless.
+	if tlp {
+		lines := strings.Split(string(input), "\n")
+		lineIdx := len(lines) - 1
+		// findPreviousQuery return the query preceding lineIdx without a
+		// semicolon. Queries are expected to be delimited with empty lines.
+		findPreviousQuery := func() string {
+			// Skip empty lines.
+			for lines[lineIdx] == "" {
+				lineIdx--
+			}
+			lastQueryLineIdx := lineIdx
+			// Now skip over all lines comprising the query.
+			for lines[lineIdx] != "" {
+				lineIdx--
+			}
+			// lineIdx right now points at an empty line before the query.
+			query := strings.Join(lines[lineIdx+1:lastQueryLineIdx+1], " ")
+			// Remove the semicolon.
+			return query[:len(query)-1]
+		}
+		partitioned := findPreviousQuery()
+		unpartitioned := findPreviousQuery()
+		inputString = strings.Join(lines[:lineIdx], "\n")
+		// tlpCheck is a query that will result in an error with tlpFailureError
+		// error message when unpartitioned and partitioned queries return
+		// different results (which is the case when there are rows in one
+		// result set that are not present in the other).
+		tlpCheck = fmt.Sprintf(`
+SELECT CASE
+  WHEN
+    (SELECT count(*) FROM ((%[1]s) EXCEPT ALL (%[2]s))) != 0
+  OR
+    (SELECT count(*) FROM ((%[2]s) EXCEPT ALL (%[1]s))) != 0
+  THEN
+    crdb_internal.force_error('', '%[3]s')
+  END;`, unpartitioned, partitioned, tlpFailureError)
+	}
+
 	// Pretty print the input so the file size comparison is useful.
-	inputSQL, err := reducesql.Pretty(string(input))
+	inputSQL, err := reducesql.Pretty(inputString)
 	if err != nil {
 		return "", err
 	}
@@ -117,6 +175,13 @@ func reduceSQL(
 	if verbose {
 		logger = log.New(os.Stderr, "", 0)
 		logger.Printf("input SQL pretty printed, %d bytes -> %d bytes\n", len(input), len(inputSQL))
+		if tlp {
+			prettyTLPCheck, err := reducesql.Pretty(tlpCheck)
+			if err != nil {
+				return "", err
+			}
+			logger.Printf("\nTLP check query:\n%s\n\n", prettyTLPCheck)
+		}
 	}
 
 	var chunkReducer reduce.ChunkReducer
@@ -137,6 +202,9 @@ func reduceSQL(
 		if !strings.HasSuffix(sql, ";") {
 			sql += ";"
 		}
+		// If -tlp was not specified, this is a noop, if it was specified, then
+		// we append the special TLP check query.
+		sql += tlpCheck
 		cmd.Stdin = strings.NewReader(sql)
 		out, err := cmd.CombinedOutput()
 		switch {


### PR DESCRIPTION
**cmd/reduce: remove stdin option and require -file argument**

We tend to not use the option of passing input SQL via stdin, so this
commit removes it. An additional argument in favor of doing that is that
the follow-up commit will introduce another mode of behavior that
requires `-file` argument to be specified, so it's just cleaner to
always require it now.

Release note: None

**cmd/reduce: add -tlp option**

This commit adds `-tlp` boolean flag that changes the behavior of
`reduce`. It is required that `-file` is specified whenever the `-tlp`
flag is used. The behavior is such that the last two queries (delimited
by empty lines) in the file contain unpartitioned and partitioned queries
that return different results although they are equivalent.

If TLP check is requested, then we remove the last two queries from the
input which we use then to construct a special TLP check query that
results in an error if two removed queries return different results.

We do not just include the TLP check query into the input string because
the reducer would then reduce the check query itself, making the
reduction meaningless.

Release note: None