### PR TITLE
opt: synthesize lookup join equalities for computed columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -11,8 +11,67 @@ statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1";
 USE multi_region_test_db
 
+statement ok
+CREATE TABLE parent (
+  id INT,
+  crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN id BETWEEN 0 AND 99 THEN 'ap-southeast-2':::crdb_internal_region WHEN id BETWEEN 100 AND 199 THEN 'us-east-1':::crdb_internal_region ELSE 'ca-central-1':::crdb_internal_region END) STORED,
+  PRIMARY KEY (id)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE child (
+  id INT,
+  crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN id BETWEEN 0 AND 99 THEN 'ap-southeast-2':::crdb_internal_region WHEN id BETWEEN 100 AND 199 THEN 'us-east-1':::crdb_internal_region ELSE 'ca-central-1':::crdb_internal_region END) STORED,
+  p_id INT REFERENCES parent (id),
+  PRIMARY KEY (id)
+) LOCALITY REGIONAL BY ROW
+
+# A foreign key check only needs to search a single region for each insert row
+# if the region column is a computed column.
+query T retry
+EXPLAIN INSERT INTO child (id, p_id) VALUES (1, 10), (2, 150)
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: child(id, crdb_region, p_id)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ estimated row count: 2
+│           │
+│           └── • render
+│               │ estimated row count: 2
+│               │
+│               └── • values
+│                     size: 2 columns, 2 rows
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
+            │ equality: (crdb_region_eq, p_id) = (crdb_region,id)
+            │ equality cols are key
+            │
+            └── • render
+                │ estimated row count: 2
+                │
+                └── • scan buffer
+                      label: buffer 1
+
+
 # NB: This doesn't include the foreign key reference to warehouse since we
 # don't need the warehouse table for this test.
+# NB: The crdb_region columns have been changed from computed columns to columns
+# with default values since a foreign key check with a computed region column
+# would only require a lookup in a single region.
 statement ok
 CREATE TABLE district (
         d_id INT8 NOT NULL,
@@ -26,7 +85,7 @@ CREATE TABLE district (
         d_tax DECIMAL(4,4) NOT NULL,
         d_ytd DECIMAL(12,2) NOT NULL,
         d_next_o_id INT8 NOT NULL,
-        crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN d_w_id BETWEEN 0:::INT8 AND 1665:::INT8 THEN 'ap-southeast-2':::crdb_internal_region WHEN d_w_id BETWEEN 1666:::INT8 AND 3332:::INT8 THEN 'us-east-1':::crdb_internal_region WHEN d_w_id BETWEEN 3333:::INT8 AND 4999:::INT8 THEN 'ca-central-1':::crdb_internal_region END) STORED,
+        crdb_region crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::crdb_internal_region,
         CONSTRAINT "primary" PRIMARY KEY (d_w_id ASC, d_id ASC),
         FAMILY "primary" (d_id, d_w_id, d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id, crdb_region)
 ) LOCALITY REGIONAL BY ROW
@@ -54,7 +113,7 @@ CREATE TABLE customer (
         c_payment_cnt INT8 NOT NULL,
         c_delivery_cnt INT8 NOT NULL,
         c_data VARCHAR(500) NOT NULL,
-        crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN c_w_id BETWEEN 0:::INT8 AND 1665:::INT8 THEN 'ap-southeast-2':::crdb_internal_region WHEN c_w_id BETWEEN 1666:::INT8 AND 3332:::INT8 THEN 'us-east-1':::crdb_internal_region WHEN c_w_id BETWEEN 3333:::INT8 AND 4999:::INT8 THEN 'ca-central-1':::crdb_internal_region END) STORED,
+        crdb_region crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::crdb_internal_region,
         CONSTRAINT "primary" PRIMARY KEY (c_w_id ASC, c_d_id ASC, c_id ASC),
         CONSTRAINT fk_c_w_id_ref_district FOREIGN KEY (c_w_id, c_d_id) REFERENCES district(d_w_id, d_id) NOT VALID,
         INDEX customer_idx (c_w_id ASC, c_d_id ASC, c_last ASC, c_first ASC),
@@ -72,7 +131,7 @@ CREATE TABLE history (
         h_date TIMESTAMP NULL,
         h_amount DECIMAL(6,2) NULL,
         h_data VARCHAR(24) NULL,
-        crdb_region crdb_internal_region NOT VISIBLE NOT NULL AS (CASE WHEN h_w_id BETWEEN 0:::INT8 AND 1665:::INT8 THEN 'ap-southeast-2':::crdb_internal_region WHEN h_w_id BETWEEN 1666:::INT8 AND 3332:::INT8 THEN 'us-east-1':::crdb_internal_region WHEN h_w_id BETWEEN 3333:::INT8 AND 4999:::INT8 THEN 'ca-central-1':::crdb_internal_region END) STORED,
+        crdb_region crdb_internal_region NOT VISIBLE NOT NULL DEFAULT gateway_region()::crdb_internal_region,
         CONSTRAINT "primary" PRIMARY KEY (h_w_id ASC, rowid ASC),
         CONSTRAINT fk_h_c_w_id_ref_customer FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES customer(c_w_id, c_d_id, c_id) NOT VALID,
         CONSTRAINT fk_h_w_id_ref_district FOREIGN KEY (h_w_id, h_d_id) REFERENCES district(d_w_id, d_id) NOT VALID,

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -379,29 +379,40 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_a_shard_8_cast: crdb_internal_a_shard_8_cast
     │
-    └── • lookup join (anti)
+    └── • project
         │ columns: (column1, column2, crdb_internal_a_shard_8_cast)
         │ estimated row count: 0 (missing stats)
-        │ table: t_hash_indexed@t_hash_indexed_pkey
-        │ equality cols are key
-        │ lookup condition: (column1 = a) AND (crdb_internal_a_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7))
         │
-        └── • cross join (anti)
-            │ columns: (column1, column2, crdb_internal_a_shard_8_cast)
-            │ estimated row count: 0 (missing stats)
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_a_shard_8_eq, column1, column2, crdb_internal_a_shard_8_cast)
+            │ table: t_hash_indexed@t_hash_indexed_pkey
+            │ equality: (crdb_internal_a_shard_8_eq, column1) = (crdb_internal_a_shard_8,a)
+            │ equality cols are key
             │
-            ├── • values
-            │     columns: (column1, column2, crdb_internal_a_shard_8_cast)
-            │     size: 3 columns, 1 row
-            │     row 0, expr 0: 4321
-            │     row 0, expr 1: 8765
-            │     row 0, expr 2: 1
-            │
-            └── • scan
-                  columns: (crdb_internal_a_shard_8, a)
-                  estimated row count: 1 (missing stats)
-                  table: t_hash_indexed@t_hash_indexed_pkey
-                  spans: /1/4321/0
+            └── • render
+                │ columns: (crdb_internal_a_shard_8_eq, column1, column2, crdb_internal_a_shard_8_cast)
+                │ estimated row count: 0 (missing stats)
+                │ render crdb_internal_a_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 8)
+                │ render column1: column1
+                │ render column2: column2
+                │ render crdb_internal_a_shard_8_cast: crdb_internal_a_shard_8_cast
+                │
+                └── • cross join (anti)
+                    │ columns: (column1, column2, crdb_internal_a_shard_8_cast)
+                    │ estimated row count: 0 (missing stats)
+                    │
+                    ├── • values
+                    │     columns: (column1, column2, crdb_internal_a_shard_8_cast)
+                    │     size: 3 columns, 1 row
+                    │     row 0, expr 0: 4321
+                    │     row 0, expr 1: 8765
+                    │     row 0, expr 2: 1
+                    │
+                    └── • scan
+                          columns: (crdb_internal_a_shard_8, a)
+                          estimated row count: 1 (missing stats)
+                          table: t_hash_indexed@t_hash_indexed_pkey
+                          spans: /1/4321/0
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT (a) DO NOTHING
@@ -686,10 +697,6 @@ vectorized: true
                           table: t_hash_indexed@idx_t_hash_indexed
                           spans: /3/8765/0
 
-# TODO(mgartner): The lookup join that checks for conflicts performs a lookup
-# into each shard of the index. The lookup shards can be computed from the
-# insert values, so it is only necessary to search a single shard for each
-# insert row.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (111, 222), (333, 444) ON CONFLICT (b) DO UPDATE SET b = excluded.b
 ----
@@ -732,16 +739,16 @@ vectorized: true
                 │ estimated row count: 2 (missing stats)
                 │
                 └── • lookup join (left outer)
-                    │ columns: (crdb_internal_b_shard_8_cast, column1, column2, a, b, crdb_internal_b_shard_8)
-                    │ estimated row count: 2 (missing stats)
+                    │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_cast, column1, column2, a, b)
                     │ table: t_hash_indexed@idx_t_hash_indexed
+                    │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
                     │ equality cols are key
-                    │ lookup condition: (column2 = b) AND (crdb_internal_b_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7))
                     │ locking strength: for update
                     │
                     └── • render
-                        │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+                        │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_cast, column1, column2)
                         │ estimated row count: 2
+                        │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                         │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
                         │ render column1: column1
                         │ render column2: column2
@@ -778,40 +785,51 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
     │
-    └── • lookup join (anti)
+    └── • project
         │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
         │ estimated row count: 0 (missing stats)
-        │ table: t_hash_indexed@idx_t_hash_indexed
-        │ equality cols are key
-        │ lookup condition: (column2 = b) AND (crdb_internal_b_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7))
         │
         └── • lookup join (anti)
-            │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
-            │ estimated row count: 0 (missing stats)
+            │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_cast)
             │ table: t_hash_indexed@idx_t_hash_indexed
-            │ equality: (crdb_internal_b_shard_8_cast, column2) = (crdb_internal_b_shard_8,b)
+            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
             │ equality cols are key
             │
-            └── • cross join (anti)
-                │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
+            └── • render
+                │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_cast)
                 │ estimated row count: 0 (missing stats)
+                │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
+                │ render column1: column1
+                │ render column2: column2
+                │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
                 │
-                ├── • values
-                │     columns: (column1, column2, crdb_internal_b_shard_8_cast)
-                │     size: 3 columns, 1 row
-                │     row 0, expr 0: 4321
-                │     row 0, expr 1: 8765
-                │     row 0, expr 2: 3
-                │
-                └── • project
-                    │ columns: ()
-                    │ estimated row count: 1 (missing stats)
+                └── • lookup join (anti)
+                    │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
+                    │ estimated row count: 0 (missing stats)
+                    │ table: t_hash_indexed@idx_t_hash_indexed
+                    │ equality: (crdb_internal_b_shard_8_cast, column2) = (crdb_internal_b_shard_8,b)
+                    │ equality cols are key
                     │
-                    └── • scan
-                          columns: (a)
-                          estimated row count: 1 (missing stats)
-                          table: t_hash_indexed@t_hash_indexed_pkey
-                          spans: /4321/0
+                    └── • cross join (anti)
+                        │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
+                        │ estimated row count: 0 (missing stats)
+                        │
+                        ├── • values
+                        │     columns: (column1, column2, crdb_internal_b_shard_8_cast)
+                        │     size: 3 columns, 1 row
+                        │     row 0, expr 0: 4321
+                        │     row 0, expr 1: 8765
+                        │     row 0, expr 2: 3
+                        │
+                        └── • project
+                            │ columns: ()
+                            │ estimated row count: 1 (missing stats)
+                            │
+                            └── • scan
+                                  columns: (a)
+                                  estimated row count: 1 (missing stats)
+                                  table: t_hash_indexed@t_hash_indexed_pkey
+                                  spans: /4321/0
 
 # TODO (issue #75498): we're using unique without index on (a) as an arbiter and
 # using the original hash sharded index as an arbiter is not necessary.
@@ -838,46 +856,57 @@ vectorized: true
     │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
     │
     └── • distinct
-        │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+        │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: crdb_internal_b_shard_8_cast, column2
+        │ distinct on: column2, crdb_internal_b_shard_8_cast
         │ nulls are distinct
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+        └── • project
+            │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
             │ estimated row count: 0 (missing stats)
-            │ table: t_hash_indexed@idx_t_hash_indexed
-            │ equality cols are key
-            │ lookup condition: (column2 = b) AND (crdb_internal_b_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7))
             │
             └── • lookup join (anti)
-                │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_hash_indexed@t_hash_indexed_pkey
-                │ equality: (column1) = (a)
+                │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_cast)
+                │ table: t_hash_indexed@idx_t_hash_indexed
+                │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
                 │ equality cols are key
                 │
-                └── • lookup join (anti)
-                    │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+                └── • render
+                    │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_cast)
                     │ estimated row count: 0 (missing stats)
-                    │ table: t_hash_indexed@idx_t_hash_indexed
-                    │ equality: (crdb_internal_b_shard_8_cast, column2) = (crdb_internal_b_shard_8,b)
-                    │ equality cols are key
+                    │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
+                    │ render column1: column1
+                    │ render column2: column2
+                    │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
                     │
-                    └── • render
+                    └── • lookup join (anti)
                         │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
-                        │ estimated row count: 2
-                        │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
-                        │ render column1: column1
-                        │ render column2: column2
+                        │ estimated row count: 0 (missing stats)
+                        │ table: t_hash_indexed@t_hash_indexed_pkey
+                        │ equality: (column1) = (a)
+                        │ equality cols are key
                         │
-                        └── • values
-                              columns: (column1, column2)
-                              size: 2 columns, 2 rows
-                              row 0, expr 0: 111
-                              row 0, expr 1: 222
-                              row 1, expr 0: 333
-                              row 1, expr 1: 444
+                        └── • lookup join (anti)
+                            │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+                            │ estimated row count: 0 (missing stats)
+                            │ table: t_hash_indexed@idx_t_hash_indexed
+                            │ equality: (crdb_internal_b_shard_8_cast, column2) = (crdb_internal_b_shard_8,b)
+                            │ equality cols are key
+                            │
+                            └── • render
+                                │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+                                │ estimated row count: 2
+                                │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
+                                │ render column1: column1
+                                │ render column2: column2
+                                │
+                                └── • values
+                                      columns: (column1, column2)
+                                      size: 2 columns, 2 rows
+                                      row 0, expr 0: 111
+                                      row 0, expr 1: 222
+                                      row 1, expr 0: 333
+                                      row 1, expr 1: 444
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT (b) DO NOTHING
@@ -942,24 +971,28 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
     │
-    └── • lookup join (anti)
-        │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
+    └── • project
+        │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
         │ estimated row count: 0 (missing stats)
-        │ table: t_hash_indexed@idx_t_hash_indexed
-        │ equality cols are key
-        │ lookup condition: (column2 = b) AND (crdb_internal_b_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7))
         │
-        └── • render
-            │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
-            │ estimated row count: 2
-            │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
-            │ render column1: column1
-            │ render column2: column2
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_cast, column1, column2)
+            │ table: t_hash_indexed@idx_t_hash_indexed
+            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
+            │ equality cols are key
             │
-            └── • values
-                  columns: (column1, column2)
-                  size: 2 columns, 2 rows
-                  row 0, expr 0: 111
-                  row 0, expr 1: 222
-                  row 1, expr 0: 333
-                  row 1, expr 1: 444
+            └── • render
+                │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_cast, column1, column2)
+                │ estimated row count: 2
+                │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
+                │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
+                │ render column1: column1
+                │ render column2: column2
+                │
+                └── • values
+                      columns: (column1, column2)
+                      size: 2 columns, 2 rows
+                      row 0, expr 0: 111
+                      row 0, expr 1: 222
+                      row 1, expr 0: 333
+                      row 1, expr 1: 444

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -293,6 +293,16 @@ func (tm *TableMeta) AddComputedCol(colID ColumnID, computedCol ScalarExpr) {
 	tm.ComputedCols[colID] = computedCol
 }
 
+// ComputedColExpr returns the computed expression for the given column, if it
+// is a computed column. If it is not a computed column, ok=false is returned.
+func (tm *TableMeta) ComputedColExpr(id ColumnID) (_ ScalarExpr, ok bool) {
+	if tm.ComputedCols == nil {
+		return nil, false
+	}
+	e, ok := tm.ComputedCols[id]
+	return e, ok
+}
+
 // AddPartialIndexPredicate adds a partial index predicate to the table's
 // metadata.
 func (tm *TableMeta) AddPartialIndexPredicate(ord cat.IndexOrdinal, pred ScalarExpr) {

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -341,10 +341,10 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 	inputProps := input.Relational()
 
 	leftEq, rightEq := memo.ExtractJoinEqualityColumns(inputProps.OutputCols, rightCols, on)
-	n := len(leftEq)
-	if n == 0 {
+	if len(leftEq) == 0 {
 		return
 	}
+	rightEqSet := rightEq.ToSet()
 
 	// Generate implicit filters from CHECK constraints and computed columns as
 	// optional filters to help generate lookup join keys.
@@ -353,6 +353,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 	optionalFilters = append(optionalFilters, computedColFilters...)
 
 	var pkCols opt.ColList
+	var eqColMap opt.ColMap
 	var iter scanIndexIter
 	iter.Init(c.e.evalCtx, c.e.f, c.e.mem, &c.im, scanPrivate, on, rejectInvertedIndexes)
 	iter.ForEach(func(index cat.Index, onFilters memo.FiltersExpr, indexCols opt.ColSet, _ bool, _ memo.ProjectionsExpr) {
@@ -374,14 +375,21 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 		var constFilters memo.FiltersExpr
 		allFilters := append(onFilters, optionalFilters...)
 
-		// Check if the first column in the index has an equality constraint, or if
-		// it is constrained to a constant value. This check doesn't guarantee that
-		// we will find lookup join key columns, but it avoids the unnecessary work
-		// in most cases.
+		// Check if the first column in the index either:
+		//
+		//   1. Has an equality constraint.
+		//   2. Is a computed column for which an equality constraint can be
+		//      generated.
+		//   3. Is constrained to a constant value or values.
+		//
+		// This check doesn't guarantee that we will find lookup join key
+		// columns, but it avoids unnecessary work in most cases.
 		firstIdxCol := scanPrivate.Table.IndexColumnID(index, 0)
 		if _, ok := rightEq.Find(firstIdxCol); !ok {
-			if _, _, ok := c.findJoinFilterConstants(allFilters, firstIdxCol); !ok {
-				return
+			if _, ok := c.findComputedColJoinEquality(scanPrivate.Table, firstIdxCol, rightEqSet); !ok {
+				if _, _, ok := c.findJoinFilterConstants(allFilters, firstIdxCol); !ok {
+					return
+				}
 			}
 		}
 
@@ -393,6 +401,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 
 		lookupJoin.KeyCols = make(opt.ColList, 0, numIndexKeyCols)
 		rightSideCols := make(opt.ColList, 0, numIndexKeyCols)
+		var inputProjections memo.ProjectionsExpr
 
 		shouldBuildMultiSpanLookupJoin := false
 
@@ -402,6 +411,32 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 			idxCol := scanPrivate.Table.IndexColumnID(index, j)
 			if eqIdx, ok := rightEq.Find(idxCol); ok {
 				lookupJoin.KeyCols = append(lookupJoin.KeyCols, leftEq[eqIdx])
+				rightSideCols = append(rightSideCols, idxCol)
+				continue
+			}
+
+			// If the column is computed and an equality constraint can be
+			// synthesized for it, we can project a column from the join's input
+			// that can be used as a key column. We create the projection here,
+			// and construct a Project expression that wraps the join's input
+			// below. See findComputedColJoinEquality for the requirements to
+			// synthesize a computed column equality constraint.
+			if expr, ok := c.findComputedColJoinEquality(scanPrivate.Table, idxCol, rightEqSet); ok {
+				colMeta := md.ColumnMeta(idxCol)
+				compEqCol := md.AddColumn(fmt.Sprintf("%s_eq", colMeta.Alias), colMeta.Type)
+
+				// Lazily initialize eqColMap.
+				if eqColMap.Empty() {
+					for i := range rightEq {
+						eqColMap.Set(int(rightEq[i]), int(leftEq[i]))
+					}
+				}
+
+				// Project the computed column expression, mapping all columns
+				// in rightEq to corresponding columns in leftEq.
+				projection := c.e.f.ConstructProjectionsItem(c.RemapCols(expr, eqColMap), compEqCol)
+				inputProjections = append(inputProjections, projection)
+				lookupJoin.KeyCols = append(lookupJoin.KeyCols, compEqCol)
 				rightSideCols = append(rightSideCols, idxCol)
 				continue
 			}
@@ -503,6 +538,16 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 		if len(lookupJoin.KeyCols) == 0 && len(lookupJoin.LookupExpr) == 0 {
 			// We couldn't find equality columns which we can lookup.
 			return
+		}
+
+		// Wrap the input in a Project if any projections are required. The
+		// lookup join will project away these synthesized columns.
+		if len(inputProjections) > 0 {
+			lookupJoin.Input = c.e.f.ConstructProject(
+				lookupJoin.Input,
+				inputProjections,
+				lookupJoin.Input.Relational().OutputCols,
+			)
 		}
 
 		tableFDs := memo.MakeTableFuncDep(md, scanPrivate.Table)
@@ -1185,6 +1230,76 @@ func (c *CustomFuncs) mapInvertedJoin(
 	invertedJoin.Cols = invertedJoin.Cols.Difference(indexCols).Union(newIndexCols)
 	invertedJoin.ConstFilters = c.MapFilterCols(invertedJoin.ConstFilters, srcCols, dstCols)
 	invertedJoin.On = c.MapFilterCols(invertedJoin.On, srcCols, dstCols)
+}
+
+// findComputedColJoinEquality returns the computed column expression of col and
+// ok=true when a join equality constraint can be generated for the column. This
+// is possible when:
+//
+//   1. col is non-nullable.
+//   2. col is a computed column.
+//   3. Columns referenced in the computed expression are a subset of columns
+//      that already have equality constraints.
+//
+// For example, consider the table and query:
+//
+//   CREATE TABLE a (
+//     a INT
+//   )
+//
+//   CREATE TABLE bc (
+//     b INT,
+//     c INT NOT NULL AS (b + 1) STORED
+//   )
+//
+//   SELECT * FROM a JOIN b ON a = b
+//
+// We can add an equality constraint for c because c is a function of b and b
+// has an equality constraint in the join predicate:
+//
+//   SELECT * FROM a JOIN b ON a = b AND a + 1 = c
+//
+// Condition (1) is required to prevent generating invalid equality constraints
+// for computed column expressions that can evaluate to NULL even when the
+// columns referenced in the expression are non-NULL. For example, consider the
+// table and query:
+//
+//   CREATE TABLE a (
+//     a INT
+//   )
+//
+//   CREATE TABLE bc (
+//     b INT,
+//     c INT AS (CASE WHEN b > 0 THEN NULL ELSE -1 END) STORED
+//   )
+//
+//   SELECT a, b FROM a JOIN b ON a = b
+//
+// The following is an invalid transformation: a row such as (a=1, b=1) would no
+// longer be returned because NULL=NULL is false.
+//
+//   SELECT a, b FROM a JOIN b ON a = b AND (CASE WHEN a > 0 THEN NULL ELSE -1 END) = c
+//
+// TODO(mgartner): We can relax condition (1) to allow nullable columns if it
+// can be proven that the expression will never evaluate to NULL. We can use
+// memo.ExprIsNeverNull to determine this, passing both NOT NULL and equality
+// columns as notNullCols.
+func (c *CustomFuncs) findComputedColJoinEquality(
+	tabID opt.TableID, col opt.ColumnID, eqCols opt.ColSet,
+) (_ opt.ScalarExpr, ok bool) {
+	tabMeta := c.e.mem.Metadata().TableMeta(tabID)
+	tab := c.e.mem.Metadata().Table(tabID)
+	if tab.Column(tabID.ColumnOrdinal(col)).IsNullable() {
+		return nil, false
+	}
+	expr, ok := tabMeta.ComputedColExpr(col)
+	if !ok {
+		return nil, false
+	}
+	if !c.OuterCols(expr).SubsetOf(eqCols) {
+		return nil, false
+	}
+	return expr, true
 }
 
 // findJoinFilterConstants tries to find a filter that is exactly equivalent to

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -73,6 +73,20 @@ CREATE TABLE virt (
 ----
 
 exec-ddl
+CREATE TABLE shard (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  shard_a INT NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 3)) STORED,
+  shard_a_b INT NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a, b)), 3)) VIRTUAL,
+  shard_b_null INT AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 3)) STORED,
+  CHECK (shard_a IN (0, 1, 2)),
+  CHECK (shard_a_b IN (0, 1, 2)),
+  CHECK (shard_b_null IN (0, 1, 2))
+)
+----
+
+exec-ddl
 CREATE TABLE large (m INT, n INT)
 ----
 
@@ -130,6 +144,17 @@ ALTER TABLE virt INJECT STATISTICS '[
     "created_at": "2018-05-01 1:00:00.00000+00:00",
     "row_count": 100000000,
     "distinct_count": 100000
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE shard INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 100000000,
+    "distinct_count": 100000000
   }
 ]'
 ----
@@ -2661,6 +2686,154 @@ anti-join (lookup abcd)
  └── filters
       └── n:2 = c:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
+exec-ddl
+CREATE INDEX shard_a_idx ON shard (shard_a, a)
+----
+
+# Generate an inner lookup join by synthesizing an equality constraint for an
+# indexed computed column.
+opt expect=GenerateLookupJoins
+SELECT m, k FROM small INNER LOOKUP JOIN shard ON small.m = shard.a
+----
+project
+ ├── columns: m:1!null k:6!null
+ ├── fd: (6)-->(1)
+ └── inner-join (lookup shard@shard_a_idx)
+      ├── columns: m:1!null k:6!null a:7!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [14 1] = [9 7]
+      ├── fd: (6)-->(7), (1)==(7), (7)==(1)
+      ├── project
+      │    ├── columns: shard_a_eq:14 m:1
+      │    ├── immutable
+      │    ├── fd: (1)-->(14)
+      │    ├── scan small
+      │    │    └── columns: m:1
+      │    └── projections
+      │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:14, outer=(1), immutable]
+      └── filters (true)
+
+# Generate a left lookup join by synthesizing an equality constraint for an
+# indexed computed column.
+opt expect=GenerateLookupJoins
+SELECT m, k FROM small LEFT LOOKUP JOIN shard ON small.m = shard.a
+----
+project
+ ├── columns: m:1 k:6
+ └── left-join (lookup shard@shard_a_idx)
+      ├── columns: m:1 k:6 a:7
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [14 1] = [9 7]
+      ├── fd: (6)-->(7)
+      ├── project
+      │    ├── columns: shard_a_eq:14 m:1
+      │    ├── immutable
+      │    ├── fd: (1)-->(14)
+      │    ├── scan small
+      │    │    └── columns: m:1
+      │    └── projections
+      │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:14, outer=(1), immutable]
+      └── filters (true)
+
+# Generate a semi lookup join by synthesizing an equality constraint for an
+# indexed computed column.
+opt expect=GenerateLookupJoins
+SELECT m FROM small WHERE EXISTS (SELECT * FROM shard WHERE small.m = shard.a)
+----
+semi-join (lookup shard@shard_a_idx)
+ ├── columns: m:1
+ ├── key columns: [14 1] = [9 7]
+ ├── project
+ │    ├── columns: shard_a_eq:14 m:1
+ │    ├── immutable
+ │    ├── fd: (1)-->(14)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    └── projections
+ │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:14, outer=(1), immutable]
+ └── filters (true)
+
+# Generate an anti lookup join by synthesizing an equality constraint for an
+# indexed computed column.
+opt expect=GenerateLookupJoins
+SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM shard WHERE small.m = shard.a)
+----
+anti-join (lookup shard@shard_a_idx)
+ ├── columns: m:1
+ ├── key columns: [14 1] = [9 7]
+ ├── project
+ │    ├── columns: shard_a_eq:14 m:1
+ │    ├── immutable
+ │    ├── fd: (1)-->(14)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    └── projections
+ │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:14, outer=(1), immutable]
+ └── filters (true)
+
+exec-ddl
+DROP INDEX shard_a_idx
+----
+
+exec-ddl
+CREATE INDEX shard_a_b_idx ON shard (shard_a_b, a, b)
+----
+
+# Generate a lookup join by synthesizing an equality constraint for an indexed
+# computed column when the expression references multiple columns.
+opt expect=GenerateLookupJoins
+SELECT m, k FROM small INNER LOOKUP JOIN shard ON small.m = shard.a AND small.n = shard.b
+----
+project
+ ├── columns: m:1!null k:6!null
+ ├── fd: (6)-->(1)
+ └── inner-join (lookup shard@shard_a_b_idx)
+      ├── columns: m:1!null n:2!null k:6!null a:7!null b:8!null
+      ├── flags: force lookup join (into right side)
+      ├── key columns: [14 1 2] = [10 7 8]
+      ├── fd: (6)-->(7,8), (1)==(7), (7)==(1), (2)==(8), (8)==(2)
+      ├── project
+      │    ├── columns: shard_a_b_eq:14 m:1 n:2
+      │    ├── immutable
+      │    ├── fd: (1,2)-->(14)
+      │    ├── scan small
+      │    │    └── columns: m:1 n:2
+      │    └── projections
+      │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1, n:2)), 3) [as=shard_a_b_eq:14, outer=(1,2), immutable]
+      └── filters (true)
+
+exec-ddl
+DROP INDEX shard_a_b_idx
+----
+
+exec-ddl
+CREATE INDEX shard_b_null_idx ON shard (shard_b_null, b)
+----
+
+# Do not synthesize an equality constraint for a nullable computed column.
+opt expect-not=GenerateLookupJoins
+SELECT m, k FROM small INNER LOOKUP JOIN shard ON small.m = shard.b
+----
+project
+ ├── columns: m:1!null k:6!null
+ ├── fd: (6)-->(1)
+ └── inner-join (hash)
+      ├── columns: m:1!null k:6!null b:8!null
+      ├── flags: force lookup join (into right side)
+      ├── fd: (6)-->(8), (1)==(8), (8)==(1)
+      ├── scan small
+      │    └── columns: m:1
+      ├── scan shard@shard_b_null_idx
+      │    ├── columns: k:6!null b:8
+      │    ├── key: (6)
+      │    └── fd: (6)-->(8)
+      └── filters
+           └── m:1 = b:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+exec-ddl
+DROP INDEX shard_b_null_idx
+----
+
 # Regression test for #59615. Ensure that invalid lookup joins are not created
 # for left and anti joins.
 exec-ddl
@@ -4114,7 +4287,8 @@ inner-join (lookup t63735)
  ├── lookup columns are key
  ├── fd: ()-->(1,2,6,7), (2)==(7), (7)==(2)
  ├── project
- │    ├── columns: "lookup_join_const_col_@6":10!null m:1!null n:2!null
+ │    ├── columns: x_eq:10!null m:1!null n:2!null
+ │    ├── immutable
  │    ├── fd: ()-->(1,2,10)
  │    ├── select
  │    │    ├── columns: m:1!null n:2!null
@@ -4125,7 +4299,7 @@ inner-join (lookup t63735)
  │    │         ├── n:2 = 15 [outer=(2), constraints=(/2: [/15 - /15]; tight), fd=()-->(2)]
  │    │         └── m:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
  │    └── projections
- │         └── 30 [as="lookup_join_const_col_@6":10]
+ │         └── n:2 * 2 [as=x_eq:10, outer=(2), immutable]
  └── filters
       └── y:7 = 15 [outer=(7), constraints=(/7: [/15 - /15]; tight), fd=()-->(7)]
 
@@ -4681,18 +4855,14 @@ project
  │    ├── flags: force lookup join (into right side)
  │    ├── key columns: [16 1] = [12 7]
  │    ├── fd: (1)==(7), (7)==(1)
- │    ├── inner-join (cross)
- │    │    ├── columns: m:1 "lookup_join_const_col_@12":16!null
- │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    ├── project
+ │    │    ├── columns: v4_eq:16 m:1
+ │    │    ├── immutable
+ │    │    ├── fd: (1)-->(16)
  │    │    ├── scan small
  │    │    │    └── columns: m:1
- │    │    ├── values
- │    │    │    ├── columns: "lookup_join_const_col_@12":16!null
- │    │    │    ├── cardinality: [3 - 3]
- │    │    │    ├── (1,)
- │    │    │    ├── (2,)
- │    │    │    └── (3,)
- │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── m:1 + 1 [as=v4_eq:16, outer=(1), immutable]
  │    └── filters (true)
  └── projections
       └── i:7 + 1 [as=v4:12, outer=(7), immutable]
@@ -4706,19 +4876,19 @@ project
  ├── columns: m:1 i:7 v4:12
  ├── immutable
  ├── fd: (7)~~>(12)
- ├── project
+ ├── left-join (lookup virt@v4_i)
  │    ├── columns: m:1 i:7
- │    └── left-join (lookup virt@v4_i)
- │         ├── columns: m:1 i:7 v4:12
- │         ├── flags: force lookup join (into right side)
- │         ├── lookup expression
- │         │    └── filters
- │         │         ├── m:1 = i:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
- │         │         └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
- │         ├── fd: (7)~~>(12)
- │         ├── scan small
- │         │    └── columns: m:1
- │         └── filters (true)
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [16 1] = [12 7]
+ │    ├── project
+ │    │    ├── columns: v4_eq:16 m:1
+ │    │    ├── immutable
+ │    │    ├── fd: (1)-->(16)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:1
+ │    │    └── projections
+ │    │         └── m:1 + 1 [as=v4_eq:16, outer=(1), immutable]
+ │    └── filters (true)
  └── projections
       └── CASE i:7 IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE i:7 + 1 END [as=v4:12, outer=(7), immutable]
 


### PR DESCRIPTION
Transformation rules that generate lookup joins can now synthesize
equality constraints for indexed computed columns. This allows lookup
joins to be planned in more cases.

For example, consider the tables and query:

    CREATE TABLE a (
      a INT
    )

    CREATE TABLE bc (
      b INT,
      c INT NOT NULL AS (b + 1) STORED,
      INDEX c_b_idx (c, b)
    )

    SELECT * FROM a JOIN b ON a = b

We can add an equality constraint for `c` because `c` is a function of
`b` and `b` has an equality constraint in the join predicate:

    SELECT * FROM a JOIN b ON a = b AND a + 1 = c

With the addition of the computed column equality, a lookup join
utilizing `c_b_idx` can be planned.

This is particularly important for improving plans for queries on tables
with hash-sharded indexes, because the shard column is a computed column
and it is unlikely to be constrained explicitly.

Release note (performance improvement): The optimizer attempts to plan
lookup joins on indexes that include computed columns in more cases,
which may improve query plans.