### PR TITLE
ci: build `workload` in CI

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -16,7 +16,7 @@ if [ "$CONFIG" == "crosslinux" ]
 then
     DOC_TARGETS=$(grep '^//' docs/generated/bazel_targets.txt)
     GO_TARGETS=$(grep -v '^#' build/bazelutil/checked_in_genfiles.txt | cut -d'|' -f1)
-    BINARY_TARGETS="@com_github_cockroachdb_go_test_teamcity//:go-test-teamcity //pkg/cmd/dev"
+    BINARY_TARGETS="@com_github_cockroachdb_go_test_teamcity//:go-test-teamcity //pkg/cmd/dev //pkg/cmd/workload"
     EXTRA_TARGETS="$DOC_TARGETS $GO_TARGETS $BINARY_TARGETS"
 fi
 


### PR DESCRIPTION
This brings us to parity with the pre-Bazel `Compile Builds` job in CI.

Release note: None