### PR TITLE
kvserver: Add replica load metrics

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3459,6 +3459,11 @@ target node(s) selected in a HotRangesRequest.
 | desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponse-cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
 | queries_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponse-int32) |  | LeaseholderNodeID indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
+| requests_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Requests per second is the recent number of requests received  per second on this range. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Writes per second is the recent number of keys written per second on this range. | [reserved](#support-status) |
+| reads_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Reads per second is the recent number of keys read per second on this range. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Write bytes per second is the recent number of bytes written per second on this range. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Read bytes per second is the recent number of bytes read per second on this range. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1323,8 +1323,12 @@ only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Queries per second (batch requests) served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Writes per second served is the number of keys written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| requests_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Requests per second is the number of requests served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| reads_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 
@@ -1564,8 +1568,12 @@ only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Queries per second (batch requests) served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Writes per second served is the number of keys written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| requests_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Requests per second is the number of requests served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| reads_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 
@@ -1769,8 +1777,12 @@ only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Queries per second (batch requests) served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Writes per second served is the number of keys written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| requests_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Requests per second is the number of requests served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| reads_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 
@@ -3739,8 +3751,12 @@ only.
 
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
-| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Queries per second served by this range.<br><br>Note that queries per second will only be known by the leaseholder. All other replicas will report it as 0. | [reserved](#support-status) |
-| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Writes per second served by this range. | [reserved](#support-status) |
+| queries_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Queries per second (batch requests) served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Writes per second served is the number of keys written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| requests_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Requests per second is the number of requests served by this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| reads_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/hotranges-other.md
+++ b/docs/generated/http/hotranges-other.md
@@ -63,5 +63,10 @@ Support status: [alpha](#support-status)
 | desc | [cockroach.roachpb.RangeDescriptor](#cockroach.roachpb.RangeDescriptor) |  | Desc is the descriptor of the range for which the report was produced.<br><br>TODO(knz): This field should be removed. See: https://github.com/cockroachdb/cockroach/issues/53212 | [reserved](#support-status) |
 | queries_per_second | [double](#double) |  | QueriesPerSecond is the recent number of queries per second on this range. | [alpha](#support-status) |
 | leaseholder_node_id | [int32](#int32) |  | LeaseholderNodeID indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
+| requests_per_second | [double](#double) |  | Requests per second is the recent number of requests received  per second on this range. | [reserved](#support-status) |
+| writes_per_second | [double](#double) |  | Writes per second is the recent number of keys written per second on this range. | [reserved](#support-status) |
+| reads_per_second | [double](#double) |  | Reads per second is the recent number of keys read per second on this range. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#double) |  | Write bytes per second is the recent number of bytes written per second on this range. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#double) |  | Read bytes per second is the recent number of bytes read per second on this range. | [reserved](#support-status) |
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1079,13 +1079,37 @@
       "type": "object",
       "properties": {
         "queries_per_second": {
-          "description": "Queries per second served by this range.\n\nNote that queries per second will only be known by the leaseholder.\nAll other replicas will report it as 0.",
+          "description": "Queries per second (batch requests) served by this range per second,\naveraged over the last 30 minute period.",
           "type": "number",
           "format": "double",
           "x-go-name": "QueriesPerSecond"
         },
+        "read_bytes_per_second": {
+          "description": "Reads (bytes) per second is the number of bytes read from this range per\nsecond, averaged over the last 30 minute period.",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "ReadBytesPerSecond"
+        },
+        "reads_per_second": {
+          "description": "Reads per second served is the number of keys read from this range per\nsecond, averaged over the last 30 minute period.",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "ReadsPerSecond"
+        },
+        "requests_per_second": {
+          "description": "Requests per second is the number of requests served by this range per\nsecond, averaged over the last 30 minute period.",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "RequestsPerSecond"
+        },
+        "write_bytes_per_second": {
+          "description": "Writes (bytes) per second is the number of bytes written to this range per\nsecond, averaged over the last 30 minute period.",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "WriteBytesPerSecond"
+        },
         "writes_per_second": {
-          "description": "Writes per second served by this range.",
+          "description": "Writes per second served is the number of keys written to this range per\nsecond, averaged over the last 30 minute period.",
           "type": "number",
           "format": "double",
           "x-go-name": "WritesPerSecond"

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "replica_gc_queue.go",
         "replica_gossip.go",
         "replica_init.go",
+        "replica_load.go",
         "replica_metrics.go",
         "replica_placeholder.go",
         "replica_proposal.go",

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -354,10 +354,10 @@ func rangeUsageInfoForRepl(repl *Replica) RangeUsageInfo {
 	info := RangeUsageInfo{
 		LogicalBytes: repl.GetMVCCStats().Total(),
 	}
-	if queriesPerSecond, dur := repl.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+	if queriesPerSecond, dur := repl.leaseholderStats.averageRatePerSecond(); dur >= MinStatsDuration {
 		info.QueriesPerSecond = queriesPerSecond
 	}
-	if writesPerSecond, dur := repl.writeStats.avgQPS(); dur >= MinStatsDuration {
+	if writesPerSecond, dur := repl.writeStats.averageRatePerSecond(); dur >= MinStatsDuration {
 		info.WritesPerSecond = writesPerSecond
 	}
 	return info
@@ -1737,7 +1737,7 @@ func (a *Allocator) TransferLeaseTarget(
 		return candidates[a.randGen.Intn(len(candidates))]
 
 	case qpsConvergence:
-		leaseReplQPS, _ := stats.avgQPS()
+		leaseReplQPS, _ := stats.averageRatePerSecond()
 		candidates := make([]roachpb.StoreID, 0, len(existing)-1)
 		for _, repl := range existing {
 			if repl.StoreID != leaseRepl.StoreID() {
@@ -1970,7 +1970,7 @@ func (a Allocator) shouldTransferLeaseForAccessLocality(
 		}
 	}
 
-	qpsStats, qpsStatsDur := stats.perLocalityDecayingQPS()
+	qpsStats, qpsStatsDur := stats.perLocalityDecayingRate()
 
 	// If we haven't yet accumulated enough data, avoid transferring for now,
 	// unless we've been explicitly asked otherwise. Do not fall back to the

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -299,6 +299,18 @@ var (
 		Measurement: "Storage",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaAverageRequestsPerSecond = metric.Metadata{
+		Name:        "rebalancing.requestspersecond",
+		Help:        "Average number of requests received recently per second.",
+		Measurement: "Requests/Sec",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaAverageReadsPerSecond = metric.Metadata{
+		Name:        "rebalancing.readspersecond",
+		Help:        "Average number of keys read recently per second.",
+		Measurement: "Keys/Sec",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Metric for tracking follower reads.
 	metaFollowerReadsCount = metric.Metadata{
@@ -1367,9 +1379,11 @@ type StoreMetrics struct {
 	Reserved           *metric.Gauge
 
 	// Rebalancing metrics.
-	AverageQueriesPerSecond *metric.GaugeFloat64
-	AverageWritesPerSecond  *metric.GaugeFloat64
-	L0SubLevelsHistogram    *metric.Histogram
+	L0SubLevelsHistogram     *metric.Histogram
+	AverageQueriesPerSecond  *metric.GaugeFloat64
+	AverageWritesPerSecond   *metric.GaugeFloat64
+	AverageReadsPerSecond    *metric.GaugeFloat64
+	AverageRequestsPerSecond *metric.GaugeFloat64
 
 	// Follower read metrics.
 	FollowerReadsCount *metric.Counter
@@ -1822,6 +1836,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			l0SublevelMaxSampled,
 			1, /* sig figures (integer) */
 		),
+		AverageRequestsPerSecond: metric.NewGaugeFloat64(metaAverageRequestsPerSecond),
+		AverageReadsPerSecond:    metric.NewGaugeFloat64(metaAverageReadsPerSecond),
 
 		// Follower reads metrics.
 		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -242,6 +242,9 @@ type Replica struct {
 	// [1]: https://github.com/cockroachdb/cockroach/pull/16664
 	writeStats *replicaStats
 
+	// loadStats tracks a sliding window of throughput on this replica.
+	loadStats *ReplicaLoad
+
 	// creatingReplica is set when a replica is created as uninitialized
 	// via a raft message.
 	creatingReplica *roachpb.ReplicaDescriptor

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -656,6 +656,7 @@ func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 		}
 		if added := res.Delta.KeyCount; added > 0 {
 			b.r.writeStats.recordCount(float64(added), 0)
+			b.r.loadStats.writeKeys.recordCount(float64(added), 0)
 		}
 		if res.AddSSTable.AtWriteTimestamp {
 			b.r.handleSSTableRaftMuLocked(
@@ -983,6 +984,9 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	// Record the write activity, passing a 0 nodeID because replica.writeStats
 	// intentionally doesn't track the origin of the writes.
 	b.r.writeStats.recordCount(float64(b.mutations), 0 /* nodeID */)
+	if b.r.loadStats != nil {
+		b.r.loadStats.writeKeys.recordCount(float64(b.mutations), 0)
+	}
 
 	now := timeutil.Now()
 	if needsSplitBySize && r.splitQueueThrottle.ShouldProcess(now) {

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -111,6 +111,7 @@ func newUnloadedReplica(
 	}
 	if store.cfg.StorePool != nil {
 		r.leaseholderStats = newReplicaStats(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
+		r.loadStats = newReplicaLoad(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
 	}
 	// Pass nil for the localityOracle because we intentionally don't track the
 	// origin locality of write load.

--- a/pkg/kv/kvserver/replica_load.go
+++ b/pkg/kv/kvserver/replica_load.go
@@ -1,0 +1,66 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import "github.com/cockroachdb/cockroach/pkg/util/hlc"
+
+// ReplicaLoad tracks a sliding window of throughput on a replica. By default,
+// there are 6, 5 minute sliding windows.
+type ReplicaLoad struct {
+	batchRequests *replicaStats
+	requests      *replicaStats
+	writeKeys     *replicaStats
+	readKeys      *replicaStats
+	writeBytes    *replicaStats
+	readBytes     *replicaStats
+}
+
+func newReplicaLoad(clock *hlc.Clock, getNodeLocality localityOracle) *ReplicaLoad {
+	return &ReplicaLoad{
+		batchRequests: newReplicaStats(clock, getNodeLocality),
+		requests:      newReplicaStats(clock, getNodeLocality),
+		writeKeys:     newReplicaStats(clock, getNodeLocality),
+		readKeys:      newReplicaStats(clock, getNodeLocality),
+		writeBytes:    newReplicaStats(clock, getNodeLocality),
+		readBytes:     newReplicaStats(clock, getNodeLocality),
+	}
+}
+
+// split will distribute the load in the calling struct, evenly between itself
+// and other.
+func (rl *ReplicaLoad) split(other *ReplicaLoad) {
+	rl.batchRequests.splitRequestCounts(other.batchRequests)
+	rl.requests.splitRequestCounts(other.requests)
+	rl.writeKeys.splitRequestCounts(other.writeKeys)
+	rl.readKeys.splitRequestCounts(other.readKeys)
+	rl.writeBytes.splitRequestCounts(other.writeBytes)
+	rl.readBytes.splitRequestCounts(other.readBytes)
+}
+
+// merge will combine the tracked load in other, into the calling struct.
+func (rl *ReplicaLoad) merge(other *ReplicaLoad) {
+	rl.batchRequests.mergeRequestCounts(other.batchRequests)
+	rl.requests.mergeRequestCounts(other.requests)
+	rl.writeKeys.mergeRequestCounts(other.writeKeys)
+	rl.readKeys.mergeRequestCounts(other.readKeys)
+	rl.writeBytes.mergeRequestCounts(other.writeBytes)
+	rl.readBytes.mergeRequestCounts(other.readBytes)
+}
+
+// reset will clear all recorded history.
+func (rl *ReplicaLoad) reset() {
+	rl.batchRequests.resetRequestCounts()
+	rl.requests.resetRequestCounts()
+	rl.writeKeys.resetRequestCounts()
+	rl.readKeys.resetRequestCounts()
+	rl.writeBytes.resetRequestCounts()
+	rl.readBytes.resetRequestCounts()
+}

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -252,7 +252,7 @@ func calcBehindCount(
 // practically none). See Replica.getBatchRequestQPS() for how this is
 // accounted for.
 func (r *Replica) QueriesPerSecond() (float64, time.Duration) {
-	return r.leaseholderStats.avgQPS()
+	return r.leaseholderStats.averageRatePerSecond()
 }
 
 // WritesPerSecond returns the range's average keys written per second. A
@@ -262,7 +262,7 @@ func (r *Replica) QueriesPerSecond() (float64, time.Duration) {
 // writes (12 for the metadata, 12 for the versions). A DeleteRange that
 // ultimately only removes one key counts as one (or two if it's transactional).
 func (r *Replica) WritesPerSecond() float64 {
-	wps, _ := r.writeStats.avgQPS()
+	wps, _ := r.writeStats.averageRatePerSecond()
 	return wps
 }
 

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -255,6 +255,13 @@ func (r *Replica) QueriesPerSecond() (float64, time.Duration) {
 	return r.leaseholderStats.averageRatePerSecond()
 }
 
+// RequestsPerSecond returns the range's average requests received per second.
+// A batch request may have one to many requests.
+func (r *Replica) RequestsPerSecond() float64 {
+	rps, _ := r.loadStats.requests.averageRatePerSecond()
+	return rps
+}
+
 // WritesPerSecond returns the range's average keys written per second. A
 // "Write" is a mutation applied by Raft as measured by
 // engine.RocksDBBatchCount(writeBatch). This corresponds roughly to the number
@@ -264,6 +271,28 @@ func (r *Replica) QueriesPerSecond() (float64, time.Duration) {
 func (r *Replica) WritesPerSecond() float64 {
 	wps, _ := r.writeStats.averageRatePerSecond()
 	return wps
+}
+
+// ReadsPerSecond returns the range's average keys read per second. A "Read" is
+// a key access during evaluation of a batch request. This includes both
+// follower and leaseholder reads.
+func (r *Replica) ReadsPerSecond() float64 {
+	rps, _ := r.loadStats.readKeys.averageRatePerSecond()
+	return rps
+}
+
+// WriteBytesPerSecond returns the range's average bytes written per second. A "Write" is
+// as described in WritesPerSecond.
+func (r *Replica) WriteBytesPerSecond() float64 {
+	wbps, _ := r.loadStats.writeBytes.averageRatePerSecond()
+	return wbps
+}
+
+// ReadBytesPerSecond returns the range's average bytes read per second. A "Read" is
+// as described in ReadsPerSecond.
+func (r *Replica) ReadBytesPerSecond() float64 {
+	rbps, _ := r.loadStats.readBytes.averageRatePerSecond()
+	return rbps
 }
 
 func (r *Replica) needsSplitBySizeRLocked() bool {

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -316,6 +316,9 @@ func (r *Replica) leasePostApplyLocked(
 		if r.leaseholderStats != nil {
 			r.leaseholderStats.resetRequestCounts()
 		}
+		if r.loadStats != nil {
+			r.loadStats.reset()
+		}
 		r.loadBasedSplitter.Reset(r.Clock().PhysicalTime())
 	}
 
@@ -374,6 +377,9 @@ func (r *Replica) leasePostApplyLocked(
 		}
 		if r.leaseholderStats != nil {
 			r.leaseholderStats.resetRequestCounts()
+		}
+		if r.loadStats != nil {
+			r.loadStats.reset()
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -170,7 +170,7 @@ func TestAddSSTQPSStat(t *testing.T) {
 		require.Nil(t, pErr)
 
 		repl.leaseholderStats.mu.Lock()
-		queriesAfter, _ := repl.leaseholderStats.sumQueriesLocked()
+		queriesAfter, _ := repl.leaseholderStats.sumLocked()
 		repl.leaseholderStats.mu.Unlock()
 
 		// If queries are correctly recorded, we should see increase in query

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sstutil"
@@ -182,5 +183,304 @@ func TestAddSSTQPSStat(t *testing.T) {
 		// interleaving with measurements.
 		require.GreaterOrEqual(t, queriesAfter, testCase.expectedQPS)
 		require.InDelta(t, queriesAfter, testCase.expectedQPS, 4)
+	}
+}
+
+// genVariableRead returns a batch request containing, start-end sequential key reads.
+func genVariableRead(ctx context.Context, start, end roachpb.Key) roachpb.BatchRequest {
+	scan := roachpb.NewScan(start, end, false)
+	readBa := roachpb.BatchRequest{}
+	readBa.Add(scan)
+	return readBa
+}
+
+func assertGreaterThanInDelta(t *testing.T, expected float64, actual float64, delta float64) {
+	require.GreaterOrEqual(t, actual, expected)
+	require.InDelta(t, expected, actual, delta)
+}
+
+func headVal(f func() (float64, int)) float64 {
+	ret, _ := f()
+	return ret
+}
+
+func TestWriteLoadStatsAccounting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+
+	const epsilonAllowed = 4
+
+	defer tc.Stopper().Stop(ctx)
+	ts := tc.Server(0)
+	db := ts.DB()
+	conn := tc.ServerConn(0)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+
+	writeSize := float64(9)
+
+	scratchKey := tc.ScratchRange(t)
+	testCases := []struct {
+		writes       int
+		expectedRQPS float64
+		expectedWPS  float64
+		expectedRPS  float64
+		expectedWBPS float64
+		expectedRBPS float64
+	}{
+		{1, 1, 1, 0, writeSize, 0},
+		{4, 4, 4, 0, 4 * writeSize, 0},
+		{64, 64, 64, 0, 64 * writeSize, 0},
+	}
+
+	store, err := ts.GetStores().(*Stores).GetStore(ts.GetFirstStoreID())
+	require.NoError(t, err)
+
+	repl := store.LookupReplica(roachpb.RKey(scratchKey))
+	require.NotNil(t, repl)
+
+	// Disable the consistency checker, to avoid interleaving requests
+	// artificially inflating measurement due to consistency checking.
+	sqlDB.Exec(t, `SET CLUSTER SETTING server.consistency_check.interval = '0'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.range_split.by_load_enabled = false`)
+
+	for _, testCase := range testCases {
+		// This test can flake, where an errant request - not sent here
+		// (commonly intent resolution) will artifically inflate the collected
+		// metrics. This results in unexpected read/write statistics and a
+		// flakey test every few hundred runs. Here we assert that the run
+		// should succeed soon, if it fails on the first.
+		testutils.SucceedsSoon(t, func() error {
+			// Reset the request counts to 0 before sending to clear previous requests.
+			repl.loadStats.reset()
+
+			repl.loadStats.requests.mu.Lock()
+			repl.loadStats.writeKeys.mu.Lock()
+			repl.loadStats.readKeys.mu.Lock()
+			repl.loadStats.writeBytes.mu.Lock()
+			repl.loadStats.readBytes.mu.Lock()
+			repl.loadStats.batchRequests.mu.Lock()
+
+			requestsBefore := headVal(repl.loadStats.requests.sumLocked)
+			writesBefore := headVal(repl.loadStats.writeKeys.sumLocked)
+			readsBefore := headVal(repl.loadStats.readKeys.sumLocked)
+			readBytesBefore := headVal(repl.loadStats.readBytes.sumLocked)
+			writeBytesBefore := headVal(repl.loadStats.writeBytes.sumLocked)
+
+			repl.loadStats.requests.mu.Unlock()
+			repl.loadStats.writeKeys.mu.Unlock()
+			repl.loadStats.readKeys.mu.Unlock()
+			repl.loadStats.writeBytes.mu.Unlock()
+			repl.loadStats.readBytes.mu.Unlock()
+			repl.loadStats.batchRequests.mu.Unlock()
+
+			for i := 0; i < testCase.writes; i++ {
+				_, pErr := db.Inc(ctx, scratchKey, 1)
+				require.Nil(t, pErr)
+			}
+			require.Equal(t, 0.0, requestsBefore)
+			require.Equal(t, 0.0, writesBefore)
+			require.Equal(t, 0.0, readsBefore)
+			require.Equal(t, 0.0, writeBytesBefore)
+			require.Equal(t, 0.0, readBytesBefore)
+
+			repl.loadStats.requests.mu.Lock()
+			repl.loadStats.writeKeys.mu.Lock()
+			repl.loadStats.readKeys.mu.Lock()
+			repl.loadStats.writeBytes.mu.Lock()
+			repl.loadStats.readBytes.mu.Lock()
+			repl.loadStats.batchRequests.mu.Lock()
+
+			requestsAfter := headVal(repl.loadStats.requests.sumLocked)
+			writesAfter := headVal(repl.loadStats.writeKeys.sumLocked)
+			readsAfter := headVal(repl.loadStats.readKeys.sumLocked)
+			readBytesAfter := headVal(repl.loadStats.readBytes.sumLocked)
+			writeBytesAfter := headVal(repl.loadStats.writeBytes.sumLocked)
+
+			repl.loadStats.requests.mu.Unlock()
+			repl.loadStats.writeKeys.mu.Unlock()
+			repl.loadStats.readKeys.mu.Unlock()
+			repl.loadStats.writeBytes.mu.Unlock()
+			repl.loadStats.readBytes.mu.Unlock()
+			repl.loadStats.batchRequests.mu.Unlock()
+
+			assertGreaterThanInDelta(t, testCase.expectedRQPS, requestsAfter, epsilonAllowed)
+			assertGreaterThanInDelta(t, testCase.expectedWPS, writesAfter, epsilonAllowed)
+			assertGreaterThanInDelta(t, testCase.expectedRPS, readsAfter, epsilonAllowed)
+			assertGreaterThanInDelta(t, testCase.expectedWBPS, writeBytesAfter, epsilonAllowed)
+			assertGreaterThanInDelta(t, testCase.expectedRBPS, readBytesAfter, epsilonAllowed)
+
+			return nil
+		})
+	}
+}
+
+func TestReadLoadMetricAccounting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+
+	defer tc.Stopper().Stop(ctx)
+	ts := tc.Server(0)
+	db := ts.DB()
+	conn := tc.ServerConn(0)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+
+	const epsilonAllowed = 4
+
+	scratchKey := tc.ScratchRange(t)
+	nextKey := scratchKey.Next()
+
+	scratchKeys := make([]roachpb.Key, 300)
+	sstKeys := make([]sstutil.KV, 300)
+	for i := range sstKeys {
+		scratchKeys[i] = nextKey
+		sstKeys[i] = sstutil.KV{
+			KeyString:     nextKey.String(),
+			WallTimestamp: 1,
+			ValueString:   "value",
+		}
+		nextKey = nextKey.Next()
+	}
+	sst, start, end := sstutil.MakeSST(t, ts.ClusterSettings(), sstKeys)
+	sstReq := &roachpb.AddSSTableRequest{
+		RequestHeader: roachpb.RequestHeader{Key: start, EndKey: end},
+		Data:          sst,
+		MVCCStats:     sstutil.ComputeStats(t, sst),
+	}
+
+	addSSTBA := roachpb.BatchRequest{}
+	addSSTBA.Add(sstReq)
+
+	// Send an AddSSTRequest once to create the key range.
+	_, pErr := db.NonTransactionalSender().Send(ctx, addSSTBA)
+	require.Nil(t, pErr)
+
+	get := &roachpb.GetRequest{
+		RequestHeader: roachpb.RequestHeader{Key: start},
+	}
+
+	getReadBA := roachpb.BatchRequest{}
+	getReadBA.Add(get)
+
+	scan := &roachpb.ScanRequest{
+		RequestHeader: roachpb.RequestHeader{Key: start, EndKey: end},
+	}
+
+	scanReadBA := roachpb.BatchRequest{}
+	scanReadBA.Add(scan)
+
+	testCases := []struct {
+		ba           roachpb.BatchRequest
+		expectedRQPS float64
+		expectedWPS  float64
+		expectedRPS  float64
+		expectedWBPS float64
+		expectedRBPS float64
+	}{
+		{getReadBA, 1, 0, 1, 0, 10},
+		{genVariableRead(ctx, start, sstKeys[1].Key()), 1, 0, 1, 0, 38},
+		{genVariableRead(ctx, start, sstKeys[4].Key()), 1, 0, 4, 0, 176},
+		{genVariableRead(ctx, start, sstKeys[64].Key()), 1, 0, 64, 0, 10496},
+	}
+
+	store, err := ts.GetStores().(*Stores).GetStore(ts.GetFirstStoreID())
+	require.NoError(t, err)
+
+	repl := store.LookupReplica(roachpb.RKey(start))
+	require.NotNil(t, repl)
+
+	replEnd := store.LookupReplica(roachpb.RKey(end))
+	require.NotNil(t, repl)
+
+	require.EqualValues(t, repl, replEnd)
+
+	// Disable the consistency checker, to avoid interleaving requests
+	// artificially inflating measurement due to consistency checking.
+	sqlDB.Exec(t, `SET CLUSTER SETTING server.consistency_check.interval = '0'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.range_split.by_load_enabled = false`)
+
+	for _, testCase := range testCases {
+		// This test can flake, where an errant request - not sent here
+		// (commonly intent resolution) will artifically inflate the collected
+		// metrics. This results in unexpected read/write statistics and a
+		// flakey test every few hundred runs. Here we assert that the run
+		// should succeed soon, if it fails on the first.
+		testutils.SucceedsSoon(t, func() error {
+			// Reset the request counts to 0 before sending to clear previous requests.
+			// Reset the request counts to 0 before sending to clear previous requests.
+			repl.loadStats.reset()
+
+			repl.loadStats.requests.mu.Lock()
+			repl.loadStats.writeKeys.mu.Lock()
+			repl.loadStats.readKeys.mu.Lock()
+			repl.loadStats.writeBytes.mu.Lock()
+			repl.loadStats.readBytes.mu.Lock()
+			repl.loadStats.batchRequests.mu.Lock()
+
+			requestsBefore := headVal(repl.loadStats.requests.sumLocked)
+			writesBefore := headVal(repl.loadStats.writeKeys.sumLocked)
+			readsBefore := headVal(repl.loadStats.readKeys.sumLocked)
+			readBytesBefore := headVal(repl.loadStats.readBytes.sumLocked)
+			writeBytesBefore := headVal(repl.loadStats.writeBytes.sumLocked)
+
+			repl.loadStats.requests.mu.Unlock()
+			repl.loadStats.writeKeys.mu.Unlock()
+			repl.loadStats.readKeys.mu.Unlock()
+			repl.loadStats.writeBytes.mu.Unlock()
+			repl.loadStats.readBytes.mu.Unlock()
+			repl.loadStats.batchRequests.mu.Unlock()
+
+			_, pErr = db.NonTransactionalSender().Send(ctx, testCase.ba)
+			require.Nil(t, pErr)
+
+			require.Equal(t, 0.0, requestsBefore)
+			require.Equal(t, 0.0, writesBefore)
+			require.Equal(t, 0.0, readsBefore)
+			require.Equal(t, 0.0, writeBytesBefore)
+			require.Equal(t, 0.0, readBytesBefore)
+
+			repl.loadStats.requests.mu.Lock()
+			repl.loadStats.writeKeys.mu.Lock()
+			repl.loadStats.readKeys.mu.Lock()
+			repl.loadStats.writeBytes.mu.Lock()
+			repl.loadStats.readBytes.mu.Lock()
+			repl.loadStats.batchRequests.mu.Lock()
+
+			requestsAfter := headVal(repl.loadStats.requests.sumLocked)
+			writesAfter := headVal(repl.loadStats.writeKeys.sumLocked)
+			readsAfter := headVal(repl.loadStats.readKeys.sumLocked)
+			readBytesAfter := headVal(repl.loadStats.readBytes.sumLocked)
+			writeBytesAfter := headVal(repl.loadStats.writeBytes.sumLocked)
+
+			repl.loadStats.requests.mu.Unlock()
+			repl.loadStats.writeKeys.mu.Unlock()
+			repl.loadStats.readKeys.mu.Unlock()
+			repl.loadStats.writeBytes.mu.Unlock()
+			repl.loadStats.readBytes.mu.Unlock()
+			repl.loadStats.batchRequests.mu.Unlock()
+
+			assertGreaterThanInDelta(t, testCase.expectedRQPS, requestsAfter, epsilonAllowed)
+			assertGreaterThanInDelta(t, testCase.expectedWPS, writesAfter, epsilonAllowed)
+			assertGreaterThanInDelta(t, testCase.expectedRPS, readsAfter, epsilonAllowed)
+			// Increase the allowance for write bytes, as although this should
+			// be zero - there exists some cases where a write will interleave
+			// with our testing. This causes the test to flake if it occurs repeatedly.
+			// TODO(kvoli): This can be determinsitic, with an general
+			// interface that records the type of request or otherwise filters
+			// out unwanted types.
+			assertGreaterThanInDelta(t, testCase.expectedWBPS, writeBytesAfter, epsilonAllowed*15)
+			assertGreaterThanInDelta(t, testCase.expectedRBPS, readBytesAfter, epsilonAllowed)
+
+			return nil
+		})
 	}
 }

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -129,6 +129,10 @@ func (r *Replica) sendWithoutRangeID(
 		r.leaseholderStats.recordCount(r.getBatchRequestQPS(ctx, ba), ba.Header.GatewayNodeID)
 	}
 
+	if r.loadStats != nil {
+		r.loadStats.requests.recordCount(float64(len(ba.Requests)), 0)
+		r.loadStats.writeBytes.recordCount(getBatchRequestWriteBytes(ba), 0)
+	}
 	// Add the range log tag.
 	ctx = r.AnnotateCtx(ctx)
 
@@ -1012,6 +1016,20 @@ func (r *Replica) getBatchRequestQPS(ctx context.Context, ba *roachpb.BatchReque
 
 	count += addSSTSize / float64(requestFact)
 	return count
+}
+
+func getBatchRequestWriteBytes(ba *roachpb.BatchRequest) float64 {
+	if !ba.IsWrite() {
+		return 0
+	}
+
+	var writeBytes int64
+	for i := range ba.Requests {
+		if swr, isSizedWrite := ba.Requests[i].GetInner().(roachpb.SizedWriteRequest); isSizedWrite {
+			writeBytes += swr.WriteBytes()
+		}
+	}
+	return float64(writeBytes)
 }
 
 // checkBatchRequest verifies BatchRequest validity requirements. In particular,

--- a/pkg/kv/kvserver/replica_stats_test.go
+++ b/pkg/kv/kvserver/replica_stats_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func floatsEqual(x, y float64) bool {
@@ -177,14 +179,14 @@ func TestReplicaStats(t *testing.T) {
 			rs.recordCount(1, req)
 		}
 		manual.Increment(int64(time.Second))
-		if actual, _ := rs.perLocalityDecayingQPS(); !floatMapsEqual(tc.expected, actual) {
+		if actual, _ := rs.perLocalityDecayingRate(); !floatMapsEqual(tc.expected, actual) {
 			t.Errorf("%d: incorrect per-locality QPS averages: %s", i, pretty.Diff(tc.expected, actual))
 		}
 		var expectedAvgQPS float64
 		for _, v := range tc.expected {
 			expectedAvgQPS += v
 		}
-		if actual, _ := rs.avgQPS(); actual != expectedAvgQPS {
+		if actual, _ := rs.averageRatePerSecond(); actual != expectedAvgQPS {
 			t.Errorf("%d: avgQPS() got %f, want %f", i, actual, expectedAvgQPS)
 		}
 		// Verify that QPS numbers get cut in half after another second.
@@ -192,15 +194,15 @@ func TestReplicaStats(t *testing.T) {
 		for k, v := range tc.expected {
 			tc.expected[k] = v / 2
 		}
-		if actual, _ := rs.perLocalityDecayingQPS(); !floatMapsEqual(tc.expected, actual) {
+		if actual, _ := rs.perLocalityDecayingRate(); !floatMapsEqual(tc.expected, actual) {
 			t.Errorf("%d: incorrect per-locality QPS averages: %s", i, pretty.Diff(tc.expected, actual))
 		}
 		expectedAvgQPS /= 2
-		if actual, _ := rs.avgQPS(); actual != expectedAvgQPS {
+		if actual, _ := rs.averageRatePerSecond(); actual != expectedAvgQPS {
 			t.Errorf("%d: avgQPS() got %f, want %f", i, actual, expectedAvgQPS)
 		}
 		rs.resetRequestCounts()
-		if actual, _ := rs.sumQueriesLocked(); actual != 0 {
+		if actual, _ := rs.sumLocked(); actual != 0 {
 			t.Errorf("%d: unexpected non-empty QPS averages after resetting: %+v", i, actual)
 		}
 	}
@@ -224,7 +226,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 	})
 
 	{
-		counts, dur := rs.perLocalityDecayingQPS()
+		counts, dur := rs.perLocalityDecayingRate()
 		if len(counts) != 0 {
 			t.Errorf("expected empty request counts, got %+v", counts)
 		}
@@ -232,7 +234,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 			t.Errorf("expected duration = 0, got %v", dur)
 		}
 		manual.Increment(1)
-		if _, dur := rs.perLocalityDecayingQPS(); dur != 1 {
+		if _, dur := rs.perLocalityDecayingRate(); dur != 1 {
 			t.Errorf("expected duration = 1, got %v", dur)
 		}
 		rs.resetRequestCounts()
@@ -247,7 +249,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 			awsLocalities[2]: 2,
 			awsLocalities[3]: 1,
 		}
-		actual, dur := rs.perLocalityDecayingQPS()
+		actual, dur := rs.perLocalityDecayingRate()
 		if dur != 0 {
 			t.Errorf("expected duration = 0, got %v", dur)
 		}
@@ -256,7 +258,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 		}
 
 		var totalDuration time.Duration
-		for i := 0; i < len(rs.mu.requests)-1; i++ {
+		for i := 0; i < len(rs.mu.records)-1; i++ {
 			manual.Increment(int64(replStatsRotateInterval))
 			totalDuration = time.Duration(float64(replStatsRotateInterval+totalDuration) * decayFactor)
 			expected := make(perLocalityCounts)
@@ -264,7 +266,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 				counts[k] = v * decayFactor
 				expected[k] = counts[k] / totalDuration.Seconds()
 			}
-			actual, dur = rs.perLocalityDecayingQPS()
+			actual, dur = rs.perLocalityDecayingRate()
 			if expectedDur := replStatsRotateInterval * time.Duration(i+1); dur != expectedDur {
 				t.Errorf("expected duration = %v, got %v", expectedDur, dur)
 			}
@@ -277,7 +279,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 
 		manual.Increment(int64(replStatsRotateInterval))
 		expected := make(perLocalityCounts)
-		if actual, _ := rs.perLocalityDecayingQPS(); !reflect.DeepEqual(expected, actual) {
+		if actual, _ := rs.perLocalityDecayingRate(); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
 		}
 		rs.resetRequestCounts()
@@ -299,7 +301,7 @@ func TestReplicaStatsDecay(t *testing.T) {
 			awsLocalities[2]: (2*decayFactor + 2) / durationDivisor,
 			awsLocalities[3]: (1*decayFactor + 3) / durationDivisor,
 		}
-		if actual, _ := rs.perLocalityDecayingQPS(); !reflect.DeepEqual(expected, actual) {
+		if actual, _ := rs.perLocalityDecayingRate(); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
 		}
 	}
@@ -332,13 +334,13 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 		awsLocalities[2]: 2,
 		awsLocalities[3]: 1,
 	}
-	if actual, _ := rs.perLocalityDecayingQPS(); !reflect.DeepEqual(expected, actual) {
+	if actual, _ := rs.perLocalityDecayingRate(); !reflect.DeepEqual(expected, actual) {
 		t.Errorf("incorrect per-locality request counts: %s", pretty.Diff(expected, actual))
 	}
 
 	increment := replStatsRotateInterval / 2
 	manual.Increment(int64(increment))
-	actual1, dur := rs.perLocalityDecayingQPS()
+	actual1, dur := rs.perLocalityDecayingRate()
 	if dur != increment {
 		t.Errorf("expected duration = %v; got %v", increment, dur)
 	}
@@ -351,7 +353,7 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 
 	// Verify that all values decrease as time advances if no requests come in.
 	manual.Increment(1)
-	actual2, _ := rs.perLocalityDecayingQPS()
+	actual2, _ := rs.perLocalityDecayingRate()
 	if len(actual1) != len(actual2) {
 		t.Fatalf("unexpected different results sizes (expected %d, got %d)", len(actual1), len(actual2))
 	}
@@ -363,7 +365,7 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 
 	// Ditto for passing a window boundary.
 	manual.Increment(int64(increment))
-	actual3, _ := rs.perLocalityDecayingQPS()
+	actual3, _ := rs.perLocalityDecayingRate()
 	if len(actual2) != len(actual3) {
 		t.Fatalf("unexpected different results sizes (expected %d, got %d)", len(actual2), len(actual3))
 	}
@@ -372,4 +374,196 @@ func TestReplicaStatsDecaySmoothing(t *testing.T) {
 			t.Errorf("expected newer count %f to be smaller than older count %f", actual3[k], actual3[k])
 		}
 	}
+}
+
+func genTestingReplicaStats(windowedMultipliers [6]int, n, offset int) *replicaStats {
+	manual := hlc.NewManualClock(123)
+	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
+	awsLocalities := map[roachpb.NodeID]string{
+		1: "region=us-east-1,zone=us-east-1a",
+		2: "region=us-east-1,zone=us-east-1b",
+		3: "region=us-west-1,zone=us-west-1a",
+	}
+	rs := newReplicaStats(clock, func(nodeID roachpb.NodeID) string {
+		return awsLocalities[nodeID]
+	})
+
+	for i := 0; i < offset; i++ {
+		manual.Increment(int64(replStatsRotateInterval))
+	}
+
+	// Here we generate recorded counts against the three localities. For
+	// simplicity, each locality has 1/5, 2/5 and 3/5 of the aggregate count
+	// recorded against it respectively.
+	for _, multiplier := range windowedMultipliers {
+		for i := 1; i <= n; i++ {
+			rs.recordCount(float64(i*1*multiplier), 1)
+			rs.recordCount(float64(i*2*multiplier), 2)
+			rs.recordCount(float64(i*3*multiplier), 3)
+		}
+		// rotate the window
+		manual.Increment(int64(replStatsRotateInterval))
+	}
+	return rs
+}
+
+// TestReplicaStatsSplit asserts that splitting replica stats distributes the
+// recorded counts evenly among the split stats. It assigns the same maximum
+// and minimum for both halves of the split.
+func TestReplicaStatsSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	windowedMultipliersInitial := [6]int{10, 20, 30, 40, 50, 60}
+	windowedMultipliersSplit := [6]int{5, 10, 15, 20, 25, 30}
+	nilMultipliers := [6]int{0, 0, 0, 0, 0, 0}
+
+	testCases := []struct {
+		expectedSplit  [6]int
+		windowsInitial [6]int
+		rotation       int
+	}{
+		{
+			expectedSplit:  windowedMultipliersSplit,
+			windowsInitial: windowedMultipliersInitial,
+			rotation:       0,
+		},
+		{
+			expectedSplit:  windowedMultipliersSplit,
+			windowsInitial: windowedMultipliersInitial,
+			rotation:       3,
+		},
+		{
+			expectedSplit:  windowedMultipliersSplit,
+			windowsInitial: windowedMultipliersInitial,
+			rotation:       50,
+		},
+	}
+
+	for _, tc := range testCases {
+		initial := genTestingReplicaStats(tc.windowsInitial, 10, 0)
+		expected := genTestingReplicaStats(tc.expectedSplit, 10, 0)
+		otherHalf := genTestingReplicaStats(nilMultipliers, 0, 0)
+
+		// Adjust the max/min/count, since the generated replica stats will have
+		// max/min that is too high and missing half the counts.
+		for i := range initial.mu.records {
+			idx := (initial.mu.idx + i) % 6
+			expected.mu.records[idx].count = initial.mu.records[idx].count / 2
+			expected.mu.records[idx].max = initial.mu.records[idx].max
+			expected.mu.records[idx].min = initial.mu.records[idx].min
+		}
+
+		initial.splitRequestCounts(otherHalf)
+
+		for i := range expected.mu.records {
+			idxExpected, leftIdx, rightIdx := (expected.mu.idx+i)%6, (initial.mu.idx+i)%6, (otherHalf.mu.idx+i)%6
+			assert.Equal(t, expected.mu.records[idxExpected], initial.mu.records[leftIdx])
+			assert.Equal(t, expected.mu.records[idxExpected], otherHalf.mu.records[rightIdx])
+		}
+	}
+}
+
+// TestReplicaStatsMerge asserts that merging two replica stats will retain the
+// aggregate properties of the more suitable record for each window. It also
+// asserts that rotated time windows are properly accounted for i.e.
+// [1,2,3,4,5,6], [4,5,6,1,2,3], where 6 is the most recent window, are
+// correctly merged together in each.
+func TestReplicaStatsMerge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	windowedMultipliers1 := [6]int{1, 2, 3, 4, 5, 6}
+	windowedMultipliers10 := [6]int{10, 20, 30, 40, 50, 60}
+	expectedMultipliers := [6]int{11, 22, 33, 44, 55, 66}
+
+	testCases := []struct {
+		windowsA   [6]int
+		windowsB   [6]int
+		windowsExp [6]int
+		rotateA    int
+		rotateB    int
+	}{
+		{
+			windowsA:   windowedMultipliers1,
+			windowsB:   windowedMultipliers10,
+			windowsExp: expectedMultipliers,
+			rotateA:    0,
+			rotateB:    0,
+		},
+		{
+			windowsA:   windowedMultipliers1,
+			windowsB:   windowedMultipliers10,
+			windowsExp: expectedMultipliers,
+			rotateA:    3,
+			rotateB:    1,
+		},
+		{
+			windowsA:   windowedMultipliers1,
+			windowsB:   windowedMultipliers10,
+			windowsExp: expectedMultipliers,
+			rotateA:    50,
+			rotateB:    109,
+		},
+	}
+
+	for _, tc := range testCases {
+		rsA := genTestingReplicaStats(tc.windowsA, 10, 0)
+		rsB := genTestingReplicaStats(tc.windowsB, 10, 0)
+		expectedRs := genTestingReplicaStats(tc.windowsExp, 10, 0)
+
+		// Adjust the max/min/count, since the generated replica stats will have
+		// max/min that is too high and missing half the counts.
+		for i := range expectedRs.mu.records {
+			idxExpected, idxA, idxB := (expectedRs.mu.idx+i)%6, (rsA.mu.idx+i)%6, (rsB.mu.idx+i)%6
+			expectedRs.mu.records[idxExpected].count = rsA.mu.records[idxA].count + rsB.mu.records[idxB].count
+			expectedRs.mu.records[idxExpected].max = math.Max(rsA.mu.records[idxA].max, rsB.mu.records[idxB].max)
+			expectedRs.mu.records[idxExpected].min = math.Min(rsA.mu.records[idxA].min, rsB.mu.records[idxB].min)
+		}
+		rsA.mergeRequestCounts(rsB)
+
+		for i := range expectedRs.mu.records {
+			idxExpected, idxA := (expectedRs.mu.idx+i)%6, (rsA.mu.idx+i)%6
+			assert.Equal(t, expectedRs.mu.records[idxExpected], rsA.mu.records[idxA])
+		}
+	}
+}
+
+// TestReplicaStatsRecordAggregate asserts that the aggregate stats collected
+// per window are accurate.
+func TestReplicaStatsRecordAggregate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	awsLocalities := map[roachpb.NodeID]string{
+		1: "region=us-east-1,zone=us-east-1a",
+		2: "region=us-east-1,zone=us-east-1b",
+		3: "region=us-west-1,zone=us-west-1a",
+	}
+
+	n := 100
+	rs := genTestingReplicaStats([6]int{1, 0, 0, 0, 0, 0}, n, 0)
+
+	expectedSum := float64(n*(n+1)) / 2.0
+
+	for i := 1; i <= n; i++ {
+		rs.recordCount(float64(i*1), 1)
+		rs.recordCount(float64(i*2), 2)
+		rs.recordCount(float64(i*3), 3)
+	}
+
+	expectedLocalityCounts := perLocalityCounts{
+		awsLocalities[1]: 1 * expectedSum,
+		awsLocalities[2]: 2 * expectedSum,
+		awsLocalities[3]: 3 * expectedSum,
+	}
+	expectedStatsRecord := &replicaStatsRecord{
+		localityCounts: expectedLocalityCounts,
+		sum:            expectedSum * 6,
+		max:            float64(n * 3),
+		min:            1,
+		count:          int64(n * 3),
+	}
+
+	require.Equal(t, expectedStatsRecord, rs.mu.records[rs.mu.idx])
 }

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1595,7 +1595,7 @@ func (rq *replicateQueue) shedLease(
 		return noTransferDryRun, nil
 	}
 
-	avgQPS, qpsMeasurementDur := repl.leaseholderStats.avgQPS()
+	avgQPS, qpsMeasurementDur := repl.leaseholderStats.averageRatePerSecond()
 	if qpsMeasurementDur < MinStatsDuration {
 		avgQPS = 0
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2946,12 +2946,12 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 		// starts? We can't easily have a countdown as its value changes like for
 		// leases/replicas.
 		var qps float64
-		if avgQPS, dur := r.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+		if avgQPS, dur := r.leaseholderStats.averageRatePerSecond(); dur >= MinStatsDuration {
 			qps = avgQPS
 			totalQueriesPerSecond += avgQPS
 			// TODO(a-robinson): Calculate percentiles for qps? Get rid of other percentiles?
 		}
-		if wps, dur := r.writeStats.avgQPS(); dur >= MinStatsDuration {
+		if wps, dur := r.writeStats.averageRatePerSecond(); dur >= MinStatsDuration {
 			totalWritesPerSecond += wps
 			writesPerReplica = append(writesPerReplica, wps)
 		}
@@ -3140,10 +3140,10 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 		}
 		behindCount += metrics.BehindCount
-		if qps, dur := rep.leaseholderStats.avgQPS(); dur >= MinStatsDuration {
+		if qps, dur := rep.leaseholderStats.averageRatePerSecond(); dur >= MinStatsDuration {
 			averageQueriesPerSecond += qps
 		}
-		if wps, dur := rep.writeStats.avgQPS(); dur >= MinStatsDuration {
+		if wps, dur := rep.writeStats.averageRatePerSecond(); dur >= MinStatsDuration {
 			averageWritesPerSecond += wps
 		}
 		locks += metrics.LockTableMetrics.Locks

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3287,8 +3287,13 @@ func (s *Store) ClusterNodeCount() int {
 
 // HotReplicaInfo contains a range descriptor and its QPS.
 type HotReplicaInfo struct {
-	Desc *roachpb.RangeDescriptor
-	QPS  float64
+	Desc                *roachpb.RangeDescriptor
+	QPS                 float64
+	RequestsPerSecond   float64
+	ReadKeysPerSecond   float64
+	WriteKeysPerSecond  float64
+	WriteBytesPerSecond float64
+	ReadBytesPerSecond  float64
 }
 
 // HottestReplicas returns the hottest replicas on a store, sorted by their
@@ -3302,6 +3307,11 @@ func (s *Store) HottestReplicas() []HotReplicaInfo {
 	for i := range topQPS {
 		hotRepls[i].Desc = topQPS[i].repl.Desc()
 		hotRepls[i].QPS = topQPS[i].qps
+		hotRepls[i].RequestsPerSecond = topQPS[i].repl.RequestsPerSecond()
+		hotRepls[i].WriteKeysPerSecond = topQPS[i].repl.WritesPerSecond()
+		hotRepls[i].ReadKeysPerSecond = topQPS[i].repl.ReadsPerSecond()
+		hotRepls[i].WriteBytesPerSecond = topQPS[i].repl.WriteBytesPerSecond()
+		hotRepls[i].ReadBytesPerSecond = topQPS[i].repl.ReadBytesPerSecond()
 	}
 	return hotRepls
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3075,6 +3075,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		quiescentCount                int64
 		uninitializedCount            int64
 		averageQueriesPerSecond       float64
+		averageRequestsPerSecond      float64
+		averageReadsPerSecond         float64
 		averageWritesPerSecond        float64
 
 		rangeCount                int64
@@ -3143,8 +3145,14 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		if qps, dur := rep.leaseholderStats.averageRatePerSecond(); dur >= MinStatsDuration {
 			averageQueriesPerSecond += qps
 		}
+		if rqps, dur := rep.loadStats.requests.averageRatePerSecond(); dur >= MinStatsDuration {
+			averageRequestsPerSecond += rqps
+		}
 		if wps, dur := rep.writeStats.averageRatePerSecond(); dur >= MinStatsDuration {
 			averageWritesPerSecond += wps
+		}
+		if rps, dur := rep.loadStats.readKeys.averageRatePerSecond(); dur >= MinStatsDuration {
+			averageReadsPerSecond += rps
 		}
 		locks += metrics.LockTableMetrics.Locks
 		totalLockHoldDurationNanos += metrics.LockTableMetrics.TotalLockHoldDurationNanos
@@ -3175,7 +3183,9 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.QuiescentCount.Update(quiescentCount)
 	s.metrics.UninitializedCount.Update(uninitializedCount)
 	s.metrics.AverageQueriesPerSecond.Update(averageQueriesPerSecond)
+	s.metrics.AverageRequestsPerSecond.Update(averageRequestsPerSecond)
 	s.metrics.AverageWritesPerSecond.Update(averageWritesPerSecond)
+	s.metrics.AverageReadsPerSecond.Update(averageReadsPerSecond)
 	s.recordNewPerSecondStats(averageQueriesPerSecond, averageWritesPerSecond)
 
 	s.metrics.RangeCount.Update(rangeCount)

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -155,6 +155,8 @@ func (s *Store) MergeRange(
 		leftRepl.writeStats.resetRequestCounts()
 	}
 
+	leftRepl.loadStats.merge(rightRepl.loadStats)
+
 	// Clear the concurrency manager's lock and txn wait-queues to redirect the
 	// queued transactions to the left-hand replica, if necessary.
 	rightRepl.concMgr.OnRangeMerge()

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -562,8 +562,8 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 	if !ok {
 		t.Fatalf("couldn't find StoreDescriptor for Store ID %d", 1)
 	}
-	QPS, _ := replica.leaseholderStats.avgQPS()
-	WPS, _ := replica.writeStats.avgQPS()
+	QPS, _ := replica.leaseholderStats.averageRatePerSecond()
+	WPS, _ := replica.writeStats.averageRatePerSecond()
 	if expectedRangeCount := int32(6); desc.Capacity.RangeCount != expectedRangeCount {
 		t.Errorf("expected RangeCount %d, but got %d", expectedRangeCount, desc.Capacity.RangeCount)
 	}

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -464,7 +464,7 @@ func loadRanges(rr *replicaRankings, s *Store, ranges []testRange) {
 		repl.mu.state.Stats = &enginepb.MVCCStats{}
 
 		repl.leaseholderStats = newReplicaStats(s.Clock(), nil)
-		repl.leaseholderStats.setAvgQPSForTesting(r.qps)
+		repl.leaseholderStats.setMeanRateForTesting(r.qps)
 
 		repl.writeStats = newReplicaStats(s.Clock(), nil)
 		acc.addReplica(replicaWithStats{

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -327,6 +327,7 @@ func (s *Store) SplitRange(
 	} else {
 		rightRepl := rightReplOrNil
 		leftRepl.writeStats.splitRequestCounts(rightRepl.writeStats)
+		leftRepl.loadStats.split(rightRepl.loadStats)
 		if err := s.addReplicaInternalLocked(rightRepl); err != nil {
 			return errors.Wrapf(err, "unable to add replica %v", rightRepl)
 		}

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -397,13 +397,24 @@ message RangeProblems {
 // RangeStatistics describes statistics reported by a range. For internal use
 // only.
 message RangeStatistics {
-  // Queries per second served by this range.
-  //
-  // Note that queries per second will only be known by the leaseholder.
-  // All other replicas will report it as 0.
+  // Queries per second (batch requests) served by this range per second,
+  // averaged over the last 30 minute period.
   double queries_per_second = 1;
-  // Writes per second served by this range.
+  // Writes per second served is the number of keys written to this range per
+  // second, averaged over the last 30 minute period.
   double writes_per_second = 2;
+  // Requests per second is the number of requests served by this range per
+  // second, averaged over the last 30 minute period.
+  double requests_per_second = 3;
+  // Reads per second served is the number of keys read from this range per
+  // second, averaged over the last 30 minute period.
+  double reads_per_second = 4;
+  // Writes (bytes) per second is the number of bytes written to this range per
+  // second, averaged over the last 30 minute period.
+  double write_bytes_per_second = 5;
+  // Reads (bytes) per second is the number of bytes read from this range per
+  // second, averaged over the last 30 minute period.
+  double read_bytes_per_second = 6;
 }
 
 message PrettySpan {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1254,6 +1254,22 @@ message HotRangesResponse {
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
     ];
+
+    // Requests per second is the recent number of requests received  per
+    // second on this range.
+    double requests_per_second = 4;
+    // Writes per second is the recent number of keys written per second on
+    // this range.
+    double writes_per_second = 5;
+    // Reads per second is the recent number of keys read per second on
+    // this range.
+    double reads_per_second = 6;
+    // Write bytes per second is the recent number of bytes written per second on
+    // this range.
+    double write_bytes_per_second = 7;
+    // Read bytes per second is the recent number of bytes read per second on
+    // this range.
+    double read_bytes_per_second = 8;
   }
 
   // StoreResponse contains the part of a hot ranges report that

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1971,8 +1971,12 @@ func (s *statusServer) rangesHelper(
 			SourceStoreID: storeID,
 			LeaseHistory:  leaseHistory,
 			Stats: serverpb.RangeStatistics{
-				QueriesPerSecond: qps,
-				WritesPerSecond:  rep.WritesPerSecond(),
+				QueriesPerSecond:    qps,
+				RequestsPerSecond:   rep.RequestsPerSecond(),
+				WritesPerSecond:     rep.WritesPerSecond(),
+				ReadsPerSecond:      rep.ReadsPerSecond(),
+				WriteBytesPerSecond: rep.WriteBytesPerSecond(),
+				ReadBytesPerSecond:  rep.ReadBytesPerSecond(),
 			},
 			Problems: serverpb.RangeProblems{
 				Unavailable:            metrics.Unavailable,

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2455,6 +2455,11 @@ func (s *statusServer) localHotRanges(ctx context.Context) serverpb.HotRangesRes
 			}
 			storeResp.HotRanges[i].Desc = *r.Desc
 			storeResp.HotRanges[i].QueriesPerSecond = r.QPS
+			storeResp.HotRanges[i].RequestsPerSecond = r.RequestsPerSecond
+			storeResp.HotRanges[i].WritesPerSecond = r.WriteKeysPerSecond
+			storeResp.HotRanges[i].ReadsPerSecond = r.ReadKeysPerSecond
+			storeResp.HotRanges[i].WriteBytesPerSecond = r.WriteBytesPerSecond
+			storeResp.HotRanges[i].ReadBytesPerSecond = r.ReadBytesPerSecond
 		}
 		resp.Stores = append(resp.Stores, storeResp)
 		return nil

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -646,6 +646,14 @@ var charts = []sectionDescription{
 				Title:   "QPS",
 				Metrics: []string{"rebalancing.queriespersecond"},
 			},
+			{
+				Title:   "Requests Per Second",
+				Metrics: []string{"rebalancing.requestspersecond"},
+			},
+			{
+				Title:   "Keys Read Per Second",
+				Metrics: []string{"rebalancing.readspersecond"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Previously, replica stats was oriented for collecting statistics on
batch requests per second - QPS. To facilitate more general use of
additional replica load statistics, this patch introduces more generic
naming in addition to allowing easy opt out of locality specific
elements.

The max, min, count and sum are now recorded per time window as
aggregate, running statistic calculated at write time in constant time.

Previously, writes-per-second representing the count of raft key
mutations applied and queries-per-second, representing the count of
batch requests processed by a replica were tracked on the replica level
by the leaseholder. This patch introduces: requests-per-second, tracking
the number of requests received; reads-per-second, tracking the number
of keys read; write-bytes-per-second and read-bytes-per-second, tracking
the number of bytes that have been read and written to this range per
second.

Only reads-per-second and requests-per-second are exposed in aggregation
over a store as a metric, which is in addition to queries-per-second and
writes-per-second, being currently exported.


Previously, HotRanges would report the replica descriptor and queries
per second (QPS) of the hottest ranges per store; ranked by QPS. This
patch introduces the additional range load information: requests per
second `RQPS`, writes per second `WPS`, reads per second `RPS`, write
bytes per second `WBPS` and read bytes per second `RBPS`. These
additional load metrics are useful for hot range inspection, as they
provide a more granular view of range load, than QPS alone.


resolves https://github.com/cockroachdb/cockroach/issues/72053
resolves https://github.com/cockroachdb/cockroach/issues/77280



Jira issue: CRDB-14773