### PR TITLE
kvserver: deflake TestStoreScanInconsistentResolvesIntents

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2091,6 +2091,7 @@ func TestStoreScanInconsistentResolvesIntents(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	var intercept atomic.Value
+	intercept.Store(uuid.Nil)
 	cfg := TestStoreConfig(nil)
 	cfg.TestingKnobs.EvalKnobs.TestingEvalFilter =
 		func(filterArgs kvserverbase.FilterArgs) *roachpb.Error {


### PR DESCRIPTION
We weren't initializing a variable using in the intercept until after
the interceptor could be invoked, leading to NPEs.

Fixes #76492.

Release note: None
