### PR TITLE
kvstreamer: minor cleanup in preparation for InOrder mode

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -75,12 +75,16 @@ type Result struct {
 	// The responses are to be considered immutable; the Streamer might hold on
 	// to the respective memory. Calling Result.Release() tells the Streamer
 	// that the response is no longer needed.
+	//
+	// GetResp is guaranteed to have nil IntentValue.
 	GetResp *roachpb.GetResponse
 	// ScanResp can contain a partial response to a ScanRequest (when Complete
 	// is false). In that case, there will be a further result with the
 	// continuation; that result will use the same Key. Notably, SQL rows will
 	// never be split across multiple results.
 	ScanResp struct {
+		// The response is always using BATCH_RESPONSE format (meaning that Rows
+		// field is always nil). IntentRows field is also nil.
 		*roachpb.ScanResponse
 		// If the Result represents a scan result, Complete indicates whether
 		// this is the last response for the respective scan, or if there are
@@ -1236,10 +1240,12 @@ func (w *workerCoordinator) performRequestAsync(
 
 			// Finally, process the results and add the ResumeSpans to be
 			// processed as well.
-			w.processSingleRangeResults(
+			if err := w.processSingleRangeResults(
 				req, br, memoryFootprintBytes, resumeReqsMemUsage,
 				numIncompleteGets, numIncompleteScans,
-			)
+			); err != nil {
+				w.s.setError(err)
+			}
 		}); err != nil {
 		// The new goroutine for the request wasn't spun up, so we have to
 		// perform the cleanup of this request ourselves.
@@ -1287,7 +1293,7 @@ func calculateFootprint(
 			}
 		case *roachpb.ScanRequest:
 			scan := reply.(*roachpb.ScanResponse)
-			if len(scan.Rows) > 0 || len(scan.BatchResponses) > 0 {
+			if len(scan.BatchResponses) > 0 {
 				memoryFootprintBytes += scanResponseSize(scan)
 			}
 			if scan.ResumeSpan != nil {
@@ -1318,7 +1324,7 @@ func (w *workerCoordinator) processSingleRangeResults(
 	memoryFootprintBytes int64,
 	resumeReqsMemUsage int64,
 	numIncompleteGets, numIncompleteScans int,
-) {
+) error {
 	numIncompleteRequests := numIncompleteGets + numIncompleteScans
 	var resumeReq singleRangeBatch
 	// We have to allocate the new slice for requests, but we can reuse the
@@ -1372,6 +1378,11 @@ func (w *workerCoordinator) processSingleRangeResults(
 				resumeReqIdx++
 			} else {
 				// This Get was completed.
+				if get.IntentValue != nil {
+					return errors.AssertionFailedf(
+						"unexpectedly got an IntentValue back from a SQL GetRequest %v", *get.IntentValue,
+					)
+				}
 				result := Result{
 					GetResp: get,
 					// This currently only works because all requests are
@@ -1388,8 +1399,18 @@ func (w *workerCoordinator) processSingleRangeResults(
 
 		case *roachpb.ScanRequest:
 			scan := reply.(*roachpb.ScanResponse)
-			if len(scan.Rows) > 0 || len(scan.BatchResponses) > 0 || scan.ResumeSpan == nil {
-				// Only the last part of the conditional is true whenever we
+			if len(scan.Rows) > 0 {
+				return errors.AssertionFailedf(
+					"unexpectedly got a ScanResponse using KEY_VALUES response format",
+				)
+			}
+			if len(scan.IntentRows) > 0 {
+				return errors.AssertionFailedf(
+					"unexpectedly got a ScanResponse with non-nil IntentRows",
+				)
+			}
+			if len(scan.BatchResponses) > 0 || scan.ResumeSpan == nil {
+				// Only the second part of the conditional is true whenever we
 				// received an empty response for the Scan request (i.e. there
 				// was no data in the span to scan). In such a scenario we still
 				// create a Result with no data that the client will skip over
@@ -1418,6 +1439,7 @@ func (w *workerCoordinator) processSingleRangeResults(
 				newScan := scans[0]
 				scans = scans[1:]
 				newScan.req.SetSpan(*scan.ResumeSpan)
+				newScan.req.ScanFormat = roachpb.BATCH_RESPONSE
 				newScan.req.KeyLocking = origRequest.KeyLocking
 				newScan.union.Scan = &newScan.req
 				resumeReq.reqs[resumeReqIdx].Value = &newScan.union
@@ -1470,6 +1492,8 @@ func (w *workerCoordinator) processSingleRangeResults(
 	if len(resumeReq.reqs) > 0 {
 		w.addRequest(resumeReq)
 	}
+
+	return nil
 }
 
 // finalizeSingleRangeResults "finalizes" the results of evaluation of a

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1502,14 +1502,14 @@ func (w *workerCoordinator) finalizeSingleRangeResults(
 	// the client as an atomic operation so that Complete is set to true only on
 	// the last partial scan response.
 	if hasNonEmptyScanResponse {
-		for _, r := range results {
-			if r.ScanResp.ScanResponse != nil {
-				if r.ScanResp.ResumeSpan == nil {
+		for i := range results {
+			if results[i].ScanResp.ScanResponse != nil {
+				if results[i].ScanResp.ResumeSpan == nil {
 					// The scan within the range is complete.
-					w.s.mu.numRangesLeftPerScanRequest[r.position]--
-					if w.s.mu.numRangesLeftPerScanRequest[r.position] == 0 {
+					w.s.mu.numRangesLeftPerScanRequest[results[i].position]--
+					if w.s.mu.numRangesLeftPerScanRequest[results[i].position] == 0 {
 						// The scan across all ranges is now complete too.
-						r.ScanResp.Complete = true
+						results[i].ScanResp.Complete = true
 						numCompleteResponses++
 					}
 				} else {
@@ -1517,7 +1517,7 @@ func (w *workerCoordinator) finalizeSingleRangeResults(
 					// confuse the user of the Streamer. Non-nil resume span was
 					// already included into resumeReq populated in
 					// performRequestAsync.
-					r.ScanResp.ResumeSpan = nil
+					results[i].ScanResp.ResumeSpan = nil
 				}
 			}
 		}

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -467,17 +467,36 @@ func (f *txnKVFetcher) nextBatch(
 			if len(t.BatchResponses) > 0 {
 				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
-			// Note that t.Rows and batchResp might be nil when the ScanResponse
-			// is empty, and the caller (the KVFetcher) will skip over it.
-			return true, t.Rows, batchResp, nil
+			if len(t.Rows) > 0 {
+				return false, nil, nil, errors.AssertionFailedf(
+					"unexpectedly got a ScanResponse using KEY_VALUES response format",
+				)
+			}
+			if len(t.IntentRows) > 0 {
+				return false, nil, nil, errors.AssertionFailedf(
+					"unexpectedly got a ScanResponse with non-nil IntentRows",
+				)
+			}
+			// Note that batchResp might be nil when the ScanResponse is empty,
+			// and the caller (the KVFetcher) will skip over it.
+			return true, nil, batchResp, nil
 		case *roachpb.ReverseScanResponse:
 			if len(t.BatchResponses) > 0 {
 				batchResp, f.remainingBatches = popBatch(t.BatchResponses)
 			}
-			// Note that t.Rows and batchResp might be nil when the
-			// ReverseScanResponse is empty, and the caller (the KVFetcher) will
-			// skip over it.
-			return true, t.Rows, batchResp, nil
+			if len(t.Rows) > 0 {
+				return false, nil, nil, errors.AssertionFailedf(
+					"unexpectedly got a ReverseScanResponse using KEY_VALUES response format",
+				)
+			}
+			if len(t.IntentRows) > 0 {
+				return false, nil, nil, errors.AssertionFailedf(
+					"unexpectedly got a ReverseScanResponse with non-nil IntentRows",
+				)
+			}
+			// Note that batchResp might be nil when the ReverseScanResponse is
+			// empty, and the caller (the KVFetcher) will skip over it.
+			return true, nil, batchResp, nil
 		case *roachpb.GetResponse:
 			if t.IntentValue != nil {
 				return false, nil, nil, errors.AssertionFailedf("unexpectedly got an IntentValue back from a SQL GetRequest %v", *t.IntentValue)
@@ -525,6 +544,10 @@ func (f *txnKVFetcher) close(ctx context.Context) {
 	f.acc.Clear(ctx)
 }
 
+// spansToRequests converts the provided spans to the corresponding requests. If
+// a span doesn't have the EndKey set, then a Get request is used for it;
+// otherwise, a Scan (or ReverseScan if reverse is true) request is used with
+// BATCH_RESPONSE format.
 func spansToRequests(
 	spans roachpb.Spans, reverse bool, keyLocking lock.Strength,
 ) []roachpb.RequestUnion {


### PR DESCRIPTION
**kvstreamer: fix a bug with populating Complete field of scan response**

Previously, we were mutating a copy of `Result` object when setting
`Complete` field of the scan response, and this is now fixed. The field
hasn't been used yet (it will be in `InOrder` mode), so the bug was
undetected and had no harm.

Release note: None

**row: clarify fetchers a bit**

Both `txnKVFetcher` and `TxnKVStreamer` are using BATCH_RESPONSE format
for the responses to the Scan requests which guarantees that `Rows`
field is unset. This commit takes advantage of this observation and
asserts that the field is nil. The check is pushed into the `Streamer`
for the `TxnKVStreamer`, and it actually revealed that we forgot to use
the BATCH_RESPONSE format whenever the Streamer needs to create Scan
requests for the ResumeSpans.

Additionally, a check that `GetResponse.IntentValue` is nil pushed
into the `Streamer` as well while the check that
`ScanResponse.IntentRows` is nil is added to both places.

These movements are prompted by the work on the `InOrder` mode of the
`Streamer` where we need to be able to spill to disk some of the
buffered `Result`s, so the less fields we need to care about, the
cleaner that code will be.

Release note: None