### PR TITLE
sql: use an implicit txn during the extended protocol

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -521,8 +521,12 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	switch s := ast.(type) {
 	case *tree.BeginTransaction:
-		// BEGIN is always an error when in the Open state. It's legitimate only in
-		// the NoTxn state.
+		// BEGIN is only allowed if we are in an implicit txn that was started
+		// in the extended protocol.
+		if isExtendedProtocol && os.ImplicitTxn.Get() {
+			ex.sessionDataStack.PushTopClone()
+			return eventTxnUpgradeToExplicit{}, nil, nil
+		}
 		return makeErrEvent(errTransactionInProgress)
 
 	case *tree.CommitTransaction:
@@ -599,57 +603,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	// For regular statements (the ones that get to this point), we
 	// don't return any event unless an error happens.
 
-	if os.ImplicitTxn.Get() {
-		// If AS OF SYSTEM TIME is already set, this has to be a bounded staleness
-		// read with nearest_only=True during a retry.
-		if p.extendedEvalCtx.AsOfSystemTime == nil {
-			asOf, err := p.isAsOf(ctx, ast)
-			if err != nil {
-				return makeErrEvent(err)
-			}
-			if asOf != nil {
-				p.extendedEvalCtx.AsOfSystemTime = asOf
-				if !asOf.BoundedStaleness {
-					p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
-					if err := ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp); err != nil {
-						return makeErrEvent(err)
-					}
-				}
-			}
-		} else {
-			if !p.extendedEvalCtx.AsOfSystemTime.BoundedStaleness ||
-				p.extendedEvalCtx.AsOfSystemTime.MaxTimestampBound.IsEmpty() {
-				return makeErrEvent(errors.AssertionFailedf(
-					"expected bounded_staleness set with a max_timestamp_bound",
-				))
-			}
-		}
-	} else {
-		// If we're in an explicit txn, we allow AOST but only if it matches with
-		// the transaction's timestamp. This is useful for running AOST statements
-		// using the InternalExecutor inside an external transaction; one might want
-		// to do that to force p.avoidLeasedDescriptors to be set below.
-		asOf, err := p.isAsOf(ctx, ast)
-		if err != nil {
-			return makeErrEvent(err)
-		}
-		if asOf != nil {
-			if asOf.BoundedStaleness {
-				return makeErrEvent(
-					pgerror.Newf(
-						pgcode.FeatureNotSupported,
-						"cannot use a bounded staleness query in a transaction",
-					),
-				)
-			}
-			if readTs := ex.state.getReadTimestamp(); asOf.Timestamp != readTs {
-				err = pgerror.Newf(pgcode.Syntax,
-					"inconsistent AS OF SYSTEM TIME timestamp; expected: %s", readTs)
-				err = errors.WithHint(err, "try SET TRANSACTION AS OF SYSTEM TIME")
-				return makeErrEvent(err)
-			}
-			p.extendedEvalCtx.AsOfSystemTime = asOf
-		}
+	if err := ex.handleAOST(ctx, ast); err != nil {
+		return makeErrEvent(err)
 	}
 
 	// The first order of business is to ensure proper sequencing
@@ -774,6 +729,66 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// No event was generated.
 	return nil, nil, nil
+}
+
+// handleAOST gets the AsOfSystemTime clause from the statement, and sets
+// the timestamps of the transaction accordingly.
+func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) error {
+	if _, isNoTxn := ex.machine.CurState().(stateNoTxn); isNoTxn {
+		return errors.AssertionFailedf(
+			"cannot handle AOST clause without a transaction",
+		)
+	}
+	p := &ex.planner
+	asOf, err := p.isAsOf(ctx, stmt)
+	if err != nil {
+		return err
+	}
+	if asOf == nil {
+		return nil
+	}
+	if ex.implicitTxn() {
+		if p.extendedEvalCtx.AsOfSystemTime == nil {
+			p.extendedEvalCtx.AsOfSystemTime = asOf
+			if !asOf.BoundedStaleness {
+				p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
+				if err := ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp); err != nil {
+					return err
+				}
+			}
+		} else if p.extendedEvalCtx.AsOfSystemTime.BoundedStaleness {
+			// This has to be a bounded staleness read with nearest_only=True during
+			// a retry. The AOST read timestamps are expected to differ.
+			if p.extendedEvalCtx.AsOfSystemTime.MaxTimestampBound.IsEmpty() {
+				return errors.AssertionFailedf(
+					"expected bounded_staleness set with a max_timestamp_bound",
+				)
+			}
+		} else if *p.extendedEvalCtx.AsOfSystemTime != *asOf {
+			return errors.AssertionFailedf(
+				"cannot specify AS OF SYSTEM TIME with different timestamps",
+			)
+		}
+	} else {
+		// If we're in an explicit txn, we allow AOST but only if it matches with
+		// the transaction's timestamp. This is useful for running AOST statements
+		// using the InternalExecutor inside an external transaction; one might want
+		// to do that to force p.avoidLeasedDescriptors to be set below.
+		if asOf.BoundedStaleness {
+			return pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"cannot use a bounded staleness query in a transaction",
+			)
+		}
+		if readTs := ex.state.getReadTimestamp(); asOf.Timestamp != readTs {
+			err = pgerror.Newf(pgcode.Syntax,
+				"inconsistent AS OF SYSTEM TIME timestamp; expected: %s", readTs)
+			err = errors.WithHint(err, "try SET TRANSACTION AS OF SYSTEM TIME")
+			return err
+		}
+		p.extendedEvalCtx.AsOfSystemTime = asOf
+	}
+	return nil
 }
 
 func formatWithPlaceholders(ast tree.Statement, evalCtx *tree.EvalContext) string {
@@ -1463,16 +1478,7 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 	ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
 	p := &ex.planner
 
-	// NB: this use of p.txn is totally bogus. The planner's txn should
-	// definitely be finalized at this point. We preserve it here because we
-	// need to make sure that the planner's txn is not made to be nil in the
-	// case of an error below. The planner's txn is never written to nil at
-	// any other point after the first prepare or exec has been run. We abuse
-	// this transaction in bind and some other contexts for resolving types and
-	// oids. Avoiding set this to nil side-steps a nil pointer panic but is still
-	// awful. Instead we ought to clear the planner state when we clear the reset
-	// the connExecutor in finishTxn.
-	ex.resetPlanner(ctx, p, p.txn, now)
+	ex.resetPlanner(ctx, p, nil, now)
 	asOf, err := p.EvalAsOfTimestamp(ctx, asOfClause)
 	if err != nil {
 		return 0, time.Time{}, nil, err
@@ -1527,23 +1533,37 @@ func (ex *connExecutor) execStmtInNoTxnState(
 		*tree.RollbackTransaction, *tree.SetTransaction, *tree.Savepoint:
 		return ex.makeErrEvent(errNoTransactionInProgress, ast)
 	default:
-		// NB: Implicit transactions are created with the session's default
-		// historical timestamp even though the statement itself might contain
-		// an AOST clause. In these cases the clause is evaluated and applied
-		// execStmtInOpenState.
-		noBeginStmt := (*tree.BeginTransaction)(nil)
-		mode, sqlTs, historicalTs, err := ex.beginTransactionTimestampsAndReadMode(ctx, noBeginStmt)
-		if err != nil {
-			return ex.makeErrEvent(err, s)
-		}
-		return eventStartImplicitTxn,
-			makeEventTxnStartPayload(
-				ex.txnPriorityWithSessionDefault(tree.UnspecifiedUserPriority),
-				mode,
-				sqlTs,
-				historicalTs,
-				ex.transitionCtx)
+		return ex.beginImplicitTxn(ctx, ast)
 	}
+}
+
+// beginImplicitTxn starts an implicit transaction. The fsm.Event that is
+// returned does not cause the state machine to advance, so the same command
+// will be executed again, but with an implicit transaction.
+// Implicit transactions are created with the session's default
+// historical timestamp even though the statement itself might contain
+// an AOST clause. In these cases the clause is evaluated and applied
+// when the command is executed again.
+func (ex *connExecutor) beginImplicitTxn(
+	ctx context.Context, ast tree.Statement,
+) (fsm.Event, fsm.EventPayload) {
+	// NB: Implicit transactions are created with the session's default
+	// historical timestamp even though the statement itself might contain
+	// an AOST clause. In these cases the clause is evaluated and applied
+	// when the command is evaluated again.
+	noBeginStmt := (*tree.BeginTransaction)(nil)
+	mode, sqlTs, historicalTs, err := ex.beginTransactionTimestampsAndReadMode(ctx, noBeginStmt)
+	if err != nil {
+		return ex.makeErrEvent(err, ast)
+	}
+	return eventStartImplicitTxn,
+		makeEventTxnStartPayload(
+			ex.txnPriorityWithSessionDefault(tree.UnspecifiedUserPriority),
+			mode,
+			sqlTs,
+			historicalTs,
+			ex.transitionCtx,
+		)
 }
 
 // execStmtInAbortedState executes a statement in a txn that's in state

--- a/pkg/sql/pgwire/testdata/pgtest/as_of_system_time
+++ b/pkg/sql/pgwire/testdata/pgtest/as_of_system_time
@@ -1,0 +1,120 @@
+# This test relies on a CoockroachDB-specific feature, so everything
+# is marked as crdb_only.
+
+send crdb_only
+Query {"String": "SELECT pg_sleep(0.1)"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"pg_sleep","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":16,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"t"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "CREATE TABLE tab(a INT8)"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Make sure AOST is handled during Parse. Preparing the statement should
+# fail since the table did not exist in the past.
+send crdb_only
+Parse {"Name": "s0", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '-0.05s'"}
+Sync
+----
+
+until crdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"42P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SELECT pg_sleep(0.1)"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"pg_sleep","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":16,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"t"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+send crdb_only
+Query {"String": "INSERT INTO tab VALUES(1)"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Make sure AOST is handled consistently during Parse/Bind/Execute. This should
+# succeed, but should not be able to read the data that was added to the table.
+send crdb_only
+Parse {"Name": "historical_stmt", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '-0.05s'"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "historical_stmt"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Make sure AOST is handled consistently during Bind/Execute. This also should
+# not be able to see the data in the table, since this is a historical read.
+send crdb_only
+Bind {"DestinationPortal": "p2", "PreparedStatement": "historical_stmt"}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SELECT pg_sleep(0.1)"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"pg_sleep","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":16,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"t"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Now, Bind/Execute again should be able to see the data.
+send crdb_only
+Bind {"DestinationPortal": "p3", "PreparedStatement": "historical_stmt"}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/implicit_txn
+++ b/pkg/sql/pgwire/testdata/pgtest/implicit_txn
@@ -1,0 +1,78 @@
+# Prepare a statement that will start an explicit transaction.
+send
+Parse {"Name": "begin_stmt", "Query": "BEGIN"}
+Sync
+----
+
+# At this point, TxStatus is still "idle" since the BEGIN was not
+# executed yet.
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Executing should start the explicit transaction.
+send
+Bind {"DestinationPortal": "p1", "PreparedStatement": "begin_stmt"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Preparing another BEGIN is allowed.
+send
+Parse {"Name": "another_begin_stmt", "Query": "BEGIN"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# But we can't execute the other BEGIN.
+send
+Bind {"DestinationPortal": "p2", "PreparedStatement": "another_begin_stmt"}
+Execute {"Portal": "p2"}
+Sync
+----
+
+# Postgres allows BEGIN inside an explicit transaction, but shows a warning.
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Severity":"WARNING","SeverityUnlocalized":"WARNING","Code":"25001","Message":"there is already a transaction in progress","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"xact.c","Line":3689,"Routine":"BeginTransactionBlock","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+until crdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"ErrorResponse","Code":"XXUUU"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Parse {"Name": "rollback_stmt", "Query": "ROLLBACK"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "rollback_stmt"}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/pgjdbc
+++ b/pkg/sql/pgwire/testdata/pgtest/pgjdbc
@@ -72,3 +72,74 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"BEGIN"}
 {"Type":"CommandComplete","CommandTag":"SAVEPOINT"}
 {"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "DROP TABLE IF EXISTS t"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE IF NOT EXISTS t(a INT8 UNIQUE)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# Test that a simple query in the middle of the extended protocol
+# causes the earlier statement to commit. Executing the prepared statement
+# again will cause a constraint error.
+send
+Parse {"Name": "S_4", "Query": "INSERT INTO t VALUES(1)"}
+Bind {"PreparedStatement": "S_4"}
+Execute
+Query {"String": "SELECT 1"}
+Bind {"PreparedStatement": "S_4"}
+Execute
+Sync
+----
+
+until ignore=RowDescription
+CommandComplete
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"BindComplete"}
+{"Type":"ErrorResponse","Code":"23505","ConstraintName":"t_a_key"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "SELECT * FROM t"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -1143,3 +1143,30 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"3"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 2"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that Sync deletes all named portals, even if they haven't been
+# executed. (Regression test of #71665.)
+send
+Parse {"Name": "s16", "Query": "SELECT 1"}
+Bind {"DestinationPortal": "p16", "PreparedStatement": "s16"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Execute {"Portal": "p16"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"34000"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -499,15 +499,10 @@ func runTTLOnRange(
 	for {
 		// Step 1. Fetch some rows we want to delete using a historical
 		// SELECT query.
-		var expiredRowsPKs []tree.Datums
-
-		if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			var err error
-			start := timeutil.Now()
-			expiredRowsPKs, err = selectBuilder.run(ctx, ie, txn)
-			metrics.DeleteDuration.RecordValue(int64(timeutil.Since(start)))
-			return err
-		}); err != nil {
+		start := timeutil.Now()
+		expiredRowsPKs, err := selectBuilder.run(ctx, ie)
+		metrics.DeleteDuration.RecordValue(int64(timeutil.Since(start)))
+		if err != nil {
 			return errors.Wrapf(err, "error selecting rows to delete")
 		}
 		metrics.RowSelections.Inc(int64(len(expiredRowsPKs)))

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -150,13 +150,16 @@ func (b *selectQueryBuilder) nextQuery() (string, []interface{}) {
 }
 
 func (b *selectQueryBuilder) run(
-	ctx context.Context, ie *sql.InternalExecutor, txn *kv.Txn,
+	ctx context.Context, ie *sql.InternalExecutor,
 ) ([]tree.Datums, error) {
 	q, args := b.nextQuery()
+	// Use a nil txn so that the AOST clause is handled correctly. Currently,
+	// the internal executor will treat a passed-in txn as an explicit txn, so
+	// the AOST clause on the SELECT query would not be interpreted correctly.
 	ret, err := ie.QueryBuffered(
 		ctx,
 		"ttl_scanner",
-		txn,
+		nil, /* txn */
 		q,
 		args...,
 	)

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -286,6 +286,7 @@ func (ts *txnState) setHistoricalTimestamp(
 	if err := ts.mu.txn.SetFixedTimestamp(ctx, historicalTimestamp); err != nil {
 		return err
 	}
+	ts.sqlTimestamp = historicalTimestamp.GoTime()
 	ts.isHistorical = true
 	return nil
 }

--- a/pkg/sql/txnstatetransitions_diagram.gv
+++ b/pkg/sql/txnstatetransitions_diagram.gv
@@ -47,4 +47,5 @@ digraph finite_state_machine {
 	"Open{ImplicitTxn:true}" -> "Open{ImplicitTxn:true}" [label = <RetriableErr{CanAutoRetry:true, IsCommit:true}<BR/><I>Retriable err; will auto-retry</I>>]
 	"Open{ImplicitTxn:true}" -> "NoTxn{}" [label = <TxnFinishAborted{}<BR/><I>ROLLBACK, or after a statement running as an implicit txn fails</I>>]
 	"Open{ImplicitTxn:true}" -> "NoTxn{}" [label = <TxnFinishCommitted{}<BR/><I>COMMIT, or after a statement running as an implicit txn</I>>]
+	"Open{ImplicitTxn:true}" -> "Open{ImplicitTxn:false}" [label = "TxnUpgradeToExplicit{}"]
 }

--- a/pkg/sql/txnstatetransitions_report.txt
+++ b/pkg/sql/txnstatetransitions_report.txt
@@ -16,6 +16,7 @@ Aborted{}
 		TxnReleased{}
 		TxnStart{ImplicitTxn:false}
 		TxnStart{ImplicitTxn:true}
+		TxnUpgradeToExplicit{}
 CommitWait{}
 	handled events:
 		NonRetriableErr{IsCommit:false}
@@ -32,6 +33,7 @@ CommitWait{}
 		TxnRestart{}
 		TxnStart{ImplicitTxn:false}
 		TxnStart{ImplicitTxn:true}
+		TxnUpgradeToExplicit{}
 NoTxn{}
 	handled events:
 		NonRetriableErr{IsCommit:false}
@@ -48,6 +50,7 @@ NoTxn{}
 		TxnFinishCommitted{}
 		TxnReleased{}
 		TxnRestart{}
+		TxnUpgradeToExplicit{}
 Open{ImplicitTxn:false}
 	handled events:
 		NonRetriableErr{IsCommit:false}
@@ -64,6 +67,7 @@ Open{ImplicitTxn:false}
 		SavepointRollback{}
 		TxnStart{ImplicitTxn:false}
 		TxnStart{ImplicitTxn:true}
+		TxnUpgradeToExplicit{}
 Open{ImplicitTxn:true}
 	handled events:
 		NonRetriableErr{IsCommit:false}
@@ -74,6 +78,7 @@ Open{ImplicitTxn:true}
 		RetriableErr{CanAutoRetry:true, IsCommit:true}
 		TxnFinishAborted{}
 		TxnFinishCommitted{}
+		TxnUpgradeToExplicit{}
 	missing events:
 		SavepointRollback{}
 		TxnReleased{}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/71665

In the Postgres wire protocol, entering the extended protocol also
starts an implicit transaction. This transaction is committed when the
Sync message is received.

Previously, we were starting 3 separate "implicit" transactions for the
Prepare, Bind, and ExecPortal commands. (Implicit is in scare quotes
because they were created entirely ad-hoc.)

Now, the same implicit txn is used for the duration of the extended
protocol.

If BEGIN is executed as a prepared statement, then the implicit
trasnaction is upgraded to an explicit one. This behavior matches
Postgres.

Release note (bug fix): Fixed a bug where the different stages of
preparing, binding, and executing a prepared statement would use
different implicit transactions. Now these stages all share the same
implicit transaction.