### PR TITLE
sql: only create a LeafTxn for local flows if Streamer is enabled

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -296,6 +296,8 @@ func max(a, b int64) int64 {
 
 // NewStreamer creates a new Streamer.
 //
+// txn must be a LeafTxn.
+//
 // limitBytes determines the maximum amount of memory this Streamer is allowed
 // to use (i.e. it'll be used lazily, as needed). The more memory it has, the
 // higher its internal concurrency and throughput.
@@ -315,6 +317,9 @@ func NewStreamer(
 	limitBytes int64,
 	acc *mon.BoundAccount,
 ) *Streamer {
+	if txn.Type() != kv.LeafTxn {
+		panic(errors.AssertionFailedf("RootTxn is given to the Streamer"))
+	}
 	s := &Streamer{
 		distSender: distSender,
 		stopper:    stopper,

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -104,6 +104,20 @@ func TestStreamerLimitations(t *testing.T) {
 		// responded to.
 		require.Error(t, streamer.Enqueue(ctx, reqs, nil /* enqueueKeys */))
 	})
+
+	t.Run("unexpected RootTxn", func(t *testing.T) {
+		require.Panics(t, func() {
+			NewStreamer(
+				s.DistSenderI().(*kvcoord.DistSender),
+				s.Stopper(),
+				kv.NewTxn(ctx, s.DB(), s.NodeID()),
+				cluster.MakeTestingClusterSettings(),
+				lock.WaitPolicy(0),
+				math.MaxInt64, /* limitBytes */
+				nil,           /* acc */
+			)
+		})
+	})
 }
 
 // TestLargeKeys verifies that the Streamer successfully completes the queries

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/faketreeeval",
         "//pkg/sql/flowinfra",
+        "//pkg/sql/row",
         "//pkg/sql/rowflow",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",


### PR DESCRIPTION
Previously, during the flow setup stage we would always choose to create
a LeafTxn for local flows if there is a processor that might use
a Streamer API. This was the case even when the Streamer is disabled by
a cluster setting. Such behavior is a regression (since leaf txns don't
have a transparent span refresh mechanism and read spans have to be
collected with the metadata at the end of the execution), so this commit
fixes things by only using a LeafTxn if the Streamer is actually
enabled. Now, the users of the Streamer API are expected to check that
they do have a LeafTxn and only use the Streamer if so.

Additionally, this commit correctly populates `HasConcurrency` field for
the local flows even when the query might be distributed. The fix is
needed since the physical planning decision to distribute the query or
not is finalized after we decide which txn to use for the flow, which is
too late. Thus, whenever the Streamer is enabled and we find an index
join in the plan, we will make sure to use the LeafTxn (this was already
the case if the plan ended up being distributed).

Release note: None