### PR TITLE
backupccl: handle RESTORE of TTL tables

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/row_level_ttl
+++ b/pkg/ccl/backupccl/testdata/backup-restore/row_level_ttl
@@ -1,0 +1,116 @@
+new-server name=s1 allow-implicit-access
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE t (id INT PRIMARY KEY) WITH (ttl_expire_after = '10 minutes')
+----
+
+exec-sql
+BACKUP DATABASE d TO 'nodelocal://1/database_backup/'
+----
+
+exec-sql
+BACKUP TO 'nodelocal://1/full_cluster_backup/'
+----
+
+new-server name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+0
+
+exec-sql
+RESTORE FROM 'nodelocal://0/full_cluster_backup/'
+----
+
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE d.public.t]
+----
+CREATE TABLE public.t (
+	id INT8 NOT NULL,
+	crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+	CONSTRAINT t_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL)
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+1
+
+exec-sql
+DROP DATABASE d
+----
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+0
+
+exec-sql
+RESTORE DATABASE d FROM 'nodelocal://0/database_backup/'
+----
+
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE d.public.t]
+----
+CREATE TABLE public.t (
+	id INT8 NOT NULL,
+	crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+	CONSTRAINT t_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL)
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+1
+
+exec-sql
+DROP DATABASE d
+----
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+0
+
+exec-sql
+CREATE DATABASE d
+----
+
+exec-sql
+RESTORE TABLE d.public.t FROM 'nodelocal://0/database_backup/'
+----
+
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE d.public.t]
+----
+CREATE TABLE public.t (
+	id INT8 NOT NULL,
+	crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+	CONSTRAINT t_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_automatic_column = 'on', ttl_expire_after = '00:10:00':::INTERVAL)
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+1
+
+exec-sql
+DROP TABLE d.public.t
+----
+
+query-sql
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label LIKE 'row-level-ttl-%'
+----
+0

--- a/pkg/sql/control_schedules.go
+++ b/pkg/sql/control_schedules.go
@@ -97,8 +97,8 @@ func updateSchedule(params runParams, schedule *jobs.ScheduledJob) error {
 	)
 }
 
-// deleteSchedule deletes specified schedule.
-func deleteSchedule(
+// DeleteSchedule deletes specified schedule.
+func DeleteSchedule(
 	ctx context.Context, execCfg *ExecutorConfig, txn *kv.Txn, scheduleID int64,
 ) error {
 	env := JobSchedulerEnv(execCfg)
@@ -164,7 +164,7 @@ func (n *controlSchedulesNode) startExec(params runParams) error {
 					return errors.Wrap(err, "failed to run OnDrop")
 				}
 			}
-			err = deleteSchedule(params.ctx, params.ExecCfg(), params.p.txn, schedule.ScheduleID())
+			err = DeleteSchedule(params.ctx, params.ExecCfg(), params.p.txn, schedule.ScheduleID())
 		default:
 			err = errors.AssertionFailedf("unhandled command %s", n.command)
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2327,10 +2327,8 @@ func newTableDesc(
 	}
 
 	// Row level TTL tables require a scheduled job to be created as well.
-	// TODO(#75428): ensure backup & restore work too - this may need to be placed in NewTableDesc.
-	// This involves plumbing InternalExecutor in there,
 	if ttl := ret.RowLevelTTL; ttl != nil {
-		j, err := createRowLevelTTLScheduledJob(
+		j, err := CreateRowLevelTTLScheduledJob(
 			params.ctx,
 			params.ExecCfg(),
 			params.p.txn,
@@ -2392,7 +2390,8 @@ func rowLevelTTLSchedule(ttl *catpb.RowLevelTTL) string {
 	return defaultTTLScheduleCron
 }
 
-func createRowLevelTTLScheduledJob(
+// CreateRowLevelTTLScheduledJob creates a new row-level TTL schedule.
+func CreateRowLevelTTLScheduledJob(
 	ctx context.Context,
 	execCfg *ExecutorConfig,
 	txn *kv.Txn,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -398,7 +398,7 @@ func (sc *SchemaChanger) maybeUpdateScheduledJobsForRowLevelTTL(
 			scheduleID := tableDesc.GetRowLevelTTL().ScheduleID
 			if scheduleID > 0 {
 				log.Infof(ctx, "dropping TTL schedule %d", scheduleID)
-				return deleteSchedule(ctx, sc.execCfg, txn, scheduleID)
+				return DeleteSchedule(ctx, sc.execCfg, txn, scheduleID)
 			}
 			return nil
 		}); err != nil {
@@ -1498,7 +1498,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 					}
 
 					if shouldCreateScheduledJob {
-						j, err := createRowLevelTTLScheduledJob(
+						j, err := CreateRowLevelTTLScheduledJob(
 							ctx,
 							sc.execCfg,
 							txn,
@@ -1513,7 +1513,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 					}
 				} else if m.Dropped() {
 					if ttl := scTable.RowLevelTTL; ttl != nil {
-						if err := deleteSchedule(ctx, sc.execCfg, txn, ttl.ScheduleID); err != nil {
+						if err := DeleteSchedule(ctx, sc.execCfg, txn, ttl.ScheduleID); err != nil {
 							return err
 						}
 					}


### PR DESCRIPTION
This commit adds schedules to restored table descriptors.

Release note: None