### PR TITLE
roachtest/test: fix ORM testing due to removed cluster setting

### DIFF
--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -48,7 +48,6 @@ func alterZoneConfigAndClusterSettings(
 		`SET CLUSTER SETTING jobs.retention_time = '15s';`,
 		`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;`,
 		`SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s';`,
-		`SET CLUSTER SETTING sql.catalog.unsafe_skip_system_config_trigger.enabled = true;`,
 
 		// Enable experimental features.
 		`SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled = 'true';`,


### PR DESCRIPTION
`sql.catalog.unsafe_skip_system_config_trigger.enabled` got removed
recently and was part of an alpha. Let's clean it up in ORMs too.

Resolves #76654
Resolves #76656
Resolves #76657
Resolves #76658
Resolves #76659
Resolves #76660
Resolves #76661
Resolves #76662
Resolves #76663
Resolves #76664
Resolves #76665
Resolves #76666

Release note: None