### PR TITLE
changefeedccl: allow users to alter changefeed options

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1258,6 +1258,7 @@ unreserved_keyword ::=
 	| 'UNCOMMITTED'
 	| 'UNKNOWN'
 	| 'UNLOGGED'
+	| 'UNSET'
 	| 'UNSPLIT'
 	| 'UNTIL'
 	| 'UPDATE'
@@ -2473,6 +2474,8 @@ alter_default_privileges_target_object ::=
 alter_changefeed_cmd ::=
 	'ADD' changefeed_targets
 	| 'DROP' changefeed_targets
+	| 'SET' kv_option_list
+	| 'UNSET' name_list
 
 alter_backup_cmd ::=
 	'ADD' backup_kms

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -66,7 +66,6 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/flowinfra",
-        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -11,15 +11,17 @@ package changefeedccl
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupresolver"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -28,11 +30,6 @@ import (
 
 func init() {
 	sql.AddPlanHook("alter changefeed", alterChangefeedPlanHook)
-}
-
-type alterChangefeedOpts struct {
-	AddTargets  []tree.TargetList
-	DropTargets []tree.TargetList
 }
 
 // alterChangefeedPlanHook implements sql.PlanHookFn.
@@ -67,7 +64,7 @@ func alterChangefeedPlanHook(
 			return err
 		}
 
-		details, ok := job.Details().(jobspb.ChangefeedDetails)
+		prevDetails, ok := job.Details().(jobspb.ChangefeedDetails)
 		if !ok {
 			return errors.Errorf(`job %d is not changefeed job`, jobID)
 		}
@@ -76,116 +73,188 @@ func alterChangefeedPlanHook(
 			return errors.Errorf(`job %d is not paused`, jobID)
 		}
 
-		var opts alterChangefeedOpts
-		for _, cmd := range alterChangefeedStmt.Cmds {
-			switch v := cmd.(type) {
-			case *tree.AlterChangefeedAddTarget:
-				opts.AddTargets = append(opts.AddTargets, v.Targets)
-			case *tree.AlterChangefeedDropTarget:
-				opts.DropTargets = append(opts.DropTargets, v.Targets)
-			}
+		// this CREATE CHANGEFEED node will be used to update the existing changefeed
+		newChangefeedStmt := &tree.CreateChangefeed{
+			SinkURI: tree.NewDString(prevDetails.SinkURI),
 		}
 
-		var initialHighWater hlc.Timestamp
+		optionsMap := make(map[string]tree.KVOption, len(prevDetails.Opts))
+
+		// pull the options that are set for the existing changefeed
+		for key, value := range prevDetails.Opts {
+			// There are some options (e.g. topics) that we set during the creation of
+			// a changefeed, but we do not allow these options to be set by the user.
+			// Hence, we can not include these options in our new CREATE CHANGEFEED
+			// statement.
+			if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
+				continue
+			}
+			existingOpt := tree.KVOption{Key: tree.Name(key)}
+			if len(value) > 0 {
+				existingOpt.Value = tree.NewDString(value)
+			}
+			optionsMap[key] = existingOpt
+		}
+
 		statementTime := hlc.Timestamp{
 			WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
 		}
 
-		if opts.AddTargets != nil {
-			var targetDescs []catalog.Descriptor
-
-			for _, targetList := range opts.AddTargets {
-				descs, err := getTableDescriptors(ctx, p, &targetList, statementTime, initialHighWater)
-				if err != nil {
-					return err
-				}
-				targetDescs = append(targetDescs, descs...)
-			}
-
-			newTargets, newTables, err := getTargetsAndTables(ctx, p, targetDescs, details.Opts)
-			if err != nil {
-				return err
-			}
-			// add old targets
-			for id, table := range details.Tables {
-				newTables[id] = table
-			}
-			details.Tables = newTables
-			details.TargetSpecifications = append(details.TargetSpecifications, newTargets...)
-
+		allDescs, err := backupresolver.LoadAllDescs(ctx, p.ExecCfg(), statementTime)
+		if err != nil {
+			return err
+		}
+		descResolver, err := backupresolver.NewDescriptorResolver(allDescs)
+		if err != nil {
+			return err
 		}
 
-		if opts.DropTargets != nil {
-			var targetDescs []catalog.Descriptor
+		newDescs := make(map[descpb.ID]*tree.UnresolvedName)
 
-			for _, targetList := range opts.DropTargets {
-				descs, err := getTableDescriptors(ctx, p, &targetList, statementTime, initialHighWater)
-				if err != nil {
-					return err
-				}
-				targetDescs = append(targetDescs, descs...)
-			}
+		for _, target := range AllTargets(prevDetails) {
+			desc := descResolver.DescByID[target.TableID]
+			newDescs[target.TableID] = tree.NewUnresolvedName(desc.GetName())
+		}
 
-			for _, desc := range targetDescs {
-				if table, isTable := desc.(catalog.TableDescriptor); isTable {
-					if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
+		for _, cmd := range alterChangefeedStmt.Cmds {
+			switch v := cmd.(type) {
+			case *tree.AlterChangefeedAddTarget:
+				for _, targetPattern := range v.Targets.Tables {
+					targetName, err := getTargetName(targetPattern)
+					if err != nil {
 						return err
 					}
-					delete(details.Tables, table.GetID())
+					found, _, desc, err := resolver.ResolveExisting(
+						ctx,
+						targetName.ToUnresolvedObjectName(),
+						descResolver,
+						tree.ObjectLookupFlags{},
+						p.CurrentDatabase(),
+						p.CurrentSearchPath(),
+					)
+					if err != nil {
+						return err
+					}
+					if !found {
+						return pgerror.Newf(pgcode.InvalidParameterValue, `target %q does not exist`, tree.ErrString(targetPattern))
+					}
+					newDescs[desc.GetID()] = tree.NewUnresolvedName(desc.GetName())
+				}
+			case *tree.AlterChangefeedDropTarget:
+				for _, targetPattern := range v.Targets.Tables {
+					targetName, err := getTargetName(targetPattern)
+					if err != nil {
+						return err
+					}
+					found, _, desc, err := resolver.ResolveExisting(
+						ctx,
+						targetName.ToUnresolvedObjectName(),
+						descResolver,
+						tree.ObjectLookupFlags{},
+						p.CurrentDatabase(),
+						p.CurrentSearchPath(),
+					)
+					if err != nil {
+						return err
+					}
+					if !found {
+						return pgerror.Newf(pgcode.InvalidParameterValue, `target %q does not exist`, tree.ErrString(targetPattern))
+					}
+					delete(newDescs, desc.GetID())
+				}
+			case *tree.AlterChangefeedSetOptions:
+				optsFn, err := p.TypeAsStringOpts(ctx, v.Options, changefeedbase.ChangefeedOptionExpectValues)
+				if err != nil {
+					return err
+				}
+
+				opts, err := optsFn()
+				if err != nil {
+					return err
+				}
+
+				for key, value := range opts {
+					if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
+						return pgerror.Newf(pgcode.InvalidParameterValue, `invalid option %q`, key)
+					}
+					if _, ok := changefeedbase.AlterChangefeedUnsupportedOptions[key]; ok {
+						return pgerror.Newf(pgcode.InvalidParameterValue, `cannot alter option %q`, key)
+					}
+					opt := tree.KVOption{Key: tree.Name(key)}
+					if len(value) > 0 {
+						opt.Value = tree.NewDString(value)
+					}
+					optionsMap[key] = opt
+				}
+			case *tree.AlterChangefeedUnsetOptions:
+				optKeys := v.Options.ToStrings()
+				for _, key := range optKeys {
+					if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
+						return pgerror.Newf(pgcode.InvalidParameterValue, `invalid option %q`, key)
+					}
+					if _, ok := changefeedbase.AlterChangefeedUnsupportedOptions[key]; ok {
+						return pgerror.Newf(pgcode.InvalidParameterValue, `cannot alter option %q`, key)
+					}
+					delete(optionsMap, key)
 				}
 			}
-
-			newTargetSpecifications := make([]jobspb.ChangefeedTargetSpecification, len(details.TargetSpecifications)-len(opts.DropTargets))
-			for _, ts := range details.TargetSpecifications {
-				if _, stillThere := details.Tables[ts.TableID]; stillThere {
-					newTargetSpecifications = append(newTargetSpecifications, ts)
-				}
-			}
-			details.TargetSpecifications = newTargetSpecifications
-
 		}
 
-		if len(details.Tables) == 0 {
-			return errors.Errorf("cannot drop all targets for changefeed job %d", jobID)
+		if len(newDescs) == 0 {
+			return pgerror.Newf(pgcode.InvalidParameterValue, "cannot drop all targets for changefeed job %d", jobID)
 		}
 
-		if err := validateSink(ctx, p, jobID, details, details.Opts); err != nil {
-			return err
+		for _, targetName := range newDescs {
+			newChangefeedStmt.Targets.Tables = append(newChangefeedStmt.Targets.Tables, targetName)
 		}
 
-		oldStmt, err := parser.ParseOne(job.Payload().Description)
+		for _, val := range optionsMap {
+			newChangefeedStmt.Options = append(newChangefeedStmt.Options, val)
+		}
+
+		sinkURIFn, err := p.TypeAsString(ctx, newChangefeedStmt.SinkURI, `ALTER CHANGEFEED`)
 		if err != nil {
 			return err
 		}
-		oldChangefeedStmt, ok := oldStmt.AST.(*tree.CreateChangefeed)
-		if !ok {
-			return errors.Errorf(`could not parse create changefeed statement for job %d`, jobID)
+
+		optsFn, err := p.TypeAsStringOpts(ctx, newChangefeedStmt.Options, changefeedbase.ChangefeedOptionExpectValues)
+		if err != nil {
+			return err
 		}
 
-		var targets tree.TargetList
-		for _, target := range details.Tables {
-			targetName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{}, tree.Name(target.StatementTimeName))
-			targets.Tables = append(targets.Tables, &targetName)
+		sinkURI, err := sinkURIFn()
+		if err != nil {
+			return err
 		}
 
-		oldChangefeedStmt.Targets = targets
-		jobDescription := tree.AsString(oldChangefeedStmt)
+		opts, err := optsFn()
+		if err != nil {
+			return err
+		}
+
+		jobRecord, err := createChangefeedJobRecord(
+			ctx,
+			p,
+			newChangefeedStmt,
+			sinkURI,
+			opts,
+			jobID,
+			``,
+		)
+		if err != nil {
+			return errors.Wrap(err, `failed to alter changefeed`)
+		}
+
+		newDetails := jobRecord.Details.(jobspb.ChangefeedDetails)
+
+		// We need to persist the statement time that was generated during the
+		// creation of the changefeed
+		newDetails.StatementTime = prevDetails.StatementTime
 
 		newPayload := job.Payload()
-		newPayload.Description = jobDescription
-		newPayload.Details = jobspb.WrapPayloadDetails(details)
-
-		finalDescs, err := getTableDescriptors(ctx, p, &targets, statementTime, initialHighWater)
-		if err != nil {
-			return err
-		}
-
-		newPayload.DescriptorIDs = func() (sqlDescIDs []descpb.ID) {
-			for _, desc := range finalDescs {
-				sqlDescIDs = append(sqlDescIDs, desc.GetID())
-			}
-			return sqlDescIDs
-		}()
+		newPayload.Details = jobspb.WrapPayloadDetails(newDetails)
+		newPayload.Description = jobRecord.Description
+		newPayload.DescriptorIDs = jobRecord.DescriptorIDs
 
 		err = p.ExecCfg().JobRegistry.UpdateJobWithTxn(ctx, jobID, p.ExtendedEvalContext().Txn, lockForUpdate, func(
 			txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
@@ -203,11 +272,24 @@ func alterChangefeedPlanHook(
 			return ctx.Err()
 		case resultsCh <- tree.Datums{
 			tree.NewDInt(tree.DInt(jobID)),
-			tree.NewDString(jobDescription),
+			tree.NewDString(jobRecord.Description),
 		}:
 			return nil
 		}
 	}
 
 	return fn, header, nil, false, nil
+}
+
+func getTargetName(targetPattern tree.TablePattern) (*tree.TableName, error) {
+	pattern, err := targetPattern.NormalizeTablePattern()
+	if err != nil {
+		return nil, err
+	}
+	targetName, ok := pattern.(*tree.TableName)
+	if !ok {
+		return nil, errors.Errorf(`CHANGEFEED cannot target %q`, tree.AsString(targetPattern))
+	}
+
+	return targetName, nil
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -233,3 +233,7 @@ var NoLongerExperimental = map[string]string{
 	DeprecatedSinkSchemeCloudStorageNodelocal: SinkSchemeCloudStorageNodelocal,
 	DeprecatedSinkSchemeCloudStorageS3:        SinkSchemeCloudStorageS3,
 }
+
+// AlterChangefeedUnsupportedOptions are changefeed options that we do not allow
+// users to alter
+var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan)

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -362,41 +362,51 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		feed, ok := foo.(cdctest.EnterpriseTestFeed)
 		require.True(t, ok)
 
-		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
-		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
-
-		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar`, feed.JobID()))
+		jobID := feed.JobID()
+		details, err := feed.Details()
+		require.NoError(t, err)
+		sinkURI := details.SinkURI
 
 		type row struct {
 			id             jobspb.JobID
+			description    string
 			SinkURI        string
 			FullTableNames []uint8
 			format         string
 			topics         string
 		}
 
-		var out row
+		obtainJobRowFn := func() row {
+			var out row
 
-		query := `SELECT job_id, sink_uri, full_table_names, format, IFNULL(topics, '') FROM [SHOW CHANGEFEED JOBS] ORDER BY sink_uri`
-		rowResults := sqlDB.Query(t, query)
+			query := fmt.Sprintf(
+				`SELECT job_id, description, sink_uri, full_table_names, format, IFNULL(topics, '') FROM [SHOW CHANGEFEED JOB %d]`,
+				jobID,
+			)
 
-		if !rowResults.Next() {
-			err := rowResults.Err()
-			if err != nil {
-				t.Fatalf("Error encountered while querying the next row: %v", err)
-			} else {
-				t.Fatalf("Expected more rows when querying and none found for query: %s", query)
+			rowResults := sqlDB.Query(t, query)
+			if !rowResults.Next() {
+				err := rowResults.Err()
+				if err != nil {
+					t.Fatalf("Error encountered while querying the next row: %v", err)
+				} else {
+					t.Fatalf("Expected more rows when querying and none found for query: %s", query)
+				}
 			}
-		}
-		err := rowResults.Scan(&out.id, &out.SinkURI, &out.FullTableNames, &out.format, &out.topics)
-		if err != nil {
-			t.Fatal(err)
+			err := rowResults.Scan(&out.id, &out.description, &out.SinkURI, &out.FullTableNames, &out.format, &out.topics)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			return out
 		}
 
-		details, err := feed.Details()
-		require.NoError(t, err)
-		sinkURI := details.SinkURI
-		jobID := feed.JobID()
+		sqlDB.Exec(t, `PAUSE JOB $1`, jobID)
+		waitForJobStatus(sqlDB, t, jobID, `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar`, jobID))
+
+		out := obtainJobRowFn()
 
 		topicsArr := strings.Split(out.topics, ",")
 		sort.Strings(topicsArr)
@@ -408,32 +418,26 @@ func TestShowChangefeedJobsAlterChangefeed(t *testing.T) {
 		require.Equal(t, "json", out.format, "Expected format:%s but found format:%s", "json", out.format)
 
 		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d DROP foo`, feed.JobID()))
-		rowResults = sqlDB.Query(t, query)
 
-		if !rowResults.Next() {
-			err := rowResults.Err()
-			if err != nil {
-				t.Fatalf("Error encountered while querying the next row: %v", err)
-			} else {
-				t.Fatalf("Expected more rows when querying and none found for query: %s", query)
-			}
-		}
-		err = rowResults.Scan(&out.id, &out.SinkURI, &out.FullTableNames, &out.format, &out.topics)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		details, err = feed.Details()
-		require.NoError(t, err)
-		sinkURI = details.SinkURI
-		jobID = feed.JobID()
+		out = obtainJobRowFn()
 
 		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/' WITH envelope = 'wrapped', format = 'json', on_error = 'fail', schema_change_events = 'default', schema_change_policy = 'backfill', virtual_columns = 'omitted'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description)
 		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
-		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar,foo", sortedTopics)
-		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.foo,d.public.bar}", string(out.FullTableNames))
+		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
+		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))
 		require.Equal(t, "json", out.format, "Expected format:%s but found format:%s", "json", out.format)
 
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d SET resolved = '5s'`, feed.JobID()))
+
+		out = obtainJobRowFn()
+
+		require.Equal(t, jobID, out.id, "Expected id:%d but found id:%d", jobID, out.id)
+		require.Equal(t, "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/' WITH envelope = 'wrapped', format = 'json', on_error = 'fail', resolved = '5s', schema_change_events = 'default', schema_change_policy = 'backfill', virtual_columns = 'omitted'", out.description, "Expected description:%s but found description:%s", "CREATE CHANGEFEED FOR TABLE bar INTO 'kafka://does.not.matter/'", out.description)
+		require.Equal(t, sinkURI, out.SinkURI, "Expected sinkUri:%s but found sinkUri:%s", sinkURI, out.SinkURI)
+		require.Equal(t, "bar", out.topics, "Expected topics:%s but found topics:%s", "bar", sortedTopics)
+		require.Equal(t, "{d.public.bar}", string(out.FullTableNames), "Expected fullTableNames:%s but found fullTableNames:%s", "{d.public.bar}", string(out.FullTableNames))
+		require.Equal(t, "json", out.format, "Expected format:%s but found format:%s", "json", out.format)
 	}
 
 	t.Run(`kafka`, kafkaTest(testFn))

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -887,7 +887,7 @@ func (u *sqlSymUnion) fetchCursor() *tree.FetchCursor {
 %token <str> TRACING
 
 %token <str> UNBOUNDED UNCOMMITTED UNION UNIQUE UNKNOWN UNLOGGED UNSPLIT
-%token <str> UPDATE UPSERT UNTIL USE USER USERS USING UUID
+%token <str> UPDATE UPSERT UNSET UNTIL USE USER USERS USING UUID
 
 %token <str> VALID VALIDATE VALUE VALUES VARBIT VARCHAR VARIADIC VIEW VARYING VIEWACTIVITY VIEWACTIVITYREDACTED
 %token <str> VIEWCLUSTERSETTING VIRTUAL VISIBLE VOTERS
@@ -4376,7 +4376,7 @@ explain_option_list:
 // %Help: ALTER CHANGEFEED - alter an existing changefeed
 // %Category: CCL
 // %Text:
-// ALTER CHANGEFEED <job_id> {{ADD|DROP} <targets...>}...
+// ALTER CHANGEFEED <job_id> {{ADD|DROP <targets...>} | SET <options...>}...
 alter_changefeed_stmt:
   ALTER CHANGEFEED a_expr alter_changefeed_cmds
   {
@@ -4410,6 +4410,18 @@ alter_changefeed_cmd:
   {
     $$.val = &tree.AlterChangefeedDropTarget{
       Targets: $2.targetList(),
+    }
+  }
+| SET kv_option_list
+  {
+    $$.val = &tree.AlterChangefeedSetOptions{
+      Options: $2.kvOptions(),
+    }
+  }
+| UNSET name_list
+  {
+    $$.val = &tree.AlterChangefeedUnsetOptions{
+      Options: $2.nameList(),
     }
   }
 
@@ -14110,6 +14122,7 @@ unreserved_keyword:
 | UNCOMMITTED
 | UNKNOWN
 | UNLOGGED
+| UNSET
 | UNSPLIT
 | UNTIL
 | UPDATE

--- a/pkg/sql/parser/testdata/alter_changefeed
+++ b/pkg/sql/parser/testdata/alter_changefeed
@@ -56,3 +56,76 @@ ALTER CHANGEFEED 123 ADD foo  DROP bar  ADD baz, qux  DROP quux -- normalized!
 ALTER CHANGEFEED (123) ADD (foo)  DROP (bar)  ADD (baz), (qux)  DROP (quux) -- fully parenthesized
 ALTER CHANGEFEED _ ADD foo  DROP bar  ADD baz, qux  DROP quux -- literals removed
 ALTER CHANGEFEED 123 ADD _  DROP _  ADD _, _  DROP _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 SET foo = 'bar'
+----
+ALTER CHANGEFEED 123 SET foo = 'bar'
+ALTER CHANGEFEED (123) SET foo = ('bar') -- fully parenthesized
+ALTER CHANGEFEED _ SET foo = '_' -- literals removed
+ALTER CHANGEFEED 123 SET _ = 'bar' -- identifiers removed
+
+
+parse
+ALTER CHANGEFEED 123 ADD foo SET bar = 'baz', qux = 'quux'
+----
+ALTER CHANGEFEED 123 ADD foo  SET bar = 'baz', qux = 'quux' -- normalized!
+ALTER CHANGEFEED (123) ADD (foo)  SET bar = ('baz'), qux = ('quux') -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo  SET bar = '_', qux = '_' -- literals removed
+ALTER CHANGEFEED 123 ADD _  SET _ = 'baz', _ = 'quux' -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 DROP foo SET bar = 'baz', qux = 'quux'
+----
+ALTER CHANGEFEED 123 DROP foo  SET bar = 'baz', qux = 'quux' -- normalized!
+ALTER CHANGEFEED (123) DROP (foo)  SET bar = ('baz'), qux = ('quux') -- fully parenthesized
+ALTER CHANGEFEED _ DROP foo  SET bar = '_', qux = '_' -- literals removed
+ALTER CHANGEFEED 123 DROP _  SET _ = 'baz', _ = 'quux' -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 SET foo = 'bar' ADD baz DROP qux
+----
+ALTER CHANGEFEED 123 SET foo = 'bar'  ADD baz  DROP qux -- normalized!
+ALTER CHANGEFEED (123) SET foo = ('bar')  ADD (baz)  DROP (qux) -- fully parenthesized
+ALTER CHANGEFEED _ SET foo = '_'  ADD baz  DROP qux -- literals removed
+ALTER CHANGEFEED 123 SET _ = 'bar'  ADD _  DROP _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo SET bar = 'baz', qux = 'quux' DROP corge
+----
+ALTER CHANGEFEED 123 ADD foo  SET bar = 'baz', qux = 'quux'  DROP corge -- normalized!
+ALTER CHANGEFEED (123) ADD (foo)  SET bar = ('baz'), qux = ('quux')  DROP (corge) -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo  SET bar = '_', qux = '_'  DROP corge -- literals removed
+ALTER CHANGEFEED 123 ADD _  SET _ = 'baz', _ = 'quux'  DROP _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 UNSET foo
+----
+ALTER CHANGEFEED 123 UNSET foo
+ALTER CHANGEFEED (123) UNSET foo -- fully parenthesized
+ALTER CHANGEFEED _ UNSET foo -- literals removed
+ALTER CHANGEFEED 123 UNSET _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo UNSET bar, baz
+----
+ALTER CHANGEFEED 123 ADD foo  UNSET bar, baz -- normalized!
+ALTER CHANGEFEED (123) ADD (foo)  UNSET bar, baz -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo  UNSET bar, baz -- literals removed
+ALTER CHANGEFEED 123 ADD _  UNSET _, _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 UNSET foo, bar ADD baz DROP qux
+----
+ALTER CHANGEFEED 123 UNSET foo, bar  ADD baz  DROP qux -- normalized!
+ALTER CHANGEFEED (123) UNSET foo, bar  ADD (baz)  DROP (qux) -- fully parenthesized
+ALTER CHANGEFEED _ UNSET foo, bar  ADD baz  DROP qux -- literals removed
+ALTER CHANGEFEED 123 UNSET _, _  ADD _  DROP _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo DROP bar SET baz = 'qux' UNSET quux, corge
+----
+ALTER CHANGEFEED 123 ADD foo  DROP bar  SET baz = 'qux'  UNSET quux, corge -- normalized!
+ALTER CHANGEFEED (123) ADD (foo)  DROP (bar)  SET baz = ('qux')  UNSET quux, corge -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo  DROP bar  SET baz = '_'  UNSET quux, corge -- literals removed
+ALTER CHANGEFEED 123 ADD _  DROP _  SET _ = 'qux'  UNSET _, _ -- identifiers removed

--- a/pkg/sql/sem/tree/alter_changefeed.go
+++ b/pkg/sql/sem/tree/alter_changefeed.go
@@ -46,11 +46,15 @@ type AlterChangefeedCmd interface {
 	alterChangefeedCmd()
 }
 
-func (*AlterChangefeedAddTarget) alterChangefeedCmd()  {}
-func (*AlterChangefeedDropTarget) alterChangefeedCmd() {}
+func (*AlterChangefeedAddTarget) alterChangefeedCmd()    {}
+func (*AlterChangefeedDropTarget) alterChangefeedCmd()   {}
+func (*AlterChangefeedSetOptions) alterChangefeedCmd()   {}
+func (*AlterChangefeedUnsetOptions) alterChangefeedCmd() {}
 
 var _ AlterChangefeedCmd = &AlterChangefeedAddTarget{}
 var _ AlterChangefeedCmd = &AlterChangefeedDropTarget{}
+var _ AlterChangefeedCmd = &AlterChangefeedSetOptions{}
+var _ AlterChangefeedCmd = &AlterChangefeedUnsetOptions{}
 
 // AlterChangefeedAddTarget represents an ADD <targets> command
 type AlterChangefeedAddTarget struct {
@@ -72,4 +76,26 @@ type AlterChangefeedDropTarget struct {
 func (node *AlterChangefeedDropTarget) Format(ctx *FmtCtx) {
 	ctx.WriteString(" DROP ")
 	ctx.FormatNode(&node.Targets.Tables)
+}
+
+// AlterChangefeedSetOptions represents an SET <options> command
+type AlterChangefeedSetOptions struct {
+	Options KVOptions
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterChangefeedSetOptions) Format(ctx *FmtCtx) {
+	ctx.WriteString(" SET ")
+	ctx.FormatNode(&node.Options)
+}
+
+// AlterChangefeedUnsetOptions represents an UNSET <options> command
+type AlterChangefeedUnsetOptions struct {
+	Options NameList
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterChangefeedUnsetOptions) Format(ctx *FmtCtx) {
+	ctx.WriteString(" UNSET ")
+	ctx.FormatNode(&node.Options)
 }


### PR DESCRIPTION
changefeedccl: allow users to alter changefeed options
with the ALTER CHANGEFEED statement

References #75895

Currently, with the ALTER CHANGEFEED statement users
can only add or drop targets from an existing
changefeed. In this PR, we would like to extend this
functionality so that an user can edit and unset
the options of an existing changefeed as well.
The syntax of this addition is the following:

ALTER CHANGEFEED <job_id> SET \<options\> UNSET <opt_list>

Note that the <options> must follow the same syntax
that is used when creating a changefeed with options.
In particular, if you would like to set an option
that requires a value, you must write

SET opt = 'value'

On the other hand, if you would like to set an
option that requires no value, you must write

SET opt

Furthermore, this PR allows users to unset options.
This can be achieved by writing

UNSET <opt_list>

Where <opt_list> is a list of options that you
would like to unset. For example, if we would like
to unset the diff and resolved options for
changefeed 123, we would achieve this by writing

ALTER CHANGEFEED 123 UNSET diff, resolved

Release note (enterprise change): Added support to
the ALTER CHANGEFEED statement so that users can edit
and unset the options of an existing changefeed. The
syntax of this addition is the following:

ALTER CHANGEFEED <job_id> SET \<options\> UNSET <opt_list>