### PR TITLE
kvserver: test that RangeFeed unaffected by Replica circuit breaker

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -72,7 +72,7 @@ var RangefeedTBIEnabled = settings.RegisterBoolSetting(
 // support for concurrent calls to Send. Note that the default implementation of
 // grpc.Stream is not safe for concurrent calls to Send.
 type lockedRangefeedStream struct {
-	wrapped roachpb.Internal_RangeFeedServer
+	wrapped rangefeed.Stream
 	sendMu  syncutil.Mutex
 }
 
@@ -143,15 +143,13 @@ func (tp *rangefeedTxnPusher) ResolveIntents(
 // complete. The provided ConcurrentRequestLimiter is used to limit the number
 // of rangefeeds using catch-up iterators at the same time.
 func (r *Replica) RangeFeed(
-	args *roachpb.RangeFeedRequest, stream roachpb.Internal_RangeFeedServer,
+	args *roachpb.RangeFeedRequest, stream rangefeed.Stream,
 ) *roachpb.Error {
 	return r.rangeFeedWithRangeID(r.RangeID, args, stream)
 }
 
 func (r *Replica) rangeFeedWithRangeID(
-	_forStacks roachpb.RangeID,
-	args *roachpb.RangeFeedRequest,
-	stream roachpb.Internal_RangeFeedServer,
+	_forStacks roachpb.RangeID, args *roachpb.RangeFeedRequest, stream rangefeed.Stream,
 ) *roachpb.Error {
 	if !r.isRangefeedEnabled() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return roachpb.NewErrorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",


### PR DESCRIPTION
`RangeFeed`s are long-running operations with a high fixed cost
(catch-up scan). They can fall behind for various reasons, replicas
becoming unavailable being one of them. However, when a replica's
circuit breaker trips, this should not abort any pending (or new, for
that matter) RangeFeeds.

Add a test that asserts that this is the case.

Touches #33007.
Touches #76146.

Release note: None
