### PR TITLE
workflow: exempt some KV issues from being marked as stale

### DIFF
--- a/.github/workflows/kv-test-failure-stale.yml
+++ b/.github/workflows/kv-test-failure-stale.yml
@@ -31,4 +31,4 @@ jobs:
         days-before-issue-stale: 30
         days-before-close: 5
         only-labels: 'T-kv,C-test-failure'
-        exempt-issue-labels: 'skipped-test'
+        exempt-issue-labels: 'skipped-test,X-nostale'


### PR DESCRIPTION
The KV workflow introduced in #75614 will mark KV test failure issues
with label `X-stale`, to be closed after 5 days unless they also have
the `X-nostale` label.  This change updates the KV workflow to not mark
KV issues with `X-nostale` as stale in the first place, to enable the
use case where there is active work going on.

Release note: None