### PR TITLE
ui: create ui pages for active queries and transactions

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
@@ -1,0 +1,377 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  ActiveStatementPhase,
+  SessionsResponse,
+  ActiveTransaction,
+  ActiveStatement,
+} from "./types";
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import moment from "moment";
+import { TimestampToMoment } from "../util/convert";
+import Long from "long";
+import {
+  getAppsFromActiveTransactions,
+  getActiveTransactionsFromSessions,
+  getAppsFromActiveStatements,
+  getActiveStatementsFromSessions,
+  filterActiveStatements,
+  filterActiveTransactions,
+} from "./activeStatementUtils";
+
+type ActiveQuery = protos.cockroach.server.serverpb.ActiveQuery;
+const Timestamp = protos.google.protobuf.Timestamp;
+
+const LAST_UPDATED = moment(new Date("2022-01-04T08:01:00"));
+const MOCK_START_TIME = moment(new Date("2022-01-04T08:00:00"));
+
+const defaultActiveQuery = {
+  sql: "SELECT 4321",
+  sql_no_constants: "SELECT _",
+  id: "queryId",
+  txn_id: new Uint8Array(),
+  phase: ActiveStatementPhase.EXECUTING,
+  start: new Timestamp({
+    seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+  }),
+};
+
+const defaultActiveStatement: ActiveStatement = {
+  executionID: defaultActiveQuery.id,
+  transactionID: "transactionID",
+  sessionID: "sessionID",
+  query: defaultActiveQuery.sql,
+  status: "Executing",
+  start: MOCK_START_TIME,
+  elapsedTimeSeconds: 60,
+  application: "test",
+  user: "user",
+  clientAddress: "clientAddress",
+};
+
+// makeActiveStatement creates an ActiveStatement object with the default active statement above
+// used as the base.
+function makeActiveStatement(
+  statementProperties: Partial<ActiveStatement> = {},
+): ActiveStatement {
+  return {
+    ...defaultActiveStatement,
+    ...statementProperties,
+  };
+}
+
+// makeActiveTxn creates an ActiveTransaction object with the provided props.
+function makeActiveTxn(
+  props: Partial<ActiveTransaction> = {},
+): ActiveTransaction {
+  return {
+    executionID: "txn",
+    sessionID: "sessionID",
+    start: MOCK_START_TIME,
+    elapsedTimeSeconds: 10,
+    application: "application",
+    mostRecentStatement: defaultActiveStatement,
+    retries: 3,
+    statementCount: 5,
+    status: "Executing",
+    ...props,
+  };
+}
+
+// makeActiveQuery creates an ActiveQuery object (which is part of the ListSessionsResponse), with
+// the default active query above used as the base.
+function makeActiveQuery(
+  props: Partial<ActiveQuery> = {},
+): Partial<ActiveQuery> {
+  return {
+    ...defaultActiveQuery,
+    ...props,
+  };
+}
+
+describe("test activeStatementUtils", () => {
+  describe("filterActiveStatements", () => {
+    it("should filter out statements that do not match filters", () => {
+      const statements: ActiveStatement[] = [
+        makeActiveStatement({ executionID: "1", application: "app1" }),
+        makeActiveStatement({ executionID: "2", application: "app2" }),
+        makeActiveStatement({ executionID: "3", application: "app3" }),
+        makeActiveStatement({ executionID: "4", application: "app1" }),
+      ];
+
+      const filters = { app: "app1" };
+      const filtered = filterActiveStatements(statements, filters);
+
+      expect(filtered.length).toBe(2);
+      expect(filtered[0].executionID).toBe("1");
+      expect(filtered[1].executionID).toBe("4");
+    });
+
+    it("should filter out statements that do not match search query", () => {
+      const statements: ActiveStatement[] = [
+        makeActiveStatement({
+          executionID: "1",
+          application: "app1",
+          query: "SELECT 1",
+        }),
+        makeActiveStatement({
+          executionID: "2",
+          application: "app1",
+          query: "SELECT 1",
+        }),
+        makeActiveStatement({
+          executionID: "3",
+          application: "app1",
+          query: "SELECT 2",
+        }),
+        makeActiveStatement({
+          executionID: "4",
+          application: "app1",
+          query: "SELECT 3",
+        }),
+      ];
+
+      const filters = { app: "app1" };
+      const search = "SELECT 1";
+      const filtered = filterActiveStatements(statements, filters, search);
+
+      expect(filtered.length).toBe(2);
+      expect(filtered[0].executionID).toBe("1");
+      expect(filtered[1].executionID).toBe("2");
+    });
+
+    it("should return all statements on empty filters and search", () => {
+      const statements: ActiveStatement[] = [
+        makeActiveStatement(),
+        makeActiveStatement(),
+        makeActiveStatement(),
+        makeActiveStatement(),
+        makeActiveStatement(),
+      ];
+
+      const filters = { app: "" };
+      const filtered = filterActiveStatements(statements, filters, "");
+
+      expect(filtered.length).toBe(statements.length);
+    });
+  });
+
+  describe("getActiveStatementsFromSessions", () => {
+    const activeQueries = [1, 2, 3, 4].map(num =>
+      makeActiveQuery({ id: num.toString() }),
+    );
+
+    const sessionsResponse: SessionsResponse = {
+      sessions: [
+        {
+          id: new Uint8Array(),
+          username: "bar",
+          application_name: "application",
+          client_address: "clientAddress",
+          active_queries: activeQueries,
+        },
+        {
+          id: new Uint8Array(),
+          username: "foo",
+          application_name: "application2",
+          client_address: "clientAddress2",
+          active_queries: activeQueries,
+        },
+      ],
+      errors: [],
+      internal_app_name_prefix: "",
+      toJSON: () => ({}),
+    };
+
+    const statements = getActiveStatementsFromSessions(
+      sessionsResponse,
+      LAST_UPDATED,
+    );
+
+    expect(statements.length).toBe(activeQueries.length * 2);
+
+    statements.forEach(stmt => {
+      if (stmt.user === "bar") {
+        expect(stmt.application).toBe("application");
+        expect(stmt.clientAddress).toBe("clientAddress");
+      } else if (stmt.user === "foo") {
+        expect(stmt.application).toBe("application2");
+        expect(stmt.clientAddress).toBe("clientAddress2");
+      } else {
+        fail(`stmt user should be foo or bar, got ${stmt.user}`);
+      }
+      // expect(stmt.transactionID).toBe(defaultActiveStatement.transactionID);
+      expect(stmt.status).toBe("Executing");
+      expect(stmt.elapsedTimeSeconds).toBe(
+        LAST_UPDATED.diff(MOCK_START_TIME, "seconds"),
+      );
+      expect(stmt.start.unix()).toBe(
+        TimestampToMoment(defaultActiveQuery.start).unix(),
+      );
+      // expect(stmt.sessionID).toBe(defaultActiveStatement.sessionID);
+      expect(stmt.query).toBe(defaultActiveStatement.query);
+    });
+  });
+
+  describe("getAppsFromActiveStatements", () => {
+    const activeStatements = [
+      makeActiveStatement({ application: "app1" }),
+      makeActiveStatement({ application: "app2" }),
+      makeActiveStatement({ application: "app3" }),
+      makeActiveStatement({ application: "app4" }),
+    ];
+    const apps = getAppsFromActiveStatements(activeStatements);
+    expect(apps).toEqual(["app1", "app2", "app3", "app4"]);
+  });
+
+  describe("getActiveTransactionsFromSessions", () => {
+    const txns = [
+      {
+        id: new Uint8Array(),
+        start: new Timestamp({
+          seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+        }),
+        num_auto_retries: 3,
+        num_statements_executed: 4,
+      },
+      {
+        id: new Uint8Array(),
+        start: new Timestamp({
+          seconds: Long.fromNumber(MOCK_START_TIME.unix()),
+        }),
+        num_auto_retries: 4,
+        num_statements_executed: 3,
+      },
+    ];
+
+    const sessionsResponse: SessionsResponse = {
+      sessions: [
+        {
+          id: new Uint8Array(),
+          username: "bar",
+          application_name: "application",
+          client_address: "clientAddress",
+          active_queries: [makeActiveQuery()],
+          active_txn: txns[0],
+        },
+        {
+          id: new Uint8Array(),
+          username: "foo",
+          application_name: "application2",
+          client_address: "clientAddress2",
+          active_queries: [makeActiveQuery()],
+          active_txn: txns[1],
+        },
+      ],
+      errors: [],
+      internal_app_name_prefix: "",
+      toJSON: () => ({}),
+    };
+
+    const activeTransactions = getActiveTransactionsFromSessions(
+      sessionsResponse,
+      LAST_UPDATED,
+    );
+
+    expect(activeTransactions.length).toBe(txns.length);
+
+    activeTransactions.forEach((txn: ActiveTransaction, i) => {
+      expect(txn.application).toBe(
+        sessionsResponse.sessions[i].application_name,
+      );
+      expect(txn.elapsedTimeSeconds).toBe(
+        LAST_UPDATED.diff(MOCK_START_TIME, "seconds"),
+      );
+      expect(txn.status).toBe("Executing");
+      expect(txn.mostRecentStatement).toBeTruthy();
+      expect(txn.start.unix()).toBe(
+        TimestampToMoment(defaultActiveQuery.start).unix(),
+      );
+    });
+  });
+
+  describe("filterActiveTransactions", () => {
+    it("should filter out txns that do not match filters", () => {
+      const txns: ActiveTransaction[] = [
+        makeActiveTxn({ executionID: "1", application: "app1" }),
+        makeActiveTxn({ executionID: "2", application: "app2" }),
+        makeActiveTxn({ executionID: "3", application: "app3" }),
+        makeActiveTxn({ executionID: "4", application: "app1" }),
+      ];
+
+      const filters = { app: "app1" };
+      const filtered = filterActiveTransactions(txns, filters);
+
+      expect(filtered.length).toBe(2);
+      expect(filtered[0].executionID).toBe("1");
+      expect(filtered[1].executionID).toBe("4");
+    });
+
+    it("should filter out txns that do not match search query", () => {
+      const txns: ActiveTransaction[] = [
+        makeActiveTxn({
+          executionID: "1",
+          application: "app1",
+          mostRecentStatement: makeActiveStatement({ query: "SELECT 1" }),
+        }),
+        makeActiveTxn({
+          executionID: "2",
+          application: "app1",
+          mostRecentStatement: makeActiveStatement({ query: "SELECT 1" }),
+        }),
+        makeActiveTxn({
+          executionID: "3",
+          application: "app1",
+          mostRecentStatement: makeActiveStatement({ query: "SELECT 2" }),
+        }),
+        makeActiveTxn({
+          executionID: "4",
+          application: "app1",
+        }),
+      ];
+
+      const filters = { app: "app1" };
+      const search = "SELECT 1";
+      const filtered = filterActiveTransactions(txns, filters, search);
+
+      expect(filtered.length).toBe(2);
+      expect(filtered[0].executionID).toBe("1");
+      expect(filtered[1].executionID).toBe("2");
+    });
+
+    it("should return all statements on empty filters and search", () => {
+      const txns: ActiveTransaction[] = [
+        makeActiveTxn(),
+        makeActiveTxn(),
+        makeActiveTxn(),
+        makeActiveTxn(),
+        makeActiveTxn(),
+      ];
+
+      const filters = { app: "" };
+      const filtered = filterActiveTransactions(txns, filters, "");
+
+      expect(filtered.length).toBe(txns.length);
+    });
+  });
+
+  describe("getAppsFromActiveTransactions", () => {
+    const activeTxns = [
+      makeActiveTxn({ application: "app1" }),
+      makeActiveTxn({ application: "app2" }),
+      makeActiveTxn({ application: "app3" }),
+      makeActiveTxn({ application: "app4" }),
+    ];
+
+    const apps = getAppsFromActiveTransactions(activeTxns);
+    expect(apps).toEqual(["app1", "app2", "app3", "app4"]);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -1,0 +1,166 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment, { Moment } from "moment";
+import { byteArrayToUuid } from "src/sessions";
+import { TimestampToMoment } from "src/util";
+import { ActiveTransaction } from ".";
+import {
+  SessionsResponse,
+  ActiveStatementPhase,
+  ExecutionStatus,
+  ActiveTransactionFilters,
+} from "./types";
+import { ActiveStatement, ActiveStatementFilters } from "./types";
+
+export const ACTIVE_STATEMENT_SEARCH_PARAM = "q";
+
+export function filterActiveStatements(
+  statements: ActiveStatement[],
+  filters: ActiveStatementFilters,
+  search?: string,
+): ActiveStatement[] {
+  if (statements == null) return [];
+
+  let filteredStatements = statements.filter(
+    stmt => filters.app === "" || stmt.application === filters.app,
+  );
+
+  if (search) {
+    filteredStatements = filteredStatements.filter(stmt =>
+      stmt.query.includes(search),
+    );
+  }
+
+  return filteredStatements;
+}
+
+export function getActiveStatementsFromSessions(
+  sessionsResponse: SessionsResponse,
+  lastUpdated: Moment | null,
+): ActiveStatement[] {
+  const activeQueries: ActiveStatement[] = [];
+  if (sessionsResponse.sessions == null) {
+    return activeQueries;
+  }
+
+  const time = lastUpdated || moment.utc();
+
+  sessionsResponse.sessions.forEach(session => {
+    session.active_queries.forEach(query => {
+      activeQueries.push({
+        executionID: query.id,
+        transactionID: byteArrayToUuid(query.txn_id),
+        sessionID: byteArrayToUuid(session.id),
+        // VIEWACTIVITYREDACTED users will not have access to the full SQL query.
+        query: query.sql?.length > 0 ? query.sql : query.sql_no_constants,
+        status:
+          query.phase === ActiveStatementPhase.EXECUTING
+            ? "Executing"
+            : "Preparing",
+        start: TimestampToMoment(query.start),
+        elapsedTimeSeconds: time.diff(
+          TimestampToMoment(query.start),
+          "seconds",
+        ),
+        application: session.application_name,
+        user: session.username,
+        clientAddress: session.client_address,
+      });
+    });
+  });
+
+  return activeQueries;
+}
+
+export function getAppsFromActiveStatements(
+  statements: ActiveStatement[] | null,
+): string[] {
+  if (statements == null) return [];
+  return Array.from(
+    statements.reduce(
+      (apps, stmt) => apps.add(stmt.application),
+      new Set<string>(),
+    ),
+  );
+}
+
+export function filterActiveTransactions(
+  txns: ActiveTransaction[] | null,
+  filters: ActiveTransactionFilters,
+  search?: string,
+): ActiveTransaction[] {
+  if (txns == null) return [];
+
+  let filteredTxns = txns;
+
+  if (filters.app) {
+    filteredTxns = filteredTxns.filter(txn => txn.application === filters.app);
+  }
+
+  if (search) {
+    filteredTxns = filteredTxns.filter(
+      txn => !search || txn.mostRecentStatement?.query.includes(search),
+    );
+  }
+
+  return filteredTxns;
+}
+
+export function getAppsFromActiveTransactions(
+  txns: ActiveTransaction[],
+): string[] {
+  if (txns == null) return [];
+
+  return Array.from(
+    txns.reduce((apps, txn) => apps.add(txn.application), new Set<string>()),
+  );
+}
+
+export function getActiveTransactionsFromSessions(
+  sessionsResponse: SessionsResponse,
+  lastUpdated: Moment,
+): ActiveTransaction[] {
+  if (sessionsResponse.sessions == null) return [];
+
+  const time = lastUpdated || moment.utc();
+
+  const activeStmts = getActiveStatementsFromSessions(sessionsResponse, time);
+  const activeStmtByTxnID: Record<string, ActiveStatement> = {};
+
+  activeStmts.forEach(stmt => {
+    activeStmtByTxnID[stmt.transactionID] = stmt;
+  });
+
+  return sessionsResponse.sessions
+    .filter(session => session.active_txn)
+    .map(session => {
+      const activeTxn = session.active_txn;
+
+      const executionID = byteArrayToUuid(activeTxn.id);
+      // Find most recent statement.
+      const mostRecentStmt = activeStmtByTxnID[executionID];
+
+      return {
+        executionID,
+        sessionID: byteArrayToUuid(session.id),
+        mostRecentStatement: mostRecentStmt,
+        status: "Executing" as ExecutionStatus,
+        start: TimestampToMoment(activeTxn.start),
+        elapsedTimeSeconds: time.diff(
+          TimestampToMoment(activeTxn.start),
+          "seconds",
+        ),
+        application: session.application_name,
+        retries: activeTxn.num_auto_retries,
+        statementCount: activeTxn.num_statements_executed,
+      };
+    });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsSection.tsx
@@ -1,0 +1,93 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import {
+  ActiveStatement,
+  ActiveStatementFilters,
+} from "src/activeExecutions/types";
+import ColumnsSelector, {
+  SelectOption,
+} from "src/columnsSelector/columnsSelector";
+import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
+import { EmptyStatementsPlaceholder } from "src/statementsPage/emptyStatementsPlaceholder";
+import { TableStatistics } from "src/tableStatistics";
+import {
+  ISortedTablePagination,
+  SortSetting,
+} from "../sortedtable/sortedtable";
+import {
+  ActiveStatementsTable,
+  getColumnOptions,
+} from "./activeStatementsTable";
+import { StatementViewType } from "src/statementsPage/statementPageTypes";
+import { calculateActiveFilters } from "src/queryFilter/filter";
+
+const sortableTableCx = classNames.bind(sortableTableStyles);
+
+type ActiveStatementsSectionProps = {
+  filters: ActiveStatementFilters;
+  pagination: ISortedTablePagination;
+  search: string;
+  statements: ActiveStatement[];
+  selectedColumns?: string[];
+  sortSetting: SortSetting;
+  onChangeSortSetting: (sortSetting: SortSetting) => void;
+  onClearFilters: () => void;
+  onColumnsSelect: (columns: string[]) => void;
+};
+
+export const ActiveStatementsSection: React.FC<ActiveStatementsSectionProps> = ({
+  filters,
+  pagination,
+  search,
+  statements,
+  selectedColumns,
+  sortSetting,
+  onClearFilters,
+  onChangeSortSetting,
+  onColumnsSelect,
+}) => {
+  const tableColumns: SelectOption[] = getColumnOptions(selectedColumns);
+  const activeFilters = calculateActiveFilters(filters);
+
+  return (
+    <section className={sortableTableCx("cl-table-container")}>
+      <div>
+        <ColumnsSelector
+          options={tableColumns}
+          onSubmitColumns={onColumnsSelect}
+        />
+        <TableStatistics
+          pagination={pagination}
+          search={search}
+          totalCount={statements.length}
+          arrayItemName="statements"
+          activeFilters={activeFilters}
+          onClearFilters={onClearFilters}
+        />
+      </div>
+      <ActiveStatementsTable
+        data={statements}
+        selectedColumns={selectedColumns}
+        sortSetting={sortSetting}
+        onChangeSortSetting={onChangeSortSetting}
+        renderNoResult={
+          <EmptyStatementsPlaceholder
+            isEmptySearchResults={search?.length > 0 && statements.length > 0}
+            statementView={StatementViewType.ACTIVE}
+          />
+        }
+        pagination={pagination}
+      />
+    </section>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
@@ -1,0 +1,121 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import {
+  SortedTable,
+  ISortedTablePagination,
+  ColumnDescriptor,
+} from "../../sortedtable";
+import { SortSetting } from "../../sortedtable";
+import { ActiveStatement } from "../types";
+import { isSelectedColumn } from "../../columnsSelector/utils";
+import { Link } from "react-router-dom";
+import { StatusIcon } from "../statusIcon";
+import {
+  getLabel,
+  executionsTableTitles,
+  ExecutionType,
+  ExecutionsColumn,
+} from "../execTableCommon";
+
+interface ActiveStatementsTable {
+  data: ActiveStatement[];
+  sortSetting: SortSetting;
+  onChangeSortSetting: (ss: SortSetting) => void;
+  pagination: ISortedTablePagination;
+  renderNoResult?: React.ReactNode;
+  selectedColumns: string[];
+}
+
+export function makeActiveStatementsColumns(): ColumnDescriptor<
+  ActiveStatement
+>[] {
+  const execType: ExecutionType = "statement";
+  const columns: ColumnDescriptor<ActiveStatement>[] = [
+    {
+      name: "executionID",
+      title: executionsTableTitles.executionID(execType),
+      cell: (item: ActiveStatement) => (
+        <Link to={`/execution/statement/${item.executionID}`}>
+          {item.executionID}
+        </Link>
+      ),
+      sort: (item: ActiveStatement) => item.executionID,
+      alwaysShow: true,
+    },
+    {
+      name: "execution",
+      title: executionsTableTitles.execution(execType),
+      cell: (item: ActiveStatement) => (
+        <Link to={`/execution/statement/${item.executionID}`}>
+          {item.query}
+        </Link>
+      ),
+      sort: (item: ActiveStatement) => item.query,
+    },
+    {
+      name: "status",
+      title: executionsTableTitles.status(execType),
+      cell: (item: ActiveStatement) => (
+        <span>
+          <StatusIcon status={item.status} />
+          {item.status}
+        </span>
+      ),
+      sort: (item: ActiveStatement) => item.status,
+    },
+    {
+      name: "startTime",
+      title: executionsTableTitles.startTime(execType),
+      cell: (item: ActiveStatement) =>
+        item.start.format("MMM D, YYYY [at] h:mm a"),
+      sort: (item: ActiveStatement) => item.start.unix(),
+    },
+    {
+      name: "elapsedTime",
+      title: executionsTableTitles.elapsedTime(execType),
+      cell: (item: ActiveStatement) => `${item.elapsedTimeSeconds} s`,
+      sort: (item: ActiveStatement) => item.elapsedTimeSeconds,
+    },
+    {
+      name: "applicationName",
+      title: executionsTableTitles.applicationName(execType),
+      cell: (item: ActiveStatement) => item.application,
+      sort: (item: ActiveStatement) => item.application,
+    },
+  ];
+  return columns;
+}
+
+export function getColumnOptions(
+  selectedColumns: string[] | null,
+): { label: string; value: string; isSelected: boolean }[] {
+  return makeActiveStatementsColumns()
+    .filter(col => !col.alwaysShow)
+    .map(col => ({
+      value: col.name,
+      label: getLabel(col.name as ExecutionsColumn, "statement"),
+      isSelected: isSelectedColumn(selectedColumns, col),
+    }));
+}
+
+export const ActiveStatementsTable: React.FC<ActiveStatementsTable> = props => {
+  const { selectedColumns, ...rest } = props;
+  const columns = makeActiveStatementsColumns().filter(col =>
+    isSelectedColumn(selectedColumns, col),
+  );
+
+  return (
+    <SortedTable columns={columns} className="statements-table" {...rest} />
+  );
+};
+
+ActiveStatementsTable.defaultProps = {};

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./activeStatementsTable";

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsSection.tsx
@@ -1,0 +1,93 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import {
+  ActiveStatementFilters,
+  ActiveTransaction,
+} from "src/activeExecutions/types";
+import ColumnsSelector, {
+  SelectOption,
+} from "src/columnsSelector/columnsSelector";
+import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
+import { EmptyTransactionsPlaceholder } from "src/transactionsPage/emptyTransactionsPlaceholder";
+import { TableStatistics } from "src/tableStatistics";
+import {
+  ISortedTablePagination,
+  SortSetting,
+} from "../sortedtable/sortedtable";
+import {
+  ActiveTransactionsTable,
+  getColumnOptions,
+} from "./activeTransactionsTable";
+import { TransactionViewType } from "src/transactionsPage/transactionsPageTypes";
+import { calculateActiveFilters } from "src/queryFilter/filter";
+
+const sortableTableCx = classNames.bind(sortableTableStyles);
+
+type ActiveTransactionsSectionProps = {
+  filters: ActiveStatementFilters;
+  pagination: ISortedTablePagination;
+  search: string;
+  transactions: ActiveTransaction[];
+  selectedColumns?: string[];
+  sortSetting: SortSetting;
+  onClearFilters: () => void;
+  onChangeSortSetting: (ss: SortSetting) => void;
+  onColumnsSelect: (columns: string[]) => void;
+};
+
+export const ActiveTransactionsSection: React.FC<ActiveTransactionsSectionProps> = ({
+  filters,
+  pagination,
+  search,
+  transactions,
+  selectedColumns,
+  sortSetting,
+  onChangeSortSetting,
+  onClearFilters,
+  onColumnsSelect,
+}) => {
+  const tableColumns: SelectOption[] = getColumnOptions(selectedColumns);
+  const activeFilters = calculateActiveFilters(filters);
+
+  return (
+    <section className={sortableTableCx("cl-table-container")}>
+      <div>
+        <ColumnsSelector
+          options={tableColumns}
+          onSubmitColumns={onColumnsSelect}
+        />
+        <TableStatistics
+          pagination={pagination}
+          search={search}
+          totalCount={transactions.length}
+          arrayItemName="transactions"
+          activeFilters={activeFilters}
+          onClearFilters={onClearFilters}
+        />
+      </div>
+      <ActiveTransactionsTable
+        data={transactions}
+        selectedColumns={selectedColumns}
+        sortSetting={sortSetting}
+        onChangeSortSetting={onChangeSortSetting}
+        renderNoResult={
+          <EmptyTransactionsPlaceholder
+            isEmptySearchResults={search?.length > 0 && transactions.length > 0}
+            transactionView={TransactionViewType.ACTIVE}
+          />
+        }
+        pagination={pagination}
+      />
+    </section>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
@@ -1,0 +1,135 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import {
+  SortedTable,
+  ISortedTablePagination,
+  ColumnDescriptor,
+} from "../../sortedtable";
+import { SortSetting } from "../../sortedtable";
+import { ActiveTransaction } from "../types";
+import { isSelectedColumn } from "../../columnsSelector/utils";
+import { Link } from "react-router-dom";
+import { StatusIcon } from "../statusIcon";
+import {
+  getLabel,
+  executionsTableTitles,
+  ExecutionType,
+  ExecutionsColumn,
+} from "../execTableCommon";
+
+interface ActiveTransactionsTable {
+  data: ActiveTransaction[];
+  sortSetting: SortSetting;
+  onChangeSortSetting: (ss: SortSetting) => void;
+  pagination: ISortedTablePagination;
+  renderNoResult?: React.ReactNode;
+  selectedColumns: string[];
+}
+
+export function makeActiveTransactionsColumns(): ColumnDescriptor<
+  ActiveTransaction
+>[] {
+  const execType: ExecutionType = "transaction";
+  const columns: ColumnDescriptor<ActiveTransaction>[] = [
+    {
+      name: "executionID",
+      title: executionsTableTitles.executionID(execType),
+      cell: (item: ActiveTransaction) => (
+        <Link to={`/execution/transaction/${item.executionID}`}>
+          {item.executionID}
+        </Link>
+      ),
+      sort: (item: ActiveTransaction) => item.executionID,
+      alwaysShow: true,
+    },
+    {
+      name: "mostRecentStatement",
+      title: executionsTableTitles.mostRecentStatement(execType),
+      cell: (item: ActiveTransaction) => (
+        <Link
+          to={`/execution/statement/${item.mostRecentStatement?.executionID}`}
+        >
+          {item.mostRecentStatement?.query}
+        </Link>
+      ),
+      sort: (item: ActiveTransaction) => item.mostRecentStatement?.query,
+    },
+    {
+      name: "status",
+      title: executionsTableTitles.status(execType),
+      cell: (item: ActiveTransaction) => (
+        <span>
+          <StatusIcon status={item.status} />
+          {item.status}
+        </span>
+      ),
+      sort: (item: ActiveTransaction) => item.status,
+    },
+    {
+      name: "startTime",
+      title: executionsTableTitles.startTime(execType),
+      cell: (item: ActiveTransaction) =>
+        item.start.format("MMM D, YYYY [at] h:mm a"),
+      sort: (item: ActiveTransaction) => item.start.unix(),
+    },
+    {
+      name: "elapsedTime",
+      title: executionsTableTitles.elapsedTime(execType),
+      cell: (item: ActiveTransaction) => `${item.elapsedTimeSeconds} s`,
+      sort: (item: ActiveTransaction) => item.elapsedTimeSeconds,
+    },
+    {
+      name: "statementCount",
+      title: executionsTableTitles.statementCount(execType),
+      cell: (item: ActiveTransaction) => item.statementCount,
+      sort: (item: ActiveTransaction) => item.statementCount,
+    },
+    {
+      name: "retries",
+      title: executionsTableTitles.retries(execType),
+      cell: (item: ActiveTransaction) => item.retries,
+      sort: (item: ActiveTransaction) => item.retries,
+    },
+    {
+      name: "applicationName",
+      title: executionsTableTitles.applicationName(execType),
+      cell: (item: ActiveTransaction) => item.application,
+      sort: (item: ActiveTransaction) => item.application,
+    },
+  ];
+  return columns;
+}
+
+export function getColumnOptions(
+  selectedColumns: string[] | null,
+): { label: string; value: string; isSelected: boolean }[] {
+  return makeActiveTransactionsColumns()
+    .filter(col => !col.alwaysShow)
+    .map(col => ({
+      value: col.name,
+      label: getLabel(col.name as ExecutionsColumn, "statement"),
+      isSelected: isSelectedColumn(selectedColumns, col),
+    }));
+}
+
+export const ActiveTransactionsTable: React.FC<ActiveTransactionsTable> = props => {
+  const { selectedColumns, ...rest } = props;
+  const columns = makeActiveTransactionsColumns().filter(col =>
+    isSelectedColumn(selectedColumns, col),
+  );
+
+  return (
+    <SortedTable columns={columns} className="statements-table" {...rest} />
+  );
+};
+
+ActiveTransactionsTable.defaultProps = {};

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./activeTransactionsTable";

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
@@ -1,0 +1,111 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { capitalize } from "lodash";
+import { Tooltip } from "@cockroachlabs/ui-components";
+
+export type ExecutionsColumn =
+  | "applicationName"
+  | "elapsedTime"
+  | "execution"
+  | "executionID"
+  | "mostRecentStatement"
+  | "retries"
+  | "startTime"
+  | "statementCount"
+  | "status";
+
+export type ExecutionType = "statement" | "transaction";
+
+export const executionsColumnLabels: Record<
+  ExecutionsColumn,
+  (execType: ExecutionType) => string
+> = {
+  applicationName: () => "Application",
+  elapsedTime: () => "Elapsed Time",
+  execution: (type: ExecutionType) => {
+    return `${capitalize(type)} Execution`;
+  },
+  executionID: (type: ExecutionType) => {
+    return `${capitalize(type)} Execution ID`;
+  },
+  mostRecentStatement: () => "Most Recent Statement",
+  retries: () => "Retries",
+  startTime: () => "Start Time (UTC)",
+  statementCount: () => "Statements",
+  status: () => "Status",
+};
+
+export type ExecutionsTableColumnKeys = keyof typeof executionsColumnLabels;
+
+type ExecutionsTableTitleType = {
+  [key in ExecutionsTableColumnKeys]: (execType: ExecutionType) => JSX.Element;
+};
+
+export function getLabel(
+  key: ExecutionsTableColumnKeys,
+  execType?: ExecutionType,
+): string {
+  return executionsColumnLabels[key](execType);
+}
+
+export const executionsTableTitles: ExecutionsTableTitleType = {
+  applicationName: () => (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={<p>The name of the application.</p>}
+    >
+      {getLabel("applicationName")}
+    </Tooltip>
+  ),
+  execution: (execType: ExecutionType) => (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={<p>The query being executed in this {execType}.</p>}
+    >
+      {getLabel("execution", execType)}
+    </Tooltip>
+  ),
+  executionID: (execType: ExecutionType) => (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={
+        <p>The unique identifier for the execution of this {execType}.</p>
+      }
+    >
+      {getLabel("executionID", execType)}
+    </Tooltip>
+  ),
+  mostRecentStatement: () => <span>{getLabel("mostRecentStatement")}</span>,
+  status: execType => (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={
+        <p>
+          {`The status of the ${execType}'s execution. If
+          "Preparing", the ${execType} is being parsed and planned.
+          If "Executing", the ${execType} is currently being
+          executed.`}
+        </p>
+      }
+    >
+      {getLabel("status")}
+    </Tooltip>
+  ),
+  startTime: () => <span>{getLabel("startTime")}</span>,
+  statementCount: () => <span>{getLabel("statementCount")}</span>,
+  elapsedTime: () => <span>{getLabel("elapsedTime")}</span>,
+  retries: () => <span>{getLabel("retries")}</span>,
+};

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/executionStatusIcon.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/executionStatusIcon.module.scss
@@ -1,0 +1,16 @@
+@import "src/core/index.module";
+
+.status-icon {
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+  margin-right: 4px;
+}
+
+.waiting {
+  fill: $colors--warning;
+}
+
+.executing {
+  fill: $colors--success;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export {
+  getActiveStatementsFromSessions,
+  getActiveTransactionsFromSessions,
+} from "./activeStatementUtils";
+
+export * from "./types";

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/statusIcon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/statusIcon.tsx
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import { CircleFilled } from "src/icon";
+import { ExecutionStatus } from "./types";
+
+import styles from "./executionStatusIcon.module.scss";
+const cx = classNames.bind(styles);
+
+export type StatusIconProps = {
+  status: ExecutionStatus;
+};
+
+export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
+  const statusClassName = status !== "Waiting" ? "executing" : "waiting";
+  return <CircleFilled className={cx("status-icon", statusClassName)} />;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -1,0 +1,51 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { Moment } from "moment";
+import { Filters } from "src/queryFilter";
+
+export type SessionsResponse = protos.cockroach.server.serverpb.ListSessionsResponse;
+export type ActiveStatementResponse = protos.cockroach.server.serverpb.ActiveQuery;
+export type ExecutionStatus = "Waiting" | "Executing" | "Preparing";
+export const ActiveStatementPhase =
+  protos.cockroach.server.serverpb.ActiveQuery.Phase;
+
+export type ActiveStatement = {
+  executionID: string;
+  transactionID: string;
+  sessionID: string;
+  query: string;
+  status: ExecutionStatus;
+  start: Moment;
+  elapsedTimeSeconds: number;
+  application: string;
+  user: string;
+  clientAddress: string;
+};
+
+export type ActiveStatementFilters = Omit<
+  Filters,
+  "database" | "sqlType" | "fullScan" | "distributed" | "regions" | "nodes"
+>;
+
+export type ActiveTransactionFilters = ActiveStatementFilters;
+
+export type ActiveTransaction = {
+  executionID: string;
+  sessionID: string;
+  mostRecentStatement: ActiveStatement | null;
+  status: ExecutionStatus;
+  start: Moment;
+  elapsedTimeSeconds: number;
+  statementCount: number;
+  retries: number;
+  application: string;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/utils.ts
@@ -1,0 +1,27 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { ColumnDescriptor } from "src/sortedtable/sortedtable";
+
+// We show a column if:
+// a. The list of visible columns was never defined by (selectedColumns is nullish) and
+// the column is set to 'showByDefault'
+// b. If the column appears in the selectedColumns list
+// c. If the column is labelled as 'alwaysShow'
+export const isSelectedColumn = (
+  selectedColumns: string[] | null | undefined,
+  c: ColumnDescriptor<unknown>,
+): boolean => {
+  return (
+    (selectedColumns == null && c.showByDefault !== false) ||
+    (selectedColumns !== null && selectedColumns.includes(c.name)) ||
+    c.alwaysShow === true
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -58,3 +58,7 @@ h3.base-heading {
   border-left: 1px solid #C0C6D9;
   padding-left: 12px;
 }
+
+.link {
+  color: $colors--link;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -35,7 +35,6 @@ import {
   statisticsClasses,
 } from "src/transactionsPage/transactionsPageClasses";
 import { Moment } from "moment";
-import { formatDate } from "antd/es/date-picker/utils";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -364,10 +363,7 @@ export class DatabaseDetailsPage extends React.Component<
         cell: table =>
           !table.details.statsLastUpdated
             ? "No table statistics found"
-            : formatDate(
-                table.details.statsLastUpdated,
-                "MMM DD, YYYY [at] h:mm A",
-              ),
+            : table.details.statsLastUpdated.format("MMM DD, YYYY [at] h:mm A"),
         sort: table => table.details.statsLastUpdated,
         className: cx("database-table__col--table-stats"),
         name: "tableStatsUpdated",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -34,7 +34,6 @@ import { commonStyles } from "src/common";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
 import moment, { Moment } from "moment";
 import { Search as IndexIcon } from "@cockroachlabs/icons";
-import { formatDate } from "antd/es/date-picker/utils";
 import { Link } from "react-router-dom";
 import classnames from "classnames/bind";
 import booleanSettingStyles from "../settings/booleanSetting.module.scss";
@@ -231,8 +230,7 @@ export class DatabaseTablePage extends React.Component<
       return "Last reset: Never";
     } else {
       return (
-        "Last reset: " +
-        formatDate(lastReset, "MMM DD, YYYY [at] h:mm A [(UTC)]")
+        "Last reset: " + lastReset.format("MMM DD, YYYY [at] h:mm A [(UTC)]")
       );
     }
   }
@@ -243,8 +241,7 @@ export class DatabaseTablePage extends React.Component<
     if (indexStat.lastUsed.isSame(this.minDate)) {
       return "Never";
     }
-    return formatDate(
-      indexStat.lastUsed,
+    return indexStat.lastUsed.format(
       `[Last ${indexStat.lastUsedType}:] MMM DD, YYYY [at] h:mm A`,
     );
   }
@@ -366,8 +363,7 @@ export class DatabaseTablePage extends React.Component<
                     {this.props.details.statsLastUpdated && (
                       <SummaryCardItem
                         label="Table Stats Last Updated"
-                        value={formatDate(
-                          this.props.details.statsLastUpdated,
+                        value={this.props.details.statsLastUpdated.format(
                           "MMM DD, YYYY [at] h:mm A [(UTC)]",
                         )}
                       />

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -44,3 +44,4 @@ export * from "./text";
 export { util, api };
 export * from "./sessions";
 export * from "./timeScaleDropdown";
+export * from "./activeExecutions";

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -20,7 +20,6 @@ import { Search as IndexIcon } from "@cockroachlabs/icons";
 import { SqlBox } from "src/sql";
 import { Col, Row, Tooltip } from "antd";
 import { SummaryCard } from "../summaryCard";
-import { formatDate } from "antd/es/date-picker/utils";
 import moment, { Moment } from "moment";
 
 const cx = classNames.bind(styles);
@@ -115,7 +114,7 @@ export class IndexDetailsPage extends React.Component<
     if (timestamp.isSame(minDate)) {
       return "Never";
     } else {
-      return formatDate(timestamp, "MMM DD, YYYY [at] h:mm A [(UTC)]");
+      return timestamp.format("MMM DD, YYYY [at] h:mm A [(UTC)]");
     }
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/loading/loading.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/loading/loading.tsx
@@ -27,7 +27,7 @@ interface LoadingProps {
   error?: Error | Error[] | null;
   className?: string;
   image?: string;
-  render: () => any;
+  render?: () => any;
   errorClassName?: string;
   loadingClassName?: string;
   renderError?: () => React.ReactElement;
@@ -127,5 +127,5 @@ export const Loading: React.FC<LoadingProps> = props => {
       <Spinner className={cx("loading-indicator", props.loadingClassName)} />
     );
   }
-  return props.render();
+  return props.children || (props.render && props.render());
 };

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/utils.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Filters, defaultFilters } from ".";
+import { Location } from "history";
+import {
+  ActiveStatementFilters,
+  ActiveTransactionFilters,
+} from "src/activeExecutions/types";
+
+// This function returns a Filters object populated with values from the URL, or null
+// if there were no filters set.
+export function getFiltersFromURL(location: Location): Partial<Filters> | null {
+  const { search } = location;
+  const queryParams = new URLSearchParams(search);
+  const filters: Filters = {};
+
+  Object.keys(defaultFilters).forEach((key: string) => {
+    const param = queryParams.get(key);
+    if (param == null) {
+      return;
+    }
+
+    filters[key] =
+      typeof defaultFilters[key] === "boolean" ? param === "true" : param;
+  });
+
+  return filters;
+}
+
+export function getActiveStatementFiltersFromURL(
+  location: Location,
+): Partial<ActiveStatementFilters> | null {
+  const filters = getFiltersFromURL(location);
+  if (!filters) return null;
+
+  const appFilters = {
+    app: filters.app,
+  };
+
+  // If every entry is null, there were no active stmt filters. Return null.
+  if (Object.values(appFilters).every(val => !val)) return null;
+
+  return appFilters;
+}
+
+export function getActiveTransactionFiltersFromURL(
+  location: Location,
+): Partial<ActiveTransactionFilters> | null {
+  const filters = getFiltersFromURL(location);
+  if (!filters) return null;
+
+  const appFilters = {
+    app: filters.app,
+  };
+
+  // If every entry is null, there were no active stmt filters. Return null.
+  if (Object.values(appFilters).every(val => !val)) return null;
+
+  return appFilters;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
@@ -30,7 +30,7 @@ interface ISearchState {
   submit?: boolean;
 }
 
-type TSearchProps = ISearchProps & InputProps;
+type TSearchProps = ISearchProps & Omit<InputProps, "onSubmit">;
 
 const cx = classNames.bind(styles);
 
@@ -40,7 +40,7 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     submitted: false,
   };
 
-  onSubmit = (e: React.SyntheticEvent) => {
+  onSubmit = (e: React.SyntheticEvent): void => {
     e && e.preventDefault();
     const { value } = this.state;
     const { onSubmit } = this.props;
@@ -52,7 +52,7 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     }
   };
 
-  onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const value: string = event.target.value;
     const submitted = value.length === 0;
     this.setState(
@@ -61,13 +61,13 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     );
   };
 
-  onClear = () => {
+  onClear = (): void => {
     const { onClear } = this.props;
     this.setState({ value: "", submit: false });
     onClear();
   };
 
-  renderSuffix = () => {
+  renderSuffix = (): React.ReactElement => {
     const { value, submitted } = this.state;
     if (value.length > 0) {
       if (submitted) {
@@ -94,9 +94,12 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
     return null;
   };
 
-  render() {
+  render(): React.ReactElement {
     const { value, submitted } = this.state;
-    const { onClear, ...inputProps } = this.props;
+    // We pull out onSubmit and onClear so that they will not be passed
+    // to the Input component as part of inputProps.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { onSubmit, onClear, ...inputProps } = this.props;
     const className = submitted ? cx("submitted") : "";
 
     return (

--- a/pkg/ui/workspaces/cluster-ui/src/selectWithDescription/selectWithDescription.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/selectWithDescription/selectWithDescription.tsx
@@ -1,0 +1,84 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useState } from "react";
+import classNames from "classnames/bind";
+import { CaretUp, CaretDown } from "@cockroachlabs/icons";
+import { Radio } from "antd";
+import { RadioChangeEvent } from "antd/lib/radio";
+import { Button } from "../button";
+
+import styles from "../statementsPage/statementTypeSelect.module.scss";
+
+const cx = classNames.bind(styles);
+
+export type Option = {
+  value: string;
+  label: string;
+  description: React.ReactChild;
+  component: React.ReactElement;
+};
+
+type SelectProps = {
+  options: Option[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const SelectWithDescription = ({
+  options,
+  value,
+  onChange,
+}: SelectProps): React.ReactElement => {
+  const [showDescription, setShowDescription] = useState<boolean>(false);
+  const onSelectChange = (e: RadioChangeEvent) => {
+    onChange(e.target.value);
+  };
+
+  const toggleDescription = (): void => {
+    setShowDescription(!showDescription);
+  };
+
+  const getDescription = (): React.ReactChild => {
+    return options.find(option => option.value === value).description;
+  };
+
+  const description = getDescription();
+
+  return (
+    <div className={cx("statement-select")}>
+      <div className={cx("select-options")}>
+        <Radio.Group
+          className={cx("radio-group")}
+          value={value}
+          onChange={onSelectChange}
+        >
+          {options.map(option => (
+            <Radio key={option.value} value={option.value}>
+              {option.label}
+            </Radio>
+          ))}
+        </Radio.Group>
+        <Button
+          className={cx("description-button")}
+          onClick={toggleDescription}
+          type="unstyled-link"
+          icon={showDescription ? <CaretUp /> : <CaretDown />}
+          iconPosition="right"
+        >
+          {showDescription ? "Hide" : "Show"} description
+        </Button>
+      </div>
+      <div className={cx("description", !showDescription && "collapsed")}>
+        {description}
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -327,7 +327,6 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                       <Link
                         to={StatementLinkTarget({
                           statementFingerprintID: stmt.id,
-                          statementNoConstants: stmt.sql_no_constants,
                           implicitTxn: session.active_txn?.implicit,
                         })}
                         onClick={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -35,7 +35,6 @@ import {
 import { Button } from "src/button/button";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { computeOrUseStmtSummary } from "../util";
-import { StatementLinkTarget } from "../statementsTable";
 import {
   statisticsTableTitles,
   StatisticType,
@@ -87,12 +86,16 @@ const StatementTableCell = (props: { session: ISession }) => {
   }
   const stmt = session.active_queries[0];
   const sql = stmt.sql;
-  const stmtSummary = session.active_queries[0].sql_summary;
-  const stmtCellText = computeOrUseStmtSummary(sql, stmtSummary);
+  const sqlNoConstants = stmt.sql_no_constants;
+  const stmtQuery = sql.length > 0 ? sql : sqlNoConstants;
+  const stmtSummary = stmt.sql_summary;
+  const stmtCellText = computeOrUseStmtSummary(stmtQuery, stmtSummary);
   return (
-    <Tooltip placement="bottom" style="tableTitle" content={<>{sql}</>}>
-      <div className={cx("cl-table__col-query-text")}>{stmtCellText}</div>
-    </Tooltip>
+    <Link to={`execution/statement/${stmt.id}`}>
+      <Tooltip placement="bottom" style="tableTitle" content={<>{sql}</>}>
+        <div className={cx("cl-table__col-query-text")}>{stmtCellText}</div>
+      </Tooltip>
+    </Link>
   );
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/getTableSortFromURL.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/getTableSortFromURL.ts
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Location } from "history";
+import { SortSetting } from "src/sortedtable";
+
+export function getTableSortFromURL(location: Location): SortSetting | null {
+  const { search } = location;
+  const queryParams = new URLSearchParams(search);
+
+  const ascending = queryParams.get("ascending");
+  const columnTitle = queryParams.get("columnTitle");
+  if (ascending == null || columnTitle == null) return null;
+
+  return {
+    ascending: ascending === "true",
+    columnTitle: columnTitle,
+  };
+}

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivityRootControls/sqlActivityRootControls.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivityRootControls/sqlActivityRootControls.tsx
@@ -1,0 +1,60 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { viewAttr, tabAttr } from "src/util";
+import { useHistory, useLocation } from "react-router-dom";
+import { queryByName } from "src/util/query";
+import {
+  SelectWithDescription,
+  Option,
+} from "src/selectWithDescription/selectWithDescription";
+
+export type SQLActivityRootControlsProps = {
+  options: Option[];
+};
+
+// SQLActivityRootControls is used by the Statement and Transaction tabs
+// to render content based on the options provided via the props and
+// the user's selection.
+export const SQLActivityRootControls = ({
+  options,
+}: SQLActivityRootControlsProps): React.ReactElement => {
+  const history = useHistory();
+  const location = useLocation();
+  const viewValue = queryByName(location, viewAttr) || options[0].value;
+  const tab = queryByName(location, tabAttr);
+
+  const onViewChange = (view: string): void => {
+    const searchParams = new URLSearchParams({
+      [viewAttr]: view,
+    });
+    if (tab) {
+      searchParams.set(tabAttr, tab);
+    }
+    history.push({
+      search: searchParams.toString(),
+    });
+  };
+
+  const content = options.find((option: Option) => option.value === viewValue)
+    .component;
+
+  return (
+    <div>
+      <SelectWithDescription
+        options={options}
+        value={viewValue}
+        onChange={onViewChange}
+      />
+      {content}
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
@@ -1,0 +1,158 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useEffect } from "react";
+import { ArrowLeft } from "@cockroachlabs/icons";
+import { Button } from "src/button";
+import Helmet from "react-helmet";
+import { Text } from "@cockroachlabs/ui-components";
+import { commonStyles } from "src/common";
+import classNames from "classnames/bind";
+import { Link, useHistory, match } from "react-router-dom";
+import { Col, Row } from "antd";
+import { SummaryCard } from "src/summaryCard";
+
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import { getMatchParamByName } from "src/util/query";
+import { executionIdAttr } from "../util/constants";
+import { ActiveStatement } from "src/activeExecutions";
+import { StatusIcon } from "src/activeExecutions/statusIcon";
+
+import styles from "./statementDetails.module.scss";
+import { SqlBox } from "src/sql/box";
+const cx = classNames.bind(styles);
+const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+
+export type ActiveStatementDetailsStateProps = {
+  statement: ActiveStatement;
+  match: match;
+};
+
+export type ActiveStatementDetailsDispatchProps = {
+  refreshSessions: () => void;
+};
+
+export type ActiveStatementDetailsProps = ActiveStatementDetailsStateProps &
+  ActiveStatementDetailsDispatchProps;
+
+export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
+  statement,
+  match,
+  refreshSessions,
+}) => {
+  const history = useHistory();
+  const executionID = getMatchParamByName(match, executionIdAttr);
+
+  useEffect(() => {
+    if (statement == null) {
+      // Refresh sessions if the statement was not found initially.
+      refreshSessions();
+    }
+  }, [refreshSessions, statement]);
+
+  const returnToActiveStatements = () => {
+    history.push("/sql-activity?tab=Statements&view=active");
+  };
+
+  return (
+    <div className={cx("root")}>
+      <Helmet title={`Details`} />
+      <div className={cx("section", "page--header")}>
+        <Button
+          onClick={returnToActiveStatements}
+          type="unstyled-link"
+          size="small"
+          icon={<ArrowLeft fontSize={"10px"} />}
+          iconPosition="left"
+          className="small-margin"
+        >
+          Active Statements
+        </Button>
+        <h3 className={commonStyles("base-heading", "no-margin-bottom")}>
+          Statement Execution ID:{" "}
+          <span className={cx("heading-execution-id")}>{executionID}</span>
+        </h3>
+      </div>
+      <section className={cx("section", "section--container")}>
+        <Row gutter={24}>
+          <Col className="gutter-row" span={24}>
+            <SqlBox value={statement?.query || "SQL Execution not found."} />
+          </Col>
+        </Row>
+        {statement && (
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
+                <Row>
+                  <Col>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Start Time (UTC)</Text>
+                      <Text>
+                        {statement.start.format(
+                          "MMM D, YYYY [at] h:mm a (UTC)",
+                        )}
+                      </Text>
+                    </div>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Elapsed Time</Text>
+                      <Text>{statement.elapsedTimeSeconds} s</Text>
+                    </div>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Status</Text>
+                      <Text>
+                        <StatusIcon status={statement.status} />
+                        {statement.status}
+                      </Text>
+                    </div>
+                  </Col>
+                </Row>
+              </SummaryCard>
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Application Name</Text>
+                  {statement.application}
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>User Name</Text>
+                  {statement.user}
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Client Address</Text>
+                  {statement.clientAddress}
+                </div>
+                <p className={summaryCardStylesCx("summary--card__divider")} />
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Session ID</Text>
+                  <Link
+                    className={cx("text-link")}
+                    to={`/session/${statement.sessionID}`}
+                  >
+                    {statement.sessionID}
+                  </Link>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Transaction Execution ID</Text>
+                  <Link
+                    className={cx("text-link")}
+                    to={`/execution/transaction/${statement.transactionID}`}
+                  >
+                    {statement.transactionID}
+                  </Link>
+                </div>
+              </SummaryCard>
+            </Col>
+          </Row>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/index.ts
@@ -13,3 +13,4 @@ export * from "./diagnostics/diagnosticsView";
 export * from "./diagnostics/diagnosticsUtils";
 export * from "./planView";
 export * from "./statementDetailsConnected";
+export * from "./activeStatementDetails";

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -1,6 +1,6 @@
 @import "src/core/index.module";
 
-.app-name {
+.text-link {
   white-space: nowrap;
   line-height: $line-height--medium;
   font-weight: $font-weight--bold;
@@ -10,6 +10,8 @@
     color: $colors--primary-blue-3;
     text-decoration: underline;
   }
+
+  color: $colors--link;
 
   &__unset {
     color: $tooltip-color;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -186,7 +186,7 @@ function AppLink(props: { app: string }) {
 
   return (
     <Link
-      className={cx("app-name")}
+      className={cx("text-link")}
       to={`/sql-activity?tab=Statements&${searchParams.toString()}`}
     >
       {props.app}
@@ -197,7 +197,7 @@ function AppLink(props: { app: string }) {
 function NodeLink(props: { node: string }) {
   return (
     <Link
-      className={cx("app-name")}
+      className={cx("text-link")}
       to={`/node/${encodeURIComponent(props.node)}`}
     >
       N{props.node}
@@ -373,7 +373,7 @@ export class StatementDetails extends React.Component<
   };
 
   backToStatementsClick = (): void => {
-    this.props.history.push("/sql-activity?tab=Statements");
+    this.props.history.push("/sql-activity?tab=Statements&view=fingerprints");
     if (this.props.onBackToStatementsClick) {
       this.props.onBackToStatementsClick();
     }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -1,0 +1,209 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useEffect, useState } from "react";
+import classNames from "classnames/bind";
+import { useHistory } from "react-router-dom";
+import {
+  ISortedTablePagination,
+  SortSetting,
+} from "src/sortedtable/sortedtable";
+import { Loading } from "src/loading/loading";
+import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
+import { Search } from "src/search/search";
+import { ActiveStatement, ActiveStatementFilters } from "src/activeExecutions";
+import { Filter } from "src/queryFilter";
+import SQLActivityError from "src/sqlActivity/errorComponent";
+import {
+  ACTIVE_STATEMENT_SEARCH_PARAM,
+  getAppsFromActiveStatements,
+  filterActiveStatements,
+} from "../activeExecutions/activeStatementUtils";
+import {
+  calculateActiveFilters,
+  getFullFiltersAsStringRecord,
+} from "../queryFilter/filter";
+import { ActiveStatementsSection } from "../activeExecutions/activeStatementsSection";
+import { inactiveFiltersState } from "../queryFilter/filter";
+import { queryByName, syncHistory } from "src/util/query";
+import { getTableSortFromURL } from "../sortedtable/getTableSortFromURL";
+import { getActiveStatementFiltersFromURL } from "src/queryFilter/utils";
+
+import styles from "./statementsPage.module.scss";
+
+const cx = classNames.bind(styles);
+
+export type ActiveStatementsViewDispatchProps = {
+  onColumnsSelect: (columns: string[]) => void;
+  onFiltersChange: (filters: ActiveStatementFilters) => void;
+  onSortChange: (ss: SortSetting) => void;
+  refreshSessions: () => void;
+};
+
+export type ActiveStatementsViewStateProps = {
+  selectedColumns: string[];
+  statements: ActiveStatement[];
+  sortSetting: SortSetting;
+  sessionsError: Error | null;
+  filters: ActiveStatementFilters;
+};
+
+export type ActiveStatementsViewProps = ActiveStatementsViewStateProps &
+  ActiveStatementsViewDispatchProps;
+
+export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
+  onColumnsSelect,
+  refreshSessions,
+  onFiltersChange,
+  onSortChange,
+  selectedColumns,
+  sortSetting,
+  statements,
+  sessionsError,
+  filters,
+}: ActiveStatementsViewProps) => {
+  const [pagination, setPagination] = useState<ISortedTablePagination>({
+    current: 1,
+    pageSize: 20,
+  });
+  const history = useHistory();
+  const [search, setSearch] = useState<string>(
+    queryByName(history.location, ACTIVE_STATEMENT_SEARCH_PARAM),
+  );
+
+  useEffect(() => {
+    // Refresh every 10 seconds.
+    refreshSessions();
+    const interval = setInterval(refreshSessions, 10 * 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [refreshSessions]);
+
+  useEffect(() => {
+    // We use this effect to sync settings defined on the URL (sort, filters),
+    // with the redux store. The only time we do this is when the user navigates
+    // to the page directly via the URL and specifies settings in the query string.
+    // Note that the desired behaviour is currently that the user is unable to
+    // clear filters via the URL, and must do so with page controls.
+    const sortSettingURL = getTableSortFromURL(history.location);
+    const filtersFromURL = getActiveStatementFiltersFromURL(history.location);
+
+    if (sortSettingURL) {
+      onSortChange(sortSettingURL);
+    }
+
+    if (filtersFromURL) {
+      onFiltersChange(filtersFromURL);
+    }
+  }, [history, onSortChange, onFiltersChange]);
+
+  useEffect(() => {
+    // This effect runs when the filters or sort settings received from
+    // redux changes and syncs the URL params with redux.
+    syncHistory(
+      {
+        ascending: sortSetting.ascending.toString(),
+        columnTitle: sortSetting.columnTitle,
+        [ACTIVE_STATEMENT_SEARCH_PARAM]: search,
+        ...getFullFiltersAsStringRecord(filters),
+      },
+      history,
+      true,
+    );
+  }, [
+    history,
+    filters,
+    sortSetting.ascending,
+    sortSetting.columnTitle,
+    search,
+  ]);
+
+  const resetPagination = () => {
+    setPagination({
+      current: 1,
+      pageSize: 20,
+    });
+  };
+
+  const onSortClick = (ss: SortSetting): void => {
+    onSortChange(ss);
+    resetPagination();
+  };
+
+  const onSubmitSearch = (newSearch: string): void => {
+    if (newSearch === search) return;
+    setSearch(search);
+    resetPagination();
+  };
+
+  const onSubmitFilters = (selectedFilters: ActiveStatementFilters) => {
+    onFiltersChange(selectedFilters);
+    resetPagination();
+  };
+
+  const clearSearch = () => onSubmitSearch("");
+  const clearFilters = () => onSubmitFilters({ app: inactiveFiltersState.app });
+
+  const apps = getAppsFromActiveStatements(statements);
+  const countActiveFilters = calculateActiveFilters(filters);
+
+  const filteredStatements = filterActiveStatements(
+    statements,
+    filters,
+    search,
+  );
+
+  return (
+    <div className={cx("root")}>
+      <PageConfig>
+        <PageConfigItem>
+          <Search
+            onSubmit={onSubmitSearch}
+            onClear={clearSearch}
+            defaultValue={search}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <Filter
+            activeFilters={countActiveFilters}
+            onSubmitFilters={onSubmitFilters}
+            appNames={apps}
+            filters={filters}
+          />
+        </PageConfigItem>
+      </PageConfig>
+      <div className={cx("table-area")}>
+        <Loading
+          loading={statements == null}
+          page="active statements"
+          error={sessionsError}
+          renderError={() =>
+            SQLActivityError({
+              statsType: "statements",
+            })
+          }
+        >
+          <ActiveStatementsSection
+            filters={filters}
+            pagination={pagination}
+            search={search}
+            statements={filteredStatements}
+            selectedColumns={selectedColumns}
+            sortSetting={sortSetting}
+            onClearFilters={clearFilters}
+            onChangeSortSetting={onSortClick}
+            onColumnsSelect={onColumnsSelect}
+          />
+        </Loading>
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/emptyStatementsPlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/emptyStatementsPlaceholder.tsx
@@ -14,29 +14,57 @@ import { Anchor } from "src/anchor";
 import { statementsTable } from "src/util";
 import magnifyingGlassImg from "../assets/emptyState/magnifying-glass.svg";
 import emptyTableResultsImg from "../assets/emptyState/empty-table-results.svg";
+import { StatementViewType } from "./statementPageTypes";
+import { tabAttr, viewAttr } from "src/util";
+import { Link } from "react-router-dom";
+import { commonStyles } from "src/common";
 
-export const EmptyStatementsPlaceholder: React.FC<{
-  isEmptySearchResults: boolean;
-}> = ({ isEmptySearchResults }) => {
-  const footer = (
-    <Anchor href={statementsTable} target="_blank">
-      Learn more about statements
-    </Anchor>
-  );
+const footer = (
+  <Anchor href={statementsTable} target="_blank">
+    Learn more about statements
+  </Anchor>
+);
 
-  const emptyPlaceholderProps: EmptyTableProps = isEmptySearchResults
-    ? {
-        title:
-          "No SQL statements match your search since this page was last cleared",
-        icon: magnifyingGlassImg,
-        footer,
-      }
-    : {
+const emptySearchResults = {
+  title: "No SQL statements match your search.",
+  icon: magnifyingGlassImg,
+  footer,
+};
+
+function getMessage(type: StatementViewType): EmptyTableProps {
+  switch (type) {
+    case StatementViewType.ACTIVE:
+      return {
+        title: "No active SQL statements",
+        icon: emptyTableResultsImg,
+        message: "There are currently no active statement executions.",
+        footer: (
+          <Link
+            className={commonStyles("link")}
+            to={`/sql-activity?${tabAttr}=Statements&${viewAttr}=fingerprints`}
+          >
+            View Statement Fingerprints to see historical statement statistics.
+          </Link>
+        ),
+      };
+    case StatementViewType.FINGERPRINTS:
+    default:
+      return {
         title: "No SQL statements since this page was last cleared",
         icon: emptyTableResultsImg,
         message:
           "Statements are cleared every hour by default, or according to your configuration.",
         footer,
       };
+  }
+}
+
+export const EmptyStatementsPlaceholder: React.FC<{
+  isEmptySearchResults: boolean;
+  statementView: StatementViewType;
+}> = ({ isEmptySearchResults, statementView }) => {
+  const emptyPlaceholderProps: EmptyTableProps = isEmptySearchResults
+    ? emptySearchResults
+    : getMessage(statementView);
   return <EmptyTable {...emptyPlaceholderProps} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/index.ts
@@ -10,3 +10,5 @@
 
 export * from "./statementsPage";
 export * from "./statementsPageConnected";
+export * from "./activeStatementsView";
+export * from "./statementsPageRoot";

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementPageTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementPageTypes.ts
@@ -1,0 +1,14 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export enum StatementViewType {
+  ACTIVE = "active",
+  FINGERPRINTS = "fingerprints",
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
@@ -1,0 +1,62 @@
+@import "src/core/index.module";
+
+.statement-select {
+  background: white;
+  box-shadow: 0px 1px 4px rgba(198, 214, 237, 0.15),
+    0px 0px 1px rgba(198, 214, 237, 0.415);
+  border-radius: 3px;
+  padding: 15px 20px;
+  margin-bottom: 10px;
+
+  .radio-group {
+    height: fit-content;
+  }
+}
+
+.select-options {
+  align-items: center;
+  display: flex;
+  height: fit-content;
+}
+
+.description-button {
+  height: fit-content;
+  display: inline-block;
+  margin-bottom: 0;
+  margin-left: auto;
+  min-width: 160px;
+  &:focus,
+  &:active {
+    outline: none;
+    border: none;
+  }
+}
+
+.description {
+  transition: 0.2s ease;
+  overflow: hidden;
+  display: block;
+  transform-origin: top;
+  max-height: 100px;
+  padding: 15px 8px 0px 8px;
+  transform: scaleY(1);
+}
+
+.collapsed {
+  max-height: 0;
+  padding: 0;
+  transform: scaleY(0);
+}
+
+:global(.ant-radio-checked .ant-radio-inner) {
+  background-color: $colors--link;
+  border-color: $colors--link;
+}
+
+:global(.ant-radio-checked .ant-radio-inner::after) {
+  background-color: white;
+  height: 6px;
+  width: 6px;
+  top: 4px;
+  left: 4px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -48,7 +48,7 @@
 
 .table-area {
   position: relative;
-  width: fit-content;
+  overflow-x: scroll;
 }
 
 .reset-btn-area {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageRoot.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageRoot.tsx
@@ -1,0 +1,67 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { StatementViewType } from "./statementPageTypes";
+import { Option } from "src/selectWithDescription/selectWithDescription";
+import { SQLActivityRootControls } from "src/sqlActivityRootControls/sqlActivityRootControls";
+import {
+  StatementsPage,
+  StatementsPageProps,
+} from "src/statementsPage/statementsPage";
+import {
+  ActiveStatementsView,
+  ActiveStatementsViewProps,
+} from "./activeStatementsView";
+import { statementsSql } from "src/util/docs";
+import { Anchor } from "src/anchor";
+
+export type StatementsPageRootProps = {
+  fingerprintsPageProps: StatementsPageProps;
+  activePageProps: ActiveStatementsViewProps;
+};
+
+export const StatementsPageRoot = ({
+  fingerprintsPageProps,
+  activePageProps,
+}: StatementsPageRootProps): React.ReactElement => {
+  const statementOptions: Option[] = [
+    {
+      value: StatementViewType.FINGERPRINTS,
+      label: "Statement Fingerprints",
+      description: (
+        <span>
+          {`A statement fingerprint represents one or more completed SQL
+          statements by replacing literal values (e.g., numbers and strings)
+          with underscores (_).\nThis can help you quickly identify
+          frequently executed SQL statements and their latencies.`}
+          <Anchor href={statementsSql}>Learn more</Anchor>
+        </span>
+      ),
+      component: <StatementsPage {...fingerprintsPageProps} />,
+    },
+    {
+      value: StatementViewType.ACTIVE,
+      label: "Active Executions",
+      description: (
+        <span>
+          Active executions represent individual statement executions in
+          progress. Use active statement execution details, such as the
+          application or elapsed time, to understand and tune workload
+          performance.
+          {/* TODO (xinhaoz) #78379 add 'Learn More' link to documentation page*/}
+        </span>
+      ),
+      component: <ActiveStatementsView {...activePageProps} />,
+    },
+  ];
+
+  return <SQLActivityRootControls options={statementOptions} />;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -161,7 +161,6 @@ type StatementLinkTargetProps = {
   aggregatedTs?: number;
   appNames?: string[];
   implicitTxn: boolean;
-  statementNoConstants?: string;
 };
 
 // StatementLinkTarget returns the link to the relevant statement page, given
@@ -190,7 +189,7 @@ interface StatementLinkProps {
   statement: string;
   statementSummary: string;
   search: string;
-  statementNoConstants?: string;
+  statementQuery?: string;
   onClick?: (statement: string) => void;
 }
 
@@ -202,7 +201,6 @@ export const StatementLink = ({
   statement,
   statementSummary,
   search,
-  statementNoConstants,
   onClick,
 }: StatementLinkProps): React.ReactElement => {
   const onStatementClick = React.useCallback(() => {
@@ -216,8 +214,6 @@ export const StatementLink = ({
     aggregationInterval,
     appNames,
     implicitTxn,
-    statement,
-    statementNoConstants,
   };
 
   const summary = computeOrUseStmtSummary(statement, statementSummary);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
@@ -1,0 +1,165 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useEffect } from "react";
+import { ArrowLeft } from "@cockroachlabs/icons";
+import { Button } from "src/button";
+import Helmet from "react-helmet";
+import { Text } from "@cockroachlabs/ui-components";
+import { commonStyles } from "src/common";
+import { SqlBox } from "src/sql/box";
+import classNames from "classnames/bind";
+import { Link, useHistory, match } from "react-router-dom";
+import { Col, Row } from "antd";
+import { SummaryCard } from "src/summaryCard";
+
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import { getMatchParamByName } from "src/util/query";
+import { executionIdAttr } from "../util/constants";
+import { ActiveTransaction } from "src/activeExecutions";
+import { StatusIcon } from "src/activeExecutions/statusIcon";
+
+import styles from "../statementDetails/statementDetails.module.scss";
+const cx = classNames.bind(styles);
+const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+
+export type ActiveTransactionDetailsStateProps = {
+  transaction: ActiveTransaction;
+  match: match;
+};
+
+export type ActiveTransactionDetailsDispatchProps = {
+  refreshSessions: () => void;
+};
+
+export type ActiveTransactionDetailsProps = ActiveTransactionDetailsStateProps &
+  ActiveTransactionDetailsDispatchProps;
+
+export const ActiveTransactionDetails: React.FC<ActiveTransactionDetailsProps> = ({
+  transaction,
+  match,
+  refreshSessions,
+}) => {
+  const history = useHistory();
+  const executionID = getMatchParamByName(match, executionIdAttr);
+
+  useEffect(() => {
+    if (transaction == null) {
+      // Refresh sessions if the transaction was not found initially.
+      refreshSessions();
+    }
+  }, [refreshSessions, transaction]);
+
+  const returnToActiveTransactions = () => {
+    history.push("/sql-activity?tab=Transactions&view=active");
+  };
+
+  return (
+    <div className={cx("root")}>
+      <Helmet title={`Details`} />
+      <div className={cx("section", "page--header")}>
+        <Button
+          onClick={returnToActiveTransactions}
+          type="unstyled-link"
+          size="small"
+          icon={<ArrowLeft fontSize={"10px"} />}
+          iconPosition="left"
+          className="small-margin"
+        >
+          Active Transactions
+        </Button>
+        <h3 className={commonStyles("base-heading", "no-margin-bottom")}>
+          Transaction Execution ID:{" "}
+          <span className={cx("heading-execution-id")}>{executionID}</span>
+        </h3>
+      </div>
+      <section className={cx("section", "section--container")}>
+        <Row gutter={24}>
+          <Col className="gutter-row" span={24}>
+            <SqlBox
+              value={
+                transaction?.mostRecentStatement?.query ||
+                "Most recent statement not found."
+              }
+            />
+          </Col>
+        </Row>
+        {transaction && (
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
+                <Row>
+                  <Col>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Start Time (UTC)</Text>
+                      <Text>
+                        {transaction.start.format(
+                          "MMM D, YYYY [at] h:mm a (UTC)",
+                        )}
+                      </Text>
+                    </div>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Elapsed Time</Text>
+                      <Text>{transaction.elapsedTimeSeconds} s</Text>
+                    </div>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Status</Text>
+                      <Text>
+                        <StatusIcon status={transaction.status} />
+                        {transaction.status}
+                      </Text>
+                    </div>
+                  </Col>
+                </Row>
+              </SummaryCard>
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard className={cx("summary-card")}>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Number of Retries</Text>
+                  {transaction.retries}
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Number of Statements</Text>
+                  {transaction.statementCount}
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Application Name</Text>
+                  {transaction.application}
+                </div>
+                <p className={summaryCardStylesCx("summary--card__divider")} />
+                {transaction.mostRecentStatement && (
+                  <div className={summaryCardStylesCx("summary--card__item")}>
+                    <Text>Most Recent Statement Execution ID</Text>
+                    <Link
+                      className={cx("text-link")}
+                      to={`/execution/statement/${transaction.mostRecentStatement.executionID}`}
+                    >
+                      {transaction.mostRecentStatement.executionID}
+                    </Link>
+                  </div>
+                )}
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Session ID</Text>
+                  <Link
+                    className={cx("text-link")}
+                    to={`/session/${transaction.sessionID}`}
+                  >
+                    {transaction.sessionID}
+                  </Link>
+                </div>
+              </SummaryCard>
+            </Col>
+          </Row>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/index.ts
@@ -10,3 +10,4 @@
 
 export * from "./transactionDetails";
 export * from "./transactionDetailsConnected";
+export * from "./activeTransactionDetails";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -192,7 +192,7 @@ export class TransactionDetails extends React.Component<
   };
 
   backToTransactionsClick = (): void => {
-    this.props.history.push("/sql-activity?tab=Transactions");
+    this.props.history.push("/sql-activity?tab=Transactions&view=fingerprints");
   };
 
   render(): React.ReactElement {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -1,0 +1,209 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useEffect, useState } from "react";
+import classNames from "classnames/bind";
+import { useHistory } from "react-router-dom";
+import {
+  ISortedTablePagination,
+  SortSetting,
+} from "src/sortedtable/sortedtable";
+import { Loading } from "src/loading/loading";
+import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
+import { Search } from "src/search/search";
+import {
+  ActiveTransaction,
+  ActiveStatementFilters,
+  ActiveTransactionFilters,
+} from "src/activeExecutions";
+import SQLActivityError from "src/sqlActivity/errorComponent";
+import {
+  calculateActiveFilters,
+  Filter,
+  getFullFiltersAsStringRecord,
+} from "../queryFilter/filter";
+import { getAppsFromActiveTransactions } from "../activeExecutions/activeStatementUtils";
+import { inactiveFiltersState } from "../queryFilter/filter";
+import { ActiveTransactionsSection } from "src/activeExecutions/activeTransactionsSection";
+
+import styles from "../statementsPage/statementsPage.module.scss";
+import { queryByName, syncHistory } from "src/util/query";
+import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
+import { getActiveTransactionFiltersFromURL } from "src/queryFilter/utils";
+import { filterActiveTransactions } from "../activeExecutions/activeStatementUtils";
+const cx = classNames.bind(styles);
+
+export type ActiveTransactionsViewDispatchProps = {
+  onColumnsSelect: (columns: string[]) => void;
+  onFiltersChange: (filters: ActiveTransactionFilters) => void;
+  onSortChange: (ss: SortSetting) => void;
+  refreshSessions: () => void;
+};
+
+export type ActiveTransactionsViewStateProps = {
+  selectedColumns: string[];
+  transactions: ActiveTransaction[];
+  sessionsError: Error | null;
+  filters: ActiveTransactionFilters;
+  sortSetting: SortSetting;
+};
+
+export type ActiveTransactionsViewProps = ActiveTransactionsViewStateProps &
+  ActiveTransactionsViewDispatchProps;
+
+const ACTIVE_TXN_SEARCH_PARAM = "q";
+
+export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
+  onColumnsSelect,
+  refreshSessions,
+  onFiltersChange,
+  onSortChange,
+  selectedColumns,
+  sortSetting,
+  transactions,
+  sessionsError,
+  filters,
+}: ActiveTransactionsViewProps) => {
+  const [pagination, setPagination] = useState<ISortedTablePagination>({
+    current: 1,
+    pageSize: 20,
+  });
+  const history = useHistory();
+  const [search, setSearch] = useState<string>(
+    queryByName(history.location, ACTIVE_TXN_SEARCH_PARAM),
+  );
+
+  useEffect(() => {
+    // Refresh every 10 seconds.
+    refreshSessions();
+    const interval = setInterval(refreshSessions, 10 * 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [refreshSessions]);
+
+  useEffect(() => {
+    // We use this effect to sync settings defined on the URL (sort, filters),
+    // with the redux store. The only time we do this is when the user navigates
+    // to the page directly via the URL and specifies settings in the query string.
+    // Note that the desired behaviour is currently that the user is unable to
+    // clear filters via the URL, and must do so with page controls.
+    const sortSettingURL = getTableSortFromURL(history.location);
+    const filtersFromURL = getActiveTransactionFiltersFromURL(history.location);
+
+    if (sortSettingURL) {
+      onSortChange(sortSettingURL);
+    }
+    if (filtersFromURL) {
+      onFiltersChange(filtersFromURL);
+    }
+  }, [history, onSortChange, onFiltersChange]);
+
+  useEffect(() => {
+    // This effect runs when the filters or sort settings received from
+    // redux changes and syncs the URL params with redux.
+    syncHistory(
+      {
+        ascending: sortSetting.ascending.toString(),
+        columnTitle: sortSetting.columnTitle,
+        ...getFullFiltersAsStringRecord(filters),
+        [ACTIVE_TXN_SEARCH_PARAM]: search,
+      },
+      history,
+    );
+  }, [
+    history,
+    filters,
+    sortSetting.ascending,
+    sortSetting.columnTitle,
+    search,
+  ]);
+
+  const resetPagination = () => {
+    setPagination({
+      current: 1,
+      pageSize: 20,
+    });
+  };
+
+  const onChangeSortSetting = (ss: SortSetting): void => {
+    onSortChange(ss);
+    resetPagination();
+  };
+
+  const onSubmitSearch = (newSearch: string) => {
+    if (newSearch === search) return;
+    setSearch(search);
+    resetPagination();
+  };
+
+  const onSubmitFilters = (selectedFilters: ActiveStatementFilters) => {
+    onFiltersChange(selectedFilters);
+    resetPagination();
+  };
+
+  const clearSearch = () => onSubmitSearch("");
+  const clearFilters = () => onSubmitFilters({ app: inactiveFiltersState.app });
+
+  const apps = getAppsFromActiveTransactions(transactions);
+  const countActiveFilters = calculateActiveFilters(filters);
+
+  const filteredTransactions = filterActiveTransactions(
+    transactions,
+    filters,
+    search,
+  );
+  return (
+    <div className={cx("root")}>
+      <PageConfig>
+        <PageConfigItem>
+          <Search
+            placeholder="Search Transactions"
+            onSubmit={onSubmitSearch}
+            onClear={clearSearch}
+            defaultValue={search}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <Filter
+            activeFilters={countActiveFilters}
+            onSubmitFilters={onSubmitFilters}
+            appNames={apps}
+            filters={filters}
+          />
+        </PageConfigItem>
+      </PageConfig>
+      <div className={cx("table-area")}>
+        <Loading
+          loading={transactions == null}
+          page="active transactions"
+          error={sessionsError}
+          renderError={() =>
+            SQLActivityError({
+              statsType: "transactions",
+            })
+          }
+        >
+          <ActiveTransactionsSection
+            filters={filters}
+            pagination={pagination}
+            search={search}
+            transactions={filteredTransactions}
+            selectedColumns={selectedColumns}
+            sortSetting={sortSetting}
+            onClearFilters={clearFilters}
+            onChangeSortSetting={onChangeSortSetting}
+            onColumnsSelect={onColumnsSelect}
+          />
+        </Loading>
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/emptyTransactionsPlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/emptyTransactionsPlaceholder.tsx
@@ -14,29 +14,59 @@ import { Anchor } from "../anchor";
 import { transactionsTable } from "../util";
 import magnifyingGlassImg from "../assets/emptyState/magnifying-glass.svg";
 import emptyTableResultsImg from "../assets/emptyState/empty-table-results.svg";
+import { TransactionViewType } from "./transactionsPageTypes";
+import { tabAttr, viewAttr } from "src/util";
+import { Link } from "react-router-dom";
+import { commonStyles } from "src/common";
 
-export const EmptyTransactionsPlaceholder: React.FC<{
-  isEmptySearchResults: boolean;
-}> = ({ isEmptySearchResults }) => {
-  const footer = (
-    <Anchor href={transactionsTable} target="_blank">
-      Learn more about statements
-    </Anchor>
-  );
+const footer = (
+  <Anchor href={transactionsTable} target="_blank">
+    Learn more about statements
+  </Anchor>
+);
 
-  const emptyPlaceholderProps: EmptyTableProps = isEmptySearchResults
-    ? {
-        title:
-          "No transactions match your search since this page was last cleared",
-        icon: magnifyingGlassImg,
-        footer,
-      }
-    : {
+const emptySearchResults = {
+  title: "No transactions match your search.",
+  icon: magnifyingGlassImg,
+  footer,
+};
+
+function getMessage(type: TransactionViewType): EmptyTableProps {
+  switch (type) {
+    case TransactionViewType.ACTIVE:
+      return {
+        title: "No active SQL transactions",
+        icon: emptyTableResultsImg,
+        message: "There are currently no active transaction executions.",
+        footer: (
+          <Link
+            className={commonStyles("link")}
+            to={`/sql-activity?${tabAttr}=Transactions&${viewAttr}=fingerprints`}
+          >
+            View Transaction Fingerprints to see historical transaction
+            statistics.
+          </Link>
+        ),
+      };
+    case TransactionViewType.FINGERPRINTS:
+    default:
+      return {
         title: "No transactions since this page was last cleared",
         icon: emptyTableResultsImg,
         message:
           "Transactions are cleared every hour by default, or according to your configuration.",
         footer,
       };
+  }
+}
+
+export const EmptyTransactionsPlaceholder: React.FC<{
+  isEmptySearchResults: boolean;
+  transactionView: TransactionViewType;
+}> = ({ isEmptySearchResults, transactionView }) => {
+  const emptyPlaceholderProps: EmptyTableProps = isEmptySearchResults
+    ? emptySearchResults
+    : getMessage(transactionView);
+
   return <EmptyTable {...emptyPlaceholderProps} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/index.ts
@@ -10,3 +10,5 @@
 
 export * from "./transactionsPage";
 export * from "./transactionsPageConnected";
+export * from "./activeTransactionsView";
+export * from "./transactionsPageRoot";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -19,7 +19,6 @@ import {
   TransactionsTable,
 } from "../transactionsTable";
 import {
-  ColumnDescriptor,
   handleSortSettingFromQueryString,
   ISortedTablePagination,
   SortSetting,
@@ -62,11 +61,12 @@ import SQLActivityError from "../sqlActivity/errorComponent";
 import { commonStyles } from "../common";
 import {
   TimeScaleDropdown,
-  defaultTimeScaleSelected,
   TimeScale,
   toDateRange,
 } from "../timeScaleDropdown";
 import { InlineAlert } from "@cockroachlabs/ui-components";
+import { TransactionViewType } from "./transactionsPageTypes";
+import { isSelectedColumn } from "../columnsSelector/utils";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 
@@ -386,7 +386,7 @@ export class TransactionsPage extends React.Component<
         <PageConfig>
           <PageConfigItem>
             <Search
-              onSubmit={this.onSubmitSearchField as any}
+              onSubmit={this.onSubmitSearchField}
               onClear={this.onClearSearchField}
               defaultValue={search}
               placeholder={"Search Transactions"}
@@ -449,17 +449,6 @@ export class TransactionsPage extends React.Component<
               .filter(c => !(c.name === "regionNodes" && regions.length < 2))
               .filter(c => !(isTenant && c.hideIfTenant));
 
-            const isColumnSelected = (c: ColumnDescriptor<TransactionInfo>) => {
-              return (
-                ((userSelectedColumnsToShow === null ||
-                  userSelectedColumnsToShow === undefined) &&
-                  c.showByDefault !== false) || // show column if list of visible was never defined and can be show by default.
-                (userSelectedColumnsToShow !== null &&
-                  userSelectedColumnsToShow.includes(c.name)) || // show column if user changed its visibility.
-                c.alwaysShow === true // show column if alwaysShow option is set explicitly.
-              );
-            };
-
             // Iterate over all available columns and create list of SelectOptions with initial selection
             // values based on stored user selections in local storage and default column configs.
             // Columns that are set to alwaysShow are filtered from the list.
@@ -472,12 +461,14 @@ export class TransactionsPage extends React.Component<
                     "transaction",
                   ),
                   value: c.name,
-                  isSelected: isColumnSelected(c),
+                  isSelected: isSelectedColumn(userSelectedColumnsToShow, c),
                 }),
               );
 
             // List of all columns that will be displayed based on the column selection.
-            const displayColumns = columns.filter(c => isColumnSelected(c));
+            const displayColumns = columns.filter(c =>
+              isSelectedColumn(userSelectedColumnsToShow, c),
+            );
 
             return (
               <>
@@ -502,6 +493,7 @@ export class TransactionsPage extends React.Component<
                     pagination={pagination}
                     renderNoResult={
                       <EmptyTransactionsPlaceholder
+                        transactionView={TransactionViewType.FINGERPRINTS}
                         isEmptySearchResults={hasData && isUsedFilter}
                       />
                     }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageRoot.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageRoot.tsx
@@ -1,0 +1,66 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { TransactionViewType } from "./transactionsPageTypes";
+import { Option } from "src/selectWithDescription/selectWithDescription";
+import { SQLActivityRootControls } from "src/sqlActivityRootControls/sqlActivityRootControls";
+import { TransactionsPageProps } from "./transactionsPage";
+import { TransactionsPage } from ".";
+import { statementsSql } from "../util/docs";
+import {
+  ActiveTransactionsView,
+  ActiveTransactionsViewProps,
+} from "./activeTransactionsView";
+import { Anchor } from "src/anchor";
+
+export type TransactionsPageRootProps = {
+  fingerprintsPageProps: TransactionsPageProps;
+  activePageProps: ActiveTransactionsViewProps;
+};
+
+export const TransactionsPageRoot = ({
+  fingerprintsPageProps,
+  activePageProps,
+}: TransactionsPageRootProps): React.ReactElement => {
+  const transactionOptions: Option[] = [
+    {
+      value: TransactionViewType.FINGERPRINTS,
+      label: "Transaction Fingerprints",
+      description: (
+        <span>
+          A transaction fingerprint represents statement fingerprints grouped by
+          transaction. Statement fingerprints represent one or more SQL
+          statements by replacing literal values (e.g., numbers and strings)
+          with underscores (_). This can help you quickly identify frequently
+          executed SQL transactions and their latencies.{" "}
+          <Anchor href={statementsSql}>Learn more</Anchor>
+        </span>
+      ),
+      component: <TransactionsPage {...fingerprintsPageProps} />,
+    },
+    {
+      value: TransactionViewType.ACTIVE,
+      label: "Active Executions",
+      description: (
+        <span>
+          Active executions represent individual statement executions in
+          progress. Use active statement execution details, such as the
+          application or elapsed time, to understand and tune workload
+          performance.
+          {/* TODO (xinhaoz) #78379 add 'Learn More' link to documentation page*/}
+        </span>
+      ),
+      component: <ActiveTransactionsView {...activePageProps} />,
+    },
+  ];
+
+  return <SQLActivityRootControls options={transactionOptions} />;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageTypes.ts
@@ -1,0 +1,14 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export enum TransactionViewType {
+  ACTIVE = "active",
+  FINGERPRINTS = "fingerprints",
+}

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -18,6 +18,7 @@ export const databaseAttr = "database";
 export const databaseNameAttr = "database_name";
 export const fingerprintIDAttr = "fingerprint_id";
 export const implicitTxnAttr = "implicitTxn";
+export const executionIdAttr = "execution_id";
 export const nodeIDAttr = "node_id";
 export const nodeQueryString = "node";
 export const rangeIDAttr = "range_id";
@@ -26,6 +27,7 @@ export const sessionAttr = "session";
 export const tabAttr = "tab";
 export const tableNameAttr = "table_name";
 export const txnFingerprintIdAttr = "txn_fingerprint_id";
+export const viewAttr = "view";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -35,6 +35,12 @@ import {
   StatementDetails,
   TransactionsPage,
   TransactionDetails,
+  TransactionsPageRoot,
+  ActiveTransactionsView,
+  ActiveStatementDetails,
+  ActiveTransactionDetails,
+  StatementsPageRoot,
+  ActiveStatementsView,
 } from "@cockroachlabs/cluster-ui";
 import Debug from "src/views/reports/containers/debug";
 import { ReduxDebug } from "src/views/reports/containers/redux";
@@ -344,12 +350,12 @@ describe("Routing to", () => {
   });
 
   describe("'/statement' path", () => {
-    it("redirected to '/sql-activity?tab=Statements'", () => {
+    it("redirected to '/sql-activity?tab=Statements&view=fingerprints'", () => {
       navigateToPath("/statement");
       const location = history.location;
       assert.equal(
         location.pathname + location.search,
-        "/sql-activity?tab=Statements",
+        "/sql-activity?tab=Statements&view=fingerprints",
       );
     });
   });
@@ -361,13 +367,40 @@ describe("Routing to", () => {
     });
   });
 
+  describe("'/sql-activity?tab=Statements' path", () => {
+    it("routes to <StatementsPageRoot> component", () => {
+      navigateToPath("/sql-activity?tab=Statements");
+      assert.lengthOf(appWrapper.find(StatementsPageRoot), 1);
+    });
+
+    it("routes to <TransactionsPage> component with view=fingerprints", () => {
+      navigateToPath("/sql-activity?tab=Statements&view=fingerprints");
+      assert.lengthOf(appWrapper.find(StatementsPage), 1);
+    });
+
+    it("routes to <ActiveTransactionsView> component with view=active", () => {
+      navigateToPath("/sql-activity?tab=Statements&view=active");
+      assert.lengthOf(appWrapper.find(ActiveStatementsView), 1);
+    });
+  });
+
   {
     /* transactions statistics */
   }
   describe("'/sql-activity?tab=Transactions' path", () => {
-    it("routes to <TransactionsPage> component", () => {
+    it("routes to <TransactionsPageRoot> component", () => {
       navigateToPath("/sql-activity?tab=Transactions");
+      assert.lengthOf(appWrapper.find(TransactionsPageRoot), 1);
+    });
+
+    it("routes to <TransactionsPage> component with view=fingerprints", () => {
+      navigateToPath("/sql-activity?tab=Transactions&view=fingerprints");
       assert.lengthOf(appWrapper.find(TransactionsPage), 1);
+    });
+
+    it("routes to <ActiveTransactionsView> component with view=active", () => {
+      navigateToPath("/sql-activity?tab=Transactions&view=active");
+      assert.lengthOf(appWrapper.find(ActiveTransactionsView), 1);
     });
   });
 
@@ -378,6 +411,19 @@ describe("Routing to", () => {
     });
   });
 
+  // Active execution details.
+
+  describe("'/execution' path", () => {
+    it("'/execution/statement/statementID' routes to <ActiveStatementDetails>", () => {
+      navigateToPath("/execution/statement/stmtID");
+      assert.lengthOf(appWrapper.find(ActiveStatementDetails), 1);
+    });
+
+    it("'/execution/transaction/transactionID' routes to <ActiveTransactionDetails>", () => {
+      navigateToPath("/execution/transaction/transactionID");
+      assert.lengthOf(appWrapper.find(ActiveTransactionDetails), 1);
+    });
+  });
   {
     /* debug pages */
   }
@@ -609,12 +655,12 @@ describe("Routing to", () => {
   });
 
   describe("'/statements' path", () => {
-    it("redirected to '/sql-activity?tab=Statements'", () => {
+    it("redirected to '/sql-activity?tab=Statements&view=fingerprints'", () => {
       navigateToPath("/statements");
       const location = history.location;
       assert.equal(
         location.pathname + location.search,
-        "/sql-activity?tab=Statements",
+        "/sql-activity?tab=Statements&view=fingerprints",
       );
     });
   });

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -25,6 +25,7 @@ import {
   dashboardNameAttr,
   databaseAttr,
   databaseNameAttr,
+  executionIdAttr,
   implicitTxnAttr,
   indexNameAttr,
   nodeIDAttr,
@@ -34,6 +35,7 @@ import {
   tabAttr,
   tableNameAttr,
   txnFingerprintIdAttr,
+  viewAttr,
 } from "src/util/constants";
 import NotFound from "src/views/app/components/errorMessage/notFound";
 import Layout from "src/views/app/containers/layout";
@@ -72,6 +74,8 @@ import TransactionDetails from "src/views/transactions/transactionDetails";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import { RedirectToStatementDetails } from "src/routes/RedirectToStatementDetails";
 import HotRangesPage from "src/views/hotRanges/index";
+import ActiveStatementDetails from "./views/statements/activeStatementDetailsConnected";
+import ActiveTransactionDetails from "./views/transactions/activeTransactionDetailsConnected";
 import "styl/app.styl";
 import { Tracez } from "src/views/tracez/tracez";
 
@@ -197,11 +201,24 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 {/* SQL activity */}
                 <Route exact path="/sql-activity" component={SQLActivityPage} />
 
+                {/* Active executions */}
+                <Route
+                  exact
+                  path={`/execution/statement/:${executionIdAttr}`}
+                  component={ActiveStatementDetails}
+                />
+
+                <Route
+                  exact
+                  path={`/execution/transaction/:${executionIdAttr}`}
+                  component={ActiveTransactionDetails}
+                />
+
                 {/* statement statistics */}
                 <Redirect
                   exact
                   from={`/statements`}
-                  to={`/sql-activity?${tabAttr}=Statements`}
+                  to={`/sql-activity?${tabAttr}=Statements&${viewAttr}=fingerprints`}
                 />
                 <Redirect
                   exact
@@ -241,7 +258,7 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                 <Redirect
                   exact
                   from={`/statement`}
-                  to={`/sql-activity?${tabAttr}=Statements`}
+                  to={`/sql-activity?${tabAttr}=Statements&view=fingerprints`}
                 />
 
                 {/* sessions */}

--- a/pkg/ui/workspaces/db-console/src/redux/localsettings.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/localsettings.ts
@@ -131,15 +131,15 @@ export class LocalSetting<S, T> {
 
   /**
    * Selector which retrieves this setting from the LocalSettingsState
-   * and return as an array.
+   * and return as an array. Returns null if the setting was undefined or null.
    * @param state The current top-level redux state of the application.
    */
-  selectorToArray = (state: S): string[] => {
-    return this._value(state)
-      ? this._value(state)
-          .toString()
-          .split(",")
-      : null;
+  selectorToArray = (state: S): string[] | null => {
+    const value = this._value(state)
+      ?.toString()
+      .split(",");
+
+    return value ?? null;
   };
 
   /**
@@ -159,7 +159,7 @@ export class LocalSetting<S, T> {
       innerSelector,
       () => getValueFromSessionStorage(this.key),
       (uiSettings, cachedValue) => {
-        return uiSettings[this.key] || cachedValue || defaultValue;
+        return uiSettings[this.key] ?? cachedValue ?? defaultValue;
       },
     );
   }

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -22,6 +22,7 @@ export const {
   databaseAttr,
   databaseNameAttr,
   fingerprintIDAttr,
+  executionIdAttr,
   implicitTxnAttr,
   nodeIDAttr,
   nodeQueryString,
@@ -31,5 +32,6 @@ export const {
   tabAttr,
   tableNameAttr,
   txnFingerprintIdAttr,
+  viewAttr,
   REMOTE_DEBUGGING_ERROR_TEXT,
 } = util;

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionsPage.tsx
@@ -83,7 +83,7 @@ export const sessionColumnsLocalSetting = new LocalSetting(
   null,
 );
 
-export const filtersLocalSetting = new LocalSetting(
+export const filtersLocalSetting = new LocalSetting<AdminUIState, Filters>(
   "filters/SessionsPage",
   (state: AdminUIState) => state.localSettings,
   defaultFilters,

--- a/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
@@ -11,43 +11,47 @@
 // All changes made on this file, should also be done on the equivalent
 // file on managed-service repo.
 
-import React, { useState, useEffect } from "react";
+import React from "react";
 import Helmet from "react-helmet";
 import { Tabs } from "antd";
-import { commonStyles, util } from "@cockroachlabs/cluster-ui";
 import SessionsPageConnected from "src/views/sessions/sessionsPage";
 import TransactionsPageConnected from "src/views/transactions/transactionsPage";
 import StatementsPageConnected from "src/views/statements/statementsPage";
+import { commonStyles, util } from "@cockroachlabs/cluster-ui";
 import { RouteComponentProps } from "react-router-dom";
+import { tabAttr } from "src/util/constants";
 
 const { TabPane } = Tabs;
 
+export enum SQLActivityTabType {
+  Statements = "Statements",
+  Sessions = "Sessions",
+  Transactions = "Transactions",
+}
+
+export const SQL_ACTIVITY_DEFAULT_TAB: SQLActivityTabType =
+  SQLActivityTabType.Statements;
+
 const SQLActivityPage = (props: RouteComponentProps) => {
-  const defaultTab = util.queryByName(props.location, "tab") || "Statements";
-  const [currentTab, setCurrentTab] = useState(defaultTab);
+  const currentTab =
+    util.queryByName(props.location, tabAttr) || SQLActivityTabType.Statements;
 
   const onTabChange = (tabId: string): void => {
-    setCurrentTab(tabId);
-    props.history.location.search = "";
-    util.syncHistory({ tab: tabId }, props.history, true);
+    props.history.push({
+      search: new URLSearchParams({ tab: tabId }).toString(),
+    });
   };
-
-  useEffect(() => {
-    const queryTab = util.queryByName(props.location, "tab") || "Statements";
-    if (queryTab !== currentTab) {
-      setCurrentTab(queryTab);
-    }
-  }, [props.location, currentTab]);
 
   return (
     <div>
-      <Helmet title={defaultTab} />
+      <Helmet title={currentTab} />
       <h3 className={commonStyles("base-heading")}>SQL Activity</h3>
       <Tabs
-        defaultActiveKey={defaultTab}
+        defaultActiveKey={SQL_ACTIVITY_DEFAULT_TAB}
         className={commonStyles("cockroach--tabs")}
         onChange={onTabChange}
         activeKey={currentTab}
+        destroyInactiveTabPane
       >
         <TabPane tab="Statements" key="Statements">
           <StatementsPageConnected />

--- a/pkg/ui/workspaces/db-console/src/views/statements/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/activeStatementDetailsConnected.tsx
@@ -1,0 +1,55 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  ActiveStatement,
+  getActiveStatementsFromSessions,
+  ActiveStatementDetails,
+  ActiveStatementDetailsStateProps,
+  ActiveStatementDetailsDispatchProps,
+} from "@cockroachlabs/cluster-ui";
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { createSelector } from "reselect";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { AdminUIState } from "src/redux/state";
+import { SessionsResponseMessage } from "src/util/api";
+import { executionIdAttr } from "src/util/constants";
+import { getMatchParamByName } from "src/util/query";
+import { refreshSessions } from "src/redux/apiReducers";
+
+export const selectActiveStatement = createSelector(
+  (state: AdminUIState) => state.cachedData.sessions,
+  (_state: AdminUIState, props: RouteComponentProps) => props,
+  (
+    state: CachedDataReducerState<SessionsResponseMessage>,
+    props: RouteComponentProps,
+  ): ActiveStatement | null => {
+    const id = getMatchParamByName(props.match, executionIdAttr);
+    if (state?.data?.sessions == null) return null;
+    return getActiveStatementsFromSessions(state.data, state.setAt).find(
+      query => query.executionID === id,
+    );
+  },
+);
+
+export default withRouter(
+  connect<
+    ActiveStatementDetailsStateProps,
+    ActiveStatementDetailsDispatchProps,
+    RouteComponentProps
+  >(
+    (state: AdminUIState, props: RouteComponentProps) => ({
+      statement: selectActiveStatement(state, props),
+      match: props.match,
+    }),
+    { refreshSessions },
+  )(ActiveStatementDetails),
+);

--- a/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  ActiveStatementFilters,
+  ActiveStatement,
+  getActiveStatementsFromSessions,
+  defaultFilters,
+  SortSetting,
+} from "@cockroachlabs/cluster-ui";
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { CachedDataReducerState, refreshSessions } from "src/redux/apiReducers";
+import { createSelector } from "reselect";
+import { SessionsResponseMessage } from "src/util/api";
+
+const selectActiveStatements = createSelector(
+  (state: AdminUIState) => state.cachedData.sessions,
+  (
+    sessions?: CachedDataReducerState<SessionsResponseMessage>,
+  ): ActiveStatement[] => {
+    if (sessions?.data == null) return [];
+
+    return getActiveStatementsFromSessions(sessions.data, sessions.setAt);
+  },
+);
+
+const selectedColumnsLocalSetting = new LocalSetting<
+  AdminUIState,
+  string | null
+>(
+  "columns/ActiveStatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
+const filtersLocalSetting = new LocalSetting<
+  AdminUIState,
+  ActiveStatementFilters
+>(
+  "filters/ActiveStatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  { app: defaultFilters.app },
+);
+
+const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "sortSetting/ActiveStatementsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "startTime" },
+);
+
+export const mapStateToActiveStatementViewProps = (state: AdminUIState) => ({
+  filters: filtersLocalSetting.selector(state),
+  selectedColumns: selectedColumnsLocalSetting.selectorToArray(state),
+  sortSetting: sortSettingLocalSetting.selector(state),
+  statements: selectActiveStatements(state),
+  sessionsError: state.cachedData?.sessions.lastError,
+});
+
+export const activeStatementsViewActions = {
+  onColumnsSelect: (columns: string[]) =>
+    selectedColumnsLocalSetting.set(columns.join(",")),
+  refreshSessions,
+  onFiltersChange: (filters: ActiveStatementFilters) =>
+    filtersLocalSetting.set(filters),
+  onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
+};

--- a/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionDetailsConnected.tsx
@@ -1,0 +1,55 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  ActiveTransaction,
+  getActiveTransactionsFromSessions,
+  ActiveTransactionDetails,
+  ActiveTransactionDetailsStateProps,
+  ActiveTransactionDetailsDispatchProps,
+} from "@cockroachlabs/cluster-ui";
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { createSelector } from "reselect";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { AdminUIState } from "src/redux/state";
+import { SessionsResponseMessage } from "src/util/api";
+import { executionIdAttr } from "src/util/constants";
+import { getMatchParamByName } from "src/util/query";
+import { refreshSessions } from "src/redux/apiReducers";
+
+const selectActiveTransaction = createSelector(
+  (state: AdminUIState) => state.cachedData.sessions,
+  (_state: AdminUIState, props: RouteComponentProps) => props,
+  (
+    state: CachedDataReducerState<SessionsResponseMessage>,
+    props: RouteComponentProps,
+  ): ActiveTransaction | null => {
+    const id = getMatchParamByName(props.match, executionIdAttr);
+    if (state?.data?.sessions == null) return null;
+    return getActiveTransactionsFromSessions(state.data, state.setAt).find(
+      txn => txn.executionID === id,
+    );
+  },
+);
+
+export default withRouter(
+  connect<
+    ActiveTransactionDetailsStateProps,
+    ActiveTransactionDetailsDispatchProps,
+    RouteComponentProps
+  >(
+    (state: AdminUIState, props: RouteComponentProps) => ({
+      transaction: selectActiveTransaction(state, props),
+      match: props.match,
+    }),
+    { refreshSessions },
+  )(ActiveTransactionDetails),
+);

--- a/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
@@ -1,0 +1,74 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  ActiveTransactionFilters,
+  ActiveTransaction,
+  getActiveTransactionsFromSessions,
+  SortSetting,
+  defaultFilters,
+} from "@cockroachlabs/cluster-ui";
+import { createSelector } from "reselect";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { SessionsResponseMessage } from "src/util/api";
+import { refreshSessions } from "src/redux/apiReducers";
+
+const selectActiveTransactions = createSelector(
+  (state: AdminUIState) => state.cachedData.sessions,
+  (
+    state?: CachedDataReducerState<SessionsResponseMessage>,
+  ): ActiveTransaction[] => {
+    if (state?.data == null) return [];
+    return getActiveTransactionsFromSessions(state.data, state.setAt);
+  },
+);
+
+const transactionsColumnsLocalSetting = new LocalSetting<
+  AdminUIState,
+  string | null
+>(
+  "columns/ActiveTransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  null,
+);
+
+const filtersLocalSetting = new LocalSetting<
+  AdminUIState,
+  ActiveTransactionFilters
+>(
+  "filters/ActiveTransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  { app: defaultFilters.app },
+);
+
+const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "sortSetting/ActiveTransactionsPage",
+  (state: AdminUIState) => state.localSettings,
+  { ascending: false, columnTitle: "startTime" },
+);
+
+export const mapStateToActiveTransactionsPageProps = (state: AdminUIState) => ({
+  selectedColumns: transactionsColumnsLocalSetting.selectorToArray(state),
+  transactions: selectActiveTransactions(state),
+  sessionsError: state.cachedData?.sessions.lastError,
+  filters: filtersLocalSetting.selector(state),
+  sortSetting: sortSettingLocalSetting.selector(state),
+});
+
+export const activeTransactionsPageActions = {
+  onColumnsSelect: (columns: string[]) =>
+    transactionsColumnsLocalSetting.set(columns.join(",")),
+  refreshSessions,
+  onFiltersChange: (filters: ActiveTransactionFilters) =>
+    filtersLocalSetting.set(filters),
+  onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
+};

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -10,7 +10,7 @@
 
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
-import { withRouter } from "react-router-dom";
+import { RouteComponentProps, withRouter } from "react-router-dom";
 import { refreshStatements } from "src/redux/apiReducers";
 import { resetSQLStatsAction } from "src/redux/sqlStats";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
@@ -20,15 +20,25 @@ import { StatementsResponseMessage } from "src/util/api";
 import { PrintTime } from "src/views/reports/containers/range/print";
 
 import {
-  TransactionsPage,
   Filters,
   defaultFilters,
   util,
+  TransactionsPageStateProps,
+  ActiveTransactionsViewDispatchProps,
+  ActiveTransactionsViewStateProps,
+  TransactionsPageDispatchProps,
+  TransactionsPageRoot,
+  TransactionsPageRootProps,
 } from "@cockroachlabs/cluster-ui";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
 import { statementsTimeScaleLocalSetting } from "src/redux/statementsTimeScale";
 import { setCombinedStatementsTimeScaleAction } from "src/redux/statements";
 import { LocalSetting } from "src/redux/localsettings";
+import { bindActionCreators } from "redux";
+import {
+  activeTransactionsPageActions,
+  mapStateToActiveTransactionsPageProps,
+} from "./activeTransactionsSelectors";
 
 // selectStatements returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.
@@ -64,7 +74,7 @@ export const sortSettingLocalSetting = new LocalSetting(
   { ascending: false, columnTitle: "executionCount" },
 );
 
-export const filtersLocalSetting = new LocalSetting(
+export const filtersLocalSetting = new LocalSetting<AdminUIState, Filters>(
   "filters/TransactionsPage",
   (state: AdminUIState) => state.localSettings,
   defaultFilters,
@@ -82,45 +92,85 @@ export const transactionColumnsLocalSetting = new LocalSetting(
   null,
 );
 
-const TransactionsPageConnected = withRouter(
-  connect(
-    (state: AdminUIState) => ({
-      columns: transactionColumnsLocalSetting.selectorToArray(state),
-      data: selectData(state),
-      timeScale: statementsTimeScaleLocalSetting.selector(state),
-      error: selectLastError(state),
-      filters: filtersLocalSetting.selector(state),
-      lastReset: selectLastReset(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
-      search: searchLocalSetting.selector(state),
-      sortSetting: sortSettingLocalSetting.selector(state),
-      statementsError: state.cachedData.statements.lastError,
+const fingerprintsPageActions = {
+  refreshData: refreshStatements,
+  resetSQLStats: resetSQLStatsAction,
+  onTimeScaleChange: setCombinedStatementsTimeScaleAction,
+  // We use `null` when the value was never set and it will show all columns.
+  // If the user modifies the selection and no columns are selected,
+  // the function will save the value as a blank space, otherwise
+  // it gets saved as `null`.
+  onColumnsChange: (value: string[]) =>
+    transactionColumnsLocalSetting.set(
+      value.length === 0 ? " " : value.join(","),
+    ),
+  onSortingChange: (
+    _tableName: string,
+    columnName: string,
+    ascending: boolean,
+  ) =>
+    sortSettingLocalSetting.set({
+      ascending: ascending,
+      columnTitle: columnName,
     }),
-    {
-      refreshData: refreshStatements,
-      resetSQLStats: resetSQLStatsAction,
-      onTimeScaleChange: setCombinedStatementsTimeScaleAction,
-      // We use `null` when the value was never set and it will show all columns.
-      // If the user modifies the selection and no columns are selected,
-      // the function will save the value as a blank space, otherwise
-      // it gets saved as `null`.
-      onColumnsChange: (value: string[]) =>
-        transactionColumnsLocalSetting.set(
-          value.length === 0 ? " " : value.join(","),
-        ),
-      onSortingChange: (
-        _tableName: string,
-        columnName: string,
-        ascending: boolean,
-      ) =>
-        sortSettingLocalSetting.set({
-          ascending: ascending,
-          columnTitle: columnName,
-        }),
-      onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
-      onSearchComplete: (query: string) => searchLocalSetting.set(query),
-    },
-  )(TransactionsPage),
+  onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
+  onSearchComplete: (query: string) => searchLocalSetting.set(query),
+};
+
+type StateProps = {
+  fingerprintsPageProps: TransactionsPageStateProps & RouteComponentProps;
+  activePageProps: ActiveTransactionsViewStateProps;
+};
+
+type DispatchProps = {
+  fingerprintsPageProps: TransactionsPageDispatchProps;
+  activePageProps: ActiveTransactionsViewDispatchProps;
+};
+
+const TransactionsPageConnected = withRouter(
+  connect<
+    StateProps,
+    DispatchProps,
+    RouteComponentProps,
+    TransactionsPageRootProps
+  >(
+    (state: AdminUIState, props: RouteComponentProps) => ({
+      fingerprintsPageProps: {
+        ...props,
+        columns: transactionColumnsLocalSetting.selectorToArray(state),
+        data: selectData(state),
+        timeScale: statementsTimeScaleLocalSetting.selector(state),
+        error: selectLastError(state),
+        filters: filtersLocalSetting.selector(state),
+        lastReset: selectLastReset(state),
+        nodeRegions: nodeRegionsByIDSelector(state),
+        search: searchLocalSetting.selector(state),
+        sortSetting: sortSettingLocalSetting.selector(state),
+        statementsError: state.cachedData.statements.lastError,
+      },
+      activePageProps: mapStateToActiveTransactionsPageProps(state),
+    }),
+    dispatch => ({
+      fingerprintsPageProps: bindActionCreators(
+        fingerprintsPageActions,
+        dispatch,
+      ),
+      activePageProps: bindActionCreators(
+        activeTransactionsPageActions,
+        dispatch,
+      ),
+    }),
+    (stateProps, dispatchProps) => ({
+      fingerprintsPageProps: {
+        ...stateProps.fingerprintsPageProps,
+        ...dispatchProps.fingerprintsPageProps,
+      },
+      activePageProps: {
+        ...stateProps.activePageProps,
+        ...dispatchProps.activePageProps,
+      },
+    }),
+  )(TransactionsPageRoot),
 );
 
 export default TransactionsPageConnected;


### PR DESCRIPTION
This commit creates the pages for active transactins and
queries in db-console. Each page calls the /sessions API
at an interval of 10 seconds to refresh the data.

Release note (ui change): Users can now see actively running
queries and transactions in the SQL Activity tab. The transactions
and statements tabs in SQL activity now have a menu to show either
active or historial transactions and statements data.

-------------------------
https://www.loom.com/share/964ee2624f4e41d0b6a88d5a280ce6a3