### PR TITLE
sql: speed up a test

### DIFF
--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/util",
         "//pkg/util/cloudinfo",
         "//pkg/util/protoutil",
         "//pkg/util/treeprinter",

--- a/pkg/sql/sqltestutils/sql_test_utils.go
+++ b/pkg/sql/sqltestutils/sql_test_utils.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
@@ -53,6 +55,19 @@ func DisableGCTTLStrictEnforcement(t *testing.T, db *gosql.DB) (cleanup func()) 
 		_, err := db.Exec(`SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = DEFAULT`)
 		require.NoError(t, err)
 	}
+}
+
+// SetShortRangeFeedIntervals is a helper to set the cluster settings
+// pertaining to rangefeeds to short durations. This is helps tests which
+// rely on zone/span configuration changes to propagate.
+func SetShortRangeFeedIntervals(t *testing.T, db sqlutils.DBHandle) {
+	tdb := sqlutils.MakeSQLRunner(db)
+	short := "'20ms'"
+	if util.RaceEnabled {
+		short = "'200ms'"
+	}
+	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = `+short)
+	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = `+short)
 }
 
 // AddDefaultZoneConfig adds an entry for the given id into system.zones.

--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
@@ -322,11 +323,15 @@ func TestUnsplitRanges(t *testing.T) {
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
 			BinaryVersionOverride:          clusterversion.ByKey(tc.binaryVersion),
 		}
+		params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 
 		defer gcjob.SetSmallMaxGCIntervalForTest()()
 
 		s, sqlDB, kvDB := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(context.Background())
+
+		// Speed up how long it takes for the zone config changes to propagate.
+		sqltestutils.SetShortRangeFeedIntervals(t, sqlDB)
 
 		// Disable strict GC TTL enforcement because we're going to shove a zero-value
 		// TTL into the system with AddImmediateGCZoneConfig.


### PR DESCRIPTION
Before this change this test took like 90s.

```
--- PASS: TestUnsplitRanges (8.45s)
    --- PASS: TestUnsplitRanges/drop-table-unsplit-sync (1.52s)
    --- PASS: TestUnsplitRanges/drop-table-unsplit-async (1.02s)
    --- PASS: TestUnsplitRanges/drop-database-unsplit-sync (0.99s)
    --- PASS: TestUnsplitRanges/drop-database-unsplit-async (0.98s)
    --- PASS: TestUnsplitRanges/truncate-table-unsplit-sync (0.99s)
    --- PASS: TestUnsplitRanges/truncate-table-unsplit-async (1.53s)
    --- PASS: TestUnsplitRanges/drop-index-unsplit-sync (0.80s)
    --- PASS: TestUnsplitRanges/drop-index-unsplit-async (0.56s)
```

Release note: None