### PR TITLE
sql: add notice for custom var with the same name as a cluster setting

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -753,6 +753,13 @@ SHOW tracing.custom
 ----
 ijk
 
+# Show a notice if a custom session variable has the same name as a cluster setting.
+query T noticetrace
+SET server.shutdown.drain_wait = '10s'
+----
+NOTICE: setting custom variable "server.shutdown.drain_wait"
+HINT: did you mean SET CLUSTER SETTING?
+
 # Test that RESET ALL changes custom options to empty strings.
 statement ok
 RESET ALL


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/74375

No release note since custom session variables are new in 22.1.

Release note: None