### PR TITLE
opt: prevent stack overflows when there is a memo cycle

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2569,6 +2569,15 @@ func (b *logicalPropsBuilder) buildNormCycleTestRelProps(
 ) {
 }
 
+func (b *logicalPropsBuilder) buildMemoCycleTestRelProps(
+	mc *MemoCycleTestRelExpr, rel *props.Relational,
+) {
+	// Make the cardinality non-zero to prevent SimplifyZeroCardinalityGroup
+	// from transforming mc into an empty Values expression.
+	inputProps := mc.Input.Relational()
+	rel.Cardinality = inputProps.Cardinality
+}
+
 // WithUses returns the WithUsesMap for the given expression.
 func WithUses(r opt.Expr) props.WithUsesMap {
 	switch e := r.(type) {

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -102,7 +102,7 @@ type Factory struct {
 // normalization rules are applied when this limit is reached, and the
 // onMaxConstructorStackDepthExceeded method is called. This can result in an
 // expression that is not fully optimized.
-const maxConstructorStackDepth = 10000
+const maxConstructorStackDepth = 10_000
 
 // Init initializes a Factory structure with a new, blank memo structure inside.
 // This must be called before the factory can be used (or reused).

--- a/pkg/sql/opt/ops/cycle.opt
+++ b/pkg/sql/opt/ops/cycle.opt
@@ -1,0 +1,23 @@
+# cycle.opt contains Optgen language definitions for testing cycle detection.
+
+# NormCycleTestRel is a relational operator for testing that normalization rule
+# cycles are detected by the Factory and a stack overflow is prevented. Two
+# rules for this expression, NormCycleTestRelTrueToFalse and
+# NormCycleTestRelFalseToTrue, create a normalization rule cycle. See the cycle
+# test file for tests that use this expression.
+[Relational]
+define NormCycleTestRel {
+    Scalar ScalarExpr
+}
+
+# MemoCycleTestRel is a relational expression for testing that memo cycles are
+# detected by the optimizer and a stack overflow is prevented. A cycle in the
+# memo occurs when there is a path from a group member's children back to the
+# group member's group. MemoCycleTestRel is similar in structure to the Select
+# expression, but matches a rule, MemoCycleTestRelRule, that creates a memo
+# cycle.
+[Relational]
+define MemoCycleTestRel {
+    Input RelExpr
+    Filters FiltersExpr
+}

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1303,13 +1303,3 @@ define FakeRel {
 define FakeRelPrivate {
     Props RelPropsPtr
 }
-
-# NormCycleTestRel is a relational operator for testing that normalization rule
-# cycles are detected by the Factory and a stack overflow is prevented. Two
-# rules for this expression, NormCycleTestRelTrueToFalse and
-# NormCycleTestRelFalseToTrue, create a normalization rule cycle. See the cycle
-# test file for tests that use this expression.
-[Relational]
-define NormCycleTestRel {
-    Scalar ScalarExpr
-}

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -363,6 +363,12 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //    exprgen.Build), applies normalization optimizations, and outputs the tree
 //    without any exploration optimizations applied to it.
 //
+//  - expropt
+//
+//    Builds an expression directly from an opt-gen-like string (see
+//    exprgen.Optimize), applies normalization and exploration optimizations,
+//    and outputs the tree.
+//
 //  - stats-quality [flags]
 //
 //    Fully optimizes the given query and saves the subexpressions as tables
@@ -692,6 +698,14 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 
 	case "exprnorm":
 		e, err := ot.ExprNorm()
+		if err != nil {
+			return fmt.Sprintf("error: %s\n", err)
+		}
+		ot.postProcess(tb, d, e)
+		return ot.FormatExpr(e)
+
+	case "expropt":
+		e, err := ot.ExprOpt()
 		if err != nil {
 			return fmt.Sprintf("error: %s\n", err)
 		}
@@ -1220,6 +1234,10 @@ func (ot *OptTester) ExprNorm() (opt.Expr, error) {
 	var f norm.Factory
 	f.Init(&ot.evalCtx, ot.catalog)
 
+	if !ot.Flags.NoStableFolds {
+		f.FoldingControl().AllowStableFolds()
+	}
+
 	f.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
 		// exprgen.Build doesn't run optimization, so we don't need to explicitly
 		// disallow exploration rules here.
@@ -1231,6 +1249,27 @@ func (ot *OptTester) ExprNorm() (opt.Expr, error) {
 	})
 
 	return exprgen.Build(ot.catalog, &f, ot.sql)
+}
+
+// ExprOpt parses the input directly into an expression and runs normalization
+// and exploration; see exprgen.Optimize.
+func (ot *OptTester) ExprOpt() (opt.Expr, error) {
+	o := ot.makeOptimizer()
+	f := o.Factory()
+
+	if !ot.Flags.NoStableFolds {
+		f.FoldingControl().AllowStableFolds()
+	}
+
+	o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
+		return !ot.Flags.DisableRules.Contains(int(ruleName))
+	})
+
+	f.NotifyOnAppliedRule(func(ruleName opt.RuleName, source, target opt.Expr) {
+		ot.appliedRules.Add(int(ruleName))
+	})
+
+	return exprgen.Optimize(ot.catalog, o, ot.sql)
 }
 
 // RuleStats performs the optimization and returns statistics about how many

--- a/pkg/sql/opt/xform/rules/cycle.opt
+++ b/pkg/sql/opt/xform/rules/cycle.opt
@@ -1,0 +1,12 @@
+# =============================================================================
+# cycle.opt contains exploration rules for creating memo cycles.
+# =============================================================================
+
+# MemoCycleTestRelRule creates a cycle in the memo, where a path exists from a
+# group member's children back to the group member's group. This rule is used to
+# test that a memo cycle can be detected and a stack overflow does not occur.
+# See the cycle test file.
+[MemoCycleTestRelRule, Explore]
+(MemoCycleTestRel $input:* $filters:*)
+=>
+(MemoCycleTestRel (MemoCycleTestRel $input $filters) $filters)

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -1,5 +1,5 @@
 # =============================================================================
-# groupby.opt contains exploration rules for the groupby operators
+# groupby.opt contains exploration rules for the groupby operators.
 # =============================================================================
 
 # ReplaceScalarMinMaxWithScalarSubqueries replaces a scalar group by having a

--- a/pkg/sql/opt/xform/testdata/rules/cycle
+++ b/pkg/sql/opt/xform/testdata/rules/cycle
@@ -1,0 +1,18 @@
+exec-ddl
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b INT,
+  INDEX (b)
+)
+----
+
+# This test ensures that a memo cycle does not cause a stack overflow. Instead,
+# the cycle is detected and the optimizer throws an internal error. The cycle is
+# created by the test-only exploration rule MemoCycleTestRelRule.
+expropt
+(MemoCycleTestRel
+    (Scan [ (Table "ab") (Cols "a,b") ])
+    [ (Eq (Var "b") (Const 1 "int")) ]
+)
+----
+error: memo group optimization passes surpassed limit of 100000; there may be a cycle in the memo


### PR DESCRIPTION
Misbehaving exploration rules can cause cycles in a memo, where a path
exists from a group member's children back to the group member's group.
In the example below, notice the cycle `G1 -> G6 -> G1`.

These cycles cause stack overflow errors and crash nodes. In addition,
they can be very difficult to debug because the cycle is not easily
observable.

This commit adds a mechanism to detect memo cycles. Once detected, the
optimizer throws an internal error, preventing a stack overflow. The
error detail includes the formatted output of the memo to aid in
debugging the cycle.

Below is an example of the error message displayed in the SQL shell when
a memo cycle is detected.

    ERROR: internal error: memo group optimization passes surpassed limit of 100000; there may be a cycle in the memo
    SQLSTATE: XX000
    DETAIL: memo (not optimized, ~17KB, required=[presentation: a:1,a:5,b:6,shard:7] [distribution: us-east1])
     ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (lookup-join G2 G5 t@t_shard_b_idx,outCols=(1,5-7)) (project G6 G7 a a b)
     ├── G2: (scan small,cols=(1))
     │    └── []
     │         ├── best: (scan small,cols=(1))
     │         └── cost: 1084.62
     ├── G3: (project G8 G9 a b)
     │    └── []
     │         ├── best: (project G8 G9 a b)
     │         └── cost: 1124.84
     ├── G4: (filters G10)
     ├── G5: (filters)
     ├── G6: (left-join G2 G8 G4) (right-join G8 G2 G4) (project G1 G11 a a b)
     ├── G7: (projections G12)
     ├── G8: (scan t,cols=(5,6)) (scan t@t_shard_b_idx,cols=(5,6))
     │    └── []
     │         ├── best: (scan t,cols=(5,6))
     │         └── cost: 1104.82
     ├── G9: (projections G13)
     ├── G10: (eq G14 G15)
     ├── G11: (projections)
     ├── G12: (case G16 G17 G13)
     ├── G13: (minus G15 G18)
     ├── G14: (variable small.a)
     ├── G15: (variable b)
     ├── G16: (is G19 G20)
     ├── G17: (scalar-list G21)
     ├── G18: (const 1)
     ├── G19: (variable t.a)
     ├── G20: (null)
     ├── G21: (when G22 G23)
     ├── G22: (true)
     └── G23: (null)
    stack trace:
    github.com/cockroachdb/cockroach/pkg/sql/opt/xform/optimizer.go:454: optimizeGroup()
    github.com/cockroachdb/cockroach/pkg/sql/opt/xform/optimizer.go:262: optimizeExpr()
    github.com/cockroachdb/cockroach/pkg/sql/opt/xform/optimizer.go:534: optimizeGroupMe
    mber()
    ...

Also, a new optimizer test directive, `expropt`, has been added to
facilitate testing of this memo cycle detection.

Fixes #42745

Release note: None