### PR TITLE
spanconfig: add ability to get all system span configs set by host

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -501,6 +501,16 @@ func (c *Connector) UpdateSpanConfigRecords(
 	})
 }
 
+// GetAllSystemSpanConfigRecordsSetByHost implements the spanconfig.KVAccessor
+// interface.
+func (c *Connector) GetAllSystemSpanConfigRecordsSetByHost(
+	_ context.Context,
+) ([]spanconfig.Record, error) {
+	return nil, errors.AssertionFailedf(
+		"secondary tenants do not have access to system tenant set system span configurations",
+	)
+}
+
 // WithTxn implements the spanconfig.KVAccessor interface.
 func (c *Connector) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
 	panic("not applicable")

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -42,6 +42,11 @@ type KVAccessor interface {
 		toUpsert []Record,
 	) error
 
+	// GetAllSystemSpanConfigRecordsSetByHost returns all system span
+	// configuration records set by the host tenant. Only the host tenant
+	// is allowed to query for this; secondary tenants are not.
+	GetAllSystemSpanConfigRecordsSetByHost(ctx context.Context) ([]Record, error)
+
 	// WithTxn returns a KVAccessor that runs using the given transaction (with
 	// its operations discarded if aborted, valid only if committed). If nil, a
 	// transaction is created internally for every operation.

--- a/pkg/spanconfig/spanconfigkvaccessor/dummy.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/dummy.go
@@ -52,6 +52,14 @@ func (k dummyKVAccessor) UpdateSpanConfigRecords(
 	return k.error
 }
 
+// GetAllSystemSpanConfigRecordsSetByHost implements the spanconfig.KVAccessor
+// interface.
+func (k dummyKVAccessor) GetAllSystemSpanConfigRecordsSetByHost(
+	_ context.Context,
+) ([]spanconfig.Record, error) {
+	return nil, k.error
+}
+
 func (k dummyKVAccessor) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
 	return k
 }

--- a/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
+++ b/pkg/spanconfig/spanconfigkvaccessor/testdata/system_span_configs
@@ -54,6 +54,13 @@ system-target {source=20,target=20}
 {source=1,target=10}:H
 {source=20,target=20}:I
 
+kvaccessor-get-all-system-span-configs-set-by-host
+----
+{cluster}:F
+{source=1,target=1}:G
+{source=1,target=10}:H
+
+
 # Delete all the system span configurations that we just added and ensure
 # they take effect.
 kvaccessor-update
@@ -69,6 +76,9 @@ system-target {cluster}
 system-target {source=1,target=1}
 system-target {source=1,target=10}
 system-target {source=20,target=20}
+----
+
+kvaccessor-get-all-system-span-configs-set-by-host
 ----
 
 # Lastly, try adding multiple system targets set by the host tenant that apply
@@ -95,3 +105,10 @@ system-target {source=10,target=10}
 {source=1,target=20}:B
 {source=1,target=30}:C
 {source=10,target=10}:G
+
+kvaccessor-get-all-system-span-configs-set-by-host
+----
+{cluster}:Z
+{source=1,target=10}:A
+{source=1,target=20}:B
+{source=1,target=30}:C

--- a/pkg/spanconfig/spanconfigtestutils/recorder.go
+++ b/pkg/spanconfig/spanconfigtestutils/recorder.go
@@ -81,6 +81,14 @@ func (r *KVAccessorRecorder) UpdateSpanConfigRecords(
 	return nil
 }
 
+// GetAllSystemSpanConfigRecordsSetByHost implements the spanconfig.KVAccessor
+// interface.
+func (r *KVAccessorRecorder) GetAllSystemSpanConfigRecordsSetByHost(
+	ctx context.Context,
+) ([]spanconfig.Record, error) {
+	return r.underlying.GetAllSystemSpanConfigRecordsSetByHost(ctx)
+}
+
 // WithTxn is part of the KVAccessor interface.
 func (r *KVAccessorRecorder) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
 	panic("unimplemented")

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -11,6 +11,7 @@
 package spanconfig
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
 )
@@ -26,7 +27,7 @@ type Target struct {
 func MakeTarget(t roachpb.SpanConfigTarget) (Target, error) {
 	switch t.Union.(type) {
 	case *roachpb.SpanConfigTarget_Span:
-		return MakeTargetFromSpan(*t.GetSpan()), nil
+		return MakeSpanTargetFromProto(t)
 	case *roachpb.SpanConfigTarget_SystemSpanConfigTarget:
 		systemTarget, err := MakeSystemTargetFromProto(t.GetSystemSpanConfigTarget())
 		if err != nil {
@@ -38,8 +39,28 @@ func MakeTarget(t roachpb.SpanConfigTarget) (Target, error) {
 	}
 }
 
-// MakeTargetFromSpan constructs and returns a span target.
+// MakeSpanTargetFromProto returns a new Target backed by an underlying span.
+// An error is returned if the proto does not contain a span or if the span
+// overlaps with the reserved system span config keyspace.
+func MakeSpanTargetFromProto(spanTarget roachpb.SpanConfigTarget) (Target, error) {
+	if spanTarget.GetSpan() == nil {
+		return Target{}, errors.AssertionFailedf("span config target did not contain a span")
+	}
+	if keys.SystemSpanConfigSpan.Overlaps(*spanTarget.GetSpan()) {
+		return Target{}, errors.AssertionFailedf(
+			"cannot target spans in reserved system span config keyspace",
+		)
+	}
+	return MakeTargetFromSpan(*spanTarget.GetSpan()), nil
+}
+
+// MakeTargetFromSpan constructs and returns a span target. Callers are not
+// allowed to target the reserved system span config keyspace (or part of it)
+// directly; system targets should be used instead.
 func MakeTargetFromSpan(span roachpb.Span) Target {
+	if keys.SystemSpanConfigSpan.Overlaps(span) {
+		panic("cannot target spans in reserved system span config keyspace")
+	}
 	return Target{span: span}
 }
 


### PR DESCRIPTION
This patch adds a `GetAllSystemSpanConfigRecordsSetByHost` method to
the KVAccessor interface. Only the host tenant's KVAccessor
implementation is allowed to query for these records; secondary tenants
are not.

This is intended as a fast path for the host tenant's reconciliation
job to populate it's in-memory view of all system span configurations.
This in-memory view can then be diffed against the implied system span
configuration state to issue targeted updates/deletes, much like we do
today for regular span configurations.

Release note: None