### PR TITLE
roachtest: ensure inconsistency avoids using encryption

### DIFF
--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -31,13 +31,14 @@ func registerInconsistency(r registry.Registry) {
 }
 
 func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
+	startOps := option.DefaultStartOpts()
 	// With encryption on, our attempt below to manually introduce an inconsistency
 	// will fail.
-	c.EncryptDefault(false)
+	startOps.RoachtestOpts.DontEncrypt = true
 
 	nodes := c.Range(1, 3)
 	c.Put(ctx, t.Cockroach(), "./cockroach", nodes)
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), nodes)
+	c.Start(ctx, t.L(), startOps, install.MakeClusterSettings(), nodes)
 
 	{
 		db := c.Conn(ctx, t.L(), 1)


### PR DESCRIPTION
Previously, the `inconsistency` roachtest, which does not work when
enterprise encryption is enabled, would sometimes reuse a cluster that
had randomly enabled encryption.  On the rare occasion that this would
occur, it would cause the test to fail.  This would frequently cause
nightly CI runs to fail.  This change fixes the issue by explicitly
marking the roachtest options to disable encryption for this test.

Fixes #70106.

Release note: None