### PR TITLE
rangefeed: memory budget to limit size of queue

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "rangefeed",
     srcs = [
+        "budget.go",
         "catchup_scan.go",
         "filter.go",
         "metrics.go",
@@ -22,7 +23,9 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/log",
+        "//pkg/util/log/logcrash",
         "//pkg/util/metric",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/retry",
         "//pkg/util/stop",
@@ -38,6 +41,7 @@ go_test(
     name = "rangefeed_test",
     size = "small",
     srcs = [
+        "budget_test.go",
         "catchup_scan_bench_test.go",
         "processor_test.go",
         "registry_test.go",
@@ -57,6 +61,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -1,0 +1,204 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+var budgetAllocationSyncPool = sync.Pool{
+	New: func() interface{} {
+		return new(SharedBudgetAllocation)
+	},
+}
+
+func getPooledBudgetAllocation(ba SharedBudgetAllocation) *SharedBudgetAllocation {
+	b := budgetAllocationSyncPool.Get().(*SharedBudgetAllocation)
+	*b = ba
+	return b
+}
+
+func putPooledBudgetAllocation(ba *SharedBudgetAllocation) {
+	*ba = SharedBudgetAllocation{}
+	budgetAllocationSyncPool.Put(ba)
+}
+
+// FeedBudget is memory budget for RangeFeed that wraps BoundAccount
+// and provides ability to wait for downstream to release budget and
+// to send individual events that exceed total budget size.
+// FeedBudget doesn't provide any fairness when acquiring as it is only
+// supposed to be used by a single caller.
+// When owning component is destroyed, budget must be closed, in that
+// case all budget allocation is returned immediately and no further
+// allocations are possible.
+// In the typical case processor will get allocations from budget which
+// would be in turn borrowed from underlying account. Once event is
+// processed, allocation would be returned.
+// To use the budget first try to obtain allocation with TryGet and if
+// it fails because budget is exhausted use WaitAndGet and use context with
+// a deadline to stop. It is not safe to just call WaitAndGet because it
+// doesn't check for available budget before waiting.
+// NB: Resource release notifications only work within context of a single
+// feed. If we start contending for memory with other feeds in the same
+// BytesMonitor pool we won't see if memory is released there and will
+// time-out if memory is not allocated.
+type FeedBudget struct {
+	mu struct {
+		syncutil.Mutex
+		// Bound account that provides budget with resource.
+		memBudget *mon.BoundAccount
+		// If true, budget was released and no more allocations could take place.
+		closed bool
+	}
+	// Maximum amount of memory to use by feed. We use separate limit here to
+	// avoid creating BytesMontior with a limit per feed.
+	limit int64
+	// Channel to notify that memory was returned to the budget.
+	replenishC chan interface{}
+	// Budget cancellation request
+	stopC chan interface{}
+
+	closed sync.Once
+}
+
+// NewFeedBudget creates a FeedBudget to be used with RangeFeed. If nil account
+// is passed, function will return nil which is safe to use with RangeFeed as
+// it effectively disables memory accounting for that feed.
+func NewFeedBudget(budget *mon.BoundAccount, limit int64) *FeedBudget {
+	if budget == nil {
+		return nil
+	}
+	// If limit is not specified, use large enough value.
+	if limit <= 0 {
+		limit = (1 << 63) - 1
+	}
+	f := &FeedBudget{
+		replenishC: make(chan interface{}, 1),
+		stopC:      make(chan interface{}),
+		limit:      limit,
+	}
+	f.mu.memBudget = budget
+	return f
+}
+
+// TryGet allocates amount from budget. If there's not enough budget available
+// returns error immediately.
+// Returned allocation has its use counter set to 1.
+func (f *FeedBudget) TryGet(ctx context.Context, amount int64) (*SharedBudgetAllocation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.mu.closed {
+		logcrash.ReportOrPanic(ctx, nil, "budget unexpectedly closed")
+		return nil, errors.AssertionFailedf("budget unexpectedly closed")
+	}
+	var err error
+	if f.mu.memBudget.Used()+amount > f.limit {
+		return nil, errors.Wrap(f.mu.memBudget.Monitor().Resource().NewBudgetExceededError(amount,
+			f.mu.memBudget.Used(),
+			f.limit), "rangefeed budget")
+	}
+	if err = f.mu.memBudget.Grow(ctx, amount); err != nil {
+		return nil, err
+	}
+	return getPooledBudgetAllocation(SharedBudgetAllocation{size: amount, refCount: 1, feed: f}), nil
+}
+
+// WaitAndGet waits for replenish channel to return any allocations back to the
+// budget and then tries to get allocation. Waiting stops when context is
+// cancelled. Context should be used to set up a timeout as needed.
+func (f *FeedBudget) WaitAndGet(
+	ctx context.Context, amount int64,
+) (*SharedBudgetAllocation, error) {
+	for {
+		select {
+		case <-f.replenishC:
+			alloc, err := f.TryGet(ctx, amount)
+			if err == nil {
+				return alloc, nil
+			}
+		case <-ctx.Done():
+			// Since we share budget with other components, it is also possible that
+			// it was returned and we are not notified by our feed channel, so we try
+			// for the last time.
+			return f.TryGet(ctx, amount)
+		case <-f.stopC:
+			// We are already stopped, current allocation is already freed so, do
+			// nothing.
+			return nil, nil
+		}
+	}
+}
+
+// Return returns amount to budget.
+func (f *FeedBudget) returnAllocation(ctx context.Context, amount int64) {
+	f.mu.Lock()
+	if f.mu.closed {
+		f.mu.Unlock()
+		return
+	}
+	if amount > 0 {
+		f.mu.memBudget.Shrink(ctx, amount)
+	}
+	f.mu.Unlock()
+	select {
+	case f.replenishC <- struct{}{}:
+	default:
+	}
+}
+
+// Close frees up all allocated budget and prevents any further allocations.
+// Safe to call on nil budget.
+func (f *FeedBudget) Close(ctx context.Context) {
+	if f == nil {
+		return
+	}
+	f.closed.Do(func() {
+		f.mu.Lock()
+		f.mu.closed = true
+		f.mu.memBudget.Close(ctx)
+		close(f.stopC)
+		f.mu.Unlock()
+	})
+}
+
+// SharedBudgetAllocation is a token that is passed around with range events
+// to registrations to maintain RangeFeed memory budget across shared queues.
+type SharedBudgetAllocation struct {
+	refCount int32
+	size     int64
+	feed     *FeedBudget
+}
+
+// Use increases usage count for the allocation. It should be called by each
+// new consumer that plans to retain allocation after returning to a caller
+// that passed this allocation.
+func (a *SharedBudgetAllocation) Use() {
+	if a != nil {
+		if atomic.AddInt32(&a.refCount, 1) == 1 {
+			panic("unexpected shared memory allocation usage increase after free")
+		}
+	}
+}
+
+// Release decreases ref count and returns true if budget could be released.
+func (a *SharedBudgetAllocation) Release(ctx context.Context) {
+	if a != nil && atomic.AddInt32(&a.refCount, -1) == 0 {
+		a.feed.returnAllocation(ctx, a.size)
+		putPooledBudgetAllocation(a)
+	}
+}

--- a/pkg/kv/kvserver/rangefeed/budget_test.go
+++ b/pkg/kv/kvserver/rangefeed/budget_test.go
@@ -1,0 +1,172 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeedBudget(t *testing.T) {
+	makeBudgetWithSize := func(poolSize, budgetSize int64) (*FeedBudget, *mon.BytesMonitor, *mon.BoundAccount) {
+		m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+		m.Start(context.Background(), nil, mon.MakeStandaloneBudget(poolSize))
+		b := m.MakeBoundAccount()
+
+		f := NewFeedBudget(&b, budgetSize)
+		return f, m, &b
+	}
+	ctx := context.Background()
+
+	t.Run("allocate one", func(t *testing.T) {
+		f, _, b := makeBudgetWithSize(40, 0)
+		// Basic case of getting and returning allocation
+		a, err := f.TryGet(ctx, 13)
+		require.NoError(t, err)
+		require.Equal(t, int64(13), b.Used(), "")
+		a.Release(ctx)
+		require.Equal(t, int64(0), b.Used(), "used budget after free")
+	})
+
+	t.Run("allocate multiple", func(t *testing.T) {
+		f, _, b := makeBudgetWithSize(40, 0)
+		// Multiple allocations returned out of order.
+		// Basic case of getting and returning allocation
+		a1, err := f.TryGet(ctx, 13)
+		require.NoError(t, err)
+		a2, err := f.TryGet(ctx, 20)
+		require.NoError(t, err)
+		require.Equal(t, int64(33), b.Used(), "allocated budget")
+		a2.Release(ctx)
+		a1.Release(ctx)
+		require.Equal(t, int64(0), b.Used(), "used budget after free")
+	})
+
+	// Wait for allocation to return some budget.
+	t.Run("wait for replenish", func(t *testing.T) {
+		f, _, b := makeBudgetWithSize(40, 0)
+		// Multiple allocations returned out of order.
+		// Basic case of getting and returning allocation
+		a1, err := f.TryGet(ctx, 30)
+		require.NoError(t, err)
+		started := make(chan interface{})
+		result := make(chan error)
+		go func() {
+			started <- struct{}{}
+			ctx2, cancel := context.WithTimeout(ctx, time.Minute)
+			defer cancel()
+			a, err := f.WaitAndGet(ctx2, 20)
+			if err != nil {
+				result <- err
+			} else {
+				f.returnAllocation(ctx2, a.size)
+				result <- nil
+			}
+		}()
+		<-started
+		require.Equal(t, int64(30), b.Used(), "allocated budget")
+		f.returnAllocation(ctx, a1.size)
+		err = <-result
+		require.NoError(t, err)
+		require.Equal(t, int64(0), b.Used(), "used budget after free")
+	})
+
+	// Fail allocation if used all budget
+	t.Run("fail to get over budget", func(t *testing.T) {
+		f, _, b := makeBudgetWithSize(40, 0)
+		_, err := f.TryGet(ctx, 50)
+		require.Error(t, err)
+		a1, err := f.TryGet(ctx, 30)
+		require.NoError(t, err)
+		_, err = f.TryGet(ctx, 20)
+		require.Error(t, err)
+		require.Equal(t, int64(30), b.Used(), "allocated budget")
+		a1.Release(ctx)
+		require.Equal(t, int64(0), b.Used(), "used budget after free")
+	})
+
+	// Timeout allocation if used all budget
+	t.Run("fail to wait over budget", func(t *testing.T) {
+		f, _, b := makeBudgetWithSize(40, 0)
+		ctx2, cancel := context.WithTimeout(ctx, time.Microsecond)
+		defer cancel()
+		a1, err := f.TryGet(ctx2, 30)
+		require.NoError(t, err)
+		_, err = f.WaitAndGet(ctx2, 20)
+		require.Error(t, err)
+		require.Equal(t, int64(30), b.Used(), "allocated budget")
+		a1.Release(ctx)
+		require.Equal(t, int64(0), b.Used(), "used budget after free")
+	})
+
+	t.Run("wait with no timeout", func(t *testing.T) {
+		f, _, b := makeBudgetWithSize(40, 0)
+		a1, err := f.TryGet(ctx, 30)
+		require.NoError(t, err)
+		started := make(chan interface{})
+		result := make(chan error)
+		go func() {
+			started <- struct{}{}
+			a, err := f.WaitAndGet(ctx, 20)
+			if err != nil {
+				result <- err
+			} else {
+				f.returnAllocation(ctx, a.size)
+				result <- nil
+			}
+		}()
+		<-started
+		f.returnAllocation(ctx, a1.size)
+		err = <-result
+		require.NoError(t, err, "waiting for budget with indefinite timeout")
+		require.Equal(t, int64(0), b.Used(), "used budget after free")
+	})
+
+	t.Run("abort wait on stopper", func(t *testing.T) {
+		f, m, _ := makeBudgetWithSize(40, 0)
+		a1, err := f.TryGet(ctx, 30)
+		require.NoError(t, err)
+		started := make(chan interface{})
+		result := make(chan error)
+		go func() {
+			started <- struct{}{}
+			a, err := f.WaitAndGet(ctx, 20)
+			if err != nil {
+				result <- err
+			} else {
+				a.Release(ctx)
+				result <- nil
+			}
+		}()
+		<-started
+		f.Close(ctx)
+
+		err = <-result
+		require.NoError(t, err, "waiting for budget with indefinite timeout")
+
+		f.returnAllocation(ctx, a1.size)
+		require.Equal(t, int64(0), m.AllocBytes(), "used budget after free")
+	})
+
+	t.Run("fail when reaching hard limit", func(t *testing.T) {
+		f, _, _ := makeBudgetWithSize(1000, 30)
+		_, err := f.TryGet(ctx, 20)
+		require.NoError(t, err)
+		// Try to send second object that would exceed hard limit and see it if fit.
+		_, err = f.TryGet(ctx, 20)
+		require.Error(t, err)
+	})
+}

--- a/pkg/kv/kvserver/rangefeed/metrics.go
+++ b/pkg/kv/kvserver/rangefeed/metrics.go
@@ -25,11 +25,25 @@ var (
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaRangeFeedExhausted = metric.Metadata{
+		Name:        "kv.rangefeed.budget_allocation_failed",
+		Help:        "Number of times RangeFeed failed because memory budget was exceeded",
+		Measurement: "Events",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeFeedBudgetBlocked = metric.Metadata{
+		Name:        "kv.rangefeed.budget_allocation_blocked",
+		Help:        "Number of times RangeFeed waited for budget availability",
+		Measurement: "Events",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // Metrics are for production monitoring of RangeFeeds.
 type Metrics struct {
 	RangeFeedCatchUpScanNanos *metric.Counter
+	RangeFeedBudgetExhausted  *metric.Counter
+	RangeFeedBudgetBlocked    *metric.Counter
 
 	RangeFeedSlowClosedTimestampLogN  log.EveryN
 	RangeFeedSlowClosedTimestampNudge singleflight.Group
@@ -47,6 +61,8 @@ func (*Metrics) MetricStruct() {}
 func NewMetrics() *Metrics {
 	return &Metrics{
 		RangeFeedCatchUpScanNanos:            metric.NewCounter(metaRangeFeedCatchUpScanNanos),
+		RangeFeedBudgetExhausted:             metric.NewCounter(metaRangeFeedExhausted),
+		RangeFeedBudgetBlocked:               metric.NewCounter(metaRangeFeedBudgetBlocked),
 		RangeFeedSlowClosedTimestampLogN:     log.Every(5 * time.Second),
 		RangeFeedSlowClosedTimestampNudgeSem: make(chan struct{}, 1024),
 	}

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -76,6 +76,9 @@ type Config struct {
 
 	// Metrics is for production monitoring of RangeFeeds.
 	Metrics *Metrics
+
+	// Optional Processor memory budget.
+	MemBudget *FeedBudget
 }
 
 // SetDefaults initializes unset fields in Config to values
@@ -157,6 +160,8 @@ type event struct {
 	// has to be done by the processor in order to avoid race conditions with the
 	// registry. Should be used only in tests.
 	testRegCatchupSpan roachpb.Span
+	// Budget allocated to process the event
+	allocation *SharedBudgetAllocation
 }
 
 // spanErr is an error across a key span that will disconnect overlapping
@@ -171,7 +176,7 @@ type spanErr struct {
 func NewProcessor(cfg Config) *Processor {
 	cfg.SetDefaults()
 	cfg.AmbientContext.AddLogTag("rangefeed", nil)
-	return &Processor{
+	p := &Processor{
 		Config: cfg,
 		reg:    makeRegistry(),
 		rts:    makeResolvedTimestamp(),
@@ -187,6 +192,7 @@ func NewProcessor(cfg Config) *Processor {
 		stopC:      make(chan *roachpb.Error, 1),
 		stoppedC:   make(chan struct{}),
 	}
+	return p
 }
 
 // IntentScannerConstructor is used to construct an IntentScanner. It
@@ -232,6 +238,7 @@ func (p *Processor) run(
 	defer close(p.stoppedC)
 	ctx, cancelOutputLoops := context.WithCancel(ctx)
 	defer cancelOutputLoops()
+	defer p.MemBudget.Close(ctx)
 
 	// Launch an async task to scan over the resolved timestamp iterator and
 	// initialize the unresolvedIntentQueue. Ignore error if quiescing.
@@ -283,7 +290,7 @@ func (p *Processor) run(
 			// timestamp might be empty but the checkpoint event is still useful to indicate that the
 			// catch-up scan has completed. This allows clients to rely on stronger ordering semantics
 			// once they observe the first checkpoint event.
-			r.publish(p.newCheckpointEvent())
+			r.publish(ctx, p.newCheckpointEvent(), nil)
 
 			// Run an output loop for the registry.
 			runOutputLoop := func(ctx context.Context) {
@@ -295,13 +302,13 @@ func (p *Processor) run(
 			}
 			if err := stopper.RunAsyncTask(ctx, "rangefeed: output loop", runOutputLoop); err != nil {
 				r.disconnect(roachpb.NewError(err))
-				p.reg.Unregister(&r)
+				p.reg.Unregister(ctx, &r)
 			}
 
 		// Respond to unregistration requests; these come from registrations that
 		// encounter an error during their output loop.
 		case r := <-p.unregC:
-			p.reg.Unregister(r)
+			p.reg.Unregister(ctx, r)
 
 		// Send errors to registrations overlapping the span and disconnect them.
 		// Requested via DisconnectSpanWithErr().
@@ -320,6 +327,7 @@ func (p *Processor) run(
 		// Transform and route events.
 		case e := <-p.eventC:
 			p.consumeEvent(ctx, e)
+			e.allocation.Release(ctx)
 			putPooledEvent(e)
 
 		// Check whether any unresolved intents need a push.
@@ -500,14 +508,14 @@ func (p *Processor) Filter() *Filter {
 // specified by the EventChanTimeout configuration. If the method returns false,
 // the processor will have been stopped, so calling Stop is not necessary. Safe
 // to call on nil Processor.
-func (p *Processor) ConsumeLogicalOps(ops ...enginepb.MVCCLogicalOp) bool {
+func (p *Processor) ConsumeLogicalOps(ctx context.Context, ops ...enginepb.MVCCLogicalOp) bool {
 	if p == nil {
 		return true
 	}
 	if len(ops) == 0 {
 		return true
 	}
-	return p.sendEvent(event{ops: ops}, p.EventChanTimeout)
+	return p.sendEvent(ctx, event{ops: ops}, p.EventChanTimeout)
 }
 
 // ConsumeSSTable informs the rangefeed processor of an SSTable that was added
@@ -515,11 +523,13 @@ func (p *Processor) ConsumeLogicalOps(ops ...enginepb.MVCCLogicalOp) bool {
 // specified by the EventChanTimeout configuration. If the method returns false,
 // the processor will have been stopped, so calling Stop is not necessary. Safe
 // to call on nil Processor.
-func (p *Processor) ConsumeSSTable(sst []byte, sstSpan roachpb.Span, writeTS hlc.Timestamp) bool {
+func (p *Processor) ConsumeSSTable(
+	ctx context.Context, sst []byte, sstSpan roachpb.Span, writeTS hlc.Timestamp,
+) bool {
 	if p == nil {
 		return true
 	}
-	return p.sendEvent(event{sst: sst, sstSpan: sstSpan, sstWTS: writeTS}, p.EventChanTimeout)
+	return p.sendEvent(ctx, event{sst: sst, sstSpan: sstSpan, sstWTS: writeTS}, p.EventChanTimeout)
 }
 
 // ForwardClosedTS indicates that the closed timestamp that serves as the basis
@@ -528,38 +538,96 @@ func (p *Processor) ConsumeSSTable(sst []byte, sstSpan roachpb.Span, writeTS hlc
 // EventChanTimeout configuration. If the method returns false, the processor
 // will have been stopped, so calling Stop is not necessary.  Safe to call on
 // nil Processor.
-func (p *Processor) ForwardClosedTS(closedTS hlc.Timestamp) bool {
+func (p *Processor) ForwardClosedTS(ctx context.Context, closedTS hlc.Timestamp) bool {
 	if p == nil {
 		return true
 	}
 	if closedTS.IsEmpty() {
 		return true
 	}
-	return p.sendEvent(event{ct: closedTS}, p.EventChanTimeout)
+	return p.sendEvent(ctx, event{ct: closedTS}, p.EventChanTimeout)
 }
 
 // sendEvent informs the Processor of a new event. If a timeout is specified,
 // the method will wait for no longer than that duration before giving up,
 // shutting down the Processor, and returning false. 0 for no timeout.
-func (p *Processor) sendEvent(e event, timeout time.Duration) bool {
+func (p *Processor) sendEvent(ctx context.Context, e event, timeout time.Duration) bool {
+	// The code is a bit unwieldy because we try to avoid any allocations on fast
+	// path where we have enough budget and outgoing channel is free. If not, we
+	// try to set up timeout for acquiring budget and then reuse it for inserting
+	// value into channel.
+	var allocation *SharedBudgetAllocation
+	if p.MemBudget != nil {
+		size := calculateDateEventSize(e)
+		if size > 0 {
+			var err error
+			// First we will try non-blocking fast path to allocate memory budget.
+			allocation, err = p.MemBudget.TryGet(ctx, size)
+			if err != nil {
+				// Since we don't have enough budget, we should try to wait for
+				// allocation returns before failing.
+				if timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, timeout) // nolint:context
+					defer cancel()
+					// We reset timeout here so that subsequent channel write op doesn't
+					// try to wait beyond what is already set up.
+					timeout = 0
+				}
+				p.Metrics.RangeFeedBudgetBlocked.Inc(1)
+				allocation, err = p.MemBudget.WaitAndGet(ctx, size)
+			}
+			if err != nil {
+				p.Metrics.RangeFeedBudgetExhausted.Inc(1)
+				p.sendStop(newErrBufferCapacityExceeded())
+				return false
+			}
+			defer func() {
+				allocation.Release(ctx)
+			}()
+		}
+	}
 	ev := getPooledEvent(e)
+	ev.allocation = allocation
 	if timeout == 0 {
+		// Timeout is zero if no timeout was requested or timeout is already set on
+		// the context by budget allocation. Just try to write using context as a
+		// timeout.
 		select {
 		case p.eventC <- ev:
+			// Reset allocation after successful posting to prevent deferred cleanup
+			// from freeing it.
+			allocation = nil
 		case <-p.stoppedC:
 			// Already stopped. Do nothing.
+		case <-ctx.Done():
+			p.sendStop(newErrBufferCapacityExceeded())
+			return false
 		}
 	} else {
+		// First try fast path operation without blocking and without creating any
+		// contexts in case channel has capacity.
 		select {
 		case p.eventC <- ev:
+			// Reset allocation after successful posting to prevent deferred cleanup
+			// from freeing it.
+			allocation = nil
 		case <-p.stoppedC:
 			// Already stopped. Do nothing.
 		default:
+			// Fast path failed since we don't have capacity in channel. Wait for
+			// slots to clear up using context timeout.
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout) // nolint:context
+			defer cancel()
 			select {
 			case p.eventC <- ev:
+				// Reset allocation after successful posting to prevent deferred cleanup
+				// from freeing it.
+				allocation = nil
 			case <-p.stoppedC:
 				// Already stopped. Do nothing.
-			case <-time.After(timeout):
+			case <-ctx.Done():
 				// Sending on the eventC channel would have blocked.
 				// Instead, tear down the processor and return immediately.
 				p.sendStop(newErrBufferCapacityExceeded())
@@ -572,8 +640,8 @@ func (p *Processor) sendEvent(e event, timeout time.Duration) bool {
 
 // setResolvedTSInitialized informs the Processor that its resolved timestamp has
 // all the information it needs to be considered initialized.
-func (p *Processor) setResolvedTSInitialized() {
-	p.sendEvent(event{initRTS: true}, 0 /* timeout */)
+func (p *Processor) setResolvedTSInitialized(ctx context.Context) {
+	p.sendEvent(ctx, event{initRTS: true}, 0)
 }
 
 // syncEventC synchronizes access to the Processor goroutine, allowing the
@@ -598,9 +666,9 @@ func (p *Processor) syncEventC() {
 func (p *Processor) consumeEvent(ctx context.Context, e *event) {
 	switch {
 	case len(e.ops) > 0:
-		p.consumeLogicalOps(ctx, e.ops)
+		p.consumeLogicalOps(ctx, e.ops, e.allocation)
 	case len(e.sst) > 0:
-		p.consumeSSTable(ctx, e.sst, e.sstSpan, e.sstWTS)
+		p.consumeSSTable(ctx, e.sst, e.sstSpan, e.sstWTS, e.allocation)
 	case !e.ct.IsEmpty():
 		p.forwardClosedTS(ctx, e.ct)
 	case e.initRTS:
@@ -621,13 +689,15 @@ func (p *Processor) consumeEvent(ctx context.Context, e *event) {
 	}
 }
 
-func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLogicalOp) {
+func (p *Processor) consumeLogicalOps(
+	ctx context.Context, ops []enginepb.MVCCLogicalOp, allocation *SharedBudgetAllocation,
+) {
 	for _, op := range ops {
 		// Publish RangeFeedValue updates, if necessary.
 		switch t := op.GetValue().(type) {
 		case *enginepb.MVCCWriteValueOp:
 			// Publish the new value directly.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, allocation)
 
 		case *enginepb.MVCCWriteIntentOp:
 			// No updates to publish.
@@ -637,7 +707,7 @@ func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLo
 
 		case *enginepb.MVCCCommitIntentOp:
 			// Publish the newly committed value.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, allocation)
 
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
@@ -658,9 +728,13 @@ func (p *Processor) consumeLogicalOps(ctx context.Context, ops []enginepb.MVCCLo
 }
 
 func (p *Processor) consumeSSTable(
-	ctx context.Context, sst []byte, sstSpan roachpb.Span, sstWTS hlc.Timestamp,
+	ctx context.Context,
+	sst []byte,
+	sstSpan roachpb.Span,
+	sstWTS hlc.Timestamp,
+	allocation *SharedBudgetAllocation,
 ) {
-	p.publishSSTable(ctx, sst, sstSpan, sstWTS)
+	p.publishSSTable(ctx, sst, sstSpan, sstWTS, allocation)
 }
 
 func (p *Processor) forwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) {
@@ -676,7 +750,11 @@ func (p *Processor) initResolvedTS(ctx context.Context) {
 }
 
 func (p *Processor) publishValue(
-	ctx context.Context, key roachpb.Key, timestamp hlc.Timestamp, value, prevValue []byte,
+	ctx context.Context,
+	key roachpb.Key,
+	timestamp hlc.Timestamp,
+	value, prevValue []byte,
+	allocation *SharedBudgetAllocation,
 ) {
 	if !p.Span.ContainsKey(roachpb.RKey(key)) {
 		log.Fatalf(ctx, "key %v not in Processor's key range %v", key, p.Span)
@@ -695,11 +773,15 @@ func (p *Processor) publishValue(
 		},
 		PrevValue: prevVal,
 	})
-	p.reg.PublishToOverlapping(roachpb.Span{Key: key}, &event)
+	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, allocation)
 }
 
 func (p *Processor) publishSSTable(
-	ctx context.Context, sst []byte, sstSpan roachpb.Span, sstWTS hlc.Timestamp,
+	ctx context.Context,
+	sst []byte,
+	sstSpan roachpb.Span,
+	sstWTS hlc.Timestamp,
+	allocation *SharedBudgetAllocation,
 ) {
 	if sstSpan.Equal(roachpb.Span{}) {
 		panic(errors.AssertionFailedf("received SSTable without span"))
@@ -707,13 +789,13 @@ func (p *Processor) publishSSTable(
 	if sstWTS.IsEmpty() {
 		panic(errors.AssertionFailedf("received SSTable without write timestamp"))
 	}
-	p.reg.PublishToOverlapping(sstSpan, &roachpb.RangeFeedEvent{
+	p.reg.PublishToOverlapping(ctx, sstSpan, &roachpb.RangeFeedEvent{
 		SST: &roachpb.RangeFeedSSTable{
 			Data:    sst,
 			Span:    sstSpan,
 			WriteTS: sstWTS,
 		},
-	})
+	}, allocation)
 }
 
 func (p *Processor) publishCheckpoint(ctx context.Context) {
@@ -721,7 +803,7 @@ func (p *Processor) publishCheckpoint(ctx context.Context) {
 	// TODO(nvanbenschoten): rate limit these? send them periodically?
 
 	event := p.newCheckpointEvent()
-	p.reg.PublishToOverlapping(all, event)
+	p.reg.PublishToOverlapping(ctx, all, event, nil)
 }
 
 func (p *Processor) newCheckpointEvent() *roachpb.RangeFeedEvent {
@@ -734,4 +816,18 @@ func (p *Processor) newCheckpointEvent() *roachpb.RangeFeedEvent {
 		ResolvedTS: p.rts.Get(),
 	})
 	return &event
+}
+
+// calculateDateEventSize returns estimated size of the event that contain actual
+// data. We only account for logical ops and sst's. Those events come from raft
+// and are budgeted. Other events come from processor jobs and update timestamps
+// we don't take them into account as they are supposed to be small and to avoid
+// complexity of having multiple producers getting from budget.
+func calculateDateEventSize(e event) int64 {
+	var size int64
+	for _, op := range e.ops {
+		size += int64(op.Size())
+	}
+	size += int64(len(e.sst))
+	return size
 }

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -14,9 +14,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -143,7 +146,6 @@ func newTestProcessorWithTxnPusher(
 		pushTxnInterval = 10 * time.Millisecond
 		pushTxnAge = 50 * time.Millisecond
 	}
-
 	p := NewProcessor(Config{
 		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
 		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
@@ -175,27 +177,27 @@ func newTestProcessor(
 func TestProcessorBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	p, stopper := newTestProcessor(t, nil /* rtsIter */)
-	defer stopper.Stop(context.Background())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	// Test processor without registrations.
 	require.Equal(t, 0, p.Len())
-	require.NotPanics(t, func() { p.ConsumeLogicalOps() })
-	require.NotPanics(t, func() { p.ConsumeLogicalOps([]enginepb.MVCCLogicalOp{}...) })
+	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx) })
+	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx, []enginepb.MVCCLogicalOp{}...) })
 	require.NotPanics(t, func() {
 		txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-		p.ConsumeLogicalOps(
+		p.ConsumeLogicalOps(ctx,
 			writeValueOp(hlc.Timestamp{WallTime: 1}),
 			writeIntentOp(txn1, hlc.Timestamp{WallTime: 2}),
 			updateIntentOp(txn1, hlc.Timestamp{WallTime: 3}),
 			commitIntentOp(txn1, hlc.Timestamp{WallTime: 4}),
 			writeIntentOp(txn2, hlc.Timestamp{WallTime: 5}),
-			abortIntentOp(txn2),
-		)
+			abortIntentOp(txn2))
 		p.syncEventC()
 		require.Equal(t, 0, p.rts.intentQ.Len())
 	})
-	require.NotPanics(t, func() { p.ForwardClosedTS(hlc.Timestamp{}) })
-	require.NotPanics(t, func() { p.ForwardClosedTS(hlc.Timestamp{WallTime: 1}) })
+	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{}) })
+	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 1}) })
 
 	// Add a registration.
 	r1Stream := newTestStream()
@@ -228,7 +230,7 @@ func TestProcessorBasic(t *testing.T) {
 	require.False(t, r1Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("z")}))
 
 	// Test checkpoint with one registration.
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 5})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 5})
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
@@ -239,9 +241,8 @@ func TestProcessorBasic(t *testing.T) {
 	)
 
 	// Test value with one registration.
-	p.ConsumeLogicalOps(
-		writeValueOpWithKV(roachpb.Key("c"), hlc.Timestamp{WallTime: 6}, []byte("val")),
-	)
+	p.ConsumeLogicalOps(ctx,
+		writeValueOpWithKV(roachpb.Key("c"), hlc.Timestamp{WallTime: 6}, []byte("val")))
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedValue(
@@ -255,20 +256,19 @@ func TestProcessorBasic(t *testing.T) {
 	)
 
 	// Test value to non-overlapping key with one registration.
-	p.ConsumeLogicalOps(
-		writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")),
-	)
+	p.ConsumeLogicalOps(ctx,
+		writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")))
 	p.syncEventAndRegistrations()
 	require.Equal(t, []*roachpb.RangeFeedEvent(nil), r1Stream.Events())
 
 	// Test intent that is aborted with one registration.
 	txn1 := uuid.MakeV4()
 	// Write intent.
-	p.ConsumeLogicalOps(writeIntentOp(txn1, hlc.Timestamp{WallTime: 6}))
+	p.ConsumeLogicalOps(ctx, writeIntentOp(txn1, hlc.Timestamp{WallTime: 6}))
 	p.syncEventAndRegistrations()
 	require.Equal(t, []*roachpb.RangeFeedEvent(nil), r1Stream.Events())
 	// Abort.
-	p.ConsumeLogicalOps(abortIntentOp(txn1))
+	p.ConsumeLogicalOps(ctx, abortIntentOp(txn1))
 	p.syncEventC()
 	require.Equal(t, []*roachpb.RangeFeedEvent(nil), r1Stream.Events())
 	require.Equal(t, 0, p.rts.intentQ.Len())
@@ -276,11 +276,11 @@ func TestProcessorBasic(t *testing.T) {
 	// Test intent that is committed with one registration.
 	txn2 := uuid.MakeV4()
 	// Write intent.
-	p.ConsumeLogicalOps(writeIntentOp(txn2, hlc.Timestamp{WallTime: 10}))
+	p.ConsumeLogicalOps(ctx, writeIntentOp(txn2, hlc.Timestamp{WallTime: 10}))
 	p.syncEventAndRegistrations()
 	require.Equal(t, []*roachpb.RangeFeedEvent(nil), r1Stream.Events())
 	// Forward closed timestamp. Should now be stuck on intent.
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 15})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 15})
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
@@ -290,7 +290,7 @@ func TestProcessorBasic(t *testing.T) {
 		r1Stream.Events(),
 	)
 	// Update the intent. Should forward resolved timestamp.
-	p.ConsumeLogicalOps(updateIntentOp(txn2, hlc.Timestamp{WallTime: 12}))
+	p.ConsumeLogicalOps(ctx, updateIntentOp(txn2, hlc.Timestamp{WallTime: 12}))
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
@@ -300,9 +300,8 @@ func TestProcessorBasic(t *testing.T) {
 		r1Stream.Events(),
 	)
 	// Commit intent. Should forward resolved timestamp to closed timestamp.
-	p.ConsumeLogicalOps(
-		commitIntentOpWithKV(txn2, roachpb.Key("e"), hlc.Timestamp{WallTime: 13}, []byte("ival")),
-	)
+	p.ConsumeLogicalOps(ctx,
+		commitIntentOpWithKV(txn2, roachpb.Key("e"), hlc.Timestamp{WallTime: 13}, []byte("ival")))
 	p.syncEventAndRegistrations()
 	require.Equal(t,
 		[]*roachpb.RangeFeedEvent{
@@ -354,7 +353,7 @@ func TestProcessorBasic(t *testing.T) {
 	require.False(t, r1And2Filter.NeedPrevVal(roachpb.Span{Key: roachpb.Key("zzz")}))
 
 	// Both registrations should see checkpoint.
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 20})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 20})
 	p.syncEventAndRegistrations()
 	chEventAM := []*roachpb.RangeFeedEvent{rangeFeedCheckpoint(
 		roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
@@ -368,9 +367,8 @@ func TestProcessorBasic(t *testing.T) {
 	require.Equal(t, chEventCZ, r2Stream.Events())
 
 	// Test value with two registration that overlaps both.
-	p.ConsumeLogicalOps(
-		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 22}, []byte("val2")),
-	)
+	p.ConsumeLogicalOps(ctx,
+		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 22}, []byte("val2")))
 	p.syncEventAndRegistrations()
 	valEvent := []*roachpb.RangeFeedEvent{rangeFeedValue(
 		roachpb.Key("k"),
@@ -383,9 +381,8 @@ func TestProcessorBasic(t *testing.T) {
 	require.Equal(t, valEvent, r2Stream.Events())
 
 	// Test value that only overlaps the second registration.
-	p.ConsumeLogicalOps(
-		writeValueOpWithKV(roachpb.Key("v"), hlc.Timestamp{WallTime: 23}, []byte("val3")),
-	)
+	p.ConsumeLogicalOps(ctx,
+		writeValueOpWithKV(roachpb.Key("v"), hlc.Timestamp{WallTime: 23}, []byte("val3")))
 	p.syncEventAndRegistrations()
 	valEvent2 := []*roachpb.RangeFeedEvent{rangeFeedValue(
 		roachpb.Key("v"),
@@ -422,21 +419,22 @@ func TestProcessorBasic(t *testing.T) {
 
 func TestNilProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	var p *Processor
 
 	// All of the following should be no-ops.
 	require.Equal(t, 0, p.Len())
 	require.NotPanics(t, func() { p.Stop() })
 	require.NotPanics(t, func() { p.StopWithErr(nil) })
-	require.NotPanics(t, func() { p.ConsumeLogicalOps() })
-	require.NotPanics(t, func() { p.ConsumeLogicalOps(make([]enginepb.MVCCLogicalOp, 5)...) })
-	require.NotPanics(t, func() { p.ForwardClosedTS(hlc.Timestamp{}) })
-	require.NotPanics(t, func() { p.ForwardClosedTS(hlc.Timestamp{WallTime: 1}) })
+	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx) })
+	require.NotPanics(t, func() { p.ConsumeLogicalOps(ctx, make([]enginepb.MVCCLogicalOp, 5)...) })
+	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{}) })
+	require.NotPanics(t, func() { p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 1}) })
 
 	// The following should panic because they are not safe
 	// to call on a nil Processor.
 	stopper := stop.NewStopper()
-	defer stopper.Stop(context.Background())
+	defer stopper.Stop(ctx)
 	require.Panics(t, func() { _ = p.Start(stopper, nil) })
 	require.Panics(t, func() { p.Register(roachpb.RSpan{}, hlc.Timestamp{}, nil, false, nil, nil) })
 }
@@ -444,7 +442,8 @@ func TestNilProcessor(t *testing.T) {
 func TestProcessorSlowConsumer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	p, stopper := newTestProcessor(t, nil /* rtsIter */)
-	defer stopper.Stop(context.Background())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	// Add a registration.
 	r1Stream := newTestStream()
@@ -496,9 +495,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 	toFill := testProcessorEventCCap + 1
 	for i := 0; i < toFill; i++ {
 		ts := hlc.Timestamp{WallTime: int64(i + 2)}
-		p.ConsumeLogicalOps(
-			writeValueOpWithKV(roachpb.Key("k"), ts, []byte("val")),
-		)
+		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(roachpb.Key("k"), ts, []byte("val")))
 
 		// Wait for just the unblocked registration to catch up. This prevents
 		// the race condition where this registration overflows anyway due to
@@ -508,9 +505,8 @@ func TestProcessorSlowConsumer(t *testing.T) {
 
 	// Consume one more event. Should not block, but should cause r1 to overflow
 	// its registration buffer and drop the event.
-	p.ConsumeLogicalOps(
-		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 18}, []byte("val")),
-	)
+	p.ConsumeLogicalOps(ctx,
+		writeValueOpWithKV(roachpb.Key("k"), hlc.Timestamp{WallTime: 18}, []byte("val")))
 
 	// Wait for just the unblocked registration to catch up.
 	p.syncEventAndRegistrationSpan(spXY)
@@ -533,6 +529,142 @@ func TestProcessorSlowConsumer(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestProcessorMemoryBudgetExceeded tests that memory budget will limit amount
+// of data buffered for the feed and result in a registration being removed as a
+// result of budget exhaustion.
+func TestProcessorMemoryBudgetExceeded(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(40))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0)
+
+	stopper := stop.NewStopper()
+	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	p := NewProcessor(Config{
+		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+		PushTxnsInterval:     pushTxnInterval,
+		PushTxnsAge:          pushTxnAge,
+		EventChanCap:         testProcessorEventCCap,
+		CheckStreamsInterval: 10 * time.Millisecond,
+		Metrics:              NewMetrics(),
+		MemBudget:            fb,
+		EventChanTimeout:     time.Millisecond,
+	})
+	require.NoError(t, p.Start(stopper, nil))
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Add a registration.
+	r1Stream := newTestStream()
+	r1ErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		r1Stream,
+		r1ErrC,
+	)
+	p.syncEventAndRegistrations()
+
+	// Block it.
+	unblock := r1Stream.BlockSend()
+	defer func() {
+		if unblock != nil {
+			unblock()
+		}
+	}()
+
+	// Write entries till budget is exhausted
+	for i := 0; i < 10; i++ {
+		if !p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+			roachpb.Key("k"),
+			hlc.Timestamp{WallTime: int64(i + 2)},
+			[]byte(fmt.Sprintf("this is big value %02d", i)))) {
+			break
+		}
+	}
+
+	// Unblock stream processing part to consume error.
+	p.syncEventAndRegistrations()
+
+	// Unblock the 'send' channel. The events should quickly be consumed.
+	unblock()
+	unblock = nil
+	p.syncEventAndRegistrations()
+
+	require.Equal(t, newErrBufferCapacityExceeded().GoError(), (<-r1ErrC).GoError())
+	require.Equal(t, 0, p.reg.Len(), "registration was not removed")
+	require.Equal(t, int64(1), p.Metrics.RangeFeedBudgetExhausted.Count())
+}
+
+// TestProcessorMemoryBudgetReleased that memory budget is correctly released.
+func TestProcessorMemoryBudgetReleased(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(40))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0)
+
+	stopper := stop.NewStopper()
+	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	p := NewProcessor(Config{
+		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+		PushTxnsInterval:     pushTxnInterval,
+		PushTxnsAge:          pushTxnAge,
+		EventChanCap:         testProcessorEventCCap,
+		CheckStreamsInterval: 10 * time.Millisecond,
+		Metrics:              NewMetrics(),
+		MemBudget:            fb,
+		EventChanTimeout:     15 * time.Minute, // Enable timeout to allow consumer to process
+		// events even if we reach memory budget capacity.
+	})
+	require.NoError(t, p.Start(stopper, nil))
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Add a registration.
+	r1Stream := newTestStream()
+	r1ErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		r1Stream,
+		r1ErrC,
+	)
+	p.syncEventAndRegistrations()
+
+	// Write entries and check they are consumed so that we could write more
+	// data than total budget if inflight messages are within budget.
+	const eventCount = 10
+	for i := 0; i < eventCount; i++ {
+		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+			roachpb.Key("k"),
+			hlc.Timestamp{WallTime: int64(i + 2)},
+			[]byte("value")))
+	}
+	p.syncEventAndRegistrations()
+
+	// Count consumed values
+	consumedOps := 0
+	for _, e := range r1Stream.Events() {
+		if e.Val != nil {
+			consumedOps++
+		}
+	}
+	require.Equal(t, 1, p.reg.Len(), "registration was removed")
+	require.Equal(t, 10, consumedOps)
 }
 
 // TestProcessorInitializeResolvedTimestamp tests that when a Processor is given
@@ -570,7 +702,8 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 	rtsIter.block = make(chan struct{})
 
 	p, stopper := newTestProcessor(t, rtsIter)
-	defer stopper.Stop(context.Background())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	// The resolved timestamp should not be initialized.
 	require.False(t, p.rts.IsInit())
@@ -603,7 +736,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 
 	// Forward the closed timestamp. The resolved timestamp should still
 	// not be initialized.
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 20})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 20})
 	require.False(t, p.rts.IsInit())
 	require.Equal(t, hlc.Timestamp{}, p.rts.Get())
 
@@ -732,19 +865,20 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 	})
 
 	p, stopper := newTestProcessorWithTxnPusher(t, nil /* rtsIter */, &tp)
-	defer stopper.Stop(context.Background())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	// Add a few intents and move the closed timestamp forward.
 	writeIntentOpFromMeta := func(txn enginepb.TxnMeta) enginepb.MVCCLogicalOp {
 		return writeIntentOpWithDetails(txn.ID, txn.Key, txn.MinTimestamp, txn.WriteTimestamp)
 	}
-	p.ConsumeLogicalOps(
+	p.ConsumeLogicalOps(ctx,
 		writeIntentOpFromMeta(txn1Meta),
 		writeIntentOpFromMeta(txn2Meta),
 		writeIntentOpFromMeta(txn2Meta),
 		writeIntentOpFromMeta(txn3Meta),
 	)
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 40})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 40})
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 9}, p.rts.Get())
 
@@ -757,7 +891,7 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 
 	// Write another intent for one of the txns. This moves the resolved
 	// timestamp forward.
-	p.ConsumeLogicalOps(writeIntentOpFromMeta(txn1MetaT2Pre))
+	p.ConsumeLogicalOps(ctx, writeIntentOpFromMeta(txn1MetaT2Pre))
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 19}, p.rts.Get())
 
@@ -771,21 +905,17 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 	require.Equal(t, hlc.Timestamp{WallTime: 40}, p.rts.Get())
 
 	// Forward the closed timestamp.
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 80})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 80})
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 49}, p.rts.Get())
 
 	// Txn1's first intent is committed. Resolved timestamp doesn't change.
-	p.ConsumeLogicalOps(
-		commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp),
-	)
+	p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 49}, p.rts.Get())
 
 	// Txn1's second intent is committed. Resolved timestamp moves forward.
-	p.ConsumeLogicalOps(
-		commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp),
-	)
+	p.ConsumeLogicalOps(ctx, commitIntentOp(txn1MetaT2Post.ID, txn1MetaT2Post.WriteTimestamp))
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 59}, p.rts.Get())
 
@@ -799,14 +929,12 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 	require.Equal(t, hlc.Timestamp{WallTime: 80}, p.rts.Get())
 
 	// Forward the closed timestamp.
-	p.ForwardClosedTS(hlc.Timestamp{WallTime: 100})
+	p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 100})
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 89}, p.rts.Get())
 
 	// Commit txn3's only intent. Resolved timestamp moves forward.
-	p.ConsumeLogicalOps(
-		commitIntentOp(txn3MetaT3Post.ID, txn3MetaT3Post.WriteTimestamp),
-	)
+	p.ConsumeLogicalOps(ctx, commitIntentOp(txn3MetaT3Post.ID, txn3MetaT3Post.WriteTimestamp))
 	p.syncEventC()
 	require.Equal(t, hlc.Timestamp{WallTime: 100}, p.rts.Get())
 
@@ -819,6 +947,7 @@ func TestProcessorTxnPushAttempt(t *testing.T) {
 // not then it would be possible for them to deadlock.
 func TestProcessorConcurrentStop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
 	const trials = 10
 	for i := 0; i < trials; i++ {
 		p, stopper := newTestProcessor(t, nil /* rtsIter */)
@@ -840,14 +969,13 @@ func TestProcessorConcurrentStop(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			runtime.Gosched()
-			p.ConsumeLogicalOps(
-				writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")),
-			)
+			p.ConsumeLogicalOps(ctx,
+				writeValueOpWithKV(roachpb.Key("s"), hlc.Timestamp{WallTime: 6}, []byte("val")))
 		}()
 		go func() {
 			defer wg.Done()
 			runtime.Gosched()
-			p.ForwardClosedTS(hlc.Timestamp{WallTime: 2})
+			p.ForwardClosedTS(ctx, hlc.Timestamp{WallTime: 2})
 		}()
 		go func() {
 			defer wg.Done()
@@ -868,7 +996,8 @@ func TestProcessorConcurrentStop(t *testing.T) {
 func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	p, stopper := newTestProcessor(t, nil /* rtsIter */)
-	defer stopper.Stop(context.Background())
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
 
 	firstC := make(chan int64)
 	regDone := make(chan struct{})
@@ -886,7 +1015,7 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 			}
 
 			// Consume the logical op. Encode the index in the timestamp.
-			p.ConsumeLogicalOps(writeValueOp(hlc.Timestamp{WallTime: i}))
+			p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: i}))
 		}
 		p.syncEventC()
 		close(firstC)
@@ -943,5 +1072,405 @@ func (p *Processor) syncEventAndRegistrationSpan(span roachpb.Span) {
 	case <-p.stoppedC:
 		putPooledEvent(ev)
 		// Already stopped. Do nothing.
+	}
+}
+
+func TestBudgetReleaseOnProcessorStop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const totalEvents = 100
+
+	// Channel capacity is used in two places, processor channel and registration
+	// channel. By having each of them half the events could we could fit
+	// everything in. Additional elements is a slack for checkpoint events as well
+	// as sync events used to flush queues.
+	const channelCapacity = totalEvents/2 + 10
+
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0)
+
+	stopper := stop.NewStopper()
+	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	p := NewProcessor(Config{
+		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+		PushTxnsInterval:     pushTxnInterval,
+		PushTxnsAge:          pushTxnAge,
+		EventChanCap:         channelCapacity,
+		CheckStreamsInterval: 10 * time.Millisecond,
+		Metrics:              NewMetrics(),
+		MemBudget:            fb,
+	})
+	require.NoError(t, p.Start(stopper, nil))
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Add a registration.
+	rStream := newConsumer(50)
+	defer func() { rStream.Resume() }()
+	rErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		rStream,
+		rErrC,
+	)
+	p.syncEventAndRegistrations()
+
+	for i := 0; i < totalEvents; i++ {
+		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+			roachpb.Key("k"),
+			hlc.Timestamp{WallTime: int64(i + 2)},
+			[]byte(fmt.Sprintf("this is value %04d", i))))
+	}
+
+	// Wait for half of the event to be processed by stream then stop processor.
+	select {
+	case <-rStream.blocked:
+	case err := <-rErrC:
+		t.Fatal("stream failed with error before all data was consumed", err)
+	}
+
+	// Since stop is blocking and needs to flush events we need to do that in
+	// parallel.
+	stopped := make(chan interface{})
+	go func() {
+		p.Stop()
+		stopped <- struct{}{}
+	}()
+
+	// Resume event loop in consumer to unblock any internal loops of processor or
+	// registrations.
+	rStream.Resume()
+
+	// Wait for top function to finish processing before verifying that we
+	// consumed all events.
+	<-stopped
+
+	// We need to wait for budget to drain as Stop would only post stop event
+	// after flushing the queue, but couldn't determine when main processor loop
+	// is actually closed.
+	testutils.SucceedsSoon(t, func() error {
+		fmt.Printf("Budget now: %d bytes remained, %d events processed\n",
+			m.AllocBytes(), rStream.Consumed())
+		if m.AllocBytes() != 0 {
+			return errors.Errorf(
+				"Failed to release all budget after stop: %d bytes remained, %d events processed",
+				m.AllocBytes(), rStream.Consumed())
+		}
+		return nil
+	})
+}
+
+// TestBudgetReleaseOnLastStreamError verifies that when stream fails memory
+// budget for discarded pending events is returned.
+func TestBudgetReleaseOnLastStreamError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const totalEvents = 100
+
+	// Add an extra capacity in channel to accommodate for checkpoint and sync
+	// objects. Ideally it would be nice to have
+	const channelCapacity = totalEvents + 5
+
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0)
+
+	stopper := stop.NewStopper()
+	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	p := NewProcessor(Config{
+		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+		PushTxnsInterval:     pushTxnInterval,
+		PushTxnsAge:          pushTxnAge,
+		EventChanCap:         channelCapacity,
+		CheckStreamsInterval: 10 * time.Millisecond,
+		MemBudget:            fb,
+	})
+	require.NoError(t, p.Start(stopper, nil))
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Add a registration.
+	rStream := newConsumer(90)
+	defer func() { rStream.Resume() }()
+	rErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		rStream,
+		rErrC,
+	)
+	p.syncEventAndRegistrations()
+
+	for i := 0; i < totalEvents; i++ {
+		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+			roachpb.Key("k"),
+			hlc.Timestamp{WallTime: int64(i + 2)},
+			[]byte(fmt.Sprintf("this is value %04d", i))))
+	}
+
+	// Wait for half of the event to be processed then raise error.
+	select {
+	case <-rStream.blocked:
+	case err := <-rErrC:
+		t.Fatal("stream failed with error before stream blocked: ", err)
+	}
+
+	// Resume event loop in consumer and fail Stream to remove registration.
+	rStream.ResumeWithFailure(errors.Errorf("Closing down stream"))
+
+	// We need to wait for budget to drain as all pending events are processed
+	// or dropped.
+	requireBudgetDrainedSoon(t, p, rStream)
+}
+
+// TestBudgetReleaseOnOneStreamError verifies that if one stream fails while
+// other keeps running, accounting correctly releases memory budget for shared
+// events.
+func TestBudgetReleaseOnOneStreamError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const totalEvents = 100
+
+	// Channel capacity is used in two places, processor channel and registration
+	// channel. By having each of them half the events could we could fit
+	// everything in. Additional elements is a slack for checkpoint events as well
+	// as sync events used to flush queues.
+	const channelCapacity = totalEvents/2 + 10
+
+	m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+	m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	b := m.MakeBoundAccount()
+	fb := NewFeedBudget(&b, 0)
+
+	stopper := stop.NewStopper()
+	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	p := NewProcessor(Config{
+		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+		PushTxnsInterval:     pushTxnInterval,
+		PushTxnsAge:          pushTxnAge,
+		EventChanCap:         channelCapacity,
+		CheckStreamsInterval: 10 * time.Millisecond,
+		Metrics:              NewMetrics(),
+		MemBudget:            fb,
+	})
+	require.NoError(t, p.Start(stopper, nil))
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Add a registration.
+	r1Stream := newConsumer(50)
+	defer func() { r1Stream.Resume() }()
+	r1ErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		r1Stream,
+		r1ErrC,
+	)
+	// Non-blocking registration that would consume all events.
+	r2Stream := newConsumer(0)
+	r2ErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		r2Stream,
+		r2ErrC,
+	)
+	p.syncEventAndRegistrations()
+
+	for i := 0; i < totalEvents; i++ {
+		p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+			roachpb.Key("k"),
+			hlc.Timestamp{WallTime: int64(i + 2)},
+			[]byte(fmt.Sprintf("this is value %04d", i))))
+	}
+
+	// Wait for half of the event to be processed then stop processor.
+	select {
+	case <-r1Stream.blocked:
+	case err := <-r1ErrC:
+		t.Fatal("stream failed with error before all data was consumed", err)
+	}
+
+	// Resume event loop in consumer and fail Stream to remove registration.
+	r1Stream.ResumeWithFailure(errors.Errorf("Closing down stream"))
+
+	// We need to wait for budget to drain as all pending events are processed
+	// or dropped.
+	requireBudgetDrainedSoon(t, p, r1Stream)
+}
+
+// requireBudgetDrainedSoon checks that memory budget drains to zero soon.
+// Since we don't stop the processor we can't rely on on stop operation syncing
+// all registrations and we resort to waiting for registration work loops to
+// stop and drain remaining allocations.
+// We use account and not a monitor for those checks because monitor doesn't
+// necessary return all data to the pool until processor is stopped.
+func requireBudgetDrainedSoon(t *testing.T, processor *Processor, stream *consumer) {
+	testutils.SucceedsSoon(t, func() error {
+		processor.MemBudget.mu.Lock()
+		used := processor.MemBudget.mu.memBudget.Used()
+		processor.MemBudget.mu.Unlock()
+		fmt.Printf("Budget used: %d bytes, %d events processed\n",
+			used, stream.Consumed())
+		if used != 0 {
+			return errors.Errorf(
+				"Failed to release all budget after stream stop: %d bytes remained, %d events processed",
+				used, stream.Consumed())
+		}
+		return nil
+	})
+}
+
+type consumer struct {
+	ctx        context.Context
+	ctxDone    func()
+	sentValues int32
+
+	blockAfter int
+	blocked    chan interface{}
+	resume     chan error
+}
+
+func newConsumer(blockAfter int) *consumer {
+	ctx, done := context.WithCancel(context.Background())
+	return &consumer{
+		ctx:        ctx,
+		ctxDone:    done,
+		blockAfter: blockAfter,
+		blocked:    make(chan interface{}),
+		resume:     make(chan error),
+	}
+}
+
+func (c *consumer) Send(e *roachpb.RangeFeedEvent) error {
+	//fmt.Printf("Stream received event %v\n", e)
+	if e.Val != nil {
+		v := int(atomic.AddInt32(&c.sentValues, 1))
+		if v == c.blockAfter {
+			// Resume test if it was waiting for stream to block.
+			close(c.blocked)
+			// Wait for resume signal with an optional error.
+			err, ok := <-c.resume
+			if ok {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *consumer) Context() context.Context {
+	return c.ctx
+}
+
+func (c *consumer) Cancel() {
+	c.ctxDone()
+}
+
+func (c *consumer) WaitBlock() {
+	<-c.blocked
+}
+
+// Resume resumes stream by closing its wait channel.
+// If there was a pending err for resuming then it would be discarded and
+// channel closed.
+func (c *consumer) Resume() {
+	select {
+	case _, ok := <-c.resume:
+		if ok {
+			close(c.resume)
+		}
+	default:
+		close(c.resume)
+	}
+}
+
+// Resume resumes stream by posting an error and then closing stream.
+// Method would block until error is posted.
+func (c *consumer) ResumeWithFailure(err error) {
+	c.resume <- err
+}
+
+func (c *consumer) Consumed() int {
+	return int(atomic.LoadInt32(&c.sentValues))
+}
+
+func BenchmarkProcessorWithBudget(b *testing.B) {
+	benchmarkEvents := 1
+
+	var budget *FeedBudget
+	if false {
+		m := mon.NewMonitor("rangefeed", mon.MemoryResource, nil, nil, 1, math.MaxInt64, nil)
+		m.Start(context.Background(), nil, mon.MakeStandaloneBudget(math.MaxInt64))
+		acc := m.MakeBoundAccount()
+		budget = NewFeedBudget(&acc, 0)
+	}
+
+	stopper := stop.NewStopper()
+	var pushTxnInterval, pushTxnAge time.Duration = 0, 0 // disable
+	p := NewProcessor(Config{
+		AmbientContext:       log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:                hlc.NewClock(hlc.UnixNano, time.Nanosecond),
+		Span:                 roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")},
+		PushTxnsInterval:     pushTxnInterval,
+		PushTxnsAge:          pushTxnAge,
+		EventChanCap:         benchmarkEvents * b.N,
+		CheckStreamsInterval: 10 * time.Millisecond,
+		Metrics:              NewMetrics(),
+		MemBudget:            budget,
+		EventChanTimeout:     time.Minute,
+	})
+	require.NoError(b, p.Start(stopper, nil))
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Add a registration.
+	r1Stream := newTestStream()
+	r1ErrC := make(chan *roachpb.Error, 1)
+	p.Register(
+		roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
+		hlc.Timestamp{WallTime: 1},
+		nil,   /* catchUpIter */
+		false, /* withDiff */
+		r1Stream,
+		r1ErrC,
+	)
+	p.syncEventAndRegistrations()
+
+	b.ResetTimer()
+	for bi := 0; bi < b.N; bi++ {
+		for i := 0; i < benchmarkEvents; i++ {
+			p.ConsumeLogicalOps(ctx, writeValueOpWithKV(
+				roachpb.Key("k"),
+				hlc.Timestamp{WallTime: int64(bi*benchmarkEvents + i + 2)},
+				[]byte("this is value")))
+		}
+	}
+
+	p.syncEventAndRegistrations()
+
+	// Sanity check that subscription was not dropped.
+	if p.reg.Len() == 0 {
+		err := <-r1ErrC
+		require.NoError(b, err.GoError())
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -36,6 +36,32 @@ type Stream interface {
 	Send(*roachpb.RangeFeedEvent) error
 }
 
+// Shared event is an entry stored in registration channel. Each entry is
+// specific to registration but allocation is shared between all registrations
+// to track memory budgets. event itself could either be shared or not in case
+// we optimized unused fields in it based on registration options.
+type sharedEvent struct {
+	event      *roachpb.RangeFeedEvent
+	allocation *SharedBudgetAllocation
+}
+
+var sharedEventSyncPool = sync.Pool{
+	New: func() interface{} {
+		return new(sharedEvent)
+	},
+}
+
+func getPooledSharedEvent(e sharedEvent) *sharedEvent {
+	ev := sharedEventSyncPool.Get().(*sharedEvent)
+	*ev = e
+	return ev
+}
+
+func putPooledSharedEvent(e *sharedEvent) {
+	*e = sharedEvent{}
+	sharedEventSyncPool.Put(e)
+}
+
 // registration is an instance of a rangefeed subscriber who has
 // registered to receive updates for a specific range of keys.
 // Updates are delivered to its stream until one of the following
@@ -70,7 +96,7 @@ type registration struct {
 	// Internal.
 	id   int64
 	keys interval.Range
-	buf  chan *roachpb.RangeFeedEvent
+	buf  chan *sharedEvent
 
 	mu struct {
 		sync.Locker
@@ -110,7 +136,7 @@ func newRegistration(
 		metrics:                metrics,
 		stream:                 stream,
 		errC:                   errC,
-		buf:                    make(chan *roachpb.RangeFeedEvent, bufferSz),
+		buf:                    make(chan *sharedEvent, bufferSz),
 	}
 	r.mu.Locker = &syncutil.Mutex{}
 	r.mu.caughtUp = true
@@ -122,22 +148,26 @@ func newRegistration(
 // indicating that live events were lost and a catch-up scan should be initiated.
 // If overflowed is already set, events are ignored and not written to the
 // buffer.
-func (r *registration) publish(event *roachpb.RangeFeedEvent) {
+func (r *registration) publish(
+	ctx context.Context, event *roachpb.RangeFeedEvent, allocation *SharedBudgetAllocation,
+) {
 	r.validateEvent(event)
-	event = r.maybeStripEvent(event)
+	e := getPooledSharedEvent(sharedEvent{event: r.maybeStripEvent(event), allocation: allocation})
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.mu.overflowed {
 		return
 	}
+	allocation.Use()
 	select {
-	case r.buf <- event:
+	case r.buf <- e:
 		r.mu.caughtUp = false
 	default:
 		// Buffer exceeded and we are dropping this event. Registration will need
 		// a catch-up scan.
 		r.mu.overflowed = true
+		allocation.Release(ctx)
 	}
 }
 
@@ -279,7 +309,10 @@ func (r *registration) outputLoop(ctx context.Context) error {
 
 		select {
 		case nextEvent := <-r.buf:
-			if err := r.stream.Send(nextEvent); err != nil {
+			err := r.stream.Send(nextEvent.event)
+			nextEvent.allocation.Release(ctx)
+			putPooledSharedEvent(nextEvent)
+			if err != nil {
 				return err
 			}
 		case <-ctx.Done():
@@ -301,6 +334,23 @@ func (r *registration) runOutputLoop(ctx context.Context, _forStacks roachpb.Ran
 	r.mu.Unlock()
 	err := r.outputLoop(ctx)
 	r.disconnect(roachpb.NewError(err))
+}
+
+// drainAllocations should be done after registration is disconnected from
+// processor to release all memory budget that its pending events hold.
+func (r *registration) drainAllocations(ctx context.Context) {
+	for {
+		select {
+		case e, ok := <-r.buf:
+			if !ok {
+				return
+			}
+			e.allocation.Release(ctx)
+			putPooledSharedEvent(e)
+		default:
+			return
+		}
+	}
 }
 
 // maybeRunCatchUpScan starts a catch-up scan which will output entries for all
@@ -380,7 +430,12 @@ func (reg *registry) nextID() int64 {
 
 // PublishToOverlapping publishes the provided event to all registrations whose
 // range overlaps the specified span.
-func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.RangeFeedEvent) {
+func (reg *registry) PublishToOverlapping(
+	ctx context.Context,
+	span roachpb.Span,
+	event *roachpb.RangeFeedEvent,
+	allocation *SharedBudgetAllocation,
+) {
 	// Determine the earliest starting timestamp that a registration
 	// can have while still needing to hear about this event.
 	var minTS hlc.Timestamp
@@ -404,7 +459,7 @@ func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.Rang
 		// Don't publish events if they are equal to or less
 		// than the registration's starting timestamp.
 		if r.catchUpTimestamp.Less(minTS) {
-			r.publish(event)
+			r.publish(ctx, event, allocation)
 		}
 		return false, nil
 	})
@@ -413,10 +468,14 @@ func (reg *registry) PublishToOverlapping(span roachpb.Span, event *roachpb.Rang
 // Unregister removes a registration from the registry. It is assumed that the
 // registration has already been disconnected, this is intended only to clean
 // up the registry.
-func (reg *registry) Unregister(r *registration) {
+// We also drain all pending events for the sake of memory accounting. To do
+// that we rely on a fact that caller is not going to post any more events
+// concurrently or after this function is called.
+func (reg *registry) Unregister(ctx context.Context, r *registration) {
 	if err := reg.tree.Delete(r, false /* fast */); err != nil {
 		panic(err)
 	}
+	r.drainAllocations(ctx)
 }
 
 // Disconnect disconnects all registrations that overlap the specified span with

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -55,7 +55,7 @@ func (s *initResolvedTSScan) Run(ctx context.Context) {
 		s.p.StopWithErr(roachpb.NewError(err))
 	} else {
 		// Inform the processor that its resolved timestamp can be initialized.
-		s.p.setResolvedTSInitialized()
+		s.p.setResolvedTSInitialized(ctx)
 	}
 }
 
@@ -65,7 +65,7 @@ func (s *initResolvedTSScan) iterateAndConsume(ctx context.Context) error {
 	return s.is.ConsumeIntents(ctx, startKey, endKey, func(op enginepb.MVCCWriteIntentOp) bool {
 		var ops [1]enginepb.MVCCLogicalOp
 		ops[0].SetValue(&op)
-		return s.p.sendEvent(event{ops: ops[:]}, 0 /* timeout */)
+		return s.p.sendEvent(ctx, event{ops: ops[:]}, 0)
 	})
 }
 
@@ -343,7 +343,7 @@ func (a *txnPushAttempt) pushOldTxns(ctx context.Context) error {
 	}
 
 	// Inform the processor of all logical ops.
-	a.p.sendEvent(event{ops: ops}, 0 /* timeout */)
+	a.p.sendEvent(ctx, event{ops: ops}, 0)
 
 	// Resolve intents, if necessary.
 	return a.p.TxnPusher.ResolveIntents(ctx, intentsToCleanup)

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -630,7 +630,7 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 	}
 
 	// Pass the ops to the rangefeed processor.
-	if !p.ConsumeLogicalOps(ops.Ops...) {
+	if !p.ConsumeLogicalOps(ctx, ops.Ops...) {
 		// Consumption failed and the rangefeed was stopped.
 		r.unsetRangefeedProcessor(p)
 	}
@@ -653,7 +653,7 @@ func (r *Replica) handleSSTableRaftMuLocked(
 	if p == nil {
 		return
 	}
-	if !p.ConsumeSSTable(sst, sstSpan, writeTS) {
+	if !p.ConsumeSSTable(ctx, sst, sstSpan, writeTS) {
 		r.unsetRangefeedProcessor(p)
 	}
 }
@@ -736,7 +736,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 	if closedTS.IsEmpty() {
 		return
 	}
-	if !p.ForwardClosedTS(closedTS) {
+	if !p.ForwardClosedTS(ctx, closedTS) {
 		// Consumption failed and the rangefeed was stopped.
 		r.unsetRangefeedProcessor(p)
 	}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -567,6 +567,13 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Rangefeed Memory Budgeting",
+				Metrics: []string{
+					"kv.rangefeed.budget_allocation_failed",
+					"kv.rangefeed.budget_allocation_blocked",
+				},
+			},
+			{
 				Title: "Snapshots",
 				Metrics: []string{
 					"range.snapshots.generated",


### PR DESCRIPTION
Previously rangefeed could buffer as many events as its EventChanCap allows regardless of event size. With an addition of addsstable mvcc operation the size of the event could become prohibitively large if multiple events are queued.
To protect KV from running out of memory in such cases this patch introduces range feed memory budget that would cap total size of queued events.

This is achieved by acquiring budget allocations in processor and subsequently tracking usage across registrations so that budget is released when all registrations are done.

Release note: None

Touches: #73616