### PR TITLE
kv: preserve stepping mode when reseting the kv.Txn object

### DIFF
--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1421,11 +1421,10 @@ func (txn *Txn) replaceRootSenderIfTxnAbortedLocked(
 	// transaction, even once the proto is reset.
 	txn.recordPreviousTxnIDLocked(txn.mu.ID)
 	txn.mu.ID = newTxn.ID
-	// Create a new txn sender. We need to preserve the stepping mode,
-	// if any.
-	// prevSteppingMode := txn.mu.sender.GetSteppingMode(ctx)
+	// Create a new txn sender. We need to preserve the stepping mode, if any.
+	prevSteppingMode := txn.mu.sender.GetSteppingMode(ctx)
 	txn.mu.sender = txn.db.factory.RootTransactionalSender(newTxn, txn.mu.userPriority)
-	// txn.mu.sender.ConfigureStepping(ctx, prevSteppingMode)
+	txn.mu.sender.ConfigureStepping(ctx, prevSteppingMode)
 }
 
 func (txn *Txn) recordPreviousTxnIDLocked(prevTxnID uuid.UUID) {


### PR DESCRIPTION
When encountering a retryable error the transaction may be
aborted. Then, the caller should call PrepareForRetry() to reset
the handle before using the Txn again. After doing that, the handle
will have SteppingMode disabled, even if the Txn object was created
with NewTxnWithSteppingEnabled(). This is because on PrepareForRetry()
we replace the poisoned sender with a new one, and the sender owns the
stepping config.

Currently the SQL code tried to enabled stepping back after such
potential reset, but this is error prone.

Users that create a Txn object with stepping enabled would expect
this configuration to remain even after such errors because they are
not aware of the implementation details of replacing the sender.
This is what this simple PR is doing. Actually this was probably
the original intent.. restoring the stepping was there but commented out.

Release note: None.