### PR TITLE
server: use channel for DisableAutomaticVersionUpgrade

### DIFF
--- a/pkg/ccl/backupccl/insert_missing_public_schema_namespace_entry_restore_test.go
+++ b/pkg/ccl/backupccl/insert_missing_public_schema_namespace_entry_restore_test.go
@@ -37,7 +37,7 @@ func TestInsertMissingPublicSchemaNamespaceEntry(t *testing.T) {
 			ExternalIODir: dir,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.InsertPublicSchemaNamespaceEntryOnRestore - 1),
 				},
 			},

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -865,7 +865,7 @@ func restorePublicSchemaMixedVersion(exportDir string) func(t *testing.T) {
 					Knobs: base.TestingKnobs{
 						JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 						Server: &server.TestingKnobs{
-							DisableAutomaticVersionUpgrade: 1,
+							DisableAutomaticVersionUpgrade: make(chan struct{}),
 							BinaryVersionOverride:          clusterversion.ByKey(clusterversion.PublicSchemasWithDescriptors - 1),
 						},
 					},
@@ -920,7 +920,7 @@ func restoreSyntheticPublicSchemaNamespaceEntry(exportDir string) func(t *testin
 					Knobs: base.TestingKnobs{
 						JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 						Server: &server.TestingKnobs{
-							DisableAutomaticVersionUpgrade: 1,
+							DisableAutomaticVersionUpgrade: make(chan struct{}),
 							BinaryVersionOverride:          clusterversion.ByKey(clusterversion.PublicSchemasWithDescriptors - 1),
 						},
 					},
@@ -951,7 +951,7 @@ func restoreSyntheticPublicSchemaNamespaceEntryCleanupOnFail(exportDir string) f
 					Knobs: base.TestingKnobs{
 						JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 						Server: &server.TestingKnobs{
-							DisableAutomaticVersionUpgrade: 1,
+							DisableAutomaticVersionUpgrade: make(chan struct{}),
 							BinaryVersionOverride:          clusterversion.ByKey(clusterversion.PublicSchemasWithDescriptors - 1),
 						},
 					},

--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -7381,7 +7381,7 @@ func TestImportMixedVersion(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.PublicSchemasWithDescriptors - 1),
 				},
 			},

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -58,7 +58,7 @@ func TestTenantUpgrade(t *testing.T) {
 			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
 				},
 			},
@@ -210,7 +210,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
 				},
 			},

--- a/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
@@ -38,7 +38,7 @@ func TestPreSeedSpanConfigsWrittenWhenActive(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.PreSeedTenantSpanConfigs,
 					),
@@ -90,7 +90,7 @@ func TestSeedTenantSpanConfigs(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.PreSeedTenantSpanConfigs - 1,
 					),
@@ -159,7 +159,7 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.PreSeedTenantSpanConfigs,
 					),

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2471,7 +2471,7 @@ func TestStartableJobMixedVersion(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
-				DisableAutomaticVersionUpgrade: 1,
+				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 		},
 	})

--- a/pkg/kv/kvserver/client_migration_test.go
+++ b/pkg/kv/kvserver/client_migration_test.go
@@ -251,7 +251,7 @@ func TestMigrateWaitsForApplication(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startV,
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				Store: &kvserver.StoreTestingKnobs{
 					TestingApplyFilter: func(args kvserverbase.ApplyFilterArgs) (int, *roachpb.Error) {

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4118,7 +4118,7 @@ func TestRangeMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startV,
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 			},
 		},

--- a/pkg/migration/migrationmanager/manager_external_test.go
+++ b/pkg/migration/migrationmanager/manager_external_test.go
@@ -68,7 +68,7 @@ func TestAlreadyRunningJobsAreHandledProperly(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startCV.Version,
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				MigrationManager: &migration.TestingKnobs{
 					ListBetweenOverride: func(from, to clusterversion.ClusterVersion) []clusterversion.ClusterVersion {
@@ -201,7 +201,7 @@ func TestMigrateUpdatesReplicaVersion(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startCV.Version,
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				MigrationManager: &migration.TestingKnobs{
 					ListBetweenOverride: func(from, to clusterversion.ClusterVersion) []clusterversion.ClusterVersion {
@@ -319,7 +319,7 @@ func TestConcurrentMigrationAttempts(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          versions[0].Version,
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				MigrationManager: &migration.TestingKnobs{
 					ListBetweenOverride: func(from, to clusterversion.ClusterVersion) []clusterversion.ClusterVersion {
@@ -401,7 +401,7 @@ func TestPauseMigration(t *testing.T) {
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startCV.Version,
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				MigrationManager: &migration.TestingKnobs{
 					ListBetweenOverride: func(from, to clusterversion.ClusterVersion) []clusterversion.ClusterVersion {
@@ -521,7 +521,7 @@ func TestPrecondition(t *testing.T) {
 	}
 	knobs := base.TestingKnobs{
 		Server: &server.TestingKnobs{
-			DisableAutomaticVersionUpgrade: 1,
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
 			BinaryVersionOverride:          v0.Version,
 		},
 		// Inject a migration which would run to upgrade the cluster.

--- a/pkg/migration/migrations/alter_statement_diagnostics_requests_test.go
+++ b/pkg/migration/migrations/alter_statement_diagnostics_requests_test.go
@@ -39,7 +39,7 @@ func TestAlterSystemStmtDiagReqs(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.AlterSystemStmtDiagReqs - 1),
 				},
 			},

--- a/pkg/migration/migrations/alter_table_protected_timestamp_records_test.go
+++ b/pkg/migration/migrations/alter_table_protected_timestamp_records_test.go
@@ -38,7 +38,7 @@ func TestAlterSystemProtectedTimestampRecordsTable(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.AlterSystemProtectedTimestampAddColumn - 1),
 				},

--- a/pkg/migration/migrations/alter_table_statistics_avg_size_test.go
+++ b/pkg/migration/migrations/alter_table_statistics_avg_size_test.go
@@ -38,7 +38,7 @@ func TestAlterSystemTableStatisticsTable(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.AlterSystemTableStatisticsAddAvgSizeCol - 1),
 				},

--- a/pkg/migration/migrations/builtins_test.go
+++ b/pkg/migration/migrations/builtins_test.go
@@ -31,7 +31,7 @@ func TestIsAtLeastVersionBuiltin(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V21_2),
 				},
 			},

--- a/pkg/migration/migrations/comment_on_index_migration_external_test.go
+++ b/pkg/migration/migrations/comment_on_index_migration_external_test.go
@@ -37,7 +37,7 @@ func TestEnsureIndexesExistForComments(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.DeleteCommentsWithDroppedIndexes - 1),
 				},

--- a/pkg/migration/migrations/ensure_constraint_id_test.go
+++ b/pkg/migration/migrations/ensure_constraint_id_test.go
@@ -41,7 +41,7 @@ func TestEnsureConstraintIDs(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						tabledesc.ConstraintIDsAddedToTableDescsVersion - 1),
 				},

--- a/pkg/migration/migrations/ensure_no_draining_names_external_test.go
+++ b/pkg/migration/migrations/ensure_no_draining_names_external_test.go
@@ -41,7 +41,7 @@ func TestEnsureNoDrainingNames(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.AvoidDrainingNames - 1),
 				},

--- a/pkg/migration/migrations/grant_option_migration_external_test.go
+++ b/pkg/migration/migrations/grant_option_migration_external_test.go
@@ -169,7 +169,7 @@ func TestGrantOptionMigration(t *testing.T) {
 				ServerArgs: base.TestServerArgs{
 					Knobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
-							DisableAutomaticVersionUpgrade: 1,
+							DisableAutomaticVersionUpgrade: make(chan struct{}),
 							BinaryVersionOverride:          clusterversion.ByKey(clusterversion.ValidateGrantOption - 1), // changed cluster version
 						},
 					},

--- a/pkg/migration/migrations/migrate_span_configs_test.go
+++ b/pkg/migration/migrations/migrate_span_configs_test.go
@@ -44,7 +44,7 @@ func TestEnsureSpanConfigReconciliation(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.EnsureSpanConfigReconciliation - 1,
 					),
@@ -120,7 +120,7 @@ func TestEnsureSpanConfigReconciliationMultiNode(t *testing.T) {
 		serverArgs[i] = base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.EnsureSpanConfigReconciliation - 1,
 					),
@@ -133,7 +133,7 @@ func TestEnsureSpanConfigReconciliationMultiNode(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.EnsureSpanConfigReconciliation - 1,
 					),
@@ -196,7 +196,7 @@ func TestEnsureSpanConfigSubscription(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.EnsureSpanConfigSubscription - 1,
 					),

--- a/pkg/migration/migrations/public_schema_migration_external_test.go
+++ b/pkg/migration/migrations/public_schema_migration_external_test.go
@@ -44,7 +44,7 @@ func publicSchemaMigrationTest(t *testing.T, ctx context.Context, numTables int)
 			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.PublicSchemasWithDescriptors - 1),
 				},
 			},

--- a/pkg/migration/migrations/raft_applied_index_term_external_test.go
+++ b/pkg/migration/migrations/raft_applied_index_term_external_test.go
@@ -124,7 +124,7 @@ func TestRaftAppliedIndexTermMigration(t *testing.T) {
 			// Start at the version immediately preceding the migration.
 			BinaryVersionOverride: bootstrapVersion,
 			// We want to exercise manual control over the upgrade process.
-			DisableAutomaticVersionUpgrade: 1,
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
 		}
 		return args
 	}
@@ -234,7 +234,7 @@ func TestLatestClusterDoesNotNeedRaftAppliedIndexTermMigration(t *testing.T) {
 		args.Knobs.Server = &server.TestingKnobs{
 			BinaryVersionOverride: binaryVersion,
 			// We want to exercise manual control over the upgrade process.
-			DisableAutomaticVersionUpgrade: 1,
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
 		}
 		return args
 	}

--- a/pkg/migration/migrations/remove_invalid_database_privileges_external_test.go
+++ b/pkg/migration/migrations/remove_invalid_database_privileges_external_test.go
@@ -38,7 +38,7 @@ func TestConvertIncompatibleDatabasePrivilegesToDefaultPrivileges(t *testing.T) 
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					DisableAutomaticVersionUpgrade: 1,
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride: clusterversion.ByKey(
 						clusterversion.RemoveIncompatibleDatabasePrivileges - 1),
 				},

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -162,7 +162,7 @@ func TestBumpClusterVersion(t *testing.T) {
 						BinaryVersionOverride: test.activeClusterVersion.Version,
 						// We're bumping cluster versions manually ourselves. We
 						// want avoid racing with the auto-upgrade process.
-						DisableAutomaticVersionUpgrade: 1,
+						DisableAutomaticVersionUpgrade: make(chan struct{}),
 					},
 				},
 			})

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -25,8 +25,8 @@ import (
 // TestingKnobs groups testing knobs for the Server.
 type TestingKnobs struct {
 	// DisableAutomaticVersionUpgrade, if set, temporarily disables the server's
-	// automatic version upgrade mechanism.
-	DisableAutomaticVersionUpgrade int32 // accessed atomically
+	// automatic version upgrade mechanism (until the channel is closed).
+	DisableAutomaticVersionUpgrade chan struct{}
 	// DefaultZoneConfigOverride, if set, overrides the default zone config
 	// defined in `pkg/config/zone.go`.
 	DefaultZoneConfigOverride *zonepb.ZoneConfig

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1490,7 +1490,7 @@ func (t *logicTest) newCluster(serverArgs TestServerArgs, opts []clusterOpt) {
 		if params.ServerArgs.Knobs.Server == nil {
 			params.ServerArgs.Knobs.Server = &server.TestingKnobs{}
 		}
-		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).DisableAutomaticVersionUpgrade = 1
+		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).DisableAutomaticVersionUpgrade = make(chan struct{})
 	}
 	for _, opt := range opts {
 		opt.apply(&params.ServerArgs)

--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -319,7 +319,7 @@ func TestUnsplitRanges(t *testing.T) {
 		params, _ := tests.CreateTestServerParams()
 		// Override binary version to be older.
 		params.Knobs.Server = &server.TestingKnobs{
-			DisableAutomaticVersionUpgrade: 1,
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
 			BinaryVersionOverride:          clusterversion.ByKey(tc.binaryVersion),
 		}
 


### PR DESCRIPTION
DisableAutomaticVersionUpgrade is an atomic integer which is rechecked
in a retry loop. This is not a very clean mechanism, and can lead to
issues where you're unknowingly dealing with a copy of the knobs and
setting the wrong atomic. The retry loop can also add unnecessary
delays in tests.

This commit changes DisableAutomaticVersionUpgrade from an atomic
integer to a channel. If the channel is set, auto-upgrade waits until
the channel is closed.

Release note: None