### PR TITLE
sql/schemachanger: adopt pausepoints

### DIFF
--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -40,6 +40,7 @@ type JobRegistry interface {
 	UpdateJobWithTxn(
 		ctx context.Context, jobID jobspb.JobID, txn *kv.Txn, useReadLock bool, updateFunc jobs.UpdateFn,
 	) error
+	CheckPausepoint(name string) error
 }
 
 // NewExecutorDependencies returns an scexec.Dependencies implementation built
@@ -257,6 +258,10 @@ var _ scexec.TransactionalJobRegistry = (*txnDeps)(nil)
 
 func (d *txnDeps) MakeJobID() jobspb.JobID {
 	return d.jobRegistry.MakeJobID()
+}
+
+func (d *txnDeps) CheckPausepoint(name string) error {
+	return d.jobRegistry.CheckPausepoint(name)
 }
 
 func (d *txnDeps) SchemaChangerJobID() jobspb.JobID {

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -708,6 +708,11 @@ func (s *TestState) CreateJob(ctx context.Context, record jobs.Record) error {
 	return nil
 }
 
+// CheckPausepoint is a no-op.
+func (s *TestState) CheckPausepoint(name string) error {
+	return nil
+}
+
 // UpdateSchemaChangeJob implements the scexec.TransactionalJobRegistry interface.
 func (s *TestState) UpdateSchemaChangeJob(
 	ctx context.Context, id jobspb.JobID, fn scexec.JobUpdateCallback,

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -107,6 +107,12 @@ type TransactionalJobRegistry interface {
 	// id which was assigned to that job, or an error otherwise.
 	CreateJob(ctx context.Context, record jobs.Record) error
 
+	// CheckPausepoint returns a PauseRequestError if the named pause-point is
+	// set.
+	//
+	// See (*jobs.Registry).CheckPausepoint
+	CheckPausepoint(name string) error
+
 	// TODO(ajwerner): Deal with setting the running status to indicate
 	// validating, backfilling, or generally performing metadata changes
 	// and waiting for lease draining.

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -434,6 +434,10 @@ func TestSchemaChanger(t *testing.T) {
 
 type noopJobRegistry struct{}
 
+func (n noopJobRegistry) CheckPausepoint(name string) error {
+	return nil
+}
+
 func (n noopJobRegistry) UpdateJobWithTxn(
 	ctx context.Context, jobID jobspb.JobID, txn *kv.Txn, useReadLock bool, updateFunc jobs.UpdateFn,
 ) error {

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -12,6 +12,7 @@ package scrun
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -100,12 +101,25 @@ func RunSchemaChangesInJob(
 	for i := range sc.Stages {
 		// Execute each stage in its own transaction.
 		if err := deps.WithTxnInJob(ctx, func(ctx context.Context, td scexec.Dependencies) error {
+			if err := td.TransactionalJobRegistry().CheckPausepoint(
+				pausepointName(state, i),
+			); err != nil {
+				return err
+			}
 			return executeStage(ctx, knobs, td, sc, i, sc.Stages[i])
 		}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// pausepointName construct a name for the job execution phase pausepoint.
+func pausepointName(state scpb.CurrentState, i int) string {
+	return fmt.Sprintf(
+		"schemachanger.%s.%s.%d",
+		state.Authorization.UserName, state.Authorization.AppName, i,
+	)
 }
 
 func executeStage(


### PR DESCRIPTION
These are super handy for manual testing.

```sql
root@localhost:26257/defaultdb> set application_name=test;
SET
root@localhost:26257/defaultdb> create table tab (i INT PRIMARY KEY);
CREATE TABLE
root@localhost:26257/defaultdb> set cluster setting jobs.debug.pausepoints = 'schemachanger://root@test/2';
SET CLUSTER SETTING
root@localhost:26257/defaultdb> set experimental_use_new_schema_changer = unsafe_always;
SET
root@localhost:26257/defaultdb> alter table tab add column j int not null default 42;
ERROR: job 737008824216879105 was paused before it completed with reason: pause point "schemachanger://root@test/2" hit
```

Release note: None