### PR TITLE
workflow: exempt some stale issues from being closed

### DIFF
--- a/.github/workflows/kv-test-failure-stale.yml
+++ b/.github/workflows/kv-test-failure-stale.yml
@@ -31,4 +31,4 @@ jobs:
         days-before-issue-stale: 30
         days-before-close: 5
         only-labels: 'T-kv,C-test-failure'
-        exempt-issue-labels: 'skipped-test'
+        exempt-issue-labels: 'skipped-test,X-no-stale'


### PR DESCRIPTION
Added `X-no-stale` GitHub label to exempt issues tagged with this label from being closed when stale (>30 days without activity).

Release Note: None