### PR TITLE
spanconfigsqltranslator: emit all SystemTarget span configs when required

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -1,7 +1,5 @@
 # Create a database with some tables and write protected timestamps on the
 # tables and database. Check that span configurations are as we expect.
-# TODO(adityamaru): Add tests with Cluster, Tenant target once the translator
-# has been taught to generate SystemSpanConfigs.
 
 exec-sql
 CREATE DATABASE db;
@@ -41,9 +39,43 @@ translate database=db
 /Table/10{6-7}                             num_replicas=7 num_voters=5 pts=[1 2]
 /Table/10{7-8}                             num_replicas=7 pts=[2]
 
+# Write a protected timestamp on the cluster.
+protect record-id=3 ts=3
+cluster
+----
+
+# Write a protected timestamp on some tenants.
+protect record-id=4 ts=4
+tenants 111,112,113
+----
+
+# Write another protected timestamp on a subset of the tenants.
+protect record-id=5 ts=3
+tenants 111,112
+----
+
+translate system-span-configurations
+----
+{entire-keyspace}                          pts=[3]
+{source=1,target=111}                      pts=[3 4]
+{source=1,target=112}                      pts=[3 4]
+{source=1,target=113}                      pts=[4]
+
+translate database=db
+----
+/Table/10{6-7}                             num_replicas=7 num_voters=5 pts=[1 2]
+/Table/10{7-8}                             num_replicas=7 pts=[2]
+
 # Release the protected timestamp on table t1
 release record-id=1
 ----
+
+translate system-span-configurations
+----
+{entire-keyspace}                          pts=[3]
+{source=1,target=111}                      pts=[3 4]
+{source=1,target=112}                      pts=[3 4]
+{source=1,target=113}                      pts=[4]
 
 translate database=db
 ----
@@ -54,10 +86,25 @@ translate database=db
 release record-id=2
 ----
 
+translate system-span-configurations
+----
+{entire-keyspace}                          pts=[3]
+{source=1,target=111}                      pts=[3 4]
+{source=1,target=112}                      pts=[3 4]
+{source=1,target=113}                      pts=[4]
+
 translate database=db
 ----
 /Table/10{6-7}                             num_replicas=7 num_voters=5
 /Table/10{7-8}                             num_replicas=7
+
+
+# Release the protected timestamp on the cluster and tenants.
+release record-id=3
+----
+
+release record-id=4
+----
 
 # Create an index on t1 to ensure that subzones also see protected timestamps.
 exec-sql
@@ -65,13 +112,18 @@ CREATE INDEX idx ON db.t1(id);
 ALTER INDEX db.t1@idx CONFIGURE ZONE USING gc.ttlseconds = 1;
 ----
 
-protect record-id=3 ts=3
+protect record-id=6 ts=6
 descs 106
 ----
 
+translate system-span-configurations
+----
+{source=1,target=111}                      pts=[3]
+{source=1,target=112}                      pts=[3]
+
 translate database=db
 ----
-/Table/106{-/2}                            num_replicas=7 num_voters=5 pts=[3]
-/Table/106/{2-3}                           ttl_seconds=1 num_replicas=7 num_voters=5 pts=[3]
-/Table/10{6/3-7}                           num_replicas=7 num_voters=5 pts=[3]
+/Table/106{-/2}                            num_replicas=7 num_voters=5 pts=[6]
+/Table/106/{2-3}                           ttl_seconds=1 num_replicas=7 num_voters=5 pts=[6]
+/Table/10{6/3-7}                           num_replicas=7 num_voters=5 pts=[6]
 /Table/10{7-8}                             num_replicas=7

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
@@ -8,9 +8,9 @@ CREATE TABLE db.t2();
 ----
 
 # Schema object IDs
-# db: 54
-# t1: 56
-# t2: 57
+# db: 104
+# t1: 106
+# t2: 107
 
 # Alter zone config fields on the database and one of the tables to ensure
 # things are cascading.
@@ -21,36 +21,64 @@ ALTER TABLE db.t1 CONFIGURE ZONE USING num_voters=5;
 
 # Write a protected timestamp on t1.
 protect record-id=1 ts=1
-descs 56
+descs 106
 ----
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 pts=[1]
 /Tenant/10/Table/10{7-8}                   num_replicas=7
 
 # Write a protected timestamp on db, so we should see it on both t1 and t2.
 protect record-id=2 ts=2
-descs 54
+descs 104
 ----
 
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 pts=[1 2]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 pts=[2]
+
+
+# Write a protected timestamp on the tenant cluster.
+protect record-id=3 ts=3
+cluster
+----
+
+# Write another protected timestamp on the tenant cluster.
+protect record-id=4 ts=3
+cluster
+----
+
+translate system-span-configurations
+----
+{source=10,target=10}                      pts=[3 3]
+
+translate database=db
+----
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 pts=[1 2]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 pts=[2]
 
 # Release the protected timestamp on table t1
 release record-id=1
 ----
 
+translate system-span-configurations
+----
+{source=10,target=10}                      pts=[3 3]
+
 translate database=db
 ----
-/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
-/Tenant/10/Table/10{7-8}                   num_replicas=7
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 pts=[2]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 pts=[2]
 
 # Release the protected timestamp on database db
 release record-id=2
 ----
+
+translate system-span-configurations
+----
+{source=10,target=10}                      pts=[3 3]
 
 translate database=db
 ----
@@ -63,13 +91,21 @@ CREATE INDEX idx ON db.t1(id);
 ALTER INDEX db.t1@idx CONFIGURE ZONE USING gc.ttlseconds = 1;
 ----
 
-protect record-id=3 ts=3
-descs 56
+protect record-id=5 ts=5
+descs 106
 ----
+
+# Release the protected timestamp on the tenant cluster.
+release record-id=3
+----
+
+translate system-span-configurations
+----
+{source=10,target=10}                      pts=[3]
 
 translate database=db
 ----
-/Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5
-/Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5
-/Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5
+/Tenant/10/Table/106{-/2}                  num_replicas=7 num_voters=5 pts=[5]
+/Tenant/10/Table/106/{2-3}                 ttl_seconds=1 num_replicas=7 num_voters=5 pts=[5]
+/Tenant/10/Table/10{6/3-7}                 num_replicas=7 num_voters=5 pts=[5]
 /Tenant/10/Table/10{7-8}                   num_replicas=7

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -108,6 +108,12 @@ func TestingDefaultSpanConfig() SpanConfig {
 	}
 }
 
+// TestingDefaultSystemSpanConfiguration exports the default span config that
+// applies to spanconfig.SystemTargets for testing purposes.
+func TestingDefaultSystemSpanConfiguration() SpanConfig {
+	return SpanConfig{}
+}
+
 // TestingSystemSpanConfig exports the system span config for testing purposes.
 func TestingSystemSpanConfig() SpanConfig {
 	config := TestingDefaultSpanConfig()

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -98,8 +98,11 @@ type KVSubscriber interface {
 type SQLTranslator interface {
 	// Translate generates the span configuration state given a list of
 	// {descriptor, named zone} IDs. Entries are unique, and are omitted for IDs
-	// that don't exist. The timestamp at which the translation is valid is also
-	// returned.
+	// that don't exist.
+	// Additionally, if `generateSystemSpanConfigurations` is set to true,
+	// Translate will generate all the span configurations that apply to
+	// `spanconfig.SystemTargets`. The timestamp at which the translation is valid
+	// is also returned.
 	//
 	// For every ID we first descend the zone configuration hierarchy with the
 	// ID as the root to accumulate IDs of all leaf objects. Leaf objects are
@@ -109,7 +112,8 @@ type SQLTranslator interface {
 	// for each one of these accumulated IDs, we generate <span, config> tuples
 	// by following up the inheritance chain to fully hydrate the span
 	// configuration. Translate also accounts for and negotiates subzone spans.
-	Translate(ctx context.Context, ids descpb.IDs) ([]Record, hlc.Timestamp, error)
+	Translate(ctx context.Context, ids descpb.IDs,
+		generateSystemSpanConfigurations bool) ([]Record, hlc.Timestamp, error)
 }
 
 // FullTranslate translates the entire SQL zone configuration state to the span
@@ -119,7 +123,8 @@ func FullTranslate(ctx context.Context, s SQLTranslator) ([]Record, hlc.Timestam
 	// As RANGE DEFAULT is the root of all zone configurations (including other
 	// named zones for the system tenant), we can construct the entire span
 	// configuration state by starting from RANGE DEFAULT.
-	return s.Translate(ctx, descpb.IDs{keys.RootNamespaceID})
+	return s.Translate(ctx, descpb.IDs{keys.RootNamespaceID},
+		true /* generateSystemSpanConfigurations */)
 }
 
 // SQLWatcherHandler is the signature of a handler that can be passed into

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -56,7 +56,7 @@ func New(
 
 // Translate is part of the spanconfig.SQLTranslator interface.
 func (s *SQLTranslator) Translate(
-	ctx context.Context, ids descpb.IDs,
+	ctx context.Context, ids descpb.IDs, generateSystemSpanConfigurations bool,
 ) ([]spanconfig.Record, hlc.Timestamp, error) {
 	var records []spanconfig.Record
 	// txn used to translate the IDs, so that we can get its commit timestamp
@@ -83,6 +83,13 @@ func (s *SQLTranslator) Translate(
 			return errors.Wrap(err, "failed to get protected timestamp state")
 		}
 		ptsStateReader := newProtectedTimestampStateReader(ctx, ptsState)
+
+		if generateSystemSpanConfigurations {
+			records, err = s.generateSystemSpanConfigRecords(ptsStateReader)
+			if err != nil {
+				return errors.Wrap(err, "failed to generate SystemTarget records")
+			}
+		}
 
 		// For every ID we want to translate, first expand it to descendant leaf
 		// IDs that have span configurations associated for them. We also
@@ -143,6 +150,55 @@ var descLookupFlags = tree.CommonLookupFlags{
 	IncludeOffline: true,
 	// We want consistent reads.
 	AvoidLeased: true,
+}
+
+// generateSystemSpanConfigRecords is responsible for generating all the SpanConfigs
+// that apply to spanconfig.SystemTargets.
+func (s *SQLTranslator) generateSystemSpanConfigRecords(
+	ptsStateReader *protectedTimestampStateReader,
+) ([]spanconfig.Record, error) {
+	tenantPrefix := s.codec.TenantPrefix()
+	_, sourceTenantID, err := keys.DecodeTenantPrefix(tenantPrefix)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]spanconfig.Record, 0)
+
+	// Aggregate cluster target protections for the tenant.
+	clusterProtections := ptsStateReader.getProtectionPoliciesForCluster()
+	if len(clusterProtections) != 0 {
+		var systemTarget spanconfig.SystemTarget
+		var err error
+		if sourceTenantID == roachpb.SystemTenantID {
+			systemTarget = spanconfig.MakeEntireKeyspaceTarget()
+		} else {
+			systemTarget, err = spanconfig.MakeTenantKeyspaceTarget(sourceTenantID, sourceTenantID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		clusterSystemRecord := spanconfig.Record{
+			Target: spanconfig.MakeTargetFromSystemTarget(systemTarget),
+			Config: roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{ProtectionPolicies: clusterProtections}}}
+		records = append(records, clusterSystemRecord)
+	}
+
+	// Aggregate tenant target protections.
+	tenantProtections := ptsStateReader.getProtectionPoliciesForTenants()
+	for _, protection := range tenantProtections {
+		tenantProtection := protection
+		systemTarget, err := spanconfig.MakeTenantKeyspaceTarget(sourceTenantID, tenantProtection.tenantID)
+		if err != nil {
+			return nil, err
+		}
+		tenantSystemRecord := spanconfig.Record{
+			Target: spanconfig.MakeTargetFromSystemTarget(systemTarget),
+			Config: roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{
+				ProtectionPolicies: tenantProtection.protections}},
+		}
+		records = append(records, tenantSystemRecord)
+	}
+	return records, nil
 }
 
 // generateSpanConfigurations generates the span configurations for the given

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -276,6 +276,31 @@ func PrintSpanConfigRecord(t *testing.T, record spanconfig.Record) string {
 	return fmt.Sprintf("%s:%s", PrintTarget(t, record.Target), PrintSpanConfig(record.Config))
 }
 
+// PrintSystemSpanConfigDiffedAgainstDefault is a helper function that diffs the
+// given config against the default system span config that applies to
+// spanconfig.SystemTargets, and returns a string for the mismatched fields.
+func PrintSystemSpanConfigDiffedAgainstDefault(conf roachpb.SpanConfig) string {
+	if conf.Equal(roachpb.TestingDefaultSystemSpanConfiguration()) {
+		return "default system span config"
+	}
+
+	var diffs []string
+	defaultSystemTargetConf := roachpb.TestingDefaultSystemSpanConfiguration()
+	if !reflect.DeepEqual(conf.GCPolicy.ProtectionPolicies, defaultSystemTargetConf.GCPolicy.ProtectionPolicies) {
+		sort.Slice(conf.GCPolicy.ProtectionPolicies, func(i, j int) bool {
+			lhs := conf.GCPolicy.ProtectionPolicies[i].ProtectedTimestamp
+			rhs := conf.GCPolicy.ProtectionPolicies[j].ProtectedTimestamp
+			return lhs.Less(rhs)
+		})
+		timestamps := make([]string, 0, len(conf.GCPolicy.ProtectionPolicies))
+		for _, pts := range conf.GCPolicy.ProtectionPolicies {
+			timestamps = append(timestamps, strconv.Itoa(int(pts.ProtectedTimestamp.WallTime)))
+		}
+		diffs = append(diffs, fmt.Sprintf("pts=[%s]", strings.Join(timestamps, " ")))
+	}
+	return strings.Join(diffs, " ")
+}
+
 // PrintSpanConfigDiffedAgainstDefaults is a helper function that diffs the given
 // config against RANGE {DEFAULT, SYSTEM} and the config for the system database
 // (as expected on both kinds of tenants), and returns a string for the


### PR DESCRIPTION
This change teaches the SQLTranslator to emit SpanConfigurations
corresponding to `spanconfig.SystemTargets`. Today, these SpanConfigurations
only contain ProtectionPolicies, corresponding to protected timestamp
records that may be written by the host tenant to protect its cluster,
a secondary tenant to protect its cluster, or the host tenant to protect
a secondary tenant.

The SystemTarget span configurations will be applied to a SystemSpanConfig
store that will be introduced in a follow up PR.

Informs: https://github.com/cockroachdb/cockroach/issues/73727

Release note: None