### PR TITLE
release-21.2: ui: downsample SQL transaction metrics using MAX

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -52,7 +52,11 @@ export default function(props: GraphDashboardProps) {
       tooltip={`The total number of open SQL transactions  ${tooltipSelection}.`}
     >
       <Axis label="transactions">
-        <Metric name="cr.node.sql.txns.open" title="Open Transactions" />
+        <Metric
+          name="cr.node.sql.txns.open"
+          title="Open Transactions"
+          downsampleMax
+        />
       </Axis>
     </LineGraph>,
 
@@ -65,6 +69,7 @@ export default function(props: GraphDashboardProps) {
         <Metric
           name="cr.node.sql.distsql.queries.active"
           title="Active Statements"
+          downsampleMax
         />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
Backport 1/1 commits from #76348.

/cc @cockroachdb/release

---

Previously, we were using the default downsampling behavior of the
timeseries query engine for "Open SQL Transactions" and "Active SQL
Statements"  on the metrics page in DB console. This led to confusion
when zooming in on transaction spikes since the spike would get larger
as the zoom got tighter.

This PR changes the aggregation function to use MAX to prevent this
confusion.

Resolves: #71827

Release note (ui change): Open SQL Transactions and Active SQL
Transactions are downsampled using MAX instead of AVG and will more
accurately reflect narrow spikes in transaction counts when looking and
downsampled data.
