### PR TITLE
ccl/sqlproxyccl: replace ConnectionCopy logic in forwarder with interceptors

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -21,10 +21,12 @@ go_library(
     deps = [
         "//pkg/ccl/sqlproxyccl/denylist",
         "//pkg/ccl/sqlproxyccl/idle",
+        "//pkg/ccl/sqlproxyccl/interceptor",
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/sqlproxyccl/throttler",
         "//pkg/roachpb",
         "//pkg/security/certmgr",
+        "//pkg/sql/pgwire",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/util/contextutil",
         "//pkg/util/grpcutil",

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -9,6 +9,7 @@
 package sqlproxyccl
 
 import (
+	"bytes"
 	"context"
 	"net"
 	"testing"
@@ -185,4 +186,116 @@ func TestForwarder_Close(t *testing.T) {
 
 	f.Close()
 	require.EqualError(t, f.ctx.Err(), context.Canceled.Error())
+}
+
+func TestForwarder_setClientConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	f := &forwarder{serverConn: nil, serverInterceptor: nil}
+
+	w, r := net.Pipe()
+	defer w.Close()
+	defer r.Close()
+
+	f.setClientConn(r)
+	require.Equal(t, r, f.clientConn)
+
+	dst := new(bytes.Buffer)
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := f.clientInterceptor.ForwardMsg(dst)
+		errChan <- err
+	}()
+
+	_, err := w.Write((&pgproto3.Query{String: "SELECT 1"}).Encode(nil))
+	require.NoError(t, err)
+
+	// Block until message has been forwarded. This checks that we are creating
+	// our interceptor properly.
+	err = <-errChan
+	require.NoError(t, err)
+	require.Equal(t, 14, dst.Len())
+}
+
+func TestForwarder_setServerConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	f := &forwarder{serverConn: nil, serverInterceptor: nil}
+
+	w, r := net.Pipe()
+	defer w.Close()
+	defer r.Close()
+
+	f.setServerConn(r)
+	require.Equal(t, r, f.serverConn)
+
+	dst := new(bytes.Buffer)
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := f.serverInterceptor.ForwardMsg(dst)
+		errChan <- err
+	}()
+
+	_, err := w.Write((&pgproto3.ReadyForQuery{TxStatus: 'I'}).Encode(nil))
+	require.NoError(t, err)
+
+	// Block until message has been forwarded. This checks that we are creating
+	// our interceptor properly.
+	err = <-errChan
+	require.NoError(t, err)
+	require.Equal(t, 6, dst.Len())
+}
+
+func TestWrapClientToServerError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		input  error
+		output error
+	}{
+		// Nil errors.
+		{nil, nil},
+		{context.Canceled, nil},
+		{context.DeadlineExceeded, nil},
+		{errors.Mark(errors.New("foo"), context.Canceled), nil},
+		{errors.Wrap(context.DeadlineExceeded, "foo"), nil},
+		// Forwarding errors.
+		{errors.New("foo"), newErrorf(
+			codeClientDisconnected,
+			"copying from client to target server: foo",
+		)},
+	} {
+		err := wrapClientToServerError(tc.input)
+		if tc.output == nil {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, tc.output.Error())
+		}
+	}
+}
+
+func TestWrapServerToClientError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		input  error
+		output error
+	}{
+		// Nil errors.
+		{nil, nil},
+		{context.Canceled, nil},
+		{context.DeadlineExceeded, nil},
+		{errors.Mark(errors.New("foo"), context.Canceled), nil},
+		{errors.Wrap(context.DeadlineExceeded, "foo"), nil},
+		// Forwarding errors.
+		{errors.New("foo"), newErrorf(
+			codeBackendDisconnected,
+			"copying from target server to client: foo",
+		)},
+	} {
+		err := wrapServerToClientError(tc.input)
+		if tc.output == nil {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, tc.output.Error())
+		}
+	}
 }

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -326,8 +326,10 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 	}
 	var f *forwarder
 	defer func() {
-		// Only close crdbConn if the forwarder hasn't been started. When the
-		// forwarder has been created, crdbConn is owned by the forwarder.
+		// Only close crdbConn if the forwarder hasn't been started. We want
+		// this here to ensure that we close the idle monitor wrapped
+		// connection. If the forwarder has been created, crdbConn is owned by
+		// the forwarder.
 		if f == nil {
 			_ = crdbConn.Close()
 		}

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -279,7 +279,7 @@ func (c *conn) serveImpl(
 
 	var sentDrainSignal bool
 	// The net.Conn is switched to a conn that exits if the ctx is canceled.
-	c.conn = newReadTimeoutConn(c.conn, func() error {
+	c.conn = NewReadTimeoutConn(c.conn, func() error {
 		// If the context was canceled, it's time to stop reading. Either a
 		// higher-level server or the command processor have canceled us.
 		if ctx.Err() != nil {
@@ -1745,7 +1745,8 @@ type readTimeoutConn struct {
 	checkExitConds func() error
 }
 
-func newReadTimeoutConn(c net.Conn, checkExitConds func() error) net.Conn {
+// NewReadTimeoutConn wraps the given connection with a readTimeoutConn.
+func NewReadTimeoutConn(c net.Conn, checkExitConds func() error) net.Conn {
 	return &readTimeoutConn{
 		Conn:           c,
 		checkExitConds: checkExitConds,

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1120,7 +1120,7 @@ func TestReadTimeoutConnExits(t *testing.T) {
 			}
 			defer c.Close()
 
-			readTimeoutConn := newReadTimeoutConn(c, func() error { return ctx.Err() })
+			readTimeoutConn := NewReadTimeoutConn(c, func() error { return ctx.Err() })
 			// Assert that reads are performed normally.
 			readBytes := make([]byte, len(expectedRead))
 			if _, err := readTimeoutConn.Read(readBytes); err != nil {


### PR DESCRIPTION
#### pgwire: expose NewReadTimeoutConn to be used outside of the pgwire package

Previously, readTimeoutConn was only used within the pgwire package to read
messages from the client for the SQL server. We want this construct when
reading messages from clients within the sqlproxy as well. This commit exposes
the readTimeoutConn construct through NewReadTimeoutConn.

#### ccl/sqlproxyccl: replace ConnectionCopy logic in forwarder with interceptors

Previously, we were using io.Copy through ConnectionCopy to forward messages
between the client and SQL server. Now that the interceptors have been merged,
we will update the forwarder to use these interceptors instead of the old
approach.

There are a few notable changes in this commit:
1. We wrap clientConn with the a readTimeoutConn that was exposed in the
  previous commit. This allows us to unblock on Read whenever an activity
  occurs (e.g. context cancellation, and in the future, when transfer is
  requested).
2. There are two goroutines per connection within the forwarder: one for the
  request processor (client to server), and the other for the response
  processor (server to client).
3. We also removed unnecessary checks for codeExpiredClientConnection and
  codeIdleDisconnect errors when copying from server to client. These are
  already handled by the idle monitor's callback as well as the denylist
  watcher's callback. When those constructs were implemented back then, we
  did not remove them from ConnectionCopy.

We need to clean up error messages, and how we propagate them back to the
user because today we just close the connection without returning a response,
resulting in, I believe, a broken pipe error.

Release note: None
