### PR TITLE
scripts: update source download link in release notes script

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -858,7 +858,7 @@ if not hidedownloads:
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-""" + current_version + """.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
+    <a target="_blank" href="https://github.com/cockroachdb/cockroach/releases/tag/""" + current_version + '"' + """><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 
 <section class="filter-content" data-scope="windows">


### PR DESCRIPTION
Previously, we generated release notes files including links to
source archives. As of 22.1, we no longer provide those archives
and instead expect users who want to build from source to do so
from the GH repo, like our internal engineers.

This is a follow-up to https://github.com/cockroachdb/docs/pull/12769.
Addresses https://cockroachlabs.atlassian.net/browse/DOC-2686.

Release note: None