### PR TITLE
build: extend pebble metamorphic timeout; lower operation count

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -20,12 +20,12 @@ exit_status=0
 # correct flags in the reproduction command.
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci test \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test -- \
-                                      --test_timeout=11000 '--test_filter=TestMeta$' \
+                                      --test_timeout=14400 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \
                                       "--test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE" \
                                       --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'GO_TEST_JSON_OUTPUT_FILE=cat,XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \
-                                      --test_arg -ops --test_arg "uniform:5000-25000" \
+                                      --test_arg -ops --test_arg "uniform:5000-10000" \
     || exit_status=$?
 
 BAZEL_SUPPORT_EXTRA_GITHUB_POST_ARGS=--formatter=pebble-metamorphic process_test_json \

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -541,7 +541,7 @@ func formatPebbleMetamorphicIssue(
 			s = strings.TrimSpace(s)
 			s = strings.TrimSpace(s[:strings.Index(s, "\n")])
 			repro = fmt.Sprintf("go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' "+
-				`-timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed %s -ops "uniform:5000-25000"`, s)
+				`-timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed %s -ops "uniform:5000-10000"`, s)
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -235,7 +235,7 @@ TestXXA - 1.00s
 					testName: "TestMeta",
 					title:    "internal/metamorphic: TestMeta failed",
 					message:  "panic: induced panic",
-					expRepro: `go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-25000"`,
+					expRepro: `go test -mod=vendor -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-10000"`,
 				},
 			},
 			formatter: formatPebbleMetamorphicIssue,


### PR DESCRIPTION
The Pebble metamorphic test runs have been timing out due to single runs
taking longer for worst-case configurations. Increase the governing
timeout from just over three hours to four hours. This gives more time
to a metamorphic test run that started close to the end of the three
hour window to complete.

Lower the upper bound on the operation count random distribution from
25k ops to 10k ops. This will shorten the time for each run, on average,
while allowing more configurations to be tested overall.

Update the reproduction message in the Pebble formatter.

Related to cockroachdb/pebble#1514.

Release note: None