### PR TITLE
ccl/sqlproxyccl: update PeekMsg to return message size instead of body size

### DIFF
--- a/pkg/ccl/sqlproxyccl/interceptor/backend_interceptor_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/backend_interceptor_test.go
@@ -45,7 +45,7 @@ func TestBackendInterceptor(t *testing.T) {
 		typ, size, err := bi.PeekMsg()
 		require.NoError(t, err)
 		require.Equal(t, pgwirebase.ClientMsgSimpleQuery, typ)
-		require.Equal(t, 9, size)
+		require.Equal(t, 14, size)
 
 		bi.Close()
 		typ, size, err = bi.PeekMsg()

--- a/pkg/ccl/sqlproxyccl/interceptor/base.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/base.go
@@ -11,6 +11,7 @@ package interceptor
 import (
 	"encoding/binary"
 	"io"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
@@ -85,9 +86,9 @@ func newPgInterceptor(src io.Reader, dst io.Writer, bufSize int) (*pgInterceptor
 
 // PeekMsg returns the header of the current pgwire message without advancing
 // the interceptor. On return, err == nil if and only if the entire header can
-// be read. Note that size corresponds to the body size, and does not account
-// for the size field itself. This will return ErrProtocolError if the packets
-// are malformed.
+// be read. The returned size corresponds to the entire message size, which
+// includes the header type and body length. This will return ErrProtocolError
+// if the packets are malformed.
 //
 // If the interceptor is closed, PeekMsg returns ErrInterceptorClosed.
 func (p *pgInterceptor) PeekMsg() (typ byte, size int, err error) {
@@ -103,12 +104,16 @@ func (p *pgInterceptor) PeekMsg() (typ byte, size int, err error) {
 	typ = p.buf[p.readPos]
 	size = int(binary.BigEndian.Uint32(p.buf[p.readPos+1:]))
 
-	// Size has to be at least itself based on pgwire's protocol.
-	if size < 4 {
+	// Size has to be at least itself based on pgwire's protocol. Theoretically,
+	// math.MaxInt32 is valid since the body's length is stored within 4 bytes,
+	// but we'll just enforce that for simplicity (because we're adding 1 below).
+	if size < 4 || size >= math.MaxInt32 {
 		return 0, 0, ErrProtocolError
 	}
 
-	return typ, size - 4, nil
+	// Add 1 to size to account for type. We don't need to add 4 (int length) to
+	// it because size is already inclusive of that.
+	return typ, size + 1, nil
 }
 
 // WriteMsg writes the given bytes to the writer dst. If err != nil and a Write
@@ -148,28 +153,27 @@ func (p *pgInterceptor) ReadMsg() (msg []byte, err error) {
 		return nil, ErrInterceptorClosed
 	}
 
-	// Peek header of the current message for body size.
+	// Peek header of the current message for message size.
 	_, size, err := p.PeekMsg()
 	if err != nil {
 		return nil, err
 	}
-	msgSizeBytes := pgHeaderSizeBytes + size
 
 	// Can the entire message fit into the buffer?
-	if msgSizeBytes <= len(p.buf) {
-		if err := p.ensureNextNBytes(msgSizeBytes); err != nil {
+	if size <= len(p.buf) {
+		if err := p.ensureNextNBytes(size); err != nil {
 			// Possibly due to a timeout or context cancellation.
 			return nil, err
 		}
 
 		// Return a slice to the internal buffer to avoid an allocation here.
-		retBuf := p.buf[p.readPos : p.readPos+msgSizeBytes]
-		p.readPos += msgSizeBytes
+		retBuf := p.buf[p.readPos : p.readPos+size]
+		p.readPos += size
 		return retBuf, nil
 	}
 
 	// Message cannot fit, so we will have to allocate.
-	msg = make([]byte, msgSizeBytes)
+	msg = make([]byte, size)
 
 	// Copy bytes which have already been read.
 	n := copy(msg, p.buf[p.readPos:p.writePos])
@@ -209,7 +213,7 @@ func (p *pgInterceptor) ForwardMsg() (n int, err error) {
 		return 0, ErrInterceptorClosed
 	}
 
-	// Retrieve header of the current message for body size.
+	// Retrieve header of the current message for message size.
 	_, size, err := p.PeekMsg()
 	if err != nil {
 		return 0, err
@@ -217,7 +221,7 @@ func (p *pgInterceptor) ForwardMsg() (n int, err error) {
 
 	// Handle overflows as current message may not fit in the current buffer.
 	startPos := p.readPos
-	endPos := startPos + pgHeaderSizeBytes + size
+	endPos := startPos + size
 	remainingBytes := 0
 	if endPos > p.writePos {
 		remainingBytes = endPos - p.writePos

--- a/pkg/ccl/sqlproxyccl/interceptor/frontend_interceptor_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/frontend_interceptor_test.go
@@ -45,7 +45,7 @@ func TestFrontendInterceptor(t *testing.T) {
 		typ, size, err := fi.PeekMsg()
 		require.NoError(t, err)
 		require.Equal(t, pgwirebase.ServerMsgReady, typ)
-		require.Equal(t, 1, size)
+		require.Equal(t, 6, size)
 
 		fi.Close()
 		typ, size, err = fi.PeekMsg()


### PR DESCRIPTION
Informs #76000. Follow-up to #76006.

Previously, PeekMsg was returning the body size (excluding header size), which
is a bit awkward from an API point of view because most callers of PeekMsg
immediately adds the header size to the returned size previously. This commit
cleans the API design up by making PeekMsg return the message size instead,
i.e. header inclusive. At the same time, returning the message size makes it
consistent with the ReadMsg API since that returns the entire message.

Release note: None