### PR TITLE
[WIP] sql: capture index usage metrics in telemetry logging channel

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2305,6 +2305,32 @@ are automatically converted server-side.
 Events in this category are logged to the `TELEMETRY` channel.
 
 
+### `captured_index_usage_stats`
+
+An event of type `captured_index_usage_stats`
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TotalReadCount` | TotalReadCount is the number of times this index has been read from. | no |
+| `LastRead` | LastRead is the timestamp that this index was last being read from. | yes |
+| `TableID` | TableID is the ID of the table this index is created on. This is same as descpb.TableID and is unique within the cluster. | no |
+| `IndexID` | IndexID is the ID of the index within the scope of the given table. | no |
+| `DatabaseName` |  | yes |
+| `TableName` |  | yes |
+| `IndexName` |  | yes |
+| `IndexType` |  | yes |
+| `IsUnique` |  | no |
+| `IsInverted` |  | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+
 ### `sampled_query`
 
 An event of type `sampled_query` is the SQL query event logged to the telemetry channel. It

--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -77,6 +77,7 @@ server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number o
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted
 server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_sessions older than this duration are periodically purged
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
+sql.capture_index_usage_stats.telemetry.interval	string	0 */8 * * *	cron-tab interval to capture index usage statistics to the telemetry logging channel
 sql.contention.txn_id_cache.max_size	byte size	64 MiB	the maximum byte size TxnID cache will use
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed
 sql.cross_db_sequence_owners.enabled	boolean	false	if true, creating sequences owned by tables from other databases is allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -88,6 +88,7 @@
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>
 <tr><td><code>server.web_session.purge.ttl</code></td><td>duration</td><td><code>1h0m0s</code></td><td>if nonzero, entries in system.web_sessions older than this duration are periodically purged</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.capture_index_usage_stats.telemetry.interval</code></td><td>string</td><td><code>0 */8 * * *</code></td><td>cron-tab interval to capture index usage statistics to the telemetry logging channel</td></tr>
 <tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the maximum byte size TxnID cache will use</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>
 <tr><td><code>sql.cross_db_sequence_owners.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating sequences owned by tables from other databases is allowed</td></tr>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2914,6 +2914,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.assignment_cast"></a><code>crdb_internal.assignment_cast(val: anyelement, type: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used internally to perform assignment casts during mutations.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.capture_index_usage_stats"></a><code>crdb_internal.capture_index_usage_stats() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>This function is used to start a job to capture index usage statistics.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.check_consistency"></a><code>crdb_internal.check_consistency(stats_only: <a href="bool.html">bool</a>, start_key: <a href="bytes.html">bytes</a>, end_key: <a href="bytes.html">bytes</a>) &rarr; tuple{int AS range_id, bytes AS start_key, string AS start_key_pretty, string AS status, string AS detail}</code></td><td><span class="funcdesc"><p>Runs a consistency check on ranges touching the specified key range. an empty start or end key is treated as the minimum and maximum possible, respectively. stats_only should only be set to false when targeting a small number of ranges to avoid overloading the cluster. Each returned row contains the range ID, the status (a roachpb.CheckConsistencyResponse_Status), and verbose detail.</p>
 <p>Example usage:
 SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -842,6 +842,12 @@ message AutoSQLStatsCompactionDetails {
 message AutoSQLStatsCompactionProgress {
 }
 
+message CaptureIndexUsageStatsDetails {
+}
+
+message CaptureIndexUsageStatsProgress {
+}
+
 message RowLevelTTLDetails {
   uint32 table_id = 1 [
     (gogoproto.customname) = "TableID",
@@ -852,6 +858,7 @@ message RowLevelTTLDetails {
 
 message RowLevelTTLProgress {
 }
+
 
 message Payload {
   string description = 1;
@@ -900,6 +907,7 @@ message Payload {
     AutoSQLStatsCompactionDetails autoSQLStatsCompaction = 30;
     StreamReplicationDetails streamReplication = 33;
     RowLevelTTLDetails row_level_ttl = 34 [(gogoproto.customname)="RowLevelTTL"];
+    CaptureIndexUsageStatsDetails captureIndexUsageStats = 35;
   }
   reserved 26;
   // PauseReason is used to describe the reason that the job is currently paused
@@ -911,7 +919,7 @@ message Payload {
   // the jobs.execution_errors.max_entries cluster setting.
   repeated RetriableExecutionFailure retriable_execution_failure_log = 32;
 
-  // NEXT ID: 34.
+  // NEXT ID: 36.
 }
 
 message Progress {
@@ -938,6 +946,7 @@ message Progress {
     AutoSQLStatsCompactionProgress autoSQLStatsCompaction = 23;
     StreamReplicationProgress streamReplication = 24;
     RowLevelTTLProgress row_level_ttl = 25 [(gogoproto.customname)="RowLevelTTL"];
+    CaptureIndexUsageStatsProgress captureIndexUsageStats = 26;
   }
 
   uint64 trace_id = 21 [(gogoproto.nullable) = false, (gogoproto.customname) = "TraceID", (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb.TraceID"];
@@ -966,6 +975,7 @@ enum Type {
   AUTO_SQL_STATS_COMPACTION = 14 [(gogoproto.enumvalue_customname) = "TypeAutoSQLStatsCompaction"];
   STREAM_REPLICATION = 15 [(gogoproto.enumvalue_customname) = "TypeStreamReplication"];
   ROW_LEVEL_TTL = 16 [(gogoproto.enumvalue_customname) = "TypeRowLevelTTL"];
+  CAPTURE_INDEX_USAGE_STATS = 17 [(gogoproto.enumvalue_customname) = "TypeCaptureIndexUsageStats"];
 }
 
 message Job {

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -125,6 +125,8 @@ func DetailsType(d isPayload_Details) Type {
 		return TypeStreamReplication
 	case *Payload_RowLevelTTL:
 		return TypeRowLevelTTL
+	case *Payload_CaptureIndexUsageStats:
+		return TypeCaptureIndexUsageStats
 	default:
 		panic(errors.AssertionFailedf("Payload.Type called on a payload with an unknown details type: %T", d))
 	}
@@ -169,6 +171,8 @@ func WrapProgressDetails(details ProgressDetails) interface {
 		return &Progress_StreamReplication{StreamReplication: &d}
 	case RowLevelTTLProgress:
 		return &Progress_RowLevelTTL{RowLevelTTL: &d}
+	case CaptureIndexUsageStatsProgress:
+		return &Progress_CaptureIndexUsageStats{CaptureIndexUsageStats: &d}
 	default:
 		panic(errors.AssertionFailedf("WrapProgressDetails: unknown details type %T", d))
 	}
@@ -208,6 +212,8 @@ func (p *Payload) UnwrapDetails() Details {
 		return *d.StreamReplication
 	case *Payload_RowLevelTTL:
 		return *d.RowLevelTTL
+	case *Payload_CaptureIndexUsageStats:
+		return *d.CaptureIndexUsageStats
 	default:
 		return nil
 	}
@@ -247,6 +253,8 @@ func (p *Progress) UnwrapDetails() ProgressDetails {
 		return *d.StreamReplication
 	case *Progress_RowLevelTTL:
 		return *d.RowLevelTTL
+	case *Progress_CaptureIndexUsageStats:
+		return *d.CaptureIndexUsageStats
 	default:
 		return nil
 	}
@@ -299,6 +307,8 @@ func WrapPayloadDetails(details Details) interface {
 		return &Payload_StreamReplication{StreamReplication: &d}
 	case RowLevelTTLDetails:
 		return &Payload_RowLevelTTL{RowLevelTTL: &d}
+	case CaptureIndexUsageStatsDetails:
+		return &Payload_CaptureIndexUsageStats{CaptureIndexUsageStats: &d}
 	default:
 		panic(errors.AssertionFailedf("jobs.WrapPayloadDetails: unknown details type %T", d))
 	}
@@ -334,7 +344,7 @@ const (
 func (Type) SafeValue() {}
 
 // NumJobTypes is the number of jobs types.
-const NumJobTypes = 17
+const NumJobTypes = 18
 
 // MarshalJSONPB implements jsonpb.JSONPBMarshaller to  redact sensitive sink URI
 // parameters from ChangefeedDetails.

--- a/pkg/sql/capture_index_usage_stats.proto
+++ b/pkg/sql/capture_index_usage_stats.proto
@@ -1,0 +1,19 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+syntax = "proto3";
+package cockroach.sql;
+option go_package = "sql";
+
+// CaptureIndexUsageStatsExecutionArgs is the arguments to the scheduled
+// sql stats compactor. This is required to support SHOW SCHEDULE queries.
+message CaptureIndexUsageStatsExecutionArgs {
+
+}

--- a/pkg/sql/capture_index_usage_stats_controller.go
+++ b/pkg/sql/capture_index_usage_stats_controller.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+)
+
+// CaptureIndexUsageStatsController implements the SQL Stats subsystem control plane. This exposes
+// administrative interfaces that can be consumed by other parts of the database
+// (e.g. status server, builtins) to control the behavior of the SQL Stats
+// subsystem.
+type CaptureIndexUsageStatsController struct {
+	db *kv.DB
+	ie sqlutil.InternalExecutor
+	st *cluster.Settings
+}
+
+// NewCaptureIndexUsageStatsController returns a new instance of CaptureIndexUsageStatsController.
+func NewCaptureIndexUsageStatsController(
+	db *kv.DB,
+	ie sqlutil.InternalExecutor,
+	st *cluster.Settings,
+) *CaptureIndexUsageStatsController {
+	return &CaptureIndexUsageStatsController{
+		db: db,
+		ie: ie,
+		st: st,
+	}
+}
+
+// CreateCaptureIndexUsageStatsSchedule implements the tree.CaptureIndexUsageStatsController
+// interface.
+func (s CaptureIndexUsageStatsController) CreateCaptureIndexUsageStatsSchedule(ctx context.Context) error {
+	return s.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := CreateCaptureIndexUsageStatsScheduleJob(ctx, s.ie, txn, s.st)
+		return err
+	})
+}

--- a/pkg/sql/capture_index_usage_stats_job.go
+++ b/pkg/sql/capture_index_usage_stats_job.go
@@ -1,0 +1,472 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/errors"
+	pbtypes "github.com/gogo/protobuf/types"
+	"github.com/robfig/cron/v3"
+	"time"
+)
+
+// CaptureIndexUsageStatsInterval is the interval at which index
+// usage stats are exported to the telemetry logging channel.
+var CaptureIndexUsageStatsInterval = settings.RegisterValidatedStringSetting(
+	settings.TenantWritable,
+	"sql.capture_index_usage_stats.telemetry.interval",
+	"cron-tab interval to capture index usage statistics to the telemetry logging channel",
+	"0 */8 * * *", /* defaultValue */
+	func(_ *settings.Values, s string) error {
+		if _, err := cron.ParseStandard(s); err != nil {
+			return errors.Wrap(err, "invalid cron expression")
+		}
+		return nil
+	},
+).WithPublic()
+
+const captureIndexStatsScheduleLabel = "capture-index-stats-telemetry"
+
+//////////////////////////////////////
+//////// SCHEDULED JOB LOGIC	////////
+//////////////////////////////////////
+
+func init() {
+	jobs.RegisterConstructor(jobspb.TypeCaptureIndexUsageStats, func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
+		return &captureIndexUsageStatsResumer{
+			job: job,
+			st:  settings,
+		}
+	})
+
+	jobs.RegisterScheduledJobExecutorFactory(
+		tree.CaptureIndexUsageStatsExecutor.InternalName(),
+		func() (jobs.ScheduledJobExecutor, error) {
+			m := jobs.MakeExecutorMetrics(tree.CaptureIndexUsageStatsExecutor.InternalName())
+			return &captureIndexUsageStatsExecutor{
+				metrics: captureIndexUsageStatsMetrics{
+					ExecutorMetrics: &m,
+				},
+			}, nil
+		})
+}
+
+func CreateCaptureIndexUsageStatsScheduleJob(
+	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, st *cluster.Settings,
+) (*jobs.ScheduledJob, error) {
+	scheduleLabel := captureIndexStatsScheduleLabel
+
+	fmt.Println("CREATING SCHEDULE LOGGING JOB")
+
+	// Check for existing scheduled logging job.
+	scheduleExists, err := checkExistingCaptureIndexUsageStatsSchedule(ctx, ie, txn, scheduleLabel)
+	if err != nil {
+		return nil, err
+	}
+	if scheduleExists {
+		return nil, errors.Newf("creating multiple %s scheduled jobs is not allowed", scheduleLabel)
+	}
+
+	captureIndexUsageStatsScheduleJob := jobs.NewScheduledJob(scheduledjobs.ProdJobSchedulerEnv)
+	schedule := CaptureIndexUsageStatsInterval.Get(&st.SV)
+	if err := captureIndexUsageStatsScheduleJob.SetSchedule(schedule); err != nil {
+		return nil, err
+	}
+
+	captureIndexUsageStatsScheduleJob.SetScheduleDetails(jobspb.ScheduleDetails{
+		Wait:    jobspb.ScheduleDetails_SKIP,
+		OnError: jobspb.ScheduleDetails_RETRY_SCHED,
+	})
+
+	// TODO(thomas): is this ok
+	args, err := pbtypes.MarshalAny(&CaptureIndexUsageStatsExecutionArgs{})
+	if err != nil {
+		return nil, err
+	}
+	captureIndexUsageStatsScheduleJob.SetExecutionDetails(
+		tree.CaptureIndexUsageStatsExecutor.InternalName(),
+		jobspb.ExecutionArguments{Args: args},
+	)
+
+	captureIndexUsageStatsScheduleJob.SetScheduleLabel(scheduleLabel)
+	captureIndexUsageStatsScheduleJob.SetOwner(security.NodeUserName())
+
+	captureIndexUsageStatsScheduleJob.SetScheduleStatus(string(jobs.StatusPending))
+	if err := captureIndexUsageStatsScheduleJob.Create(ctx, ie, txn); err != nil {
+		return nil, err
+	}
+
+	return captureIndexUsageStatsScheduleJob, nil
+}
+
+func checkExistingCaptureIndexUsageStatsSchedule(
+	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, label string,
+) (exists bool, _ error) {
+	query := "SELECT count(*) FROM system.scheduled_jobs WHERE schedule_name = $1"
+
+	row, err := ie.QueryRowEx(ctx, "check-existing-sql-stats-schedule", txn,
+		sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+		query, label,
+	)
+
+	if err != nil {
+		return false /* exists */, err
+	}
+
+	if row == nil {
+		return false /* exists */, errors.AssertionFailedf("unexpected empty result when querying system.scheduled_job")
+	}
+
+	if len(row) != 1 {
+		return false /* exists */, errors.AssertionFailedf("unexpectedly received %d columns", len(row))
+	}
+
+	// Defensively check the count.
+	return tree.MustBeDInt(row[0]) > 0, nil /* err */
+}
+
+//////////////////////////////////
+//////// SYSTEM JOB LOGIC	////////
+//////////////////////////////////
+
+type captureIndexUsageStatsResumer struct {
+	job *jobs.Job
+	st  *cluster.Settings
+	sj  *jobs.ScheduledJob
+}
+
+// Pass linting (unused type).
+var _ jobs.Resumer = &captureIndexUsageStatsResumer{}
+
+func (r *captureIndexUsageStatsResumer) Resume(ctx context.Context, execCtx interface{}) error {
+	log.Infof(ctx, "starting capture of index usage stats job")
+	fmt.Println("starting capture of index usage stats job")
+	p := execCtx.(JobExecContext)
+	ie := p.ExecCfg().InternalExecutor
+
+	// Get all database names.
+	var allDatabaseNames []string
+	var ok bool
+	var expectedNumDatums = 1
+	it, err := ie.QueryIteratorEx(
+		ctx,
+		"get-all-db-names",
+		nil,
+		sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+		`SELECT database_name FROM [SHOW DATABASES]`,
+	)
+	if err != nil {
+		return err
+	}
+
+	// We have to make sure to close the iterator since we might return from the
+	// for loop early (before Next() returns false).
+	defer func() { err = errors.CombineErrors(err, it.Close()) }()
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		var row tree.Datums
+		if row = it.Cur(); row == nil {
+			return errors.New("unexpected null row while capturing index usage stats")
+		}
+		if row.Len() != expectedNumDatums {
+			return errors.Newf("expected %d columns, received %d while capturing index usage stats", expectedNumDatums, row.Len())
+		}
+
+		databaseName := string(tree.MustBeDString(row[0]))
+		allDatabaseNames = append(allDatabaseNames, databaseName)
+	}
+
+	// Capture index usage statistics for each database.
+	//var collectedCapturedIndexStats eventpb.CollectedCapturedIndexUsageStats
+	expectedNumDatums = 10
+	for _, databaseName := range allDatabaseNames {
+		// Omit index usage statistics of the 'system' database.
+		if databaseName == "system" {
+			continue
+		}
+		stmt := fmt.Sprintf(`
+		SELECT
+		'%s' as database_name,
+		 ti.descriptor_name as table_name,
+		 ti.descriptor_id as table_id,
+		 ti.index_name,
+		 ti.index_id,
+		 ti.index_type,
+		 ti.is_unique,
+		 ti.is_inverted,
+		 total_reads,
+		 last_read
+		FROM %s.crdb_internal.index_usage_statistics AS us
+		JOIN %s.crdb_internal.table_indexes ti
+		ON us.index_id = ti.index_id
+		 AND us.table_id = ti.descriptor_id
+		ORDER BY total_reads ASC;
+	`, databaseName, databaseName, databaseName)
+
+		it, err = ie.QueryIteratorEx(
+			ctx,
+			"capture-index-usage-stats",
+			nil,
+			sessiondata.InternalExecutorOverride{User: security.NodeUserName()},
+			stmt,
+		)
+		if err != nil {
+			return err
+		}
+
+		for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+			var row tree.Datums
+			if row = it.Cur(); row == nil {
+				return errors.New("unexpected null row while capturing index usage stats")
+			}
+
+			if row.Len() != expectedNumDatums {
+				return errors.Newf("expected %d columns, received %d while capturing index usage stats", expectedNumDatums, row.Len())
+			}
+
+			databaseName := tree.MustBeDString(row[0])
+			tableName := tree.MustBeDString(row[1])
+			tableID := tree.MustBeDInt(row[2])
+			indexName := tree.MustBeDString(row[3])
+			indexID := tree.MustBeDInt(row[4])
+			indexType := tree.MustBeDString(row[5])
+			isUnique := tree.MustBeDBool(row[6])
+			isInverted := tree.MustBeDBool(row[7])
+			totalReads := uint64(tree.MustBeDInt(row[8]))
+			lastRead := time.Time{}
+			if row[9] != tree.DNull {
+				lastRead = tree.MustBeDTimestampTZ(row[9]).Time
+			}
+
+			capturedIndexStats := &eventpb.CapturedIndexUsageStats{
+				TableID:        uint32(roachpb.TableID(tableID)),
+				IndexID:        uint32(roachpb.IndexID(indexID)),
+				TotalReadCount: totalReads,
+				LastRead:       lastRead.String(),
+				DatabaseName:   string(databaseName),
+				TableName:      string(tableName),
+				IndexName:      string(indexName),
+				IndexType:      string(indexType),
+				IsUnique:       bool(isUnique),
+				IsInverted:     bool(isInverted),
+			}
+
+			//collectedCapturedIndexStats.Stats = append(collectedCapturedIndexStats.Stats, capturedIndexStats)
+			log.StructuredEvent(ctx, capturedIndexStats)
+		}
+		err = it.Close()
+		if err != nil {
+			return err
+		}
+	}
+	//log.StructuredEvent(ctx, collectedCapturedIndexStats)
+	return nil
+}
+
+// OnFailOrCancel implements the jobs.Resumer interface.
+// TODO(thomas): using archer's fail/cancel logic. Not really sure what other cases we'd need to consider,
+// the logic seems like it would be applicable to most jobs.
+func (r *captureIndexUsageStatsResumer) OnFailOrCancel(ctx context.Context, execCtx interface{}) error {
+	p := execCtx.(JobExecContext)
+	execCfg := p.ExecCfg()
+	ie := execCfg.InternalExecutor
+	return r.maybeNotifyJobTerminated(ctx, ie, execCfg, jobs.StatusFailed)
+}
+
+// maybeNotifyJobTerminated will notify the job termination
+// (with termination status).
+// TODO(thomas): using archer's fail/cancel logic. Not really sure what other cases we'd need to consider,
+// the logic seems like it would be applicable to most jobs.
+func (r *captureIndexUsageStatsResumer) maybeNotifyJobTerminated(
+	ctx context.Context, ie sqlutil.InternalExecutor, exec *ExecutorConfig, status jobs.Status,
+) error {
+	log.Infof(ctx, "sql stats compaction job terminated with status = %s", status)
+	if r.sj != nil {
+		env := scheduledjobs.ProdJobSchedulerEnv
+		if knobs, ok := exec.DistSQLSrv.TestingKnobs.JobsTestingKnobs.(*jobs.TestingKnobs); ok {
+			if knobs.JobSchedulerEnv != nil {
+				env = knobs.JobSchedulerEnv
+			}
+		}
+		if err := jobs.NotifyJobTermination(
+			ctx, env, r.job.ID(), status, r.job.Details(), r.sj.ScheduleID(),
+			ie, nil /* txn */); err != nil {
+			return err
+		}
+
+		return nil
+	}
+	return nil
+}
+
+type captureIndexUsageStatsMetrics struct {
+	*jobs.ExecutorMetrics
+}
+
+var _ metric.Struct = &captureIndexUsageStatsMetrics{}
+
+// MetricStruct implements metric.Struct interface.
+func (m captureIndexUsageStatsMetrics) MetricStruct() {}
+
+// captureIndexUsageStatsExecutor is executed by scheduledjob subsystem
+// to launch captureIndexUsageStatsResumer through the job subsystem.
+type captureIndexUsageStatsExecutor struct {
+	metrics captureIndexUsageStatsMetrics
+}
+
+// Pass linting (unused type).
+var _ jobs.ScheduledJobExecutor = &captureIndexUsageStatsExecutor{}
+
+// Metrics implements jobs.ScheduledJobExecutor interface.
+func (e *captureIndexUsageStatsExecutor) Metrics() metric.Struct {
+	return e.metrics
+}
+
+// ExecuteJob implements the jobs.ScheduledJobExecutor interface.
+func (e *captureIndexUsageStatsExecutor) ExecuteJob(
+	ctx context.Context,
+	cfg *scheduledjobs.JobExecutionConfig,
+	env scheduledjobs.JobSchedulerEnv,
+	sj *jobs.ScheduledJob,
+	txn *kv.Txn,
+) error {
+	fmt.Println("executing capture index usage stats job")
+	if err := e.createCaptureIndexUsageStatsJob(ctx, cfg, sj, txn); err != nil {
+		e.metrics.NumFailed.Inc(1)
+	}
+	e.metrics.NumStarted.Inc(1)
+	return nil
+}
+
+func (e *captureIndexUsageStatsExecutor) createCaptureIndexUsageStatsJob(
+	ctx context.Context, cfg *scheduledjobs.JobExecutionConfig, sj *jobs.ScheduledJob, txn *kv.Txn,
+) error {
+	p, cleanup := cfg.PlanHookMaker("invoke-capture-index-usage-stats", txn, security.NodeUserName())
+	defer cleanup()
+
+	_, err :=
+		CreateCaptureIndexUsageStatsJob(ctx, &jobs.CreatedByInfo{
+			ID:   sj.ScheduleID(),
+			Name: jobs.CreatedByScheduledJobs,
+		}, txn, cfg.InternalExecutor, p.(*planner).ExecCfg().JobRegistry)
+
+	if err != nil {
+		return err
+	}
+	fmt.Println("Created capture index usage stats job")
+	return nil
+}
+
+// CreateCaptureIndexUsageStatsJob creates a system.jobs record if there is no other
+// logging jobs (under the same label) running. This is invoked by the
+// scheduled job Executor.
+// This function is exported for use by createCaptureIndexUsageStatsJob in the sql package,
+// as createCaptureIndexUsageStatsJob will have scope of planner, giving access to the job
+// registry.
+func CreateCaptureIndexUsageStatsJob(
+	ctx context.Context,
+	createdByInfo *jobs.CreatedByInfo,
+	txn *kv.Txn,
+	ie sqlutil.InternalExecutor,
+	jobRegistry *jobs.Registry,
+) (jobspb.JobID, error) {
+
+	// TODO(thomas): Check for an existing logging job with the same label
+	err := CheckExistingCaptureIndexUsageStatsJob(ctx, nil /* job */, ie, txn)
+	if err != nil {
+		return jobspb.InvalidJobID, err
+	}
+
+	record := jobs.Record{
+		Description: "Capture index usage statistics to telemetry logging channel",
+		Username:    security.NodeUserName(),
+		Details:     jobspb.CaptureIndexUsageStatsDetails{},
+		Progress:    jobspb.CaptureIndexUsageStatsProgress{},
+		CreatedBy:   createdByInfo,
+	}
+
+	jobID := jobRegistry.MakeJobID()
+	if _, err := jobRegistry.CreateAdoptableJobWithTxn(ctx, record, jobID, txn); err != nil {
+		return jobspb.InvalidJobID, err
+	}
+	return jobID, nil
+}
+
+// NotifyJobTermination implements the jobs.ScheduledJobExecutor interface.
+func (e *captureIndexUsageStatsExecutor) NotifyJobTermination(
+	ctx context.Context,
+	jobID jobspb.JobID,
+	jobStatus jobs.Status,
+	details jobspb.Details,
+	env scheduledjobs.JobSchedulerEnv,
+	sj *jobs.ScheduledJob,
+	ex sqlutil.InternalExecutor,
+	txn *kv.Txn,
+) error {
+	if jobStatus == jobs.StatusFailed {
+		jobs.DefaultHandleFailedRun(sj, "capturing index usage statistics job %d failed", jobID)
+		e.metrics.NumFailed.Inc(1)
+		return nil
+	}
+
+	if jobStatus == jobs.StatusSucceeded {
+		e.metrics.NumSucceeded.Inc(1)
+	}
+
+	sj.SetScheduleStatus(string(jobStatus))
+	return nil
+}
+
+// GetCreateScheduleStatement implements the jobs.ScheduledJobExecutor interface.
+func (e *captureIndexUsageStatsExecutor) GetCreateScheduleStatement(
+	ctx context.Context,
+	env scheduledjobs.JobSchedulerEnv,
+	txn *kv.Txn,
+	sj *jobs.ScheduledJob,
+	ex sqlutil.InternalExecutor,
+) (string, error) {
+	// TODO(thomas): get create schedule statement
+	return "SELECT crdb_internal.capture_index_usage_stats()", nil
+}
+
+// CheckExistingCaptureIndexUsageStatsJob checks for existing logging job
+// that are either PAUSED, CANCELED, or RUNNING. If so, it returns a
+// ErrConcurrentSQLStatsCompaction.
+func CheckExistingCaptureIndexUsageStatsJob(
+	ctx context.Context, job *jobs.Job, ie sqlutil.InternalExecutor, txn *kv.Txn,
+) error {
+	jobID := jobspb.InvalidJobID
+	if job != nil {
+		jobID = job.ID()
+	}
+	exists, err := jobs.RunningJobExists(ctx, jobID, ie, txn, func(payload *jobspb.Payload) bool {
+		return payload.Type() == jobspb.TypeCaptureIndexUsageStats
+	})
+
+	if err == nil && exists {
+		err = errors.New("another capture index usage stats job is running")
+	}
+	return err
+}

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -348,18 +348,19 @@ func (ds *ServerImpl) setupFlow(
 			Tracer:           ds.ServerConfig.Tracer,
 			// Most processors will override this Context with their own context in
 			// ProcessorBase. StartInternal().
-			Context:                   ctx,
-			Planner:                   &faketreeeval.DummyEvalPlanner{},
-			PrivilegedAccessor:        &faketreeeval.DummyPrivilegedAccessor{},
-			SessionAccessor:           &faketreeeval.DummySessionAccessor{},
-			ClientNoticeSender:        &faketreeeval.DummyClientNoticeSender{},
-			Sequence:                  &faketreeeval.DummySequenceOperators{},
-			Tenant:                    &faketreeeval.DummyTenantOperator{},
-			Regions:                   &faketreeeval.DummyRegionOperator{},
-			Txn:                       leafTxn,
-			SQLLivenessReader:         ds.ServerConfig.SQLLivenessReader,
-			SQLStatsController:        ds.ServerConfig.SQLStatsController,
-			IndexUsageStatsController: ds.ServerConfig.IndexUsageStatsController,
+			Context:                          ctx,
+			Planner:                          &faketreeeval.DummyEvalPlanner{},
+			PrivilegedAccessor:               &faketreeeval.DummyPrivilegedAccessor{},
+			SessionAccessor:                  &faketreeeval.DummySessionAccessor{},
+			ClientNoticeSender:               &faketreeeval.DummyClientNoticeSender{},
+			Sequence:                         &faketreeeval.DummySequenceOperators{},
+			Tenant:                           &faketreeeval.DummyTenantOperator{},
+			Regions:                          &faketreeeval.DummyRegionOperator{},
+			Txn:                              leafTxn,
+			SQLLivenessReader:                ds.ServerConfig.SQLLivenessReader,
+			SQLStatsController:               ds.ServerConfig.SQLStatsController,
+			CaptureIndexUsageStatsController: ds.ServerConfig.CapturedIndexUsageStatsController,
+			IndexUsageStatsController:        ds.ServerConfig.IndexUsageStatsController,
 		}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -162,6 +162,9 @@ type ServerConfig struct {
 	// introduce dependency on the sql package.
 	SQLStatsController tree.SQLStatsController
 
+	// CaptureIndexUsageStatsController
+	CapturedIndexUsageStatsController tree.CaptureIndexUsageStatsController
+
 	// IndexUsageStatsController is an interface used to reset index usage stats without
 	// the need to introduce dependency on the sql package.
 	IndexUsageStatsController tree.IndexUsageStatsController

--- a/pkg/sql/idxusage/index_usage_stats_controller.go
+++ b/pkg/sql/idxusage/index_usage_stats_controller.go
@@ -12,13 +12,12 @@ package idxusage
 
 import (
 	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 )
 
 // Controller implements the index usage stats subsystem control plane. This exposes
 // administrative interfaces that can be consumed by other parts of the database
-// (e.g. status server, builtins) to control the behavior of index usage stas
+// (e.g. status server, builtins) to control the behavior of index usage stats
 // subsystem.
 type Controller struct {
 	statusServer serverpb.SQLStatusServer

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -434,11 +434,13 @@ func internalExtendedEvalCtx(
 
 	var indexUsageStats *idxusage.LocalIndexUsageStats
 	var sqlStatsController tree.SQLStatsController
+	var capturedIndexUsageStatsController tree.CaptureIndexUsageStatsController
 	var indexUsageStatsController tree.IndexUsageStatsController
 	if execCfg.InternalExecutor != nil {
 		if execCfg.InternalExecutor.s != nil {
 			indexUsageStats = execCfg.InternalExecutor.s.indexUsageStats
 			sqlStatsController = execCfg.InternalExecutor.s.sqlStatsController
+			capturedIndexUsageStatsController = execCfg.InternalExecutor.s.captureIndexUsageStatsController
 			indexUsageStatsController = execCfg.InternalExecutor.s.indexUsageStatsController
 		} else {
 			// If the indexUsageStats is nil from the sql.Server, we create a dummy
@@ -448,22 +450,24 @@ func internalExtendedEvalCtx(
 				Setting: execCfg.Settings,
 			})
 			sqlStatsController = &persistedsqlstats.Controller{}
+			capturedIndexUsageStatsController = CaptureIndexUsageStatsController{}
 			indexUsageStatsController = &idxusage.Controller{}
 		}
 	}
 	ret := extendedEvalContext{
 		EvalContext: tree.EvalContext{
-			Txn:                       txn,
-			SessionDataStack:          sds,
-			TxnReadOnly:               false,
-			TxnImplicit:               true,
-			Context:                   ctx,
-			Mon:                       plannerMon,
-			TestingKnobs:              evalContextTestingKnobs,
-			StmtTimestamp:             stmtTimestamp,
-			TxnTimestamp:              txnTimestamp,
-			SQLStatsController:        sqlStatsController,
-			IndexUsageStatsController: indexUsageStatsController,
+			Txn:                              txn,
+			SessionDataStack:                 sds,
+			TxnReadOnly:                      false,
+			TxnImplicit:                      true,
+			Context:                          ctx,
+			Mon:                              plannerMon,
+			TestingKnobs:                     evalContextTestingKnobs,
+			StmtTimestamp:                    stmtTimestamp,
+			TxnTimestamp:                     txnTimestamp,
+			SQLStatsController:               sqlStatsController,
+			CaptureIndexUsageStatsController: capturedIndexUsageStatsController,
+			IndexUsageStatsController:        indexUsageStatsController,
 		},
 		Tracing:         &SessionTracing{},
 		Descs:           tables,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6492,6 +6492,30 @@ table's zone configuration this will return NULL.`,
 		},
 	),
 
+	"crdb_internal.capture_index_usage_stats": makeBuiltin(
+		tree.FunctionProperties{
+			Category: categorySystemInfo,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if evalCtx.CaptureIndexUsageStatsController == nil {
+					return nil, errors.AssertionFailedf("capture index usage stats controller not set")
+				}
+
+				ctx := evalCtx.Ctx()
+				if err := evalCtx.CaptureIndexUsageStatsController.CreateCaptureIndexUsageStatsSchedule(ctx); err != nil {
+
+					return tree.DNull, err
+				}
+				return tree.DBoolTrue, nil
+			},
+			Info:       "This function is used to start a job to capture index usage statistics.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
 	"crdb_internal.revalidate_unique_constraints_in_all_tables": makeBuiltin(
 		tree.FunctionProperties{
 			Category: categorySystemInfo,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3554,6 +3554,13 @@ type SQLStatsController interface {
 	CreateSQLStatsCompactionSchedule(ctx context.Context) error
 }
 
+// CaptureIndexUsageStatsController is an interface embedded in EvalCtx which
+// can be used by the builtins to capture index usage statistics. This
+// interface is introduced to avoid circular dependency.
+type CaptureIndexUsageStatsController interface {
+	CreateCaptureIndexUsageStatsSchedule(ctx context.Context) error
+}
+
 // IndexUsageStatsController is an interface embedded in EvalCtx which can be
 // used by the builtins to reset index usage stats in the cluster. This interface
 // is introduced to avoid circular dependency.
@@ -3699,6 +3706,8 @@ type EvalContext struct {
 	SQLLivenessReader sqlliveness.Reader
 
 	SQLStatsController SQLStatsController
+
+	CaptureIndexUsageStatsController CaptureIndexUsageStatsController
 
 	IndexUsageStatsController IndexUsageStatsController
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -779,6 +779,11 @@ const (
 	// ScheduledRowLevelTTLExecutor is an executor responsible for the cleanup
 	// of rows on row level TTL tables.
 	ScheduledRowLevelTTLExecutor
+
+	// CaptureIndexUsageStatsExecutor is an executor responsible for the
+	// execution of capturing index usages statistics to the telemetry logging
+	// channel.
+	CaptureIndexUsageStatsExecutor
 )
 
 var scheduleExecutorInternalNames = map[ScheduledJobExecutorType]string{
@@ -786,6 +791,7 @@ var scheduleExecutorInternalNames = map[ScheduledJobExecutorType]string{
 	ScheduledBackupExecutor:             "scheduled-backup-executor",
 	ScheduledSQLStatsCompactionExecutor: "scheduled-sql-stats-compaction-executor",
 	ScheduledRowLevelTTLExecutor:        "scheduled-row-level-ttl-executor",
+	CaptureIndexUsageStatsExecutor:      "captured-index-usage-stats-executor",
 }
 
 // InternalName returns an internal executor name.

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -267,6 +267,9 @@ func (m *DropRole) LoggingChannel() logpb.Channel { return logpb.Channel_USER_AD
 func (m *PasswordHashConverted) LoggingChannel() logpb.Channel { return logpb.Channel_USER_ADMIN }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *CapturedIndexUsageStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *SampledQuery) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -565,6 +565,117 @@ func (m *AlterTypeOwner) AppendJSONFields(printComma bool, b redact.RedactableBy
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TotalReadCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TotalReadCount\":"...)
+		b = strconv.AppendUint(b, uint64(m.TotalReadCount), 10)
+	}
+
+	if m.LastRead != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LastRead\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.LastRead)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.TableID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableID\":"...)
+		b = strconv.AppendUint(b, uint64(m.TableID), 10)
+	}
+
+	if m.IndexID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexID\":"...)
+		b = strconv.AppendUint(b, uint64(m.IndexID), 10)
+	}
+
+	if m.DatabaseName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DatabaseName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.TableName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.IndexName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexName\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.IndexType != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexType\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexType)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	if m.IsUnique {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsUnique\":true"...)
+	}
+
+	if m.IsInverted {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsInverted\":true"...)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *CertsReload) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -13,8 +13,10 @@ package cockroach.util.log.eventpb;
 option go_package = "eventpb";
 
 import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
 import "util/log/eventpb/events.proto";
 import "util/log/eventpb/sql_audit_events.proto";
+
 
 // Category: Telemetry events
 // Channel: TELEMETRY
@@ -45,3 +47,34 @@ message SampledQuery {
   string distribution = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// CapturedIndexUsageStats
+message CapturedIndexUsageStats {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // Couldn't use roachpb.CollectedIndexUsageStatistics due to circular dependency.
+
+  // TotalReadCount is the number of times this index has been read from.
+  uint64 total_read_count = 2;
+
+  // LastRead is the timestamp that this index was last being read from.
+  string last_read = 3 [(gogoproto.jsontag) = ",omitempty"];
+
+  // TableID is the ID of the table this index is created on. This is same as
+  // descpb.TableID and is unique within the cluster.
+  uint32 table_id = 8 [(gogoproto.customname) = "TableID"];
+
+  // IndexID is the ID of the index within the scope of the given table.
+  uint32 index_id = 9 [(gogoproto.customname) = "IndexID"];
+
+  string database_name = 10 [(gogoproto.jsontag) = ",omitempty"];
+  string table_name = 11 [(gogoproto.jsontag) = ",omitempty"];
+  string index_name = 12 [(gogoproto.jsontag) = ",omitempty"];
+  string index_type = 13 [(gogoproto.jsontag) = ",omitempty"];
+  bool is_unique = 14 [(gogoproto.jsontag) = ",omitempty"];
+  bool is_inverted = 15 [(gogoproto.jsontag) = ",omitempty"];
+}
+
+//// CollectedCapturedIndexUsageStats
+//message CollectedCapturedIndexUsageStats {
+//  repeated CapturedIndexUsageStats stats = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+//}


### PR DESCRIPTION
Previously, we did not capture index usage metrics to our telemetry logging
channel, this change adds this functionality.

Release note (sql change): Initial implementation of capturing index usage
statistics to the telemetry logging channel.
_________________________________________________________________

Note: This PR is not complete. Some `TODO`s:
- move the logic into a separate package
- create the scheduled job on cluster startup
- testing
- would like to create a wrapper around the job to allow for any log event to use this job