### PR TITLE
build: display pebble git SHA in GitHub messages

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -20,8 +20,11 @@ bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 
-PEBBLE_SUM=$(grep 'version =' DEPS.bzl | cut -d'"' -f2)
-echo "Pebble module sum: $PEBBLE_SUM"
+# Use the Pebble SHA from the version in the modified DEPS.bzl file.
+# Note that we need to pluck the Git SHA from the go.sum-style version, i.e.
+# v0.0.0-20220214174839-6af77d5598c9SUM => 6af77d5598c9
+PEBBLE_SHA=$(grep 'version =' DEPS.bzl | cut -d'"' -f2 | cut -d'-' -f3)
+echo "Pebble module Git SHA: $PEBBLE_SHA"
 
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$PEBBLE_SUM -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$PEBBLE_SHA -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
                                run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh


### PR DESCRIPTION
Use the short from of the Git SHA from the go.mod-style version in
DEPS.bzl as the Pebble commit. This ensures that failure messages
created by Team City link to a GitHub page that renders correctly.

Release note: None