### PR TITLE
storage: add `MVCCStats` for range keys

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -181,4 +181,4 @@ trace.debug.enable	boolean	false	if set, traces for recent requests can be seen 
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	21.2-78	set the active cluster version in the format '<major>.<minor>'
+version	version	21.2-80	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -194,6 +194,6 @@
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>21.2-78</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>21.2-80</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -306,6 +306,9 @@ const (
 	// ExperimentalMVCCRangeTombstones enables the use of highly experimental MVCC
 	// range tombstones.
 	ExperimentalMVCCRangeTombstones
+	// ExperimentalGCRanges is the version where the ExperimentalRanges parameter
+	// for GCRequest was added.
+	ExperimentalGCRanges
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -498,7 +501,10 @@ var versionsSingleton = keyedVersions{
 		Key:     ExperimentalMVCCRangeTombstones,
 		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 78},
 	},
-
+	{
+		Key:     ExperimentalGCRanges,
+		Version: roachpb.Version{Major: 21, Minor: 2, Internal: 80},
+	},
 	// *************************************************
 	// Step (2): Add new versions here.
 	// Do not add new versions to a patch release.

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -48,11 +48,12 @@ func _() {
 	_ = x[EnablePebbleFormatVersionRangeKeys-37]
 	_ = x[BackupResolutionInJob-38]
 	_ = x[ExperimentalMVCCRangeTombstones-39]
+	_ = x[ExperimentalGCRanges-40]
 }
 
-const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersTenantSettingsTableEnablePebbleFormatVersionBlockPropertiesDisableSystemConfigGossipTriggerMVCCIndexBackfillerEnableLeaseHolderRemovalEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysBackupResolutionInJobExperimentalMVCCRangeTombstones"
+const _Key_name = "V21_2Start22_1TargetBytesAvoidExcessAvoidDrainingNamesDrainingNamesMigrationTraceIDDoesntImplyStructuredRecordingAlterSystemTableStatisticsAddAvgSizeColAlterSystemStmtDiagReqsMVCCAddSSTableInsertPublicSchemaNamespaceEntryOnRestoreUnsplitRangesInAsyncGCJobsValidateGrantOptionPebbleFormatBlockPropertyCollectorProbeRequestSelectRPCsTakeTracingInfoInbandPreSeedTenantSpanConfigsSeedTenantSpanConfigsPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreScanWholeRowsSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersTenantSettingsTableEnablePebbleFormatVersionBlockPropertiesDisableSystemConfigGossipTriggerMVCCIndexBackfillerEnableLeaseHolderRemovalEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysBackupResolutionInJobExperimentalMVCCRangeTombstonesExperimentalGCRanges"
 
-var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 455, 483, 504, 517, 536, 570, 608, 642, 674, 710, 742, 778, 820, 839, 879, 911, 930, 954, 988, 1022, 1043, 1074}
+var _Key_index = [...]uint16{0, 5, 14, 36, 54, 76, 113, 152, 175, 189, 230, 256, 275, 309, 321, 352, 376, 397, 425, 455, 483, 504, 517, 536, 570, 608, 642, 674, 710, 742, 778, 820, 839, 879, 911, 930, 954, 988, 1022, 1043, 1074, 1094}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -51,7 +51,8 @@ func declareKeysClearRange(
 }
 
 // ClearRange wipes all MVCC versions of keys covered by the specified
-// span, adjusting the MVCC stats accordingly.
+// span, adjusting the MVCC stats accordingly. It clears both point keys
+// and range tombstones.
 //
 // Note that "correct" use of this command is only possible for key
 // spans consisting of user data that we know is not being written to

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -164,7 +164,10 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled,
 	// compute stats across the key span to be cleared.
 	if !fast || util.RaceEnabled {
-		iter := readWriter.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: to})
+		iter := readWriter.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			UpperBound: to,
+		})
 		computed, err := iter.ComputeStats(from, to, delta.LastUpdateNanos)
 		iter.Close()
 		if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1165,7 +1165,10 @@ func mergeTrigger(
 	{
 		ridPrefix := keys.MakeRangeIDReplicatedPrefix(merge.RightDesc.RangeID)
 		// NB: Range-ID local keys have no versions and no intents.
-		iter := batch.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: ridPrefix.PrefixEnd()})
+		iter := batch.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			UpperBound: ridPrefix.PrefixEnd(),
+		})
 		defer iter.Close()
 		sysMS, err := iter.ComputeStats(ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
 		if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -104,6 +104,9 @@ func TruncateLog(
 	// bugs that let it diverge. It might be easier to compute the stats
 	// from scratch, stopping when 4mb (defaultRaftLogTruncationThreshold)
 	// is reached as at that point we'll truncate aggressively anyway.
+	//
+	// We do not use IterKeyTypePointsAndRanges since there should be no
+	// range keys here.
 	iter := readWriter.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: end})
 	defer iter.Close()
 	// We can pass zero as nowNanos because we're only interested in SysBytes.

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -147,7 +147,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys)
+							err := gcer.GC(ctx, batchGCKeys, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -206,7 +206,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
 			return Info{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -184,16 +184,18 @@ func BenchmarkRun(b *testing.B) {
 }
 
 type fakeGCer struct {
-	gcKeys     map[string]roachpb.GCRequest_GCKey
-	threshold  Threshold
-	intents    []roachpb.Intent
-	batches    [][]roachpb.Intent
-	txnIntents []txnIntents
+	gcKeys      map[string]roachpb.GCRequest_GCKey
+	gcRangeKeys map[string]roachpb.GCRequest_GCRangeKey
+	threshold   Threshold
+	intents     []roachpb.Intent
+	batches     [][]roachpb.Intent
+	txnIntents  []txnIntents
 }
 
 func makeFakeGCer() fakeGCer {
 	return fakeGCer{
-		gcKeys: make(map[string]roachpb.GCRequest_GCKey),
+		gcKeys:      make(map[string]roachpb.GCRequest_GCKey),
+		gcRangeKeys: make(map[string]roachpb.GCRequest_GCRangeKey),
 	}
 }
 
@@ -204,9 +206,14 @@ func (f *fakeGCer) SetGCThreshold(ctx context.Context, t Threshold) error {
 	return nil
 }
 
-func (f *fakeGCer) GC(ctx context.Context, keys []roachpb.GCRequest_GCKey) error {
+func (f *fakeGCer) GC(
+	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+) error {
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
+	}
+	for _, rk := range rangeKeys {
+		f.gcRangeKeys[rk.String()] = rk
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -478,12 +478,15 @@ func (r *replicaGCer) SetGCThreshold(ctx context.Context, thresh gc.Threshold) e
 	return r.send(ctx, req)
 }
 
-func (r *replicaGCer) GC(ctx context.Context, keys []roachpb.GCRequest_GCKey) error {
-	if len(keys) == 0 {
+func (r *replicaGCer) GC(
+	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+) error {
+	if len(keys) == 0 && len(rangeKeys) == 0 {
 		return nil
 	}
 	req := r.template()
 	req.Keys = keys
+	req.ExperimentalRangeKeys = rangeKeys
 	return r.send(ctx, req)
 }
 

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -26,8 +26,10 @@ func ComputeStatsForRange(
 	var err error
 	for _, keyRange := range MakeReplicatedKeyRangesExceptLockTable(d) {
 		func() {
-			iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind,
-				storage.IterOptions{UpperBound: keyRange.End})
+			iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				KeyTypes:   storage.IterKeyTypePointsAndRanges,
+				UpperBound: keyRange.End,
+			})
 			defer iter.Close()
 
 			var msDelta enginepb.MVCCStats

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -576,7 +576,8 @@ func (r *Replica) sha512(
 	var timestampBuf []byte
 	hasher := sha512.New()
 
-	visitor := func(unsafeKey storage.MVCCKey, unsafeValue []byte) error {
+	// TODO(erikgrinaker): add a range key visitor to hash range keys.
+	pointKeyVisitor := func(unsafeKey storage.MVCCKey, unsafeValue []byte) error {
 		// Rate Limit the scan through the range
 		if err := limiter.WaitN(ctx, int64(len(unsafeKey.Key)+len(unsafeValue))); err != nil {
 			return err
@@ -633,9 +634,8 @@ func (r *Replica) sha512(
 		for _, span := range rditer.MakeReplicatedKeyRangesExceptLockTable(&desc) {
 			iter := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind,
 				storage.IterOptions{UpperBound: span.End})
-			spanMS, err := storage.ComputeStatsForRange(
-				iter, span.Start, span.End, 0 /* nowNanos */, visitor,
-			)
+			spanMS, err := storage.ComputeStatsForRangeWithVisitors(
+				iter, span.Start, span.End, 0 /* nowNanos */, pointKeyVisitor, nil /* rangeKeyVisitor */)
 			iter.Close()
 			if err != nil {
 				return nil, err

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -630,6 +630,10 @@ func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeK
 	return s.w.ExperimentalClearMVCCRangeKey(rangeKey)
 }
 
+func (s spanSetWriter) ExperimentalClearMVCCRangeKeys(start, end roachpb.Key) error {
+	panic("not implemented")
+}
+
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {
 	if s.spansOnly {
 		if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -961,6 +961,12 @@ message GCRequest {
     util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
   }
 
+  message GCRange {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    bytes end_key = 2 [(gogoproto.casttype) = "Key"];
+    util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+  }
+
   // Keys specifies any point keys to GC. Only versions up to and including
   // the given timestamp are GCed.
   repeated GCKey keys = 3 [(gogoproto.nullable) = false];
@@ -973,6 +979,24 @@ message GCRequest {
   // to check this during GC, because if a range key exists to be GCed then it
   // must have been written while the check succeeded.
   repeated GCRangeKey experimental_range_keys = 6 [(gogoproto.nullable) = false];
+
+  // ExperimentalRanges specifies entire key ranges to GC. All versions of point
+  // keys, range keys, and intents will be removed. The timestamp signals the
+  // highest timestamp of any expected key in the range -- if any keys are found
+  // above the timestamp, the request may fail.
+  //
+  // Callers must check the ExperimentalGCRanges cluster versions before using
+  // this parameter, as it was introduced in 22.1.
+  //
+  // This parameter is EXPERIMENTAL: it will not yield correct results e.g. for
+  // MVCCStats, and lacks sufficient safeguards.
+  // 
+  // TODO(erikgrinaker): This is not yet in use, but should be used to GC large
+  // swathes of keys where all versions are being GCed. In particular, it should
+  // be used to GC below an MVCC range tombstone with no visible keys above it
+  // (e.g. after a table deletion). Since MVCC range tombstones are
+  // experimental, this can possibly be added in a 22.1 patch release.
+  repeated GCRange experimental_ranges = 7 [(gogoproto.nullable) = false];
 
   // Threshold is the expiration timestamp.
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -369,11 +369,11 @@ message DeleteRangeResponse {
   repeated bytes keys = 2 [(gogoproto.casttype) = "Key"];
 }
 
-// A ClearRangeRequest is the argument to the ClearRange() method. It
-// specifies a range of keys to clear from the underlying engine. Note
-// that this differs from the behavior of DeleteRange, which sets
-// transactional intents and writes tombstones to the deleted
-// keys. ClearRange is used when permanently dropping or truncating
+// A ClearRangeRequest is the argument to the ClearRange() method. It specifies
+// a range of keys to clear from the underlying engine, removing both point keys
+// and any MVCC range tombstones. Note that this differs from the behavior of
+// DeleteRange, which sets transactional intents and writes tombstones to the
+// deleted keys. ClearRange is used when permanently dropping or truncating
 // table data.
 //
 // ClearRange also updates the GC threshold for the range to the

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -954,7 +954,26 @@ message GCRequest {
     bytes key = 1 [(gogoproto.casttype) = "Key"];
     util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   }
+
+  message GCRangeKey {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    bytes end_key = 2 [(gogoproto.casttype) = "Key"];
+    util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
+  }
+
+  // Keys specifies any point keys to GC. Only versions up to and including
+  // the given timestamp are GCed.
   repeated GCKey keys = 3 [(gogoproto.nullable) = false];
+
+  // ExperimentalRangeKeys specifies any range keys to GC. Only the range keys
+  // themselves are cleared, any point keys they overlap are not touched.
+  //
+  // Range keys are currently experimental, and only written when
+  // storage.CanUseExperimentalMVCCRangeTombstones() is enabled. We don't need
+  // to check this during GC, because if a range key exists to be GCed then it
+  // must have been written while the check succeeded.
+  repeated GCRangeKey experimental_range_keys = 6 [(gogoproto.nullable) = false];
+
   // Threshold is the expiration timestamp.
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];
 

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -853,7 +853,10 @@ func runMVCCScan(ctx context.Context, b *testing.B, emk engineMaker, opts benchS
 		// Pull all of the sstables into the RocksDB cache in order to make the
 		// timings more stable. Otherwise, the first run will be penalized pulling
 		// data into the cache while later runs will not.
-		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+			KeyTypes:   IterKeyTypePointsAndRanges,
+			UpperBound: roachpb.KeyMax,
+		})
 		_, _ = iter.ComputeStats(keys.LocalMax, roachpb.KeyMax, 0)
 		iter.Close()
 	}
@@ -1338,7 +1341,10 @@ func runMVCCComputeStats(ctx context.Context, b *testing.B, emk engineMaker, val
 	var stats enginepb.MVCCStats
 	var err error
 	for i := 0; i < b.N; i++ {
-		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+			KeyTypes:   IterKeyTypePointsAndRanges,
+			UpperBound: roachpb.KeyMax,
+		})
 		stats, err = iter.ComputeStats(keys.LocalMax, roachpb.KeyMax, 0)
 		iter.Close()
 		if err != nil {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -354,15 +354,22 @@ type IterOptions struct {
 // IterKeyType configures which types of keys an iterator should surface.
 //
 // TODO(erikgrinaker): Combine this with MVCCIterKind somehow.
-type IterKeyType = pebble.IterKeyType
+type IterKeyType uint8
 
 const (
 	// IterKeyTypePointsOnly iterates over point keys only.
-	IterKeyTypePointsOnly = pebble.IterKeyTypePointsOnly
+	IterKeyTypePointsOnly IterKeyType = iota
 	// IterKeyTypePointsAndRanges iterates over both point and range keys.
-	IterKeyTypePointsAndRanges = pebble.IterKeyTypePointsAndRanges
+	IterKeyTypePointsAndRanges
 	// IterKeyTypeRangesOnly iterates over only range keys.
-	IterKeyTypeRangesOnly = pebble.IterKeyTypeRangesOnly
+	IterKeyTypeRangesOnly
+	// IterKeyTypePointsWithRanges iterates over point keys only, but reveals
+	// range keys overlapping those points. Range keys that do not overlap with
+	// point keys are not surfaced.
+	//
+	// TODO(erikgrinaker): Consider moving this down into Pebble.
+	// TODO(erikgrinaker): This needs tests.
+	IterKeyTypePointsWithRanges
 )
 
 // MVCCIterKind is used to inform Reader about the kind of iteration desired

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -601,22 +601,21 @@ type Writer interface {
 
 	// ClearRawRange removes a set of entries, from start (inclusive) to end
 	// (exclusive). It can be applied to a range consisting of MVCCKeys or the
-	// more general EngineKeys -- it simply uses the roachpb.Key parameters as
-	// the Key field of an EngineKey. Similar to the other Clear* methods,
-	// this method actually removes entries from the storage engine.
+	// more general EngineKeys -- it simply uses the roachpb.Key parameters as the
+	// Key field of an EngineKey. Range keys are not affected. Similar to the
+	// other Clear* methods, this method actually removes entries from the storage
+	// engine.
 	//
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearRawRange(start, end roachpb.Key) error
-	// ClearMVCCRangeAndIntents removes MVCC keys and intents from start (inclusive)
-	// to end (exclusive). This is a higher-level method that handles both
-	// interleaved and separated intents. Similar to the other Clear* methods,
-	// this method actually removes entries from the storage engine.
+	// ClearMVCCRangeAndIntents removes MVCC point keys, range keys, and intents
+	// from start (inclusive) to end (exclusive). Similar to the other Clear*
+	// methods, this method actually removes entries from the storage engine.
 	//
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearMVCCRangeAndIntents(start, end roachpb.Key) error
-	// ClearMVCCRange removes MVCC keys from start (inclusive) to end
-	// (exclusive). It should not be expected to clear intents, though may clear
-	// interleaved intents that it encounters. It is meant for efficiently
+	// ClearMVCCRange removes MVCC keys from start (inclusive) to end (exclusive).
+	// It does not remove range keys nor intents. It is meant for efficiently
 	// clearing a subset of versions of a key, since the parameters are MVCCKeys
 	// and not roachpb.Keys. Similar to the other Clear* methods, this method
 	// actually removes entries from the storage engine.
@@ -624,13 +623,16 @@ type Writer interface {
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearMVCCRange(start, end MVCCKey) error
 
-	// ClearIterRange removes a set of entries, from start (inclusive) to end
-	// (exclusive). Similar to Clear and ClearRange, this method actually
-	// removes entries from the storage engine. Unlike ClearRange, the entries
-	// to remove are determined by iterating over iter and per-key storage
-	// tombstones (not MVCC tombstones) are generated. If the MVCCIterator was
-	// constructed using MVCCKeyAndIntentsIterKind, any separated intents/locks
-	// will also be cleared.
+	// ClearIterRange removes point keys and range keys from start (inclusive) to
+	// end (exclusive). Similar to Clear and ClearRange, this method actually
+	// removes entries from the storage engine. Unlike ClearRange, the entries to
+	// remove are determined by iterating over iter and per-key Pebble tombstones
+	// (not MVCC tombstones) are generated. If the MVCCIterator was constructed
+	// using MVCCKeyAndIntentsIterKind, any separated intents/locks will also be
+	// cleared.
+	//
+	// All range keys in the interval [start,end) will be removed regardless of
+	// iterator settings such as KeyTypes and timestamp hints.
 	//
 	// It is safe to modify the contents of the arguments after ClearIterRange
 	// returns.
@@ -645,14 +647,24 @@ type Writer interface {
 	// internal use. It mutates MVCC history, and does not check for intents or
 	// other conflicts.
 	//
-	// TODO(erikgrinaker): We'll likely need another method that calls through to
-	// Pebble's RangeKeyDelete(), which removes all range keys in a span. This
-	// will be used e.g. when removing replicas.
-	//
 	// This method is EXPERIMENTAL: range keys are under active development, and
 	// have severe limitations including being ignored by all KV and MVCC APIs and
 	// only being stored in memory.
 	ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error
+
+	// ExperimentalClearMVCCRangeKeys deletes all MVCC range keys from start
+	// (inclusive) to end (exclusive) at all timestamps. For any range key
+	// that straddles the start and end boundaries, only the segments within the
+	// boundaries will be cleared. Clears are idempotent.
+	//
+	// This method is primarily intended for MVCC garbage collection and similar
+	// internal use. It mutates MVCC history, and does not check for intents or
+	// other conflicts.
+	//
+	// This method is EXPERIMENTAL: range keys are under active development, and
+	// have severe limitations including being ignored by all KV and MVCC APIs and
+	// only being stored in memory.
+	ExperimentalClearMVCCRangeKeys(start, end roachpb.Key) error
 
 	// ExperimentalPutMVCCRangeKey writes a value to an MVCC range key. It is
 	// currently only used for range tombstones, which have a value of nil. Range

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -189,11 +189,12 @@ type MVCCIterator interface {
 	ValueProto(msg protoutil.Message) error
 	// ComputeStats scans the underlying engine from start to end keys and
 	// computes stats counters based on the values. This method is used after a
-	// range is split to recompute stats for each subrange. The start key is
-	// always adjusted to avoid counting local keys in the event stats are being
-	// recomputed for the first range (i.e. the one with start key == KeyMin).
-	// The nowNanos arg specifies the wall time in nanoseconds since the
-	// epoch and is used to compute the total age of all intents.
+	// range is split to recompute stats for each subrange. The nowNanos arg
+	// specifies the wall time in nanoseconds since the epoch and is used to
+	// compute the total age of intents and garbage.
+	//
+	// To account for intents and range keys, the iterator must be created with
+	// MVCCKeyAndIntentsIterKind and IterKeyTypePointsAndRanges.
 	ComputeStats(start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error)
 	// FindSplitKey finds a key from the given span such that the left side of
 	// the split is roughly targetSize bytes. The returned key will never be

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -668,9 +668,13 @@ type Writer interface {
 
 	// ExperimentalPutMVCCRangeKey writes a value to an MVCC range key. It is
 	// currently only used for range tombstones, which have a value of nil. Range
-	// keys exist separately from point keys in Pebble, and must be accessed via
-	// specialized iterator options and methods -- see e.g. IterOptions.KeyTypes,
-	// SimpleMVCCIterator.RangeKeys(), and MVCCRangeKeyIterator.
+	// keys with non-nil values will currently cause e.g. GC, backups, and
+	// rangefeeds to fail, as their semantics are not yet specified.
+	//
+	// Range keys exist separately from point keys in Pebble, and must be accessed
+	// via specialized iterator options and methods -- see e.g.
+	// IterOptions.KeyTypes, SimpleMVCCIterator.RangeKeys(), and
+	// MVCCRangeKeyIterator.
 	//
 	// A range key does not have a distinct identity, but should be considered a
 	// key continuum. They can be fragmented by Pebble as overlapping keys are

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -90,15 +90,17 @@ func (t TxnMeta) Short() redact.SafeString {
 }
 
 // Total returns the range size as the sum of the key and value
-// bytes. This includes all non-live keys and all versioned values.
+// bytes. This includes all non-live keys and all versioned values,
+// both for point and range keys.
 func (ms MVCCStats) Total() int64 {
-	return ms.KeyBytes + ms.ValBytes
+	return ms.KeyBytes + ms.ValBytes + ms.RangeKeyBytes
 }
 
 // GCBytes is a convenience function which returns the number of gc bytes,
-// that is the key and value bytes excluding the live bytes.
+// that is the key and value bytes excluding the live bytes, both for
+// point keys and range keys.
 func (ms MVCCStats) GCBytes() int64 {
-	return ms.KeyBytes + ms.ValBytes - ms.LiveBytes
+	return ms.KeyBytes + ms.ValBytes + ms.RangeKeyBytes - ms.LiveBytes
 }
 
 // AvgIntentAge returns the average age of outstanding intents,
@@ -169,6 +171,8 @@ func (ms *MVCCStats) Add(oms MVCCStats) {
 	ms.ValCount += oms.ValCount
 	ms.IntentCount += oms.IntentCount
 	ms.SeparatedIntentCount += oms.SeparatedIntentCount
+	ms.RangeKeyCount += oms.RangeKeyCount
+	ms.RangeKeyBytes += oms.RangeKeyBytes
 	ms.SysBytes += oms.SysBytes
 	ms.SysCount += oms.SysCount
 	ms.AbortSpanBytes += oms.AbortSpanBytes
@@ -196,6 +200,8 @@ func (ms *MVCCStats) Subtract(oms MVCCStats) {
 	ms.ValCount -= oms.ValCount
 	ms.IntentCount -= oms.IntentCount
 	ms.SeparatedIntentCount -= oms.SeparatedIntentCount
+	ms.RangeKeyCount -= oms.RangeKeyCount
+	ms.RangeKeyBytes -= oms.RangeKeyBytes
 	ms.SysBytes -= oms.SysBytes
 	ms.SysCount -= oms.SysCount
 	ms.AbortSpanBytes -= oms.AbortSpanBytes

--- a/pkg/storage/enginepb/mvcc.proto
+++ b/pkg/storage/enginepb/mvcc.proto
@@ -163,8 +163,8 @@ message MVCCStats {
   // intent_age is the cumulative age of the tracked intents.
   // See the comment on MVCCStats.
   optional sfixed64 intent_age = 2 [(gogoproto.nullable) = false];
-  // gc_bytes_age is the cumulative age of the non-live data (i.e.
-  // data included in key_bytes and val_bytes, but not live_bytes).
+  // gc_bytes_age is the cumulative age of the non-live data (i.e. data
+  // included in key_bytes, val_bytes, and range_key_bytes, but not live_bytes).
   // See the comment on MVCCStats.
   optional sfixed64 gc_bytes_age = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "GCBytesAge"];
   // live_bytes is the number of bytes stored in keys and values which can in
@@ -177,7 +177,7 @@ message MVCCStats {
   // live_count is the number of meta keys tracked under live_bytes.
   optional sfixed64 live_count = 5 [(gogoproto.nullable) = false];
   // key_bytes is the number of bytes stored in all non-system
-  // keys, including live, meta, old, and deleted keys.
+  // point keys, including live, meta, old, and deleted keys.
   // Only meta keys really account for the "full" key; value
   // keys only for the timestamp suffix.
   optional sfixed64 key_bytes = 6 [(gogoproto.nullable) = false];
@@ -201,6 +201,25 @@ message MVCCStats {
   // intents, so mixed-version clusters with nodes preceding this knowledge
   // will always have a 0 value for this field.
   optional sfixed64 separated_intent_count = 16 [(gogoproto.nullable) = false];
+  // range_key_count is the number of logical range keys tracked under
+  // range_key_bytes, disregarding fragmentation and overlap. All abutting range
+  // key fragments at the same timestamp are considered part of the same logical
+  // range key (assuming they have the same value). However, a range key that
+  // straddles a range split boundary will become two separate logical range
+  // keys (one in each range), and merge back to one when the ranges merge.
+  // Overlapping range keys (at different timestamps) are counted independently,
+  // because it is unclear how to otherwise handle partial overlap.
+  //
+  // MVCC range tombstones are EXPERIMENTAL, and will only be written when
+  // storage.CanUseExperimentalMVCCRangeTombstones() is enabled.
+  //
+  // NB: Currently, all range keys are MVCC range tombstones with no value.
+  // Therefore, these do not contribute to live_count nor live_bytes, and there
+  // is no range_val_bytes or range_val_count.
+  optional sfixed64 range_key_count = 17 [(gogoproto.nullable) = false];
+  // range_key_bytes is the encoded size of logical range keys, disregarding
+  // fragmentation and overlap.
+  optional sfixed64 range_key_bytes = 18 [(gogoproto.nullable) = false];
 
   // sys_bytes is the number of bytes stored in system-local kv-pairs.
   // This tracks the same quantity as (key_bytes + val_bytes), but

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -159,6 +159,8 @@ message MVCCStatsDelta {
   sint64 intent_bytes = 10;
   sint64 intent_count = 11;
   sint64 separated_intent_count = 16;
+  sint64 range_key_count = 17;
+  sint64 range_key_bytes = 18;
   sint64 sys_bytes = 12;
   sint64 sys_count = 13;
   sint64 abort_span_bytes = 15;
@@ -188,6 +190,8 @@ message MVCCPersistentStats {
   int64 intent_bytes = 10;
   int64 intent_count = 11;
   int64 separated_intent_count = 16;
+  int64 range_key_count = 17;
+  int64 range_key_bytes = 18;
   int64 sys_bytes = 12;
   int64 sys_count = 13;
   int64 abort_span_bytes = 15;

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -717,17 +717,24 @@ func (i *intentInterleavingIter) Value() []byte {
 
 // HasPointAndRange implements SimpleMVCCIterator.
 func (i *intentInterleavingIter) HasPointAndRange() (bool, bool) {
-	panic("not implemented")
+	// TODO(erikgrinaker): Verify this, it probably doesn't always hold.
+	hasPoint, hasRange := i.iter.HasPointAndRange()
+	if i.isCurAtIntentIter() {
+		hasPoint = true
+	}
+	return hasPoint, hasRange
 }
 
 // RangeBounds implements SimpleMVCCIterator.
 func (i *intentInterleavingIter) RangeBounds() (roachpb.Key, roachpb.Key) {
-	panic("not implemented")
+	// TODO(erikgrinaker): Verify this.
+	return i.iter.RangeBounds()
 }
 
 // RangeKeys implements SimpleMVCCIterator.
 func (i *intentInterleavingIter) RangeKeys() []MVCCRangeKeyValue {
-	panic("not implemented")
+	// TODO(erikgrinaker): Verify this.
+	return i.iter.RangeKeys()
 }
 
 func (i *intentInterleavingIter) Close() {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3701,11 +3701,11 @@ func MVCCResolveWriteIntentRange(
 	return num, nil, nil
 }
 
-// MVCCGarbageCollect creates an iterator on the ReadWriter. In parallel
-// it iterates through the keys listed for garbage collection by the
-// keys slice. The iterator is seeked in turn to each listed
-// key, clearing all values with timestamps <= to expiration. The
-// timestamp parameter is used to compute the intent age on GC.
+// MVCCGarbageCollect garbage collects the given point keys. It creates an
+// iterator on the ReadWriter, and in parallel it iterates through the keys
+// listed for garbage collection by the keys slice. The iterator is seeked in
+// turn to each listed key, clearing all values with timestamps <= to
+// expiration. The timestamp parameter is used to compute the intent age on GC.
 //
 // Note that this method will be sorting the keys.
 //
@@ -3713,6 +3713,8 @@ func MVCCResolveWriteIntentRange(
 // not a mix of the two. This is to accommodate the implementation below
 // that creates an iterator with bounds that span from the first to last
 // key (in sorted order).
+//
+// TODO(erikgrinaker): This needs to adjust MVCCStats for range tombstones.
 func MVCCGarbageCollect(
 	ctx context.Context,
 	rw ReadWriter,
@@ -3745,6 +3747,7 @@ func MVCCGarbageCollect(
 	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		LowerBound: keys[0].Key,
 		UpperBound: keys[len(keys)-1].Key.Next(),
+		KeyTypes:   IterKeyTypePointsWithRanges,
 	})
 	defer iter.Close()
 	supportsPrev := iter.SupportsPrev()
@@ -3763,6 +3766,26 @@ func MVCCGarbageCollect(
 		}
 		inlinedValue := meta.IsInline()
 		implicitMeta := iter.UnsafeKey().IsValue()
+
+		// Check whether the key is below a range tombstone, and get the lowest
+		// tombstone's timestamp.
+		//
+		// TODO(erikgrinaker): This should possibly be done in mvccGetMetadata.
+		var nextRangeTombstone hlc.Timestamp
+		if rangeKeys := iter.RangeKeys(); len(rangeKeys) > 0 {
+			for i := len(rangeKeys) - 1; i >= 0; i-- {
+				rkv := rangeKeys[i]
+				if len(rkv.Value) > 0 {
+					return errors.AssertionFailedf("unexpected non-tombstone range key %s with value %x",
+						rkv.Key, rkv.Value)
+				}
+				if gcKey.Timestamp.LessEq(rkv.Key.Timestamp) {
+					nextRangeTombstone = rkv.Key.Timestamp
+					break
+				}
+			}
+		}
+
 		// First, check whether all values of the key are being deleted.
 		//
 		// Note that we naively can't terminate GC'ing keys loop early if we
@@ -3776,7 +3799,7 @@ func MVCCGarbageCollect(
 			// not marked deleted. However, for inline values we allow it;
 			// they are internal and GCing them directly saves the extra
 			// deletion step.
-			if !meta.Deleted && !inlinedValue {
+			if !meta.Deleted && nextRangeTombstone.IsEmpty() && !inlinedValue {
 				return errors.Errorf("request to GC non-deleted, latest value of %q", gcKey.Key)
 			}
 			if meta.Txn != nil {
@@ -3919,6 +3942,36 @@ func MVCCGarbageCollect(
 		}
 	}
 
+	return nil
+}
+
+// ExperimentalMVCCGarbageCollectRangeKeys garbage collects the given range
+// keys. Only the range keys themselves are cleared, point keys below them must
+// be garbage collected separately with MVCCGarbageCollect.
+//
+// This method is EXPERIMENTAL: range keys are under active development, and
+// have severe limitations including being ignored by all KV and MVCC APIs and
+// only being stored in memory.
+//
+// TODO(erikgrinaker): Needs MVCCStats handling.
+// TODO(erikgrinaker): Should verify that there are no point keys below them.
+func ExperimentalMVCCGarbageCollectRangeKeys(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	rangeKeys []roachpb.GCRequest_GCRangeKey,
+	timestamp hlc.Timestamp,
+) error {
+	for _, rk := range rangeKeys {
+		err := rw.ExperimentalClearMVCCRangeKey(MVCCRangeKey{
+			StartKey:  rk.StartKey,
+			EndKey:    rk.EndKey,
+			Timestamp: rk.Timestamp,
+		})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4120,29 +4120,63 @@ func willOverflow(a, b int64) bool {
 	return math.MinInt64-b > a
 }
 
-// ComputeStatsForRange scans the underlying engine from start to end keys and
-// computes stats counters based on the values. This method is used after a
-// range is split to recompute stats for each subrange. The nowNanos arg
-// specifies the wall time in nanoseconds since the epoch and is used to compute
-// the total age of all intents.
+// ComputeStatsForRange scans the iterator from start to end keys and computes
+// stats counters based on the values. This method is used after a range is
+// split to recompute stats for each subrange. The nowNanos arg specifies the
+// wall time in nanoseconds since the epoch and is used to compute the total age
+// of all intents.
 //
-// When optional callbacks are specified, they are invoked for each physical
+// To account for intents and range keys, the iterator must be created with
+// MVCCKeyAndIntentsIterKind and IterKeyTypePointsAndRanges.
+func ComputeStatsForRange(
+	iter SimpleMVCCIterator, start, end roachpb.Key, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	return ComputeStatsForRangeWithVisitors(iter, start, end, nowNanos, nil, nil)
+}
+
+// ComputeStatsForRangeWithVisitors is like ComputeStatsForRange, but also
+// takes a point and/or range key callback that is invoked for each physical
 // key-value pair (i.e. not for implicit meta records), and iteration is aborted
-// on the first error returned from any of them.
+// on the first error returned from either of them.
 //
 // Callbacks must copy any data they intend to hold on to.
-func ComputeStatsForRange(
+func ComputeStatsForRangeWithVisitors(
 	iter SimpleMVCCIterator,
 	start, end roachpb.Key,
 	nowNanos int64,
-	callbacks ...func(MVCCKey, []byte) error,
+	pointKeyVisitor func(MVCCKey, []byte) error,
+	rangeKeyVisitor func(MVCCRangeKey, []byte) error,
 ) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
 	// Only some callers are providing an MVCCIterator. The others don't have
 	// any intents.
 	var meta enginepb.MVCCMetadata
-	var prevKey []byte
+	var prevKey, prevRangeStart []byte
 	first := false
+
+	// Range keys are defragmented during iteration and processed when
+	// fully degragmented.
+	rangeKeyDefrag := NewMVCCRangeKeyDefragmenter()
+
+	addRangeKeyFragments := func(fragments []MVCCRangeKeyValue) error {
+		completed := rangeKeyDefrag.AppendFragments(fragments)
+		for _, rangeKV := range completed {
+			if rangeKeyVisitor != nil {
+				if err := rangeKeyVisitor(rangeKV.Key, rangeKV.Value); err != nil {
+					return err
+				}
+			}
+			// NB: Point keys always use 12 bytes for the key timestamp, even though
+			// it is actually variable-length, likely for historical reasons. But for
+			// range keys we may as well use the actual encoded size including the
+			// variable-length timestamp.
+			keyBytes := int64(rangeKV.Key.EncodedSize())
+			ms.RangeKeyCount++
+			ms.RangeKeyBytes += keyBytes
+			ms.GCBytesAge += keyBytes * (nowNanos/1e9 - rangeKV.Key.Timestamp.WallTime/1e9)
+		}
+		return nil
+	}
 
 	// Values start accruing GCBytesAge at the timestamp at which they
 	// are shadowed (i.e. overwritten) whereas deletion tombstones
@@ -4151,22 +4185,49 @@ func ComputeStatsForRange(
 	// of the point in time at which the current key begins to age.
 	var accrueGCAgeNanos int64
 	mvccEndKey := MakeMVCCMetadataKey(end)
+	rangeTombstones := []hlc.Timestamp{}
 
-	iter.SeekGE(MakeMVCCMetadataKey(start))
-	for ; ; iter.Next() {
-		ok, err := iter.Valid()
-		if err != nil {
+	for iter.SeekGE(MakeMVCCMetadataKey(start)); ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
 			return ms, err
-		}
-		if !ok || !iter.UnsafeKey().Less(mvccEndKey) {
+		} else if !ok || !iter.UnsafeKey().Less(mvccEndKey) {
 			break
+		}
+
+		hasPoint, hasRange := iter.HasPointAndRange()
+
+		if hasRange {
+			rangeStart, _ := iter.RangeBounds()
+			if !bytes.Equal(rangeStart, prevRangeStart) {
+				prevRangeStart = rangeStart.Clone()
+				rangeKeys := iter.RangeKeys()
+				rangeTombstones = rangeTombstones[:0]
+				for _, rkv := range rangeKeys {
+					// Currently, all range keys are range tombstones. It's unclear how
+					// other range keys should be accounted for considering e.g.
+					// partially overlapping keys, so we reject them for now until we have
+					// an actual use-case for them and know more about their semantics.
+					if len(rkv.Value) > 0 {
+						return enginepb.MVCCStats{}, errors.AssertionFailedf(
+							"unexpected non-tombstone range key %s with value %x", rkv.Key, rkv.Value)
+					}
+					rangeTombstones = append(rangeTombstones, rkv.Key.Timestamp)
+				}
+				if err := addRangeKeyFragments(rangeKeys); err != nil {
+					return enginepb.MVCCStats{}, err
+				}
+			}
+		}
+
+		if !hasPoint {
+			continue
 		}
 
 		unsafeKey := iter.UnsafeKey()
 		unsafeValue := iter.UnsafeValue()
 
-		for _, f := range callbacks {
-			if err := f(unsafeKey, unsafeValue); err != nil {
+		if pointKeyVisitor != nil {
+			if err := pointKeyVisitor(unsafeKey, unsafeValue); err != nil {
 				return enginepb.MVCCStats{}, err
 			}
 		}
@@ -4193,6 +4254,21 @@ func ComputeStatsForRange(
 		implicitMeta := isValue && !bytes.Equal(unsafeKey.Key, prevKey)
 		prevKey = append(prevKey[:0], unsafeKey.Key...)
 
+		// Range tombstones cannot exist above intents, and are undefined across
+		// inline values, so we only take them into account for versioned values.
+		//
+		// TODO(erikgrinaker): rangeTombstones is sorted, so this can be optimized.
+		var nextRangeTombstone hlc.Timestamp
+		if isValue {
+			for i := len(rangeTombstones) - 1; i >= 0; i-- {
+				rts := rangeTombstones[i]
+				if unsafeKey.Timestamp.LessEq(rts) {
+					nextRangeTombstone = rts
+					break
+				}
+			}
+		}
+
 		if implicitMeta {
 			// No MVCCMetadata entry for this series of keys.
 			meta.Reset()
@@ -4218,18 +4294,23 @@ func ComputeStatsForRange(
 			}
 
 			if isSys {
+				// TODO(erikgrinaker): Do we need to handle MVCC range tombstones here?
 				ms.SysBytes += totalBytes
 				ms.SysCount++
 				if isAbortSpanKey(unsafeKey.Key) {
 					ms.AbortSpanBytes += totalBytes
 				}
 			} else {
-				if !meta.Deleted {
-					ms.LiveBytes += totalBytes
-					ms.LiveCount++
-				} else {
+				if meta.Deleted {
 					// First value is deleted, so it's GC'able; add meta key & value bytes to age stat.
 					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - meta.Timestamp.WallTime/1e9)
+				} else if !nextRangeTombstone.IsEmpty() {
+					// First value was deleted by a range tombstone, so it accumulates GC age from
+					// its timestamp.
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - nextRangeTombstone.WallTime/1e9)
+				} else {
+					ms.LiveBytes += totalBytes
+					ms.LiveCount++
 				}
 				ms.KeyBytes += metaKeySize
 				ms.ValBytes += metaValSize
@@ -4249,11 +4330,15 @@ func ComputeStatsForRange(
 		} else {
 			if first {
 				first = false
-				if !meta.Deleted {
-					ms.LiveBytes += totalBytes
-				} else {
+				if meta.Deleted {
 					// First value is deleted, so it's GC'able; add key & value bytes to age stat.
 					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - meta.Timestamp.WallTime/1e9)
+				} else if !nextRangeTombstone.IsEmpty() {
+					// First value was deleted by a range tombstone; add key & value bytes to
+					// age stat from range tombstone onwards.
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - nextRangeTombstone.WallTime/1e9)
+				} else {
+					ms.LiveBytes += totalBytes
 				}
 				if meta.Txn != nil {
 					ms.IntentBytes += totalBytes
@@ -4276,6 +4361,10 @@ func ComputeStatsForRange(
 				if isTombstone {
 					// The contribution of the tombstone picks up GCByteAge from its own timestamp on.
 					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - unsafeKey.Timestamp.WallTime/1e9)
+				} else if !nextRangeTombstone.IsEmpty() && nextRangeTombstone.WallTime < accrueGCAgeNanos {
+					// The kv pair was deleted by a range tombstone below the next
+					// version, so it accumulates garbage from the range tombstone value.
+					ms.GCBytesAge += totalBytes * (nowNanos/1e9 - nextRangeTombstone.WallTime/1e9)
 				} else {
 					// The kv pair is an overwritten value, so it became non-live when the closest more
 					// recent value was written.
@@ -4288,6 +4377,11 @@ func ComputeStatsForRange(
 			ms.ValBytes += int64(len(unsafeValue))
 			ms.ValCount++
 		}
+	}
+
+	// Complete any pending defragmented range keys.
+	if err := addRangeKeyFragments(nil); err != nil {
+		return enginepb.MVCCStats{}, err
 	}
 
 	ms.LastUpdateNanos = nowNanos

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3975,6 +3975,36 @@ func ExperimentalMVCCGarbageCollectRangeKeys(
 	return nil
 }
 
+// ExperimentalMVCCGarbageCollectRanges garbage collects the given ranges. It
+// clears all versions for all point keys and range keys in the given ranges.
+// Any intents in the ranges will return WriteIntentError to be resolved first.
+//
+// TODO(erikgrinaker): Needs MVCCStats handling.
+// TODO(erikgrinaker): Should verify that there are no versions above the given
+// timestamps, if necessary.
+func ExperimentalMVCCGarbageCollectRanges(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	ranges []roachpb.GCRequest_GCRange,
+	timestamp hlc.Timestamp,
+	maxIntents int64,
+) error {
+	for _, rng := range ranges {
+		if intents, err := ScanIntents(ctx, rw, rng.StartKey, rng.EndKey, maxIntents, 0); err != nil {
+			return err
+		} else if len(intents) > 0 {
+			return &roachpb.WriteIntentError{Intents: intents}
+		}
+	}
+	for _, rng := range ranges {
+		if err := rw.ClearMVCCRangeAndIntents(rng.StartKey, rng.EndKey); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // MVCCFindSplitKey finds a key from the given span such that the left side of
 // the split is roughly targetSize bytes. The returned key will never be chosen
 // from the key ranges listed in keys.NoSplitSpans.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -120,6 +120,15 @@ type MVCCRangeKeyValue struct {
 	Value []byte
 }
 
+// Clone copies the MVCCRangeKeyValue.
+func (rkv MVCCRangeKeyValue) Clone() MVCCRangeKeyValue {
+	c := MVCCRangeKeyValue{Key: rkv.Key.Clone()}
+	if rkv.Value != nil {
+		c.Value = append([]byte{}, rkv.Value...)
+	}
+	return c
+}
+
 // optionalValue represents an optional roachpb.Value. It is preferred
 // over a *roachpb.Value to avoid the forced heap allocation.
 type optionalValue struct {

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1607,7 +1607,10 @@ func runIncrementalBenchmark(
 		// Pull all of the sstables into the cache.  This
 		// probably defeats a lot of the benefits of the
 		// time-based optimization.
-		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: roachpb.KeyMax})
+		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+			KeyTypes:   IterKeyTypePointsAndRanges,
+			UpperBound: roachpb.KeyMax,
+		})
 		_, _ = iter.ComputeStats(keys.LocalMax, roachpb.KeyMax, 0)
 		iter.Close()
 	}

--- a/pkg/storage/mvcc_range_key_iterator_test.go
+++ b/pkg/storage/mvcc_range_key_iterator_test.go
@@ -290,3 +290,7 @@ func rangeKV(start, end string, ts int, value string) MVCCRangeKeyValue {
 func pointKey(key string, ts int) MVCCKey {
 	return MVCCKey{Key: roachpb.Key(key), Timestamp: hlc.Timestamp{Logical: int32(ts)}}
 }
+
+func pointKV(key string, ts int, value string) MVCCKeyValue {
+	return MVCCKeyValue{Key: pointKey(key, ts), Value: []byte(value)}
+}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -911,7 +911,10 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 					switch which {
 					case "get":
 						iterOptions.Prefix = true
-					case "scan", "findSplitKey", "computeStats":
+					case "computeStats":
+						iterOptions.KeyTypes = IterKeyTypePointsAndRanges
+						iterOptions.UpperBound = roachpb.KeyMax
+					case "scan", "findSplitKey":
 						iterOptions.UpperBound = roachpb.KeyMax
 					}
 
@@ -2302,7 +2305,10 @@ func computeStats(
 	t *testing.T, reader Reader, from, to roachpb.Key, nowNanos int64,
 ) enginepb.MVCCStats {
 	t.Helper()
-	iter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{UpperBound: to})
+	iter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		UpperBound: to,
+	})
 	defer iter.Close()
 	s, err := ComputeStatsForRange(iter, from, to, nowNanos)
 	if err != nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1138,6 +1138,14 @@ func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 		pebble.Sync)
 }
 
+// ExperimentalClearMVCCRangeKeys implements the Engine interface.
+func (p *Pebble) ExperimentalClearMVCCRangeKeys(start, end roachpb.Key) error {
+	return p.db.Experimental().RangeKeyDelete(
+		encodeMVCCKeyPrefix(start),
+		encodeMVCCKeyPrefix(end),
+		pebble.Sync)
+}
+
 // ExperimentalPutMVCCRangeKey implements the Engine interface.
 func (p *Pebble) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value []byte) error {
 	if err := rangeKey.Validate(); err != nil {
@@ -1944,6 +1952,10 @@ func (p *pebbleReadOnly) ExperimentalPutMVCCRangeKey(_ MVCCRangeKey, _ []byte) e
 }
 
 func (p *pebbleReadOnly) ExperimentalClearMVCCRangeKey(_ MVCCRangeKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ExperimentalClearMVCCRangeKeys(_, _ roachpb.Key) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -410,6 +410,10 @@ func (p *pebbleBatch) ClearIterRange(iter MVCCIterator, start, end roachpb.Key) 
 			return err
 		}
 	}
+	err := p.ExperimentalClearMVCCRangeKeys(start, end)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -422,6 +426,14 @@ func (p *pebbleBatch) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error
 		encodeMVCCKeyPrefix(rangeKey.StartKey),
 		encodeMVCCKeyPrefix(rangeKey.EndKey),
 		encodeMVCCTimestampSuffix(rangeKey.Timestamp),
+		nil)
+}
+
+// ExperimentalClearMVCCRangeKeys implements the Engine interface.
+func (p *pebbleBatch) ExperimentalClearMVCCRangeKeys(start, end roachpb.Key) error {
+	return p.batch.Experimental().RangeKeyDelete(
+		encodeMVCCKeyPrefix(start),
+		encodeMVCCKeyPrefix(end),
 		nil)
 }
 

--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -56,6 +56,10 @@ func NewSSTIterator(file sstable.ReadableFile) (SimpleMVCCIterator, error) {
 // It's compatible with sstables written by `RocksDBSstFileWriter` and
 // Pebble's `sstable.Writer`, and assumes the keys use Cockroach's MVCC
 // format.
+//
+// TODO(erikgrinaker): When this gets support for iterating over range keys, all
+// call sites that use ComputeStatsForRange() must be updated to enable range
+// keys for the iterators.
 func NewMemSSTIterator(data []byte, verify bool) (SimpleMVCCIterator, error) {
 	sst, err := sstable.NewReader(vfs.NewMemFile(data), sstable.ReaderOptions{
 		Comparer: EngineComparer,
@@ -160,16 +164,18 @@ func (r *sstIterator) UnsafeValue() []byte {
 }
 
 // HasPointAndRange implements SimpleMVCCIterator.
+//
+// TODO(erikgrinaker): implement range key support.
 func (r *sstIterator) HasPointAndRange() (bool, bool) {
-	panic("not implemented")
+	return true, false
 }
 
 // RangeBounds implements SimpleMVCCIterator.
 func (r *sstIterator) RangeBounds() (roachpb.Key, roachpb.Key) {
-	panic("not implemented")
+	return nil, nil
 }
 
 // RangeKeys implements SimpleMVCCIterator.
 func (r *sstIterator) RangeKeys() []MVCCRangeKeyValue {
-	panic("not implemented")
+	return nil
 }

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -152,6 +152,11 @@ func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error 
 	panic("not implemented")
 }
 
+// ExperimentalClearMVCCRangeKeys implements the Writer interface.
+func (fw *SSTWriter) ExperimentalClearMVCCRangeKeys(start, end roachpb.Key) error {
+	panic("not implemented")
+}
+
 func (fw *SSTWriter) clearRange(start, end MVCCKey) error {
 	if fw.fw == nil {
 		return errors.New("cannot call ClearRange on a closed writer")

--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -9,9 +9,15 @@ with t=A v=abc resolve
   put  k=b
   put  k=b/123
   put  k=c
+del_range_ts k=a end=d ts=50 # range tombstone
+del_range_ts k=ba end=f ts=60 # range tombstone
 ----
+del_range_ts: {a-d}/50.000000000,0
+del_range_ts: {ba-f}/60.000000000,0
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
+range key: {a-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
 data: "a"/44.000000000,0 -> /BYTES/abc
 data: "a/123"/44.000000000,0 -> /BYTES/abc
 data: "b"/44.000000000,0 -> /BYTES/abc
@@ -23,6 +29,8 @@ run ok
 clear_range k=a end=+a
 ----
 >> at end:
+range key: {a\x00-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
 data: "a/123"/44.000000000,0 -> /BYTES/abc
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
@@ -32,6 +40,8 @@ run ok
 clear_range k=a end=-a
 ----
 >> at end:
+range key: {b-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
@@ -40,6 +50,8 @@ run ok
 clear_range k=a end==b
 ----
 >> at end:
+range key: {b-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
@@ -48,6 +60,8 @@ run ok
 clear_range k=a end=+b
 ----
 >> at end:
+range key: {b\x00-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
 
@@ -55,10 +69,104 @@ run ok
 clear_range k=a end=-b
 ----
 >> at end:
+range key: {c-d}/50.000000000,0 -> []
+range key: {c-f}/60.000000000,0 -> []
 data: "c"/44.000000000,0 -> /BYTES/abc
 
 run ok
 clear_range k=a end=-c
+----
+>> at end:
+range key: {d-f}/60.000000000,0 -> []
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Now do it again using an iterator, i.e. Engine.ClearIterRange().
+
+run ok
+with t=B v=abc resolve
+  txn_begin ts=44
+  put  k=a
+  put  k=a/123
+  put  k=b
+  put  k=b/123
+  put  k=c
+del_range_ts k=a end=d ts=50 # range tombstone
+del_range_ts k=ba end=f ts=60 # range tombstone
+----
+del_range_ts: {a-d}/50.000000000,0
+del_range_ts: {ba-f}/60.000000000,0
+>> at end:
+txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
+range key: {a-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
+data: "a"/44.000000000,0 -> /BYTES/abc
+data: "a/123"/44.000000000,0 -> /BYTES/abc
+data: "b"/44.000000000,0 -> /BYTES/abc
+data: "b/123"/44.000000000,0 -> /BYTES/abc
+data: "c"/44.000000000,0 -> /BYTES/abc
+
+
+run ok
+clear_range k=a end=+a useIter
+----
+>> at end:
+range key: {a\x00-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
+data: "a/123"/44.000000000,0 -> /BYTES/abc
+data: "b"/44.000000000,0 -> /BYTES/abc
+data: "b/123"/44.000000000,0 -> /BYTES/abc
+data: "c"/44.000000000,0 -> /BYTES/abc
+
+run ok
+clear_range k=a end=-a useIter
+----
+>> at end:
+range key: {b-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
+data: "b"/44.000000000,0 -> /BYTES/abc
+data: "b/123"/44.000000000,0 -> /BYTES/abc
+data: "c"/44.000000000,0 -> /BYTES/abc
+
+run ok
+clear_range k=a end==b useIter
+----
+>> at end:
+range key: {b-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
+data: "b"/44.000000000,0 -> /BYTES/abc
+data: "b/123"/44.000000000,0 -> /BYTES/abc
+data: "c"/44.000000000,0 -> /BYTES/abc
+
+run ok
+clear_range k=a end=+b useIter
+----
+>> at end:
+range key: {b\x00-d}/50.000000000,0 -> []
+range key: {ba-f}/60.000000000,0 -> []
+data: "b/123"/44.000000000,0 -> /BYTES/abc
+data: "c"/44.000000000,0 -> /BYTES/abc
+
+run ok
+clear_range k=a end=-b useIter
+----
+>> at end:
+range key: {c-d}/50.000000000,0 -> []
+range key: {c-f}/60.000000000,0 -> []
+data: "c"/44.000000000,0 -> /BYTES/abc
+
+run ok
+clear_range k=a end=-c useIter
+----
+>> at end:
+range key: {d-f}/60.000000000,0 -> []
+
+run ok
+clear_range k=a end=z useIter
 ----
 >> at end:
 <no data>


### PR DESCRIPTION
Only the last 2 commits should be reviewed here, the others are from #76783.

---

**storage: split out `MVCCRangeKeyDefragmenter`** 

This patch split out `MVCCRangeKeyDefragmenter` from
`MVCCRangeKeyIterator`. Keeping defragmentation separate from the
iterator allows for ad hoc range key defragmentation in other contexts,
e.g. during combined point/range key iteration.

Release note: None

**storage: add `MVCCStats` for range keys**

This patch adds `MVCCStats` tracking for range keys. It only considers
range tombstones for now, since the semantics of other range keys are
still unclear (e.g. how should overlapping range keys be interpreted?),
and will error if encountering non-tombstone range keys.

Two new fields are added to `MVCCStats`:

* `RangeKeyCount`: the number of individual defragmented logical range
  keys, regardless of any overlap with other range keys. Multiple versions
  count as separate range keys, even if they overlap exactly.

* `RangeKeyBytes`: the logical encoded byte size of all range keys,
  excluding value. This ignores fragmentation, and counts the key bounds
  separately for each version even if multiple range keys overlap exactly.
  Unlike point keys, which for historical reasons use a fixed-size
  timestamp contribution, this uses the actual variable-length timestamp
  encoding contribution.

`ComputeStatsForRange()` has been extended to calculate the above
quantities, and additionally account for range tombstones themselves in
`GCBytesAge` along with their effect on point keys.  However, these
statistics are not yet updated during range key mutations and GC, nor on
CRDB range splits and merges -- this will be addressed separately. All
relevant call sites have been updated to surface range keys for the MVCC
iterators passed to `ComputeStatsForRange()`.

Touches #70412.

Release note: None