### PR TITLE
release-21.2: optbuilder: do not create invalid casts when building CASE expressions

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -1461,3 +1461,18 @@ is [type=bool]
  │    │         └── null [type=unknown]
  │    └── array: [type=string[]]
  └── null [type=unknown]
+
+# Regression test for #75365. Do not create invalid casts when building CASE
+# expressions. We build a Select expressions here instead of a scalar so that
+# logical properties are generated, which is required to reproduce the bug.
+# TODO(#75103): We should be more permissive with casts of arrays of tuples.
+# These tests should be successful, not user-facing errors.
+build
+SELECT CASE WHEN false THEN ARRAY[('', 0)] ELSE ARRAY[]::RECORD[] END
+----
+error (42804): CASE types tuple[] and tuple{string, int}[] cannot be matched
+
+build
+SELECT CASE WHEN false THEN ARRAY[('', 0)] WHEN true THEN ARRAY[]::RECORD[] ELSE ARRAY[('', 0)] END
+----
+error (42804): CASE types tuple[] and tuple{string, int}[] cannot be matched


### PR DESCRIPTION
Backport 1/1 commits from #76193.

/cc @cockroachdb/release

---

The optbuilder no longer creates invalid casts when building CASE
expressions that have branches of different types. CASE expressions that
previously caused internal errors now result in user-facing errors. A
similar change was made recently to UNION expressions in #75219.

Note that there is more work to be done to be fully consistent with
Postgres's CASE typing behavior, see #75365.

Fixes #75365

Release note (bug fix): CASE expressions with branches that result in
types that cannot be cast to a common type now result in a user-facing
error instead of an internal error.

---

Release justification: This fixes a minor bug that causes an internal error.