### PR TITLE
backupccl: Moved checkpoint and latest files into new directories.

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -181,4 +181,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-82	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-84	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -194,6 +194,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-82</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-84</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -12,11 +12,14 @@ import (
 	"context"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -315,7 +318,9 @@ func readLatestFile(
 		return "", err
 	}
 	defer collection.Close()
-	latestFile, err := collection.ReadFile(ctx, latestFileName)
+
+	latestFile, err := findLatestFile(ctx, collection)
+
 	if err != nil {
 		if errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
@@ -330,4 +335,40 @@ func readLatestFile(
 		return "", errors.Errorf("malformed LATEST file")
 	}
 	return string(latest), nil
+}
+
+// findLatestFile returns a ioctx.ReaderCloserCtx of the most recent LATEST
+// file. First it tries reading from the latest-history directory. If
+// the backup is from an older version, it may not exist there yet so
+// it tries reading in the base directory if the first attempt fails.
+func findLatestFile(
+	ctx context.Context, exportStore cloud.ExternalStorage,
+) (ioctx.ReadCloserCtx, error) {
+	latestFile, err := exportStore.ReadFile(ctx, latestHistoryDirectory+"/"+latestFileName)
+	if err != nil {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return nil, err
+		}
+
+		latestFile, err = exportStore.ReadFile(ctx, latestFileName)
+	}
+	return latestFile, err
+}
+
+// writeNewLatestFile writes a new LATEST file to both the base directory
+// and latest-history directory, depending on cluster version.
+func writeNewLatestFile(
+	ctx context.Context, settings *cluster.Settings, exportStore cloud.ExternalStorage, suffix string,
+) error {
+	// If the cluster is still running on a mixed version, we want to write
+	// to the base directory as well the progress directory. That way if
+	// an old node resumes a backup, it doesn't have to start over.
+	if !settings.Version.IsActive(ctx, clusterversion.BackupDoesNotOverwriteLatestAndCheckpoint) {
+		err := cloud.WriteFile(ctx, exportStore, latestFileName, strings.NewReader(suffix))
+		if err != nil {
+			return err
+		}
+	}
+
+	return cloud.WriteFile(ctx, exportStore, latestHistoryDirectory+"/"+latestFileName, strings.NewReader(suffix))
 }

--- a/pkg/ccl/backupccl/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backup_destination_test.go
@@ -73,7 +73,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 		storage, err := externalStorageFromURI(ctx, collectionURI, security.RootUserName())
 		defer storage.Close()
 		require.NoError(t, err)
-		require.NoError(t, cloud.WriteFile(ctx, storage, latestFileName, bytes.NewReader([]byte(latestBackupSuffix))))
+		require.NoError(t, writeNewLatestFile(ctx, storage.Settings(), storage, latestBackupSuffix))
 	}
 
 	// localizeURI returns a slice of just the base URI if localities is nil.

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1716,7 +1716,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 	var checkpointPath string
 
 	checkBackup := func(ctx context.Context, ip inProgressState) error {
-		checkpointPath = filepath.Join(ip.dir, ip.name, backupManifestCheckpointName)
+		checkpointPath = filepath.Join(ip.dir, ip.name, backupProgressDirectory+"/"+backupManifestCheckpointName)
 		checkpointDescBytes, err := ioutil.ReadFile(checkpointPath)
 		if err != nil {
 			return errors.Wrap(err, "error while reading checkpoint")
@@ -1834,10 +1834,10 @@ func TestBackupRestoreResume(t *testing.T) {
 			t.Fatal(err)
 		}
 		backupDir := dir + "/backup"
-		if err := os.MkdirAll(backupDir, 0755); err != nil {
+		if err := os.MkdirAll(backupDir+"/"+backupProgressDirectory, 0755); err != nil {
 			t.Fatal(err)
 		}
-		checkpointFile := backupDir + "/" + backupManifestCheckpointName
+		checkpointFile := backupDir + "/" + backupProgressDirectory + "/" + backupManifestCheckpointName
 		if err := ioutil.WriteFile(checkpointFile, mockManifest, 0644); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -555,16 +555,10 @@ func checkForExistingBackupsInCollection(
 	if err != nil {
 		return err
 	}
-	defaultStore, err := makeCloudFactory(ctx, collectionURI, p.User())
-	if err != nil {
-		return err
-	}
-	defer defaultStore.Close()
 
-	r, err := defaultStore.ReadFile(ctx, latestFileName)
+	_, err = readLatestFile(ctx, collectionURI, makeCloudFactory, p.User())
 	if err == nil {
 		// A full backup has already been taken to this location.
-		r.Close(ctx)
 		return errors.Newf("backups already created in %s; to ignore existing backups, "+
 			"the schedule can be created with the 'ignore_existing_backups' option",
 			collectionURI)

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -801,7 +801,7 @@ INSERT INTO t1 values (-1), (10), (-100);
 				}
 
 				// Verify backup.
-				latest, err := ioutil.ReadFile(path.Join(th.iodir, "backup", testName, latestFileName))
+				latest, err := ioutil.ReadFile(path.Join(th.iodir, "backup", testName, latestHistoryDirectory+"/"+latestFileName))
 				require.NoError(t, err)
 				backedUp := th.sqlDB.QueryStr(t,
 					`SELECT database_name, object_name FROM [SHOW BACKUP $1] WHERE object_type='table' ORDER BY database_name, object_name`,

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
@@ -73,6 +74,11 @@ const (
 	// BackupFormatDescriptorTrackingVersion added tracking of complete DBs.
 	BackupFormatDescriptorTrackingVersion uint32 = 1
 
+	// backupProgressDirectory is the directory where all 22.1 and beyond
+	// CHECKPOINT files will be stored as we no longer want to overwrite
+	// them.
+	backupProgressDirectory = "progress"
+
 	// DateBasedIncFolderName is the date format used when creating sub-directories
 	// storing incremental backups for auto-appendable backups.
 	// It is exported for testing backup inspection tooling.
@@ -86,6 +92,10 @@ const (
 	// latestFileName is the name of a file in the collection which contains the
 	// path of the most recently taken full backup in the backup collection.
 	latestFileName = "LATEST"
+
+	// latestHistoryDirectory is the directory where all 22.1 and beyond
+	// LATEST files will be stored as we no longer want to overwrite it.
+	latestHistoryDirectory = "latest"
 )
 
 // isGZipped detects whether the given bytes represent GZipped data. This check
@@ -213,9 +223,19 @@ func readBackupManifest(
 	filename string,
 	encryption *jobspb.BackupEncryptionOptions,
 ) (BackupManifest, int64, error) {
-	r, err := exportStore.ReadFile(ctx, filename)
-	if err != nil {
-		return BackupManifest{}, 0, err
+	// The backup manifest should only be found in the base directory,
+	// unlike the checkpoints which can be found in both the base and
+	// progress directory depending on the version.
+	var r ioctx.ReadCloserCtx
+	var err error
+	if filename != backupManifestName {
+		if r, err = readLatestCheckpointFile(ctx, exportStore, filename); err != nil {
+			return BackupManifest{}, 0, err
+		}
+	} else {
+		if r, err = exportStore.ReadFile(ctx, filename); err != nil {
+			return BackupManifest{}, 0, err
+		}
 	}
 	defer r.Close(ctx)
 	descBytes, err := mon.ReadAll(ctx, r, mem)
@@ -226,7 +246,12 @@ func readBackupManifest(
 		mem.Shrink(ctx, int64(cap(descBytes)))
 	}()
 
-	checksumFile, err := exportStore.ReadFile(ctx, filename+backupManifestChecksumSuffix)
+	var checksumFile ioctx.ReadCloserCtx
+	if filename != backupManifestName {
+		checksumFile, err = readLatestCheckpointFile(ctx, exportStore, filename+backupManifestChecksumSuffix)
+	} else {
+		checksumFile, err = exportStore.ReadFile(ctx, filename+backupManifestChecksumSuffix)
+	}
 	if err == nil {
 		// If there is a checksum file present, check that it matches.
 		defer checksumFile.Close(ctx)
@@ -405,6 +430,8 @@ func readTableStatistics(
 	return &tableStats, err
 }
 
+// TODO (Aditya): Restructure manifest reading/writing so that checkpoint
+// manifest and actual manifests are no longer shared.
 func writeBackupManifest(
 	ctx context.Context,
 	settings *cluster.Settings,
@@ -436,8 +463,17 @@ func writeBackupManifest(
 		}
 	}
 
-	if err := cloud.WriteFile(ctx, exportStore, filename, bytes.NewReader(descBuf)); err != nil {
-		return err
+	// The backup manifest should only be written to the base directory,
+	// unlike the checkpoints which can be written to both the base and
+	// progress directory depending on the version.
+	if filename != backupManifestName {
+		if err := writeNewCheckpointFile(ctx, settings, exportStore, filename, descBuf); err != nil {
+			return err
+		}
+	} else {
+		if err := cloud.WriteFile(ctx, exportStore, filename, bytes.NewReader(descBuf)); err != nil {
+			return err
+		}
 	}
 
 	// Write the checksum file after we've successfully wrote the manifest.
@@ -445,8 +481,15 @@ func writeBackupManifest(
 	if err != nil {
 		return errors.Wrap(err, "calculating checksum")
 	}
-	if err := cloud.WriteFile(ctx, exportStore, filename+backupManifestChecksumSuffix, bytes.NewReader(checksum)); err != nil {
-		return errors.Wrap(err, "writing manifest checksum")
+
+	if filename != backupManifestName {
+		if err := writeNewCheckpointFile(ctx, settings, exportStore, filename+backupManifestChecksumSuffix, checksum); err != nil {
+			return errors.Wrap(err, "writing manifest checksum")
+		}
+	} else {
+		if err := cloud.WriteFile(ctx, exportStore, filename+backupManifestChecksumSuffix, bytes.NewReader(checksum)); err != nil {
+			return errors.Wrap(err, "writing manifest checksum")
+		}
 	}
 
 	return nil
@@ -699,13 +742,21 @@ func FindPriorBackups(
 func checkForLatestFileInCollection(
 	ctx context.Context, store cloud.ExternalStorage,
 ) (bool, error) {
-	_, err := store.ReadFile(ctx, latestFileName)
+	r, err := findLatestFile(ctx, store)
+	if err != nil {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return false, pgerror.WithCandidateCode(err, pgcode.Io)
+		}
+
+		r, err = store.ReadFile(ctx, latestFileName)
+	}
 	if err != nil {
 		if errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return false, nil
 		}
 		return false, pgerror.WithCandidateCode(err, pgcode.Io)
 	}
+	r.Close(ctx)
 	return true, nil
 }
 
@@ -1153,7 +1204,7 @@ func checkForPreviousBackup(
 			redactedURI, backupManifestName)
 	}
 
-	r, err = exportStore.ReadFile(ctx, backupManifestCheckpointName)
+	r, err = readLatestCheckpointFile(ctx, exportStore, backupManifestCheckpointName)
 	if err == nil {
 		r.Close(ctx)
 		return pgerror.Newf(pgcode.FileAlreadyExists,
@@ -1195,4 +1246,45 @@ func ListFullBackupsInCollection(
 		backupPaths[i] = strings.TrimSuffix(backupPath, "/"+backupManifestName)
 	}
 	return backupPaths, nil
+}
+
+// readLatestCheckpointFile returns an ioctx.ReaderCloserCtx of the latest
+// checkpoint file.
+func readLatestCheckpointFile(
+	ctx context.Context, exportStore cloud.ExternalStorage, filename string,
+) (ioctx.ReadCloserCtx, error) {
+	// First try reading from the progress directory. If the backup is from
+	// an older version, it may not exist there yet so try reading
+	// in the base directory if the first attempt fails.
+	r, err := exportStore.ReadFile(ctx, backupProgressDirectory+"/"+filename)
+	if err != nil {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return nil, err
+		}
+
+		return exportStore.ReadFile(ctx, filename)
+	}
+	return r, nil
+}
+
+// writeNewCheckpointFile writes a new BACKUP-CHECKPOINT file to both the base
+// directory and latest-history directory, depending on cluster version.
+func writeNewCheckpointFile(
+	ctx context.Context,
+	settings *cluster.Settings,
+	exportStore cloud.ExternalStorage,
+	filename string,
+	descBuf []byte,
+) error {
+	// If the cluster is still running on a mixed version, we want to write
+	// to the base directory as well the progress directory. That way if
+	// an old node resumes a backup, it doesn't have to start over.
+	if !settings.Version.IsActive(ctx, clusterversion.BackupDoesNotOverwriteLatestAndCheckpoint) {
+		err := cloud.WriteFile(ctx, exportStore, filename, bytes.NewReader(descBuf))
+		if err != nil {
+			return err
+		}
+	}
+
+	return cloud.WriteFile(ctx, exportStore, backupProgressDirectory+"/"+filename, bytes.NewReader(descBuf))
 }

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -301,6 +301,10 @@ const (
 	// ChangefeedIdleness is the version where changefeed aggregators forward
 	// idleness-related information alnog with resolved spans to the frontier
 	ChangefeedIdleness
+	// BackupDoesNotOverwriteLatestAndCheckpoint is the version where we
+	// stop overwriting the LATEST and checkpoint files during backup execution.
+	// Instead, it writes new files alongside the old in reserved subdirectories.
+	BackupDoesNotOverwriteLatestAndCheckpoint
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -491,6 +495,10 @@ var versionsSingleton = keyedVersions{
 	{
 		Key:     ChangefeedIdleness,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 82},
+	},
+	{
+		Key:     BackupDoesNotOverwriteLatestAndCheckpoint,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 84},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -47,11 +47,12 @@ func _() {
 	_ = x[BackupResolutionInJob-36]
 	_ = x[LooselyCoupledRaftLogTruncation-37]
 	_ = x[ChangefeedIdleness-38]
+	_ = x[BackupDoesNotOverwriteLatestAndCheckpoint-39]
 }
 
-const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersTenantSettingsTableEnablePebbleFormatVersionBlockPropertiesDisableSystemConfigGossipTriggerMVCCIndexBackfillerEnableLeaseHolderRemovalBackupResolutionInJobLooselyCoupledRaftLogTruncationChangefeedIdleness"
+const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersTenantSettingsTableEnablePebbleFormatVersionBlockPropertiesDisableSystemConfigGossipTriggerMVCCIndexBackfillerEnableLeaseHolderRemovalBackupResolutionInJobLooselyCoupledRaftLogTruncationChangefeedIdlenessBackupDoesNotOverwriteLatestAndCheckpoint"
 
-var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 455, 483, 504, 517, 536, 570, 608, 642, 674, 710, 742, 778, 820, 839, 879, 911, 930, 954, 975, 1006, 1024}
+var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 455, 483, 504, 517, 536, 570, 608, 642, 674, 710, 742, 778, 820, 839, 879, 911, 930, 954, 975, 1006, 1024, 1065}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {


### PR DESCRIPTION
This moves backup checkpoint and latest files in /progress and /latest-history directories respectively. In the future, we want to no longer overwrite these files and instead write them side by side. This commit teaches BACKUP statements to look for these new directories instead of just the file, but still keeps the overwriting logic. To ensure that we can still restore, show backup, and run incremental backups on an older existing backup chain, we continue to read from both the subdir and base directory. This logic can be simplified in a post 22.1 release when all backups will be exclusively writing to the subdir.

Informs: https://github.com/cockroachdb/cockroach/issues/76438

Release note enterprise: LATEST and CHECKPOINT files are now found in their own directories