### PR TITLE
sql: add missing specs to plan diagrams

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "//pkg/sql/types",
         "//pkg/util/leaktest",
         "//pkg/util/optional",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -514,12 +514,38 @@ func (post *PostProcessSpec) summary() []string {
 }
 
 // summary implements the diagramCellType interface.
+func (c *RestoreDataSpec) summary() (string, []string) {
+	return "RestoreDataSpec", []string{}
+}
+
+// summary implements the diagramCellType interface.
+func (c *SplitAndScatterSpec) summary() (string, []string) {
+	detail := fmt.Sprintf("%d chunks", len(c.Chunks))
+	return "SplitAndScatterSpec", []string{detail}
+}
+
+// summary implements the diagramCellType interface.
 func (c *ReadImportDataSpec) summary() (string, []string) {
 	ss := make([]string, 0, len(c.Uri))
 	for _, s := range c.Uri {
 		ss = append(ss, s)
 	}
 	return "ReadImportData", ss
+}
+
+// summary implements the diagramCellType interface.
+func (s *StreamIngestionDataSpec) summary() (string, []string) {
+	return "StreamIngestionData", []string{}
+}
+
+// summary implements the diagramCellType interface.
+func (s *StreamIngestionFrontierSpec) summary() (string, []string) {
+	return "StreamIngestionFrontier", []string{}
+}
+
+// summary implements the diagramCellType interface.
+func (s *IndexBackfillMergerSpec) summary() (string, []string) {
+	return "IndexBackfillMerger", []string{}
 }
 
 // summary implements the diagramCellType interface.

--- a/pkg/sql/execinfrapb/flow_diagram_test.go
+++ b/pkg/sql/execinfrapb/flow_diagram_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 // compareDiagrams verifies that two JSON strings decode to equal diagramData
@@ -403,4 +404,11 @@ func TestPlanDiagramJoin(t *testing.T) {
 	`
 
 	compareDiagrams(t, s, expected)
+}
+
+func TestProcessorsImplementDiagramCellType(t *testing.T) {
+	pcu := reflect.ValueOf(ProcessorCoreUnion{})
+	for i := 0; i < pcu.NumField(); i++ {
+		require.Implements(t, (*diagramCellType)(nil), pcu.Field(i).Interface())
+	}
 }


### PR DESCRIPTION
This change allows missing specs (e.g., RestoreDataSpec and
SplitAndScatterSpec) to be shown in plan diagrams. Before this change a
plan involving these types would result in an error generating the
diagrams. Also added a test to make sure future specs implement the
`diagramCellType` interface, which is required to generate diagrams.

Release note: None
