### PR TITLE
tenantcostcontrol: change settings to TenantReadOnly

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -69,3 +69,35 @@ query B
 SHOW CLUSTER SETTING sql.notices.enabled
 ----
 true
+
+# Verify that the tenant cannot modify TenantReadOnly settings.
+query T
+SHOW CLUSTER SETTING kv.protectedts.reconciliation.interval
+----
+00:05:00
+
+statement error only settable by the operator
+SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '45s'
+
+# Verify that even writing to the system table directly doesn't work.
+statement ok
+INSERT INTO system.settings (name, value, "valueType") VALUES ('kv.protectedts.reconciliation.interval', '45s', 'd')
+
+query T
+SHOW CLUSTER SETTING kv.protectedts.reconciliation.interval
+----
+00:05:00
+
+# Verify that we can control it from the operator.
+user host-cluster-root
+
+statement ok
+INSERT INTO system.tenant_settings (tenant_id, name, value, value_type)
+  VALUES (10, 'kv.protectedts.reconciliation.interval', '45s', 'd')
+
+user root
+
+query T retry
+SHOW CLUSTER SETTING kv.protectedts.reconciliation.interval
+----
+00:00:45

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -30,11 +30,8 @@ import (
 
 // ReconcileInterval is the interval between two reconciliations of protected
 // timestamp records.
-//
-// TODO(adityamaru): Set to TenantReadOnly once the work for #73349 is
-// completed.
 var ReconcileInterval = settings.RegisterDurationSetting(
-	settings.TenantWritable,
+	settings.TenantReadOnly,
 	"kv.protectedts.reconciliation.interval",
 	"the frequency for reconciling jobs with protected timestamp records",
 	5*time.Minute,

--- a/pkg/multitenant/tenantcostmodel/settings.go
+++ b/pkg/multitenant/tenantcostmodel/settings.go
@@ -27,7 +27,7 @@ import (
 // from the host cluster.
 var (
 	readRequestCost = settings.RegisterFloatSetting(
-		settings.TenantWritable,
+		settings.TenantReadOnly,
 		"tenant_cost_model.kv_read_request_cost",
 		"base cost of a read request in Request Units",
 		0.6993,
@@ -35,7 +35,7 @@ var (
 	)
 
 	readCostPerMB = settings.RegisterFloatSetting(
-		settings.TenantWritable,
+		settings.TenantReadOnly,
 		"tenant_cost_model.kv_read_cost_per_megabyte",
 		"cost of a read in Request Units per MB",
 		107.6563,
@@ -43,7 +43,7 @@ var (
 	)
 
 	writeRequestCost = settings.RegisterFloatSetting(
-		settings.TenantWritable,
+		settings.TenantReadOnly,
 		"tenant_cost_model.kv_write_request_cost",
 		"base cost of a write request in Request Units",
 		5.7733,
@@ -51,7 +51,7 @@ var (
 	)
 
 	writeCostPerMB = settings.RegisterFloatSetting(
-		settings.TenantWritable,
+		settings.TenantReadOnly,
 		"tenant_cost_model.kv_write_cost_per_megabyte",
 		"cost of a write in Request Units per MB",
 		2026.3021,
@@ -59,7 +59,7 @@ var (
 	)
 
 	podCPUSecondCost = settings.RegisterFloatSetting(
-		settings.TenantWritable,
+		settings.TenantReadOnly,
 		"tenant_cost_model.pod_cpu_second_cost",
 		"cost of a CPU-second on the tenant POD in Request Units",
 		1000.0,
@@ -67,7 +67,7 @@ var (
 	)
 
 	pgwireEgressCostPerMB = settings.RegisterFloatSetting(
-		settings.TenantWritable,
+		settings.TenantReadOnly,
 		"tenant_cost_model.pgwire_egress_cost_per_megabyte",
 		"cost of client <-> SQL ingress/egress per MB",
 		878.9063,


### PR DESCRIPTION
#### tenant settings: implement TenantReadOnly semantics

This commit implements the advertised `TenantReadOnly` semantics,
changes the `kv.protectedts.reconciliation.interval` setting to
`TenantReadOnly`, and adds some relevant tests.

Note that the settings watcher already ignores any values for
`TenantReadOnly` variables in the `system.settings` table. This commit
includes a test for that.

Release note: None

#### tenantcostcontrol: change settings to TenantReadOnly

This commit changes the settings relevant for RU accounting and
limiting to `TenantReadOnly`. The tenant cost model values are now
used (instead of always using the default values). The range of values
for `tenant_cpu_usage_allowance` is extended since we no longer have
to worry about the tenant bumping it up.

Release note: None