### PR TITLE
ui: cached data reducer with pagination

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -17,6 +17,8 @@ import {
   CachedDataReducerState,
   KeyedCachedDataReducer,
   KeyedCachedDataReducerState,
+  PaginatedCachedDataReducer,
+  PaginatedCachedDataReducerState,
 } from "./cachedDataReducer";
 import * as api from "src/util/api";
 import { VersionList } from "src/interfaces/cockroachlabs";
@@ -99,7 +101,19 @@ const databaseDetailsReducerObj = new KeyedCachedDataReducer(
   "databaseDetails",
   databaseRequestToID,
 );
+
+const hotRangesRequestToID = (req: api.HotRangesRequestMessage) =>
+  req.page_token;
+
+export const hotRangesReducerObj = new PaginatedCachedDataReducer(
+  api.getHotRanges,
+  "hotRanges",
+  hotRangesRequestToID,
+);
+
 export const refreshDatabaseDetails = databaseDetailsReducerObj.refresh;
+
+export const refreshHotRanges = hotRangesReducerObj.refresh;
 
 // NOTE: We encode the db and table name so we can combine them as a string.
 // TODO(maxlang): there's probably a nicer way to do this
@@ -371,6 +385,7 @@ export interface APIReducersState {
     api.StatementDiagnosticsReportsResponseMessage
   >;
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
+  hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -408,6 +423,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [statementDiagnosticsReportsReducerObj.actionNamespace]:
     statementDiagnosticsReportsReducerObj.reducer,
   [userSQLRolesReducerObj.actionNamespace]: userSQLRolesReducerObj.reducer,
+  [hotRangesReducerObj.actionNamespace]: hotRangesReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
@@ -17,6 +17,10 @@ import {
   CachedDataReducerState,
   KeyedCachedDataReducer,
   KeyedCachedDataReducerState,
+  WithPaginationRequest,
+  WithPaginationResponse,
+  PaginatedCachedDataReducer,
+  PaginatedCachedDataReducerState,
 } from "./cachedDataReducer";
 
 describe("basic cachedDataReducer", function() {
@@ -330,6 +334,236 @@ describe("keyed cachedDataReducer", function() {
         expected = new KeyedCachedDataReducerState<Response>();
         expected[id] = new CachedDataReducerState<Response>();
         assert.deepEqual(state, expected);
+      });
+    });
+  });
+});
+
+describe.only("PaginatedCachedDataReducer", function() {
+  class Request implements WithPaginationRequest {
+    constructor(
+      public request: string,
+      public page_size: number,
+      public page_token: string,
+    ) {}
+  }
+
+  class Response implements WithPaginationResponse {
+    constructor(public response: string, public next_page_token: string) {}
+  }
+
+  const apiEndpointMockFactory: (
+    totalPages: number,
+    pageSize: number,
+  ) => (req: Request) => Promise<Response> = (
+    totalPages: number = 5,
+    pageSize: number = 10,
+  ) => {
+    let requestCounter = 0;
+    return (req = new Request(null, pageSize, requestCounter.toString())) => {
+      if (requestCounter < totalPages) {
+        requestCounter++;
+      }
+      return new Promise((resolve, _reject) => {
+        resolve(
+          new Response(`${req.request}-${requestCounter}`, `${requestCounter}`),
+        );
+      });
+    };
+  };
+
+  const requestToID = (req: Request) => req.page_token;
+
+  let expected: PaginatedCachedDataReducerState<Response>;
+
+  describe("reducerObj", function() {
+    const actionNamespace = "paginatedKey";
+    const totalPagesNum = 5;
+    const testReducerObj = new PaginatedCachedDataReducer<Request, Response>(
+      apiEndpointMockFactory(totalPagesNum, 10),
+      actionNamespace,
+      requestToID,
+    );
+
+    describe("actions", function() {
+      it("requestData() creates the correct action type.", function() {
+        const request = new Request("testRequestRequest", undefined, undefined);
+        const requestAction = testReducerObj.cachedDataReducer.requestData(
+          request,
+        );
+        assert.equal(
+          requestAction.type,
+          testReducerObj.cachedDataReducer.REQUEST,
+        );
+        assert.deepEqual(requestAction.payload, { request });
+      });
+
+      it("receiveData() creates the correct action type.", function() {
+        const response = new Response("testResponse", "1");
+        const request = new Request("testRequestRequest", 5, undefined);
+        const receiveAction = testReducerObj.cachedDataReducer.receiveData(
+          response,
+          request,
+        );
+        assert.equal(
+          receiveAction.type,
+          testReducerObj.cachedDataReducer.RECEIVE,
+        );
+        assert.deepEqual(receiveAction.payload, { request, data: response });
+      });
+
+      it("errorData() creates the correct action type.", function() {
+        const error = new Error();
+        const request = new Request("testRequestRequest", 5, undefined);
+        const errorAction = testReducerObj.cachedDataReducer.errorData(
+          error,
+          request,
+        );
+        assert.equal(errorAction.type, testReducerObj.cachedDataReducer.ERROR);
+        assert.deepEqual(errorAction.payload, { request, data: error });
+      });
+
+      it("invalidateData() creates the correct action type.", function() {
+        const request = new Request("testRequestRequest", 5, undefined);
+        const invalidateAction = testReducerObj.cachedDataReducer.invalidateData(
+          request,
+        );
+        assert.equal(
+          invalidateAction.type,
+          testReducerObj.cachedDataReducer.INVALIDATE,
+        );
+        assert.deepEqual(invalidateAction.payload, { request });
+      });
+    });
+
+    const reducer = testReducerObj.reducer;
+    const testMoment = moment();
+    testReducerObj.setTimeSource(() => testMoment);
+
+    describe("paginated reducer", function() {
+      let state: PaginatedCachedDataReducerState<Response>;
+      let id: string;
+      let request: Request;
+      beforeEach(() => {
+        state = reducer(undefined, { type: "unknown" });
+        id = Math.random().toString();
+        request = new Request(id, 10, id);
+      });
+
+      it("should have the correct default value.", function() {
+        expected = new PaginatedCachedDataReducerState<Response>();
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch requestData", function() {
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.requestData(request),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.requestedAt = testMoment;
+        expected.inFlight = true;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch receiveData", function() {
+        const expectedResponse = new Response(null, "1");
+
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.receiveData(
+            expectedResponse,
+            request,
+          ),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.valid = false;
+        expected.inFlight = true;
+        expected.data[id] = expectedResponse;
+        expected.lastError = null;
+        expected.setAt = testMoment;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch errorData", function() {
+        const e = new Error();
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.errorData(e, request),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.lastError = e;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch invalidateData", function() {
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.invalidateData(request),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.valid = false;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch cleanData", function() {
+        state = reducer(state, testReducerObj.clearData(request));
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.data = {};
+        expected.valid = false;
+        expected.setAt = undefined;
+        expected.requestedAt = undefined;
+        console.log("state", JSON.stringify(state, undefined, 2));
+        console.log("expected", JSON.stringify(expected, undefined, 2));
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch receiveCompleted", function() {
+        state = reducer(state, testReducerObj.receiveCompleted(request));
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.valid = true;
+        expected.inFlight = false;
+        expected.setAt = testMoment;
+        expected.lastError = null;
+        assert.deepEqual(state, expected);
+      });
+    });
+
+    describe("refresh", function() {
+      let state: PaginatedCachedDataReducerState<Response>;
+      let id: string;
+      let request: Request;
+
+      beforeEach(() => {
+        state = reducer(undefined, undefined);
+        id = Math.random().toString();
+        request = new Request(id, 10, "");
+      });
+
+      const mockDispatch = <A extends Action>(action: A): A => {
+        state = testReducerObj.reducer(state, action);
+        return undefined;
+      };
+
+      it("correctly dispatches refresh", function() {
+        const pageState = new PaginatedCachedDataReducerState<Response>();
+        pageState.valid = true;
+        pageState.lastError = null;
+        pageState.setAt = testMoment;
+        pageState.requestedAt = testMoment;
+
+        const expectedPageTokens = Array(totalPagesNum)
+          .fill("")
+          .map((_, i) => `${i + 1}`)
+          .concat(["", id]);
+
+        return testReducerObj
+          .refresh(request, s => s[id])(mockDispatch, () => state, undefined)
+          .then(() => {
+            Object.keys(state.data).forEach(k => {
+              assert.isTrue(expectedPageTokens.some(t => t === k));
+            });
+          });
       });
     });
   });

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -27,6 +27,15 @@ import { APIRequestFn } from "src/util/api";
 
 import { PayloadAction, WithRequest } from "src/interfaces/action";
 
+export interface WithPaginationRequest {
+  page_size: number;
+  page_token: string;
+}
+
+export interface WithPaginationResponse {
+  next_page_token: string;
+}
+
 // CachedDataReducerState is used to track the state of the cached data.
 export class CachedDataReducerState<TResponseMessage> {
   data?: TResponseMessage; // the latest data received
@@ -41,6 +50,22 @@ export class CachedDataReducerState<TResponseMessage> {
 // that is associated with a key.
 export class KeyedCachedDataReducerState<TResponseMessage> {
   [id: string]: CachedDataReducerState<TResponseMessage>;
+}
+
+export class PaginatedCachedDataReducerState<TResponseMessage> {
+  // the latest data received
+  data?: {
+    [id: string]: TResponseMessage;
+  };
+  inFlight = false; // true if a request is in flight
+  valid = false; // true if data has been received and has not been invalidated
+  requestedAt?: moment.Moment; // Timestamp when data was last requested.
+  setAt?: moment.Moment; // Timestamp when this data was last updated.
+  lastError?: Error; // populated with the most recent error, if the last request failed
+
+  constructor() {
+    this.data = {};
+  }
 }
 
 /**
@@ -366,4 +391,205 @@ export class KeyedCachedDataReducer<
         return state;
     }
   };
+}
+
+export class PaginatedCachedDataReducer<
+  TRequest extends WithPaginationRequest,
+  TResponseMessage extends WithPaginationResponse,
+  TActionNamespace extends string = string
+> {
+  cachedDataReducer: CachedDataReducer<
+    TRequest,
+    TResponseMessage,
+    TActionNamespace
+  >;
+
+  CLEAR_DATA: string; // clear previously received data.
+  RECEIVE_COMPLETED: string; // action indicates that there's no more data to receive.
+
+  constructor(
+    protected apiEndpoint: APIRequestFn<TRequest, TResponseMessage>,
+    public actionNamespace: TActionNamespace,
+    private requestToID: (req: TRequest) => string,
+    private pageLimit: number = 1000,
+    protected invalidationPeriod?: moment.Duration,
+    protected requestTimeout?: moment.Duration,
+  ) {
+    this.cachedDataReducer = new CachedDataReducer<
+      TRequest,
+      TResponseMessage,
+      TActionNamespace
+    >(apiEndpoint, actionNamespace, invalidationPeriod, requestTimeout);
+
+    this.CLEAR_DATA = `cockroachui/CachedDataReducer/${actionNamespace}/CLEAR_DATA`;
+    this.RECEIVE_COMPLETED = `cockroachui/CachedDataReducer/${actionNamespace}/RECEIVE_COMPLETED`;
+  }
+
+  // receiveCompleted is action creator to indicate that no more data to receive.
+  receiveCompleted = (
+    request?: TRequest,
+  ): PayloadAction<WithRequest<Error, TRequest>> => {
+    return {
+      type: this.RECEIVE_COMPLETED,
+      payload: { request },
+    };
+  };
+
+  // clearData is action creator to delete previously received data.
+  clearData = (
+    request?: TRequest,
+  ): PayloadAction<WithRequest<Error, TRequest>> => {
+    return {
+      type: this.CLEAR_DATA,
+      payload: { request },
+    };
+  };
+
+  reducer = (
+    state = new PaginatedCachedDataReducerState<TResponseMessage>(),
+    action: Action,
+  ): PaginatedCachedDataReducerState<TResponseMessage> => {
+    if (_.isNil(action)) {
+      return state;
+    }
+
+    switch (action.type) {
+      case this.cachedDataReducer.REQUEST:
+        // A request is in progress.
+        state = _.clone(state);
+        state.requestedAt = this.timeSource();
+        state.inFlight = true;
+        return state;
+      case this.cachedDataReducer.RECEIVE: {
+        // The results of a request have been received.
+        const { request, data } = (action as PayloadAction<
+          WithRequest<TResponseMessage, TRequest>
+        >).payload;
+        const id = this.requestToID(request);
+        state = _.clone(state);
+        state.inFlight = true;
+        state.data[id] = data;
+        state.valid = false;
+        state.setAt = this.timeSource();
+        state.lastError = null;
+        return state;
+      }
+      case this.RECEIVE_COMPLETED: {
+        state = _.clone(state);
+        state.inFlight = false;
+        state.setAt = this.timeSource();
+        state.valid = true;
+        state.lastError = null;
+        return state;
+      }
+      case this.CLEAR_DATA: {
+        state = _.clone(state);
+        state.data = {};
+        state.inFlight = false;
+        state.setAt = undefined;
+        state.requestedAt = undefined;
+        state.valid = false;
+        return state;
+      }
+      case this.cachedDataReducer.ERROR: {
+        // A request failed.
+        const { payload: error } = action as PayloadAction<
+          WithRequest<Error, TRequest>
+        >;
+        state = _.clone(state);
+        state.inFlight = false;
+        state.lastError = error.data;
+        state.valid = false;
+        return state;
+      }
+      case this.cachedDataReducer.INVALIDATE:
+        // The data is invalidated.
+        state = _.clone(state);
+        state.valid = false;
+        return state;
+      default:
+        return state;
+    }
+  };
+
+  refresh = <S>(
+    req?: TRequest,
+    stateAccessor = (state: any, _: TRequest) =>
+      state.cachedData[this.actionNamespace],
+  ): ThunkAction<any, S, any, Action> => {
+    return async (
+      dispatch: ThunkDispatch<S, unknown, Action>,
+      getState: () => S,
+    ) => {
+      // override page_token and page_size fields to ensure that exactly same
+      // pagination params are used across entire app, because all results are
+      // stored in single store's slice. Current implementation doesn't support
+      // to request data with different page sizes or call some arbitrary page.
+      req.page_token = "";
+      req.page_size = this.pageLimit;
+
+      const state: PaginatedCachedDataReducerState<TResponseMessage> = stateAccessor(
+        getState(),
+        req,
+      );
+      if (
+        state &&
+        (state.inFlight || (this.invalidationPeriod && state.valid))
+      ) {
+        return;
+      }
+
+      // clean up previously received data to ensure that fresh data won't be mixed with
+      // previously invalidated data.
+      dispatch(this.clearData(req));
+
+      let hasMoreData = true;
+      while (hasMoreData) {
+        dispatch(this.cachedDataReducer.requestData(req));
+        try {
+          const resp = await this.apiEndpoint(req, this.requestTimeout);
+          dispatch(this.cachedDataReducer.receiveData(resp, req));
+          if (req.page_token === resp.next_page_token) {
+            // there's no more data to request since next page token is the same as current one.
+            hasMoreData = false;
+            dispatch(this.receiveCompleted(req));
+          } else {
+            req.page_token = resp.next_page_token;
+          }
+        } catch (error) {
+          // duplicate the same error handling as in base CachedDataReducer#refresh method.
+          if (error.message === "Unauthorized") {
+            // TODO(couchand): This is an unpleasant dependency snuck in here...
+            const { location } = createHashHistory();
+            if (location && !location.pathname.startsWith("/login")) {
+              dispatch(push(getLoginPage(location)));
+            }
+          }
+          setTimeout(
+            () => dispatch(this.cachedDataReducer.errorData(error, req)),
+            1000,
+          );
+          break;
+        } finally {
+          // Invalidate data after the invalidation period if one exists.
+          if (this.invalidationPeriod) {
+            setTimeout(
+              () => dispatch(this.cachedDataReducer.invalidateData(req)),
+              this.invalidationPeriod.asMilliseconds(),
+            );
+          }
+        }
+      }
+    };
+  };
+
+  /**
+   * setTimeSource overrides the source of timestamps used by this component.
+   * Intended for use in tests only.
+   */
+  setTimeSource(timeSource: { (): moment.Moment }) {
+    this.timeSource = timeSource;
+  }
+
+  private timeSource: { (): moment.Moment } = () => moment();
 }


### PR DESCRIPTION
Depends on https://github.com/cockroachdb/cockroach/pull/74377

This change implements new type of CachedDataReducer that
can handle sequential requests for paginated data.
When user requests some (paginated) data, it requests
page by page to aggregate all data.

Release note: None