### PR TITLE
vendor: bump Pebble to 821db50635d6

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1287,10 +1287,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "945bf10361af6d85419d8e02ad93ec49b3bf6f2e60599296f2fa8091dcf83111",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220203230416-19e11cfe195f",
+        sha256 = "1d4eff199bd4952fad40c7c1c64e167ef8600f222f57058ae7a050979c7650d8",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220217165617-821db50635d6",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220203230416-19e11cfe195f.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220217165617-821db50635d6.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220203230416-19e11cfe195f
+	github.com/cockroachdb/pebble v0.0.0-20220217165617-821db50635d6
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220119200057-43d99a9e6d7f

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220203230416-19e11cfe195f h1:AhOD3m/cV+YeDtzJytgHoxn6b89yPXHg7or48EiXTps=
-github.com/cockroachdb/pebble v0.0.0-20220203230416-19e11cfe195f/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220217165617-821db50635d6 h1:h0QXUCqMzrxfdxAh+WTYZZOqilZBc7sOpDTMFZHzhy4=
+github.com/cockroachdb/pebble v0.0.0-20220217165617-821db50635d6/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -511,7 +511,7 @@ func TestWithOnSSTable(t *testing.T) {
 	now.Logical = 0
 	ts := now.WallTime
 	sstKVs := []sstutil.KV{{"a", ts, "1"}, {"b", ts, "2"}, {"c", ts, "3"}, {"d", ts, "4"}, {"e", ts, "5"}}
-	sst, sstStart, sstEnd := sstutil.MakeSST(t, sstKVs)
+	sst, sstStart, sstEnd := sstutil.MakeSST(ctx, srv.ClusterSettings(), t, sstKVs)
 	_, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
 		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
 		false /* ingestAsWrites */, now)
@@ -587,7 +587,7 @@ func TestWithOnSSTableCatchesUpIfNotSet(t *testing.T) {
 	ts := now.WallTime
 	sstKVs := []sstutil.KV{{"a", ts, "1"}, {"b", ts, "2"}, {"c", ts, "3"}, {"d", ts, "4"}, {"e", ts, "5"}}
 	expectKVs := []sstutil.KV{{"c", ts, "3"}, {"d", ts, "4"}}
-	sst, sstStart, sstEnd := sstutil.MakeSST(t, sstKVs)
+	sst, sstStart, sstEnd := sstutil.MakeSST(ctx, srv.ClusterSettings(), t, sstKVs)
 	_, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
 		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
 		false /* ingestAsWrites */, now)

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -641,7 +641,7 @@ func TestEvalAddSSTable(t *testing.T) {
 				ctx := context.Background()
 
 				dir := t.TempDir()
-				engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")))
+				engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")), storage.Settings(st))
 				require.NoError(t, err)
 				defer engine.Close()
 
@@ -660,7 +660,7 @@ func TestEvalAddSSTable(t *testing.T) {
 				stats := engineStats(t, engine)
 
 				// Build and add SST.
-				sst, start, end := sstutil.MakeSST(t, tc.sst)
+				sst, start, end := sstutil.MakeSST(ctx, st, t, tc.sst)
 				reqTS := hlc.Timestamp{WallTime: defaultReqTS}
 				if tc.atReqTS != 0 {
 					reqTS.WallTime = tc.atReqTS
@@ -823,7 +823,7 @@ func TestEvalAddSSTableRangefeed(t *testing.T) {
 			opLogger := storage.NewOpLoggerBatch(engine.NewBatch())
 
 			// Build and add SST.
-			sst, start, end := sstutil.MakeSST(t, tc.sst)
+			sst, start, end := sstutil.MakeSST(ctx, st, t, tc.sst)
 			result, err := batcheval.EvalAddSSTable(ctx, opLogger, batcheval.CommandArgs{
 				EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext(),
 				Header: roachpb.Header{
@@ -902,9 +902,10 @@ func runTestDBAddSSTable(
 	var allowShadowingBelow hlc.Timestamp
 	var nilStats *enginepb.MVCCStats
 	var noTS hlc.Timestamp
+	cs := cluster.MakeTestingClusterSettings()
 
 	{
-		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bb", 2, "1"}})
+		sst, start, end := sstutil.MakeSST(ctx, cs, t, []sstutil.KV{{"bb", 2, "1"}})
 
 		// Key is before the range in the request span.
 		err := db.AddSSTable(
@@ -946,7 +947,7 @@ func runTestDBAddSSTable(
 	// Check that ingesting a key with an earlier mvcc timestamp doesn't affect
 	// the value returned by Get.
 	{
-		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bb", 1, "2"}})
+		sst, start, end := sstutil.MakeSST(ctx, cs, t, []sstutil.KV{{"bb", 1, "2"}})
 		require.NoError(t, db.AddSSTable(
 			ctx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS))
 		r, err := db.Get(ctx, "bb")
@@ -960,7 +961,7 @@ func runTestDBAddSSTable(
 	// Key range in request span is not empty. First time through a different
 	// key is present. Second time through checks the idempotency.
 	{
-		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bc", 1, "3"}})
+		sst, start, end := sstutil.MakeSST(ctx, cs, t, []sstutil.KV{{"bc", 1, "3"}})
 
 		var before int64
 		if store != nil {
@@ -996,7 +997,7 @@ func runTestDBAddSSTable(
 
 	// ... and doing the same thing but via write-batch works the same.
 	{
-		sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"bd", 1, "3"}})
+		sst, start, end := sstutil.MakeSST(ctx, cs, t, []sstutil.KV{{"bd", 1, "3"}})
 
 		var before int64
 		if store != nil {
@@ -1054,7 +1055,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	evalCtx := (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext()
 
 	dir := t.TempDir()
-	engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")))
+	engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")), storage.Settings(st))
 	require.NoError(t, err)
 	defer engine.Close()
 
@@ -1072,7 +1073,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		require.NoError(t, engine.PutMVCC(kv.MVCCKey(), kv.ValueBytes()))
 	}
 
-	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{
+	sst, start, end := sstutil.MakeSST(ctx, st, t, []sstutil.KV{
 		{"a", 4, "aaaaaa"}, // mvcc-shadowed by existing delete.
 		{"a", 2, "aa"},     // mvcc-shadowed within SST.
 		{"c", 6, "ccc"},    // same TS as existing, LSM-shadows existing.
@@ -1124,7 +1125,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	require.Equal(t, engineStats(t, engine), statsEvaled)
 
 	// Check stats for a single KV.
-	sst, start, end = sstutil.MakeSST(t, []sstutil.KV{{"zzzzzzz", ts.WallTime, "zzz"}})
+	sst, start, end = sstutil.MakeSST(ctx, st, t, []sstutil.KV{{"zzzzzzz", ts.WallTime, "zzz"}})
 	cArgs = batcheval.CommandArgs{
 		EvalCtx: evalCtx,
 		Header:  roachpb.Header{Timestamp: ts},
@@ -1188,7 +1189,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 		{"c", 2, "bb"},
 		{"h", 6, "hh"},
 	}
-	sst, start, end := sstutil.MakeSST(t, kvs)
+	sst, start, end := sstutil.MakeSST(ctx, st, t, kvs)
 
 	// Accumulate stats across SST ingestion.
 	commandStats := enginepb.MVCCStats{}
@@ -1219,7 +1220,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 
 	// Evaluate the second SST. Both the KVs are perfectly shadowing and should
 	// not contribute to the stats.
-	sst, start, end = sstutil.MakeSST(t, []sstutil.KV{
+	sst, start, end = sstutil.MakeSST(ctx, st, t, []sstutil.KV{
 		{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
 		{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
 	})
@@ -1238,7 +1239,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 
 	// Evaluate the third SST. Two of the three KVs are perfectly shadowing, but
 	// there is one valid KV which should contribute to the stats.
-	sst, start, end = sstutil.MakeSST(t, []sstutil.KV{
+	sst, start, end = sstutil.MakeSST(ctx, st, t, []sstutil.KV{
 		{"c", 2, "bb"}, // key has the same timestamp and value as the one present in the existing data.
 		{"e", 2, "ee"},
 		{"h", 6, "hh"}, // key has the same timestamp and value as the one present in the existing data.
@@ -1287,7 +1288,7 @@ func TestAddSSTableIntentResolution(t *testing.T) {
 	// Generate an SSTable that covers keys a, b, and c, and submit it with high
 	// priority. This is going to abort the transaction above, encounter its
 	// intent, and resolve it.
-	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{
+	sst, start, end := sstutil.MakeSST(ctx, s.ClusterSettings(), t, []sstutil.KV{
 		{"a", 1, "1"},
 		{"b", 1, "2"},
 		{"c", 1, "3"},
@@ -1329,7 +1330,7 @@ func TestAddSSTableWriteAtRequestTimestampRespectsTSCache(t *testing.T) {
 	txnTS := txn.CommitTimestamp()
 
 	// Add an SST writing below the previous write.
-	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"key", 1, "sst"}})
+	sst, start, end := sstutil.MakeSST(ctx, s.ClusterSettings(), t, []sstutil.KV{{"key", 1, "sst"}})
 	sstReq := &roachpb.AddSSTableRequest{
 		RequestHeader:           roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:                    sst,
@@ -1389,7 +1390,7 @@ func TestAddSSTableWriteAtRequestTimestampRespectsClosedTS(t *testing.T) {
 
 	// Add an SST writing below the closed timestamp. It should get pushed above it.
 	reqTS := closedTS.Prev()
-	sst, start, end := sstutil.MakeSST(t, []sstutil.KV{{"key", 1, "sst"}})
+	sst, start, end := sstutil.MakeSST(ctx, store.ClusterSettings(), t, []sstutil.KV{{"key", 1, "sst"}})
 	sstReq := &roachpb.AddSSTableRequest{
 		RequestHeader:           roachpb.RequestHeader{Key: start, EndKey: end},
 		Data:                    sst,

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -111,7 +111,7 @@ func TestAddSSTQPSStat(t *testing.T) {
 		}
 		nextKey = nextKey.Next()
 	}
-	sst, start, end := sstutil.MakeSST(t, sstKeys)
+	sst, start, end := sstutil.MakeSST(ctx, ts.ClusterSettings(), t, sstKeys)
 	requestSize := float64(len(sst))
 
 	sstReq := &roachpb.AddSSTableRequest{

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -1247,7 +1246,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	// TODO(sumeer): change this test before interleaved intents are disallowed.
 	ingest := func(it MVCCIterator, count int) {
 		memFile := &MemFile{}
-		sst := MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), memFile)
+		sst := MakeIngestionSSTWriter(ctx, db2.settings, memFile)
 		defer sst.Close()
 
 		for i := 0; i < count; i++ {

--- a/pkg/testutils/sstutil/sstutil.go
+++ b/pkg/testutils/sstutil/sstutil.go
@@ -25,13 +25,13 @@ import (
 
 // MakeSST builds a binary in-memory SST from the given tests data. It returns
 // the binary SST data as well as the start and end (exclusive) keys of the SST.
-func MakeSST(t *testing.T, kvs []KV) ([]byte, roachpb.Key, roachpb.Key) {
+func MakeSST(
+	ctx context.Context, cs *cluster.Settings, t *testing.T, kvs []KV,
+) ([]byte, roachpb.Key, roachpb.Key) {
 	t.Helper()
 
 	sstFile := &storage.MemFile{}
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	writer := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
+	writer := storage.MakeIngestionSSTWriter(ctx, cs, sstFile)
 	defer writer.Close()
 
 	start, end := keys.MaxKey, keys.MinKey


### PR DESCRIPTION
```
821db506 db: respect IterOptions bounds during range-key iteration
c3ead1bc internal/rangekey: add DefragmentingIter
51cf6fbd internal/metamorphic: disable disk-backed FS for random configs
6af77d55 internal/metamorphic: use at least FormatRangeKeys
b1af263a internal/metamorphic: write range keys
3dce07ae db: add format major version for range keys
caab54e5 internal/manifest: Add randomized test for incremental sublevels
b6bb9870 internal/cache: enable debug stack collection when tracing enabled
b2295acd db: add experimental DB.RegisterFlushCompletedCallback
4402015c db: add OnlyReadGuaranteedDurable to IterOptions
20377e7d sstable: estimate indexBlock.estimatedSize()
db46dab6 internal/rangekey: fix interleaving iteration bug
b7b78b1c internal/manifest: incrementally generate L0Sublevels for L0 additions
788ef98e sstable: estimate Writer.EstimatedSize for cases when parallelism is enabled
a29a18b5 sstable: close `Writer` on `RewriteKeySuffixes` error
```

Release note: none