### PR TITLE
dev: don't exit immediately in ./dev ui watch

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=17
+DEV_VERSION=18
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/io/exec/exec.go
+++ b/pkg/cmd/dev/io/exec/exec.go
@@ -259,3 +259,9 @@ func (e *Exec) Next(command string, f func() (output string, err error)) (string
 	}
 	return e.Recorder.Next(command, f)
 }
+
+// IsDryrun returns whether or not this exec is running in "dryrun" mode, which is useful to avoid
+// behavior that would otherwise permanently block execution during testing.
+func (e *Exec) IsDryrun() bool {
+	return e.knobs.dryrun
+}

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -174,6 +174,10 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
+			// Wait for OS signals to cancel if we're not in test-mode
+			if !d.exec.IsDryrun() {
+				<-ctx.Done()
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
./dev ui watch previously didn't wait for the command context for webpack commands to complete before returning. This caused the 'watch' subcommand to stop immediately, then the 'ui' subcommand, then the entire 'dev' command to stop, exiting the entire process likely before webpack could even start. Wait for the webpack commands to complete (which they never should, since they're meant to run indefinitely) before returning from ./dev ui watch's implementation.

Release note: None