### PR TITLE
util/tracing: improve span recording interface

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2204,7 +2204,7 @@ func (st *SessionTracing) StartTracing(
 			opName,
 			tracing.WithForceRealSpan(),
 		)
-		st.connSpan.SetVerbose(true)
+		st.connSpan.SetRecordingType(tracing.RecordingVerbose)
 		st.ex.ctxHolder.hijack(newConnCtx)
 	}
 
@@ -2248,7 +2248,7 @@ func (st *SessionTracing) StopTracing() error {
 	// We're about to finish this span, but there might be a child that remains
 	// open - the child corresponding to the current transaction. We don't want
 	// that span to be recording any more.
-	st.connSpan.SetVerbose(false)
+	st.connSpan.SetRecordingType(tracing.RecordingOff)
 	st.connSpan.Finish()
 	st.connSpan = nil
 	st.ex.ctxHolder.unhijack()

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4507,7 +4507,13 @@ value if you rely on the HLC for accuracy.`,
 					return tree.DBoolFalse, nil
 				}
 
-				rootSpan.SetVerbose(verbosity)
+				var recType tracing.RecordingType
+				if verbosity {
+					recType = tracing.RecordingVerbose
+				} else {
+					recType = tracing.RecordingOff
+				}
+				rootSpan.SetRecordingType(recType)
 				return tree.DBoolTrue, nil
 			},
 			Info:       "Returns true if root span was found and verbosity was set, false otherwise.",

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -798,7 +798,7 @@ func BenchmarkEventf_WithVerboseTraceSpan(b *testing.B) {
 			tracer.SetRedactable(redactable)
 			ctx, sp := tracer.StartSpanCtx(ctx, "benchspan", tracing.WithForceRealSpan())
 			defer sp.Finish()
-			sp.SetVerbose(true)
+			sp.SetRecordingType(tracing.RecordingVerbose)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				Eventf(ctx, "%s %s %s", "foo", "bar", "baz")

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -872,11 +872,6 @@ func (s *crdbSpan) SetVerbose(to bool) {
 	for _, child := range s.mu.openChildren {
 		child.SetVerbose(to)
 	}
-
-	// TODO(andrei): The children that have started while this span was not
-	// recording are not linked into openChildren. The children that are still
-	// open can be found through the registry, so we could go spelunking in there
-	// and link them into the parent.
 }
 
 // withLock calls f while holding s' lock.

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -320,15 +320,6 @@ func (s *crdbSpan) enableRecording(recType RecordingType) {
 	s.mu.recording.recordingType.swap(recType)
 }
 
-func (s *crdbSpan) disableRecording() {
-	if s.recordingType() == RecordingOff {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.mu.recording.recordingType.swap(RecordingOff)
-}
-
 // TraceID is part of the RegistrySpan interface.
 func (s *crdbSpan) TraceID() tracingpb.TraceID {
 	return s.traceID
@@ -859,18 +850,14 @@ func (s *crdbSpan) parentFinished() {
 	s.mu.parent.release()
 }
 
-// SetVerbose is part of the RegistrySpan interface.
-func (s *crdbSpan) SetVerbose(to bool) {
-	if to {
-		s.enableRecording(RecordingVerbose)
-	} else {
-		s.disableRecording()
-	}
+// SetRecordingType is part of the RegistrySpan interface.
+func (s *crdbSpan) SetRecordingType(to RecordingType) {
+	s.mu.recording.recordingType.swap(to)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, child := range s.mu.openChildren {
-		child.SetVerbose(to)
+		child.SetRecordingType(to)
 	}
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -367,26 +367,14 @@ func (sp *Span) Meta() SpanMeta {
 	return sp.i.Meta()
 }
 
-// SetVerbose toggles verbose recording on the Span, which must not be a noop
-// span (see the WithForceRealSpan option).
-//
-// With 'true', future calls to Record are actually recorded, and any future
-// descendants of this Span will do so automatically as well. This does not
-// apply to past derived Spans, which may in fact be noop spans.
-//
-// When set to 'false', Record will cede to add data to the recording (though
-// they may still be collected, should the Span have been set up with an
-// auxiliary trace sink). This does not apply to Spans derived from this one
-// when it was verbose.
-func (sp *Span) SetVerbose(to bool) {
+// SetRecordingType sets the recording mode of the span and its children,
+// recursively. Setting it to RecordingOff disables further recording.
+// Everything recorded so far remains in memory.
+func (sp *Span) SetRecordingType(to RecordingType) {
 	if sp.detectUseAfterFinish() {
 		return
 	}
-	// We allow toggling verbosity on and off for a finished span. This shouldn't
-	// matter either way as a finished span drops all new data, but if we
-	// prevented the toggling we could end up in weird states since IsVerbose()
-	// won't reflect what the caller asked for.
-	sp.i.SetVerbose(to)
+	sp.i.SetRecordingType(to)
 }
 
 // RecordingType returns the range's current recording mode.

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -69,11 +69,11 @@ func (s *spanInner) RecordingType() RecordingType {
 	return s.crdb.recordingType()
 }
 
-func (s *spanInner) SetVerbose(to bool) {
+func (s *spanInner) SetRecordingType(to RecordingType) {
 	if s.isNoop() {
 		panic(errors.AssertionFailedf("SetVerbose called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
 	}
-	s.crdb.SetVerbose(to)
+	s.crdb.SetRecordingType(to)
 }
 
 // GetRecording returns the span's recording.

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -292,7 +292,7 @@ func TestSpanRecordStructuredLimit(t *testing.T) {
 		sp.RecordStructured(payload(i))
 	}
 
-	sp.SetVerbose(true)
+	sp.SetRecordingType(RecordingVerbose)
 	rec := sp.GetRecording(RecordingVerbose)
 	require.Len(t, rec, 1)
 	require.Len(t, rec[0].StructuredRecords, numStructuredRecordings)
@@ -528,7 +528,7 @@ func TestSpanTagsInRecordings(t *testing.T) {
 	// We didn't stringify the log tag.
 	require.Zero(t, int(counter))
 
-	sp.SetVerbose(true)
+	sp.SetRecordingType(RecordingVerbose)
 	rec = sp.GetRecording(RecordingVerbose)
 	require.Len(t, rec, 1)
 	require.Len(t, rec[0].Tags, 5) // _unfinished:1 _verbose:1 foo:tagbar foo1:1 foor2:bar2

--- a/pkg/util/tracing/tags_test.go
+++ b/pkg/util/tracing/tags_test.go
@@ -30,7 +30,7 @@ func TestLogTags(t *testing.T) {
 	l := logtags.SingleTagBuffer("tag1", "val1")
 	l = l.Add("tag2", "val2")
 	sp1 := tr.StartSpan("foo", WithLogTags(l))
-	sp1.SetVerbose(true)
+	sp1.SetRecordingType(RecordingVerbose)
 	require.NoError(t, CheckRecordedSpans(sp1.FinishAndGetRecording(RecordingVerbose), `
 		span: foo
 			tags: _verbose=1 tag1=val1 tag2=val2
@@ -49,7 +49,7 @@ func TestLogTags(t *testing.T) {
 	RegisterTagRemapping("tag2", "two")
 
 	sp2 := tr.StartSpan("bar", WithLogTags(l))
-	sp2.SetVerbose(true)
+	sp2.SetRecordingType(RecordingVerbose)
 	require.NoError(t, CheckRecordedSpans(sp2.FinishAndGetRecording(RecordingVerbose), `
 		span: bar
 			tags: _verbose=1 one=val1 two=val2
@@ -66,7 +66,7 @@ func TestLogTags(t *testing.T) {
 	}
 
 	sp3 := tr.StartSpan("baz", WithLogTags(l))
-	sp3.SetVerbose(true)
+	sp3.SetRecordingType(RecordingVerbose)
 	require.NoError(t, CheckRecordedSpans(sp3.FinishAndGetRecording(RecordingVerbose), `
 		span: baz
 			tags: _verbose=1 one=val1 two=val2

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1353,9 +1353,10 @@ type RegistrySpan interface {
 	// span registry, we want as much information as possible to be included.
 	GetFullRecording(recType RecordingType) Recording
 
-	// SetVerbose sets the verbosity of the span appropriately and
-	// recurses on its children.
-	SetVerbose(to bool)
+	// SetRecordingType sets the recording mode of the span and its children,
+	// recursively. Setting it to RecordingOff disables further recording.
+	// Everything recorded so far remains in memory.
+	SetRecordingType(to RecordingType)
 }
 
 var _ RegistrySpan = &crdbSpan{}

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -94,14 +94,14 @@ func TestTracerRecording(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s1.SetVerbose(true)
+	s1.SetRecordingType(RecordingVerbose)
 	if err := CheckRecordedSpans(s1.GetRecording(RecordingVerbose), `
 		span: a
 			tags: _unfinished=1 _verbose=1
 	`); err != nil {
 		t.Fatal(err)
 	}
-	s1.SetVerbose(false)
+	s1.SetRecordingType(RecordingOff)
 
 	// Real parent --> real child.
 	real3 := tr.StartSpan("noop3", WithRemoteParentFromSpanMeta(s1.Meta()))
@@ -111,7 +111,7 @@ func TestTracerRecording(t *testing.T) {
 	real3.Finish()
 
 	s1.Recordf("x=%d", 1)
-	s1.SetVerbose(true)
+	s1.SetRecordingType(RecordingVerbose)
 	s1.Recordf("x=%d", 2)
 	s2 := tr.StartSpan("b", WithParent(s1))
 	if !s2.IsVerbose() {
@@ -176,7 +176,7 @@ func TestTracerRecording(t *testing.T) {
 	s1.Finish()
 
 	s4 := tr.StartSpan("a", WithRecording(RecordingStructured))
-	s4.SetVerbose(false)
+	s4.SetRecordingType(RecordingOff)
 	s4.Recordf("x=%d", 100)
 	require.Nil(t, s4.GetRecording(RecordingStructured))
 	s4.Finish()


### PR DESCRIPTION
Before this patch, the Span's recording interface was left over from a
time when there were only one recording mode: verbose. We now have two
modes: verbose recording and structured recording. They can be enabled
at span creation time through the WithRecording(<type>) option. This
patch changes the Span's SetVerbose() method to expose the two options.

Release note: None