### PR TITLE
release-21.2: builtins: add rehome_row to DistSQLBlocklist

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5989,7 +5989,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		),
 	),
 	RehomeRowBuiltinName: makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true,
+		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),


### PR DESCRIPTION
Backport 1/1 commits from #76544.

/cc @cockroachdb/release

Release justification: low-risk change

---

fixes https://github.com/cockroachdb/cockroach/issues/76153

This builtin always needs to run on the gateway node.

Release note: None
