### PR TITLE
sql: remove public key column check when fetching

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -326,7 +326,7 @@ DROP INDEX t_secondary CASCADE;
 ALTER TABLE t DROP COLUMN b;
 INSERT INTO t SELECT a + 1 FROM t;
 
-statement error pgcode 23505 duplicate key value got decoding error: column \"b\" \(2\) is not public
+statement error pgcode 23505 duplicate key value violates unique constraint "t_secondary"\nDETAIL: Key \(b\)=\(0\.0\) already exists
 UPSERT INTO t SELECT a + 1 FROM t;
 
 statement ok

--- a/pkg/sql/rowenc/index_fetch.go
+++ b/pkg/sql/rowenc/index_fetch.go
@@ -11,8 +11,6 @@
 package rowenc
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -103,10 +101,6 @@ func InitIndexFetchSpec(
 	}
 	for i := range s.KeyAndSuffixColumns {
 		col := indexCols[i]
-		if !col.Public() {
-			// Key columns must be public.
-			return fmt.Errorf("column %q (%d) is not public", col.GetName(), col.GetID())
-		}
 		colID := col.GetID()
 		dir := descpb.IndexDescriptor_ASC
 		// If this is a unique index, the suffix columns are not part of the full


### PR DESCRIPTION
This commit removes a check that fails creation of an IndexFetchSpec
if a key column is not public.

The only case where this comes up AFAICT is when we hit a duplicate
key error and try to fetch the row to get the values for the error
message. In this case, even though the column is not public, we know
that the row we care about exists in the index, or we wouldn't have
hit the error.

Release note: None