### PR TITLE
release-2.1.55: DNM: release: release-infra-related testing

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Set this to 1 to require a "release justification" note in the commit message
+# or the PR description.
+require_justification=0
+
 set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -43,6 +43,11 @@ saveIFS=$IFS
 IFS='
 '
 notes=($($grep -iE '^release note' "$1"))
+
+# Set this to 1 to require a release justification note.
+require_justification=0
+justification=($($grep -iE '^release justification: \S+' "$1"))
+
 IFS=$saveIFS
 
 

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -2,6 +2,8 @@
 #
 # Prepare the commit message by adding a release note.
 
+require_justification=0
+
 set -euo pipefail
 
 if [[ "${2-}" = "message" ]]; then


### PR DESCRIPTION
Backport 1/1 commits from #46732.

DO-NOT-MERGE! This is testing to see if backport works
with a `release-MM.d.p` type branch.

/cc @cockroachdb/release

---

release-20.1 is cut.

Release note: None


Jira issue: CRDB-14812