### PR TITLE
sqlproxyccl: block session revival token in StartupMessage from client

### DIFF
--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -31,6 +31,9 @@ import (
 // will activate token-based authentication if present in the startup message.
 const sessionRevivalTokenStartupParam = "crdb:session_revival_token_base64"
 
+// remoteAddrStartupParam contains the remote address of the original client.
+const remoteAddrStartupParam = "crdb:remote_addr"
+
 // TenantResolver is an interface for the tenant directory. Currently only
 // tenant.Directory implements it.
 //

--- a/pkg/ccl/sqlproxyccl/frontend_admitter.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter.go
@@ -76,6 +76,17 @@ var FrontendAdmit = func(
 		if sniServerName != "" {
 			startup.Parameters["sni-server"] = sniServerName
 		}
+		// This forwards the remote addr to the backend.
+		startup.Parameters[remoteAddrStartupParam] = conn.RemoteAddr().String()
+		// The client is blocked from using session revival tokens; only the proxy
+		// itself can.
+		if _, ok := startup.Parameters[sessionRevivalTokenStartupParam]; ok {
+			return conn, nil, newErrorf(
+				codeUnexpectedStartupMessage,
+				"parameter %s is not allowed",
+				sessionRevivalTokenStartupParam,
+			)
+		}
 		return conn, startup, nil
 	}
 

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -65,6 +65,7 @@ func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 	require.NotNil(t, msg)
 	require.Contains(t, msg.Parameters, "p1")
 	require.Equal(t, msg.Parameters["p1"], "a")
+	require.Contains(t, msg.Parameters, remoteAddrStartupParam)
 }
 
 func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
@@ -94,6 +95,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	defer func() { _ = frontendCon.Close() }()
 	require.NotEqual(t, srv, frontendCon) // The connection was replaced by SSL
 	require.NotNil(t, msg)
+	require.Contains(t, msg.Parameters, remoteAddrStartupParam)
 }
 
 // TestFrontendAdmitRequireEncryption sends StartupRequest when SSlRequest is
@@ -173,6 +175,37 @@ func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 		"codeUnexpectedStartupMessage: "+
 			"unsupported post-TLS startup message: *pgproto3.CancelRequest",
 	)
+	require.NotNil(t, frontendCon)
+	require.Nil(t, msg)
+}
+
+func TestFrontendAdmitSessionRevivalToken(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cli, srv := net.Pipe()
+	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
+	require.NoError(t, cli.SetReadDeadline(timeutil.Now().Add(3e9)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		cfg, err := pgconn.ParseConfig(
+			"postgres://localhost?sslmode=disable&crdb:session_revival_token_base64=abc",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		cfg.DialFunc = func(
+			ctx context.Context, network, addr string,
+		) (net.Conn, error) {
+			return cli, nil
+		}
+		_, _ = pgconn.ConnectConfig(ctx, cfg)
+		fmt.Printf("Done\n")
+	}()
+
+	frontendCon, msg, err := FrontendAdmit(srv, nil)
+	require.EqualError(t, err, "codeUnexpectedStartupMessage: parameter crdb:session_revival_token_base64 is not allowed")
 	require.NotNil(t, frontendCon)
 	require.Nil(t, msg)
 }

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -226,8 +226,6 @@ func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn
 		updateMetricsAndSendErrToClient(clientErr, conn, handler.metrics)
 		return clientErr
 	}
-	// This forwards the remote addr to the backend.
-	backendStartupMsg.Parameters["crdb:remote_addr"] = conn.RemoteAddr().String()
 
 	ctx = logtags.AddTag(ctx, "cluster", clusterName)
 	ctx = logtags.AddTag(ctx, "tenant", tenID)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/74643

Only the SQL proxy itself should be setting this. To prevent an outsider
from trying to authenticate with a token, the proxy now checks for the
token in any incoming startup message. If it is present, it returns an
error.

Release note: None