### PR TITLE
kvtenantccl: better address randomization in the connector

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -568,10 +568,9 @@ func (c *Connector) getClient(ctx context.Context) (*client, error) {
 // The method will only return a non-nil error on context cancellation.
 func (c *Connector) dialAddrs(ctx context.Context) (*client, error) {
 	for r := retry.StartWithCtx(ctx, c.rpcRetryOptions); r.Next(); {
-		// Try each address on each retry iteration.
-		randStart := rand.Intn(len(c.addrs))
-		for i := range c.addrs {
-			addr := c.addrs[(i+randStart)%len(c.addrs)]
+		// Try each address on each retry iteration (in random order).
+		for _, i := range rand.Perm(len(c.addrs)) {
+			addr := c.addrs[i]
 			conn, err := c.dialAddr(ctx, addr)
 			if err != nil {
 				log.Warningf(ctx, "error dialing tenant KV address %s: %v", addr, err)


### PR DESCRIPTION
#### kvtenantccl: better address randomization in the connector

The current dial code in the connector tries to dial all nodes in
circular order with randomized starting point.

This partial randomization is not quite what we want. For example,
if we have three addresses (0,1,2) and address 1 is down, two starting
points end up in choosing node 2 (so we choose it 67% of the time).

This commit changes to using `rand.Perm` instead. In the example
above, 0 and 2 have equal chances of being first in the permutation,
so we choose either of them 50% of the time.

Release justification: low risk change to existing functionality, only
affects multitenant (Serverless)

Release note: None