### PR TITLE
ui: Remove "reset time" n Statements and Transactions Pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -251,10 +251,6 @@ export class StatementsPage extends React.Component<
     }
   };
 
-  resetTime = (): void => {
-    this.changeTimeScale(defaultTimeScaleSelected);
-  };
-
   resetPagination = (): void => {
     this.setState(prevState => {
       return {
@@ -643,11 +639,6 @@ export class StatementsPage extends React.Component<
               currentScale={this.props.timeScale}
               setTimeScale={this.changeTimeScale}
             />
-          </PageConfigItem>
-          <PageConfigItem>
-            <button className={cx("reset-btn")} onClick={this.resetTime}>
-              reset time
-            </button>
           </PageConfigItem>
           <PageConfigItem className={commonStyles("separator")}>
             <ClearStats resetSQLStats={resetSQLStats} tooltipType="statement" />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -324,10 +324,6 @@ export class TransactionsPage extends React.Component<
     }
   };
 
-  resetTime = (): void => {
-    this.changeTimeScale(defaultTimeScaleSelected);
-  };
-
   render(): React.ReactElement {
     const {
       data,
@@ -403,11 +399,6 @@ export class TransactionsPage extends React.Component<
               currentScale={this.props.timeScale}
               setTimeScale={this.changeTimeScale}
             />
-          </PageConfigItem>
-          <PageConfigItem>
-            <button className={cx("reset-btn")} onClick={this.resetTime}>
-              reset time
-            </button>
           </PageConfigItem>
           <PageConfigItem className={commonStyles("separator")}>
             <ClearStats


### PR DESCRIPTION
Addresses #70997

This commit removes the "reset time" link  on Statements and Transactions Pages.

Release note (ui): The "Now" button had been added in this commit
https://github.com/jocrl/cockroach/commit/82f2673babe8f930114cf6b8289caaa64ff84045
to the Statements and Transactions Pages. This commit removes the "reset time"
link which the "Now" button replaces.

Before, Statements Page:
<img width="1356" alt="image" src="https://user-images.githubusercontent.com/91907326/154362540-4268376e-9e4e-4ed2-9f0e-86727ce0ce23.png">

After, Statements Page:
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/91907326/154362398-ac1cd126-a5bc-4268-aad5-823e82327271.png">

Before, Transactions Page:
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/91907326/154362513-c107240f-f8c3-44ad-95d3-ca0f54db8a48.png">

After, Transactions Page:
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/91907326/154362438-33911b3b-cd23-428d-97af-b2fbf69acb94.png">