### PR TITLE
kvserver: prevent build-up of abandoned consistency checks

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_compute_checksum.go
+++ b/pkg/kv/kvserver/batcheval/cmd_compute_checksum.go
@@ -46,12 +46,9 @@ func declareKeysComputeChecksum(
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
 }
 
-// Version numbers for Replica checksum computation. Requests silently no-op
-// unless the versions are compatible.
-const (
-	ReplicaChecksumVersion    = 4
-	ReplicaChecksumGCInterval = time.Hour
-)
+// ReplicaChecksumVersion versions the checksum computation. Requests silently no-op
+// unless the versions between the requesting and requested replica are compatible.
+const ReplicaChecksumVersion = 4
 
 // ComputeChecksum starts the process of computing a checksum on the replica at
 // a particular snapshot. The checksum is later verified through a

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -231,7 +231,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// This test prints a consistency checker diff, so it's
-	// good to make sure we're overly redacting said diff.
+	// good to make sure we're not overly redacting said diff.
 	defer log.TestingSetRedactable(true)()
 
 	// Test uses sticky registry to have persistent pebble state that could

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -557,7 +557,7 @@ type Replica struct {
 		lastUpdateTimes lastUpdateTimesMap
 
 		// Computed checksum at a snapshot UUID.
-		checksums map[uuid.UUID]ReplicaChecksum
+		checksums map[uuid.UUID]replicaChecksum
 
 		// proposalQuota is the quota pool maintained by the lease holder where
 		// incoming writes acquire quota from a fixed quota pool before going

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -370,6 +370,8 @@ type Replica struct {
 	// timestamp, independent of the source.
 	sideTransportClosedTimestamp sidetransportAccess
 
+	checksumStorage checksumStorage
+
 	mu struct {
 		// Protects all fields in the mu struct.
 		syncutil.RWMutex
@@ -555,9 +557,6 @@ type Replica struct {
 		// this kind of risk though: a replica that gets stuck on an otherwise
 		// live node will not lose leaseholdership.
 		lastUpdateTimes lastUpdateTimesMap
-
-		// Computed checksum at a snapshot UUID.
-		checksums map[uuid.UUID]replicaChecksum
 
 		// proposalQuota is the quota pool maintained by the lease holder where
 		// incoming writes acquire quota from a fixed quota pool before going

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -19,15 +19,18 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -419,6 +422,15 @@ func (r *Replica) RunConsistencyCheck(
 	return results, nil
 }
 
+func (r *Replica) gcOldChecksumEntriesLocked(now time.Time) {
+	for id, val := range r.mu.checksums {
+		// The timestamp is valid only if set.
+		if !val.gcTimestamp.IsZero() && now.After(val.gcTimestamp) {
+			delete(r.mu.checksums, id)
+		}
+	}
+}
+
 // getChecksum waits for the result of ComputeChecksum and returns it.
 // It returns false if there is no checksum being computed for the id,
 // or it has already been GCed.
@@ -683,4 +695,123 @@ func (r *Replica) sha512(
 	result.RecomputedMS.AgeTo(result.PersistedMS.LastUpdateNanos)
 
 	return &result, nil
+}
+
+func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.ComputeChecksum) {
+	stopper := r.store.Stopper()
+	now := timeutil.Now()
+	r.mu.Lock()
+	var notify chan struct{}
+	if c, ok := r.mu.checksums[cc.ChecksumID]; !ok {
+		// There is no record of this ID. Make a new notification.
+		notify = make(chan struct{})
+	} else if !c.started {
+		// A CollectChecksumRequest is waiting on the existing notification.
+		notify = c.notify
+	} else {
+		log.Fatalf(ctx, "attempted to apply ComputeChecksum command with duplicated checksum ID %s",
+			cc.ChecksumID)
+	}
+
+	r.gcOldChecksumEntriesLocked(now)
+
+	// Create an entry with checksum == nil and gcTimestamp unset.
+	r.mu.checksums[cc.ChecksumID] = ReplicaChecksum{started: true, notify: notify}
+	desc := *r.mu.state.Desc
+	r.mu.Unlock()
+
+	if cc.Version != batcheval.ReplicaChecksumVersion {
+		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
+		log.Infof(ctx, "incompatible ComputeChecksum versions (requested: %d, have: %d)",
+			cc.Version, batcheval.ReplicaChecksumVersion)
+		return
+	}
+
+	// Caller is holding raftMu, so an engine snapshot is automatically
+	// Raft-consistent (i.e. not in the middle of an AddSSTable).
+	snap := r.store.engine.NewSnapshot()
+	if cc.Checkpoint {
+		sl := stateloader.Make(r.RangeID)
+		as, err := sl.LoadRangeAppliedState(ctx, snap)
+		if err != nil {
+			log.Warningf(ctx, "unable to load applied index, continuing anyway")
+		}
+		// NB: the names here will match on all nodes, which is nice for debugging.
+		tag := fmt.Sprintf("r%d_at_%d", r.RangeID, as.RaftAppliedIndex)
+		if dir, err := r.store.checkpoint(ctx, tag); err != nil {
+			log.Warningf(ctx, "unable to create checkpoint %s: %+v", dir, err)
+		} else {
+			log.Warningf(ctx, "created checkpoint %s", dir)
+		}
+	}
+
+	// Compute SHA asynchronously and store it in a map by UUID.
+	// Don't use the proposal's context for this, as it likely to be canceled very
+	// soon.
+	if err := stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "storage.Replica: computing checksum", func(ctx context.Context) {
+		func() {
+			defer snap.Close()
+			var snapshot *roachpb.RaftSnapshotData
+			if cc.SaveSnapshot {
+				snapshot = &roachpb.RaftSnapshotData{}
+			}
+
+			result, err := r.sha512(ctx, desc, snap, snapshot, cc.Mode, r.store.consistencyLimiter)
+			if err != nil {
+				log.Errorf(ctx, "%v", err)
+				result = nil
+			}
+			r.computeChecksumDone(ctx, cc.ChecksumID, result, snapshot)
+		}()
+
+		var shouldFatal bool
+		for _, rDesc := range cc.Terminate {
+			if rDesc.StoreID == r.store.StoreID() && rDesc.ReplicaID == r.replicaID {
+				shouldFatal = true
+			}
+		}
+
+		if shouldFatal {
+			// This node should fatal as a result of a previous consistency
+			// check (i.e. this round is carried out only to obtain a diff).
+			// If we fatal too early, the diff won't make it back to the lease-
+			// holder and thus won't be printed to the logs. Since we're already
+			// in a goroutine that's about to end, simply sleep for a few seconds
+			// and then terminate.
+			auxDir := r.store.engine.GetAuxiliaryDir()
+			_ = r.store.engine.MkdirAll(auxDir)
+			path := base.PreventedStartupFile(auxDir)
+
+			const attentionFmt = `ATTENTION:
+
+this node is terminating because a replica inconsistency was detected between %s
+and its other replicas. Please check your cluster-wide log files for more
+information and contact the CockroachDB support team. It is not necessarily safe
+to replace this node; cluster data may still be at risk of corruption.
+
+A checkpoints directory to aid (expert) debugging should be present in:
+%s
+
+A file preventing this node from restarting was placed at:
+%s
+`
+			preventStartupMsg := fmt.Sprintf(attentionFmt, r, auxDir, path)
+			if err := fs.WriteFile(r.store.engine, path, []byte(preventStartupMsg)); err != nil {
+				log.Warningf(ctx, "%v", err)
+			}
+
+			if p := r.store.cfg.TestingKnobs.ConsistencyTestingKnobs.OnBadChecksumFatal; p != nil {
+				p(*r.store.Ident)
+			} else {
+				time.Sleep(10 * time.Second)
+				log.Fatalf(r.AnnotateCtx(context.Background()), attentionFmt, r, auxDir, path)
+			}
+		}
+
+	}); err != nil {
+		defer snap.Close()
+		log.Errorf(ctx, "could not run async checksum computation (ID = %s): %v", cc.ChecksumID, err)
+		// Set checksum to nil.
+		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
+	}
 }

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -579,7 +579,7 @@ type replicaHash struct {
 
 // sha512 computes the SHA512 hash of all the replica data at the snapshot.
 // It will dump all the kv data into snapshot if it is provided.
-func (r *Replica) sha512(
+func (*Replica) sha512(
 	ctx context.Context,
 	desc roachpb.RangeDescriptor,
 	snap storage.Reader,

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -77,7 +77,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 
 	// Simple condition, the checksum is notified, but not computed.
 	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = ReplicaChecksum{notify: notify}
+	tc.repl.mu.checksums[id] = replicaChecksum{notify: notify}
 	tc.repl.mu.Unlock()
 	rc, err := tc.repl.getChecksum(ctx, id)
 	if !testutils.IsError(err, "no checksum found") {
@@ -88,7 +88,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	// this will take 10ms.
 	id = uuid.FastMakeV4()
 	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = ReplicaChecksum{notify: make(chan struct{})}
+	tc.repl.mu.checksums[id] = replicaChecksum{notify: make(chan struct{})}
 	tc.repl.mu.Unlock()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	if !testutils.IsError(err, "checksum computation did not start") {
@@ -99,7 +99,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	// so next step is for context deadline.
 	id = uuid.FastMakeV4()
 	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = ReplicaChecksum{notify: make(chan struct{}), started: true}
+	tc.repl.mu.checksums[id] = replicaChecksum{notify: make(chan struct{}), started: true}
 	tc.repl.mu.Unlock()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	if !testutils.IsError(err, "context deadline exceeded") {

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -47,12 +49,12 @@ func TestReplicaChecksumVersion(t *testing.T) {
 			cc.Version = 1
 		}
 		tc.repl.computeChecksumPostApply(ctx, cc)
-		rc, err := tc.repl.getChecksum(ctx, cc.ChecksumID)
+		rc, err := getChecksum(ctx, &tc.repl.checksumStorage, cc.ChecksumID)
 		if !matchingVersion {
 			if !testutils.IsError(err, "no checksum found") {
 				t.Fatal(err)
 			}
-			require.Nil(t, rc.Checksum)
+			require.Nil(t, rc)
 		} else {
 			require.NoError(t, err)
 			require.NotNil(t, rc.Checksum)
@@ -60,61 +62,69 @@ func TestReplicaChecksumVersion(t *testing.T) {
 	})
 }
 
-func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
+func TestChecksumStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-	defer cancel()
+	ctx := context.Background()
+	css := &checksumStorage{}
 
-	tc := testContext{}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	tc.Start(ctx, t, stopper)
+	id, err := uuid.NewV4()
+	require.NoError(t, err)
 
-	id := uuid.FastMakeV4()
-	notify := make(chan struct{})
-	close(notify)
+	t0 := timeutil.Unix(0, 0)
 
-	// Simple condition, the checksum is notified, but not computed.
-	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = replicaChecksum{notify: notify}
-	tc.repl.mu.Unlock()
-	rc, err := tc.repl.getChecksum(ctx, id)
-	if !testutils.IsError(err, "no checksum found") {
-		t.Fatal(err)
-	}
-	require.Nil(t, rc.Checksum)
-	// Next condition, the initial wait expires and checksum is not started,
-	// this will take 10ms.
-	id = uuid.FastMakeV4()
-	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = replicaChecksum{notify: make(chan struct{})}
-	tc.repl.mu.Unlock()
-	rc, err = tc.repl.getChecksum(ctx, id)
-	if !testutils.IsError(err, "checksum computation did not start") {
-		t.Fatal(err)
-	}
-	require.Nil(t, rc.Checksum)
-	// Next condition, initial wait expired and we found the started flag,
-	// so next step is for context deadline.
-	id = uuid.FastMakeV4()
-	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = replicaChecksum{notify: make(chan struct{}), started: true}
-	tc.repl.mu.Unlock()
-	rc, err = tc.repl.getChecksum(ctx, id)
-	if !testutils.IsError(err, "context deadline exceeded") {
-		t.Fatal(err)
-	}
-	require.Nil(t, rc.Checksum)
+	// Expected usage.
+	t.Run("basic", func(t *testing.T) {
+		c := css.GetOrInit(id, t0.Add(time.Minute))
+		var canceled bool
+		c.SignalStart(func() {
+			canceled = true
+		})
+		require.NoError(t, c.WaitStarted(ctx, time.Nanosecond))
+		hash := &replicaHash{PersistedMS: enginepb.MVCCStats{AbortSpanBytes: 123}}
+		raftData := &roachpb.RaftSnapshotData{}
+		c.SignalResult(hash, raftData)
+		ccr, err := c.WaitResult(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 123, ccr.Persisted.AbortSpanBytes)
+		require.Equal(t, raftData, ccr.Snapshot)
+		require.True(t, css.Delete(id))
+		require.True(t, canceled)
+	})
 
-	// Need to reset the context, since we deadlined it above.
-	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	// Next condition, node should quiesce.
-	tc.repl.store.Stopper().Quiesce(ctx)
-	rc, err = tc.repl.getChecksum(ctx, uuid.FastMakeV4())
-	if !testutils.IsError(err, "store quiescing") {
-		t.Fatal(err)
-	}
-	require.Nil(t, rc.Checksum)
+	// Context deadline respected in getChecksum.
+	t.Run("deadline-getchecksum", func(t *testing.T) {
+		c := css.GetOrInit(id, timeutil.Now().Add(24*time.Hour))
+		require.NotNil(t, c)
+		ctx, cancel := context.WithTimeout(ctx, time.Millisecond)
+		ccr, err := getChecksum(ctx, css, id)
+		// We don't verify the error because it could either be Canceled
+		// or DeadlineExceeded.
+		t.Log(err)
+		cancel()
+		require.Error(t, err)
+		require.Nil(t, ccr)
+		require.False(t, css.Delete(id)) // getChecksum deleted it
+	})
+
+	// Deadline on the computation itself is observed by GC.
+	t.Run("deadline-gc", func(t *testing.T) {
+		tBegin := timeutil.Now()
+		c := css.GetOrInit(id, tBegin.Add(time.Millisecond))
+		require.NotNil(t, c)
+		css.GC(tBegin.Add(2 * time.Millisecond))
+		require.False(t, css.Delete(id)) // GC deleted it
+	})
+
+	// Ongoing computation is canceled on deletion.
+	t.Run("delete-cancels", func(t *testing.T) {
+		c := css.GetOrInit(id, timeutil.Now().Add(24*time.Hour))
+		require.NotNil(t, c)
+		var canceled bool
+		c.SignalStart(func() {
+			canceled = true
+		})
+		require.True(t, css.Delete(id))
+		require.True(t, canceled)
+	})
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"go.etcd.io/etcd/raft/v3"
@@ -100,7 +99,6 @@ func newUnloadedReplica(
 		return kvserverbase.SplitByLoadMergeDelay.Get(&store.cfg.Settings.SV)
 	})
 	r.mu.proposals = map[kvserverbase.CmdIDKey]*ProposalData{}
-	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
 	r.mu.proposalBuf.Init((*replicaProposer)(r), tracker.NewLockfreeTracker(), r.Clock(), r.ClusterSettings())
 	r.mu.proposalBuf.testing.allowLeaseProposalWhenNotLeader = store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader
 	r.mu.proposalBuf.testing.dontCloseTimestamps = store.cfg.TestingKnobs.DontCloseTimestamps

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -100,7 +100,7 @@ func newUnloadedReplica(
 		return kvserverbase.SplitByLoadMergeDelay.Get(&store.cfg.Settings.SV)
 	})
 	r.mu.proposals = map[kvserverbase.CmdIDKey]*ProposalData{}
-	r.mu.checksums = map[uuid.UUID]ReplicaChecksum{}
+	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
 	r.mu.proposalBuf.Init((*replicaProposer)(r), tracker.NewLockfreeTracker(), r.Clock(), r.ClusterSettings())
 	r.mu.proposalBuf.testing.allowLeaseProposalWhenNotLeader = store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader
 	r.mu.proposalBuf.testing.dontCloseTimestamps = store.cfg.TestingKnobs.DontCloseTimestamps

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -17,22 +17,18 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -171,139 +167,6 @@ func (proposal *ProposalData) releaseQuota() {
 	if proposal.quotaAlloc != nil {
 		proposal.quotaAlloc.Release()
 		proposal.quotaAlloc = nil
-	}
-}
-
-// TODO(tschottdorf): we should find new homes for the checksum, lease
-// code, and various others below to leave here only the core logic.
-// Not moving anything right now to avoid awkward diffs. These should
-// all be moved to replica_application_result.go.
-
-func (r *Replica) gcOldChecksumEntriesLocked(now time.Time) {
-	for id, val := range r.mu.checksums {
-		// The timestamp is valid only if set.
-		if !val.gcTimestamp.IsZero() && now.After(val.gcTimestamp) {
-			delete(r.mu.checksums, id)
-		}
-	}
-}
-
-func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.ComputeChecksum) {
-	stopper := r.store.Stopper()
-	now := timeutil.Now()
-	r.mu.Lock()
-	var notify chan struct{}
-	if c, ok := r.mu.checksums[cc.ChecksumID]; !ok {
-		// There is no record of this ID. Make a new notification.
-		notify = make(chan struct{})
-	} else if !c.started {
-		// A CollectChecksumRequest is waiting on the existing notification.
-		notify = c.notify
-	} else {
-		log.Fatalf(ctx, "attempted to apply ComputeChecksum command with duplicated checksum ID %s",
-			cc.ChecksumID)
-	}
-
-	r.gcOldChecksumEntriesLocked(now)
-
-	// Create an entry with checksum == nil and gcTimestamp unset.
-	r.mu.checksums[cc.ChecksumID] = ReplicaChecksum{started: true, notify: notify}
-	desc := *r.mu.state.Desc
-	r.mu.Unlock()
-
-	if cc.Version != batcheval.ReplicaChecksumVersion {
-		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
-		log.Infof(ctx, "incompatible ComputeChecksum versions (requested: %d, have: %d)",
-			cc.Version, batcheval.ReplicaChecksumVersion)
-		return
-	}
-
-	// Caller is holding raftMu, so an engine snapshot is automatically
-	// Raft-consistent (i.e. not in the middle of an AddSSTable).
-	snap := r.store.engine.NewSnapshot()
-	if cc.Checkpoint {
-		sl := stateloader.Make(r.RangeID)
-		as, err := sl.LoadRangeAppliedState(ctx, snap)
-		if err != nil {
-			log.Warningf(ctx, "unable to load applied index, continuing anyway")
-		}
-		// NB: the names here will match on all nodes, which is nice for debugging.
-		tag := fmt.Sprintf("r%d_at_%d", r.RangeID, as.RaftAppliedIndex)
-		if dir, err := r.store.checkpoint(ctx, tag); err != nil {
-			log.Warningf(ctx, "unable to create checkpoint %s: %+v", dir, err)
-		} else {
-			log.Warningf(ctx, "created checkpoint %s", dir)
-		}
-	}
-
-	// Compute SHA asynchronously and store it in a map by UUID.
-	// Don't use the proposal's context for this, as it likely to be canceled very
-	// soon.
-	if err := stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "storage.Replica: computing checksum", func(ctx context.Context) {
-		func() {
-			defer snap.Close()
-			var snapshot *roachpb.RaftSnapshotData
-			if cc.SaveSnapshot {
-				snapshot = &roachpb.RaftSnapshotData{}
-			}
-
-			result, err := r.sha512(ctx, desc, snap, snapshot, cc.Mode, r.store.consistencyLimiter)
-			if err != nil {
-				log.Errorf(ctx, "%v", err)
-				result = nil
-			}
-			r.computeChecksumDone(ctx, cc.ChecksumID, result, snapshot)
-		}()
-
-		var shouldFatal bool
-		for _, rDesc := range cc.Terminate {
-			if rDesc.StoreID == r.store.StoreID() && rDesc.ReplicaID == r.replicaID {
-				shouldFatal = true
-			}
-		}
-
-		if shouldFatal {
-			// This node should fatal as a result of a previous consistency
-			// check (i.e. this round is carried out only to obtain a diff).
-			// If we fatal too early, the diff won't make it back to the lease-
-			// holder and thus won't be printed to the logs. Since we're already
-			// in a goroutine that's about to end, simply sleep for a few seconds
-			// and then terminate.
-			auxDir := r.store.engine.GetAuxiliaryDir()
-			_ = r.store.engine.MkdirAll(auxDir)
-			path := base.PreventedStartupFile(auxDir)
-
-			const attentionFmt = `ATTENTION:
-
-this node is terminating because a replica inconsistency was detected between %s
-and its other replicas. Please check your cluster-wide log files for more
-information and contact the CockroachDB support team. It is not necessarily safe
-to replace this node; cluster data may still be at risk of corruption.
-
-A checkpoints directory to aid (expert) debugging should be present in:
-%s
-
-A file preventing this node from restarting was placed at:
-%s
-`
-			preventStartupMsg := fmt.Sprintf(attentionFmt, r, auxDir, path)
-			if err := fs.WriteFile(r.store.engine, path, []byte(preventStartupMsg)); err != nil {
-				log.Warningf(ctx, "%v", err)
-			}
-
-			if p := r.store.cfg.TestingKnobs.ConsistencyTestingKnobs.OnBadChecksumFatal; p != nil {
-				p(*r.store.Ident)
-			} else {
-				time.Sleep(10 * time.Second)
-				log.Fatalf(r.AnnotateCtx(context.Background()), attentionFmt, r, auxDir, path)
-			}
-		}
-
-	}); err != nil {
-		defer snap.Close()
-		log.Errorf(ctx, "could not run async checksum computation (ID = %s): %v", cc.ChecksumID, err)
-		// Set checksum to nil.
-		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
 	}
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10409,7 +10409,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 		// Regression test for #31870.
 		snap := tc.engine.NewSnapshot()
 		defer snap.Close()
-		res, err := tc.repl.sha512(ctx, *tc.repl.Desc(), tc.engine,
+		res, err := sha512Checksum(ctx, *tc.repl.Desc(), tc.engine,
 			nil /* diff */, roachpb.ChecksumMode_CHECK_FULL,
 			quotapool.NewRateLimiter("ConsistencyQueue", quotapool.Limit(math.MaxFloat64), math.MaxInt64))
 		if err != nil {


### PR DESCRIPTION
We've seen in the events leading up to #75448 that a build-up of
consistency check computations on a node can severely impact node
performance. This commit attempts to address the main source of
that, while re-working the code for easier maintainability.

The way the consistency checker works is by replicating a command through
Raft that, on each Replica, triggers an async checksum computations
the results of which the caller collects via `CollectChecksum` requests
addressed to each `Replica`.

If for any reason, the caller does *not* wait to collect the checksums
but instead moves on to run another consistency check (perhaps on
another Range), these inflight computations can build up over time.

This was the main issue in #75448; we were accidentally canceling the
context on the leaseholder "right away", failing the consistency check
(but leaving it running on all other replicas), and moving on to the
next Range.
As a result, some (but with spread out leaseholders, ultimately all)
Replicas ended up with dozens of consistency check computations,
starving I/O and CPU.  We "addressed" this by avoiding this errant ctx
cancellation (#75448 but longer-term #75656), but this isn't a holistic
fix yet.

In this commit, we make three main changes:

- give the inflight consistency check computations a clean API, which
  makes it much easier to understand "how it works".
- when returning from CollectChecksum (either on success or error,
  notably including context cancellation), cancel the corresponding
  consistency check. This solves the problem, *assuming* that
  CollectChecksum is reliably issued to each Replica.
- reliably issue CollectChecksum to each Replica on which a computation
  may have been triggered. When the caller's context is canceled, still
  do the call with a one-second-timeout one-off Context which should be
  good enough to make it to the Replica and short-circuit the call.

Release note: None
