### PR TITLE
ui:increase timeout for statements api call

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/loading/loading.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/loading/loading.module.scss
@@ -6,5 +6,5 @@
 }
 
 .alerts-container {
-  margin: 0 $spacing-medium;
+  margin: $spacing-smaller $spacing-medium;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -57,6 +57,7 @@ import { ISortedTablePagination } from "../sortedtable";
 import styles from "./statementsPage.module.scss";
 import { EmptyStatementsPlaceholder } from "./emptyStatementsPlaceholder";
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
+import { InlineAlert } from "@cockroachlabs/ui-components";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 type IDuration = google.protobuf.IDuration;
@@ -611,6 +612,12 @@ export class StatementsPage extends React.Component<
       ? []
       : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
     const { filters, activeFilters } = this.state;
+    const longLoadingMessage = isNil(this.props.statements) && (
+      <InlineAlert
+        intent="info"
+        title="If the selected time period contains a large amount of data, this page might take a few minutes to load."
+      />
+    );
 
     return (
       <div className={cx("root", "table-area")}>
@@ -664,6 +671,7 @@ export class StatementsPage extends React.Component<
             })
           }
         />
+        {longLoadingMessage}
         <ActivateStatementDiagnosticsModal
           ref={this.activateDiagnosticsRef}
           activate={onActivateStatementDiagnostics}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -66,6 +66,7 @@ import {
   TimeScale,
   toDateRange,
 } from "../timeScaleDropdown";
+import { InlineAlert } from "@cockroachlabs/ui-components";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 
@@ -374,6 +375,12 @@ export class TransactionsPage extends React.Component<
       data?.transactions || [],
       internal_app_name_prefix,
     );
+    const longLoadingMessage = !this.props?.data && (
+      <InlineAlert
+        intent="info"
+        title="If the selected time period contains a large amount of data, this page might take a few minutes to load."
+      />
+    );
 
     return (
       <div className={cx("table-area")}>
@@ -521,6 +528,7 @@ export class TransactionsPage extends React.Component<
             })
           }
         />
+        {longLoadingMessage}
       </div>
     );
   }

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -295,7 +295,7 @@ const queriesReducerObj = new CachedDataReducer(
   api.getStatements,
   "statements",
   moment.duration(5, "m"),
-  moment.duration(1, "m"),
+  moment.duration(30, "m"),
 );
 export const invalidateStatements = queriesReducerObj.invalidateData;
 export const refreshStatements = queriesReducerObj.refresh;


### PR DESCRIPTION
Previously, the timeout for statement api was 1 minute,
which was causing timeout error messages when the user
selected long time periods containing a lot of data.
This commit increases the timeout to 30min and adds a message
when the Statement and Transactions pages are loading,
indicating it could take a few minutes to load.
This commit also fixes the position for the error message
when the user still hits the error.

New messages on Statements and Transactions page
 
<img width="1610" alt="Screen Shot 2022-02-17 at 12 01 58 PM" src="https://user-images.githubusercontent.com/1017486/154532654-bda3d7ea-f932-49fa-85ad-d1594816ac99.png">
<img width="1634" alt="Screen Shot 2022-02-17 at 12 02 10 PM" src="https://user-images.githubusercontent.com/1017486/154532672-fa617ac2-0889-4344-b351-18ce87e45f9b.png">

Error message before
<img width="1341" alt="Screen Shot 2022-02-16 at 9 27 01 AM" src="https://user-images.githubusercontent.com/1017486/154532726-20c65d32-6790-440e-9038-ddbb1543eda8.png">

after
<img width="1333" alt="Screen Shot 2022-02-16 at 9 27 15 AM" src="https://user-images.githubusercontent.com/1017486/154532753-970c85be-edc5-4cb1-995d-001694ad99df.png">


Release note (ui change): Add long loading messages to SQL Activity
pages.