### PR TITLE
rowenc: fix splitting lookup rows into family spans in some cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -673,3 +673,33 @@ SELECT k FROM t47976 WHERE
   (a > 4 OR b <= 5.23 OR c IN (1, 2, 3)) AND
   (a = 12 OR b = 15.23 OR c = 14) AND
   (a > 58 OR b < 0 OR c >= 13)
+
+# Regression test for incorrectly splitting a lookup row (with NULL values not
+# in the lookup key) into family spans (#76289).
+statement ok
+CREATE TABLE t76289_1 (
+  pk1 DECIMAL NOT NULL, pk2 INT8 NOT NULL, c1 INT8, c2 INT8,
+  PRIMARY KEY (pk1, pk2),
+  UNIQUE (pk2),
+  FAMILY fam_c1 (c1), FAMILY fam_c2 (pk1, pk2, c2)
+);
+INSERT INTO t76289_1 (pk1, pk2, c1) VALUES (1:::DECIMAL, 0:::INT8, 0:::INT8);
+
+query I
+SELECT c2 FROM t76289_1 WHERE pk2 = 0;
+----
+NULL
+
+statement ok
+CREATE TABLE t76289_2 (
+  pk1 DECIMAL NOT NULL, pk2 INT8 NOT NULL, c1 INT8, c2 INT8,
+  PRIMARY KEY (pk1, pk2),
+  INDEX (pk2),
+  FAMILY fam_c1 (c1), FAMILY fam_c2 (pk1, pk2, c2)
+);
+INSERT INTO t76289_2 (pk1, pk2, c1) VALUES (1:::DECIMAL, 0:::INT8, 0:::INT8);
+
+query I
+SELECT c2 FROM t76289_2@t76289_2_pk2_idx WHERE pk2 = 0;
+----
+NULL

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -286,18 +286,16 @@ func NeededColumnFamilyIDs(
 			if nc.Contains(columnOrdinal) {
 				needed = true
 			}
-			if !columns[columnOrdinal].IsNullable() && (!indexedCols.Contains(columnOrdinal) ||
-				compositeCols.Contains(columnOrdinal) && !hasSecondaryEncoding) {
-				// The column is non-nullable and cannot be decoded from a different
-				// family, so this column family must have a KV entry for every row.
+			if !columns[columnOrdinal].IsNullable() && !indexedCols.Contains(columnOrdinal) {
+				// This column is non-nullable and is not indexed, thus, it must
+				// be stored in the value part of the KV entry. As a result,
+				// this column family is non-nullable too.
 				nullable = false
 			}
 		}
 		if needed {
 			neededFamilyIDs = append(neededFamilyIDs, family.ID)
-			if !nullable {
-				allFamiliesNullable = false
-			}
+			allFamiliesNullable = allFamiliesNullable && nullable
 		}
 		return nil
 	})


### PR DESCRIPTION
Previously, we could incorrectly calculate whether fetching a KV for
`FamilyID==0` is needed. The zeroth KV is always present, and we rely on
it to find NULL values in columns in other column families. Before this
patch we could "optimize" the behavior to not fetch the zeroth column
family with composite non-nullable columns when we need to lookup
nullable column families (families that only contain nullable columns);
as a result, the lookup could come back empty when those columns only
have NULLs.

Consider the following example:
```
CREATE TABLE t (
  pk1 DECIMAL NOT NULL, pk2 INT8 NOT NULL, c1 INT8, c2 INT8,
  PRIMARY KEY (pk1, pk2),
  UNIQUE (pk2),
  FAMILY fam_c1 (c1), FAMILY fam_c2 (pk1, pk2, c2)
);
INSERT INTO t (pk1, pk2, c1, c2) VALUES (1:::DECIMAL, 0:::INT8, 0:::INT8);
```
When the INSERT statement is evaluated, only a KV entry for `fam_c1` is
actually put into the KV layer (because the value part of `fam_c2`  - `c2`
column - is NULL).

Next, when evaluating a query `SELECT c2 FROM t WHERE pk2 = 0;`, we
first will scan the secondary unique index to fetch `/1/0` primary
key. Then, we'll do an index join against the primary key to fetch `c2`.
Before this patch, we would perform a Get of `/t/pk/1/0/1/1` (essentially
trying to read `c2` directly of `fam_c2` - `/1/1` suffix is the varlen
encoding of family ID 1); however, there is no such entry, so we would
mistakenly think that the row is absent and return no rows.

The problem was that we incorrectly determined `fam_c2` to be
non-nullable, so we assumed it to always have a KV entry if a row is
present. We made that determination based on the fact that `pk1` column
(which is non-nullable, indexed, and composite) must force the existence
of that KV entry because we're using the primary index encoding.

However, I think that reasoning is just bogus. Any column family should
be considered non-nullable IFF it has a non-nullable non-indexed column,
so this patch removes all the business about non-nullable, indexed,
composite columns. The zeroth column family is an exception that it is
always non-nullable.

Note that this patch makes us fetch more column families, so it should
not be a correctness regression although it could be a performance
regression if my reasoning is wrong.

With this change in place we now correctly perform a scan of
`/t/pk/1/{0-1}` span.

Fixes: #76289.

Release note (bug fix): Previously, CockroachDB could incorrectly not
return a row from a table with multiple column families when that row
contains a NULL value when a composite type (FLOAT, DECIMAL, COLLATED
STRING, or an arrays of such a type) is included in the PRIMARY KEY. For
the bug to occur composite column from the PRIMARY KEY must be included
in any column family other than the first one.