### PR TITLE
server: remove query constants in sessions response for VIEWACTIVITYR…

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -187,6 +187,11 @@ func (b *baseStatusServer) getLocalSessions(
 		}
 	}
 
+	hasViewActivityRedacted, err := b.privilegeChecker.hasRoleOption(ctx, sessionUser, roleoption.VIEWACTIVITYREDACTED)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+
 	// The empty username means "all sessions".
 	showAll := reqUsername.Undefined()
 
@@ -197,6 +202,16 @@ func (b *baseStatusServer) getLocalSessions(
 	for _, session := range sessions {
 		if reqUsername.Normalized() != session.Username && !showAll {
 			continue
+		}
+
+		if !isAdmin && hasViewActivityRedacted && (sessionUser != reqUsername) {
+			// Remove queries with constants if user doesn't have correct privileges.
+			// Note that users can have both VIEWACTIVITYREDACTED and VIEWACTIVITY,
+			// with the former taking precedence.
+			for _, query := range session.ActiveQueries {
+				query.Sql = ""
+			}
+			session.LastActiveQuery = ""
 		}
 
 		userSessions = append(userSessions, session)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -2888,3 +2888,66 @@ func TestStatusCancelSessionGatewayMetadataPropagation(t *testing.T) {
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "status: 403 Forbidden")
 }
+
+func TestStatusAPIListSessions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	ctx := context.Background()
+	testCluster := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: params,
+	})
+	defer testCluster.Stopper().Stop(ctx)
+
+	serverProto := testCluster.Server(0)
+	serverSQL := sqlutils.MakeSQLRunner(testCluster.ServerConn(0))
+
+	appName := "test_sessions_api"
+	serverSQL.Exec(t, fmt.Sprintf(`SET application_name = "%s"`, appName))
+
+	getSessionWithTestAppName := func(response *serverpb.ListSessionsResponse) *serverpb.Session {
+		require.NotEmpty(t, response.Sessions)
+		for _, s := range response.Sessions {
+			if s.ApplicationName == appName {
+				return &s
+			}
+		}
+		t.Errorf("expected to find session with app name %s", appName)
+		return nil
+	}
+
+	userNoAdmin := authenticatedUserNameNoAdmin()
+	var resp serverpb.ListSessionsResponse
+	// Non-admin without VIEWWACTIVITY or VIEWACTIVITYREDACTED should work and fetch user's own sessions.
+	err := getStatusJSONProtoWithAdminOption(serverProto, "sessions", &resp, false)
+	require.NoError(t, err)
+
+	// Grant VIEWACTIVITYREDACTED.
+	serverSQL.Exec(t, fmt.Sprintf("ALTER USER %s VIEWACTIVITYREDACTED", userNoAdmin.Normalized()))
+	serverSQL.Exec(t, "SELECT 1")
+	err = getStatusJSONProtoWithAdminOption(serverProto, "sessions", &resp, false)
+	require.NoError(t, err)
+	session := getSessionWithTestAppName(&resp)
+	require.Empty(t, session.LastActiveQuery)
+	require.Equal(t, "SELECT _", session.LastActiveQueryNoConstants)
+
+	// Grant VIEWACTIVITY, VIEWACTIVITYREDACTED should take precedence.
+	serverSQL.Exec(t, fmt.Sprintf("ALTER USER %s VIEWACTIVITY", userNoAdmin.Normalized()))
+	serverSQL.Exec(t, "SELECT 1, 1")
+	err = getStatusJSONProtoWithAdminOption(serverProto, "sessions", &resp, false)
+	require.NoError(t, err)
+	session = getSessionWithTestAppName(&resp)
+	require.Equal(t, appName, session.ApplicationName)
+	require.Empty(t, session.LastActiveQuery)
+	require.Equal(t, "SELECT _, _", session.LastActiveQueryNoConstants)
+
+	// Remove VIEWACTIVITYREDCATED. User should now see full query.
+	serverSQL.Exec(t, fmt.Sprintf("ALTER USER %s NOVIEWACTIVITYREDACTED", userNoAdmin.Normalized()))
+	serverSQL.Exec(t, "SELECT 2")
+	err = getStatusJSONProtoWithAdminOption(serverProto, "sessions", &resp, false)
+	require.NoError(t, err)
+	session = getSessionWithTestAppName(&resp)
+	require.Equal(t, "SELECT _", session.LastActiveQueryNoConstants)
+	require.Equal(t, "SELECT 2", session.LastActiveQuery)
+}


### PR DESCRIPTION
…EDACTED

Previously, we return the full query in ListSessions for admin users,
users requesting their own sessions and users requesting all sessions
with VIEWACTIVITY or VIEWACTIVITYREDACTED roles. This commit removes
the query with constants from the response for users that have the
VIEWACTIVITYREDACTED role if requesting all sessions in the cluster. The
query without constants remains in the response.

Release note (api change): Users with the VIEWACTIVITYREDACTED
role will not have access to the full queries with constants in
the the ListSessions response.