### PR TITLE
sql: do not create duplicate expression index columns

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -250,8 +250,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 					false, /* isInverted */
 					false, /* isNewTable */
 					params.p.SemaCtx(),
-					params.EvalContext(),
-					params.SessionData(),
 				); err != nil {
 					return err
 				}

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1059,7 +1059,17 @@ func (desc *wrapper) validateTableIndexes(columnNames map[string]descpb.ColumnID
 					idx.GetName(), name, colID, inIndexColID)
 			}
 			if validateIndexDup.Contains(colID) {
-				return pgerror.Newf(pgcode.FeatureNotSupported, "index %q contains duplicate column %q", idx.GetName(), name)
+				col, _ := desc.FindColumnWithID(colID)
+				if col.IsExpressionIndexColumn() {
+					return pgerror.Newf(pgcode.FeatureNotSupported,
+						"index %q contains duplicate expression %q",
+						idx.GetName(), col.GetComputeExpr(),
+					)
+				}
+				return pgerror.Newf(pgcode.FeatureNotSupported,
+					"index %q contains duplicate column %q",
+					idx.GetName(), name,
+				)
 			}
 			validateIndexDup.Add(colID)
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1750,8 +1750,6 @@ func NewTableDesc(
 				d.Inverted,
 				true, /* isNewTable */
 				semaCtx,
-				evalCtx,
-				sessionData,
 			); err != nil {
 				return nil, err
 			}
@@ -1870,8 +1868,6 @@ func NewTableDesc(
 				false, /* isInverted */
 				true,  /* isNewTable */
 				semaCtx,
-				evalCtx,
-				sessionData,
 			); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -154,8 +154,8 @@ CREATE INDEX t_lower_c_a_plus_b_idx ON t (lower(c), (a + b))
 statement ok
 CREATE INDEX t_a_plus_ten_idx ON t ((a + 10))
 
-statement ok
-CREATE INDEX t_a_plus_ten_a_plus_ten_idx ON t ((a + 10), (a + 10))
+statement error index \"err\" contains duplicate expression
+CREATE INDEX err ON t ((a + 10), (a + 10))
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
@@ -172,109 +172,111 @@ CREATE TABLE public.t (
    INDEX t_lower_c_idx (lower(c) ASC),
    INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
    INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
-   INDEX t_a_plus_ten_a_plus_ten_idx ((a + 10:::INT8) ASC, (a + 10:::INT8) ASC),
    FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
 )
 
 # Referencing an inaccessible column in a CHECK constraint is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
-ALTER TABLE t ADD CONSTRAINT err CHECK (crdb_internal_idx_expr_4 > 0)
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
+ALTER TABLE t ADD CONSTRAINT err CHECK (crdb_internal_idx_expr_2 > 0)
 
 # Referencing an inaccessible column in a NOT NULL constraint is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
-ALTER TABLE t ALTER COLUMN crdb_internal_idx_expr_4 SET NOT NULL
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
+ALTER TABLE t ALTER COLUMN crdb_internal_idx_expr_2 SET NOT NULL
 
 # Referencing an inaccessible column in a UNIQUE constraint is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
-ALTER TABLE t ADD CONSTRAINT err UNIQUE (crdb_internal_idx_expr_4)
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
+ALTER TABLE t ADD CONSTRAINT err UNIQUE (crdb_internal_idx_expr_2)
 
 # Referencing an inaccessible column in a computed column expression is not
 # allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced in a computed column expression
-ALTER TABLE t ADD COLUMN err INT AS (crdb_internal_idx_expr_4 + 10) STORED
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced in a computed column expression
+ALTER TABLE t ADD COLUMN err INT AS (crdb_internal_idx_expr_2 + 10) STORED
 
 # Referencing an inaccessible column in an index is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
-CREATE INDEX err ON t (crdb_internal_idx_expr_4)
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
+CREATE INDEX err ON t (crdb_internal_idx_expr_2)
 
 # Referencing an inaccessible column in a partial index predicate expression is
 # not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced
-CREATE INDEX err ON t (a) WHERE crdb_internal_idx_expr_4 > 0
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
+CREATE INDEX err ON t (a) WHERE crdb_internal_idx_expr_2 > 0
 
 # Referencing an inaccessible column in a FK is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a foreign key
-CREATE TABLE child (a INT REFERENCES t(crdb_internal_idx_expr_4))
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced by a foreign key
+CREATE TABLE child (a INT REFERENCES t(crdb_internal_idx_expr_2))
 
 statement ok
 CREATE TABLE child (a INT)
 
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be referenced by a foreign key
-ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_idx_expr_4)
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced by a foreign key
+ALTER TABLE child ADD CONSTRAINT err FOREIGN KEY (a) REFERENCES t(crdb_internal_idx_expr_2)
 
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot reference a foreign key
-ALTER TABLE t ADD CONSTRAINT err FOREIGN KEY (crdb_internal_idx_expr_4) REFERENCES child(a)
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot reference a foreign key
+ALTER TABLE t ADD CONSTRAINT err FOREIGN KEY (crdb_internal_idx_expr_2) REFERENCES child(a)
 
 # Dropping an inaccessible column is not allowed.
-statement error cannot drop inaccessible column \"crdb_internal_idx_expr_4\"
-ALTER TABLE t DROP COLUMN crdb_internal_idx_expr_4
+statement error cannot drop inaccessible column \"crdb_internal_idx_expr_2\"
+ALTER TABLE t DROP COLUMN crdb_internal_idx_expr_2
 
 # Renaming a column to the same name as one of the inaccessible expression index
 # columns is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" of relation \"t\" already exists
-ALTER TABLE t RENAME COLUMN a TO crdb_internal_idx_expr_4
+statement error column \"crdb_internal_idx_expr_2\" of relation \"t\" already exists
+ALTER TABLE t RENAME COLUMN a TO crdb_internal_idx_expr_2
 
 # Renaming an inaccessible expression index column is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" is inaccessible and cannot be renamed
-ALTER TABLE t RENAME COLUMN crdb_internal_idx_expr_4 TO err
+statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be renamed
+ALTER TABLE t RENAME COLUMN crdb_internal_idx_expr_2 TO err
 
 # Adding a column with the same name as one of the inaccessible columns created
 # for an expression index is not allowed.
-statement error column \"crdb_internal_idx_expr_4\" of relation \"t\" already exists
-ALTER TABLE t ADD COLUMN crdb_internal_idx_expr_4 INT
+statement error column \"crdb_internal_idx_expr_2\" of relation \"t\" already exists
+ALTER TABLE t ADD COLUMN crdb_internal_idx_expr_2 INT
 
 query T
 SELECT * FROM (
   SELECT json_array_elements(
     crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
-) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_4"'
+) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_2"'
 ----
-{"computeExpr": "a + 10:::INT8", "id": 11, "inaccessible": true, "name": "crdb_internal_idx_expr_4", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "a + 10:::INT8", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
 
 statement ok
-DROP INDEX t_a_plus_ten_idx
+DROP INDEX t_lower_c_a_plus_b_idx
 
-# Verify that the inaccessible column created for t_a_plus_ten_idx no longer
+# Verify that the inaccessible columns in t_lower_c_a_plus_b_idx are not dropped
+# because other indexes contain them.
 # exists in the descriptor.
 query T
 SELECT * FROM (
   SELECT json_array_elements(
     crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
-) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_4"'
+) AS cols WHERE cols.desc->>'name' IN ('crdb_internal_idx_expr', 'crdb_internal_idx_expr_1')
 ----
+{"computeExpr": "a + b", "id": 7, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "lower(c)", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
 
 statement ok
-DROP INDEX t_a_plus_ten_a_plus_ten_idx
+DROP INDEX t_a_plus_b_idx
 
-# Verify that the inaccessible columns created for t_a_plus_ten_a_plus_b_idx no
-# longer exists in the descriptor.
+# Verify that the inaccessible column created for t_a_plus_b_idx no longer
+# exists in the descriptor.
 query T
 SELECT * FROM (
   SELECT json_array_elements(
     crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, false)->'table'->'columns'
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
-) AS cols WHERE cols.desc->'name' IN ('"crdb_internal_idx_expr_5"', '"crdb_internal_idx_expr_6"')
+) AS cols WHERE cols.desc->>'name' = 'crdb_internal_idx_expr'
 ----
 
 # Adding a column with the same name as one of the inaccessible columns created
 # for an expression index is allowed after the index has been dropped.
 statement ok
-ALTER TABLE t ADD COLUMN crdb_internal_idx_expr_4 INT
+ALTER TABLE t ADD COLUMN crdb_internal_idx_expr INT
 
 statement ok
-ALTER TABLE t DROP COLUMN crdb_internal_idx_expr_4
+ALTER TABLE t DROP COLUMN crdb_internal_idx_expr
 
 statement error volatile functions are not allowed in index element
 CREATE INDEX err ON t ((a + random()::INT))
@@ -434,7 +436,7 @@ SELECT count(*) FROM (
   ) AS desc FROM system.descriptor WHERE id = 'copy_indexes'::REGCLASS
 ) AS cols WHERE cols.desc->>'name' LIKE 'crdb_internal_idx_expr%'
 ----
-5
+4
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_all]
@@ -461,7 +463,7 @@ SELECT count(*) FROM (
   ) AS desc FROM system.descriptor WHERE id = 'copy_all'::REGCLASS
 ) AS cols WHERE cols.desc->>'name' LIKE 'crdb_internal_idx_expr%'
 ----
-5
+4
 
 # Test anonymous index name generation.
 
@@ -529,6 +531,10 @@ CREATE TABLE public.anon (
 )
 
 # Querying expression indexes.
+
+statement ok
+CREATE INDEX t_a_plus_b_idx ON t ((a + b));
+CREATE INDEX t_lower_c_a_plus_b_idx ON t (lower(c), (a + b))
 
 statement ok
 INSERT INTO t VALUES

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -727,9 +727,9 @@ attrelid    relname            attname                   atttypid  attstattarget
 2129466852  t6_pkey            rowid                     20        0              8       6       0         -1
 2129466855  t6_expr_idx        crdb_internal_idx_expr    20        0              8       5       0         -1
 2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      7       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_2  20        0              8       8       0         -1
-2129466848  t6_expr_key        crdb_internal_idx_expr_3  25        0              -1      9       0         -1
-2129466850  t6_expr_idx1       crdb_internal_idx_expr_4  16        0              1       10      0         -1
+2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr    20        0              8       5       0         -1
+2129466848  t6_expr_key        crdb_internal_idx_expr_1  25        0              -1      7       0         -1
+2129466850  t6_expr_idx1       crdb_internal_idx_expr_2  16        0              1       8       0         -1
 121         mv1                ?column?                  20        0              8       1       0         -1
 121         mv1                rowid                     20        0              8       2       0         -1
 784389845   mv1_pkey           rowid                     20        0              8       2       0         -1
@@ -796,9 +796,9 @@ t6                 rowid                     -1         NULL      NULL        NU
 t6_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
 t6_expr_idx        crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       false      ·            v
 t6_expr_expr1_idx  crdb_internal_idx_expr_1  -1         NULL      NULL        NULL      false       false      ·            v
-t6_expr_expr1_idx  crdb_internal_idx_expr_2  -1         NULL      NULL        NULL      false       false      ·            v
-t6_expr_key        crdb_internal_idx_expr_3  -1         NULL      NULL        NULL      false       false      ·            v
-t6_expr_idx1       crdb_internal_idx_expr_4  -1         NULL      NULL        NULL      false       false      ·            v
+t6_expr_expr1_idx  crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       false      ·            v
+t6_expr_key        crdb_internal_idx_expr_1  -1         NULL      NULL        NULL      false       false      ·            v
+t6_expr_idx1       crdb_internal_idx_expr_2  -1         NULL      NULL        NULL      false       false      ·            v
 mv1                ?column?                  -1         NULL      NULL        NULL      false       false      ·            ·
 mv1                rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
 mv1_pkey           rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
@@ -865,9 +865,9 @@ t6                 rowid                     false         true        0        
 t6_pkey            rowid                     false         true        0            NULL    NULL        NULL
 t6_expr_idx        crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
 t6_expr_expr1_idx  crdb_internal_idx_expr_1  false         true        0            NULL    NULL        NULL
-t6_expr_expr1_idx  crdb_internal_idx_expr_2  false         true        0            NULL    NULL        NULL
-t6_expr_key        crdb_internal_idx_expr_3  false         true        0            NULL    NULL        NULL
-t6_expr_idx1       crdb_internal_idx_expr_4  false         true        0            NULL    NULL        NULL
+t6_expr_expr1_idx  crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
+t6_expr_key        crdb_internal_idx_expr_1  false         true        0            NULL    NULL        NULL
+t6_expr_idx1       crdb_internal_idx_expr_2  false         true        0            NULL    NULL        NULL
 mv1                ?column?                  false         true        0            NULL    NULL        NULL
 mv1                rowid                     false         true        0            NULL    NULL        NULL
 mv1_pkey           rowid                     false         true        0            NULL    NULL        NULL
@@ -927,7 +927,7 @@ WHERE n.nspname = 'public'
 ----
 relname            attname                   typname   attcollation  collname
 t1                 d                         varchar   3403232968    default
-t6_expr_key        crdb_internal_idx_expr_3  text      3403232968    default
+t6_expr_key        crdb_internal_idx_expr_1  text      3403232968    default
 t6_expr_expr1_idx  crdb_internal_idx_expr_1  text      3403232968    default
 t6                 c                         text      3403232968    default
 t5                 c                         text      3403232968    default
@@ -1360,7 +1360,7 @@ check_b        true        0            true          {2}
 uwi_b_c        true        0            true          NULL
 fk_b_c         true        0            true          {2,3}
 check_c        true        0            true          {3}
-t6_expr_key    true        0            true          {9}
+t6_expr_key    true        0            true          {7}
 uwi_b_partial  true        0            true          NULL
 index_key      true        0            true          {3,4}
 t1_a_key       true        0            true          {2}

--- a/pkg/sql/opt/exec/execbuilder/testdata/expression_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/expression_index
@@ -96,20 +96,8 @@ SELECT * FROM [
       table: t@t_lower_c_a_plus_b_idx
       spans: [/'foo'/111 - /'foo']
 
+
 # Lookup joins can be planned on expression indexes.
-# TODO(mgartner): We must drop these indexes to be able to plan a lookup join.
-# This is required because of a limitation of the normalization rule
-# ExtractJoinEqualities: it can only choose a single virtual column to project
-# from the children of the join. When there are multiple expression indexes with
-# the same expression, we create multiple virtual columns with the same
-# expression in the table descriptor. If ExtractJoinEqualities picks the wrong
-# virtual column to project, GenerateLookupJoinsWithVirtualCols will fail to
-# generate a lookup join. This can be solved by making the opt catalog present
-# all expression index virtual columns with the same expressions as a single
-# virtual column.
-statement ok
-DROP INDEX t_a_plus_b_idx;
-DROP INDEX t_lower_c_idx
 
 query T
 SELECT * FROM [
@@ -123,8 +111,8 @@ SELECT * FROM [
 │ equality cols are key
 │
 └── • lookup join
-    │ table: t@t_lower_c_a_plus_b_idx
-    │ equality: (n) = (crdb_internal_idx_expr_2)
+    │ table: t@t_lower_c_idx
+    │ equality: (n) = (crdb_internal_idx_expr_1)
     │
     └── • scan
           missing stats
@@ -144,7 +132,7 @@ SELECT * FROM [
 │
 └── • lookup join
     │ table: t@t_lower_c_a_plus_b_idx
-    │ equality: (n, m) = (crdb_internal_idx_expr_2,crdb_internal_idx_expr_3)
+    │ equality: (n, m) = (crdb_internal_idx_expr_1,crdb_internal_idx_expr)
     │
     └── • scan
           missing stats

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -131,46 +131,41 @@ TABLE xyz
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
  ├── crdb_internal_idx_expr string as (lower(z)) virtual [inaccessible]
- ├── crdb_internal_idx_expr_1 string as (lower(z)) virtual [inaccessible]
- ├── crdb_internal_idx_expr_2 int as (y + 1) virtual [inaccessible]
- ├── crdb_internal_idx_expr_3 string as (lower(z)) virtual [inaccessible]
- ├── crdb_internal_idx_expr_4 jsonb as (j->'a') virtual [inaccessible]
- ├── crdb_internal_idx_expr_4_inverted_key jsonb not null [inverted]
- ├── crdb_internal_idx_expr_5 jsonb as (j->'a') virtual [inaccessible]
- ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
- ├── crdb_internal_idx_expr_6 int as (x + y) virtual [inaccessible]
- ├── crdb_internal_idx_expr_7 int as (x + y) virtual [inaccessible]
- ├── crdb_internal_idx_expr_8 jsonb as (j->'a') virtual [inaccessible]
- ├── crdb_internal_idx_expr_8_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_1 int as (y + 1) virtual [inaccessible]
+ ├── crdb_internal_idx_expr_2 jsonb as (j->'a') virtual [inaccessible]
+ ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
+ ├── crdb_internal_idx_expr_3 int as (x + y) virtual [inaccessible]
+ ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
  ├── PRIMARY INDEX xyz_pkey
  │    └── x int not null
  ├── INDEX idx1
  │    ├── crdb_internal_idx_expr string as (lower(z)) virtual [inaccessible]
  │    └── x int not null
  ├── INDEX idx2
- │    ├── crdb_internal_idx_expr_1 string as (lower(z)) virtual [inaccessible]
+ │    ├── crdb_internal_idx_expr string as (lower(z)) virtual [inaccessible]
  │    ├── y int
  │    └── x int not null
  ├── INDEX idx3
- │    ├── crdb_internal_idx_expr_2 int as (y + 1) virtual [inaccessible]
- │    ├── crdb_internal_idx_expr_3 string as (lower(z)) virtual [inaccessible]
+ │    ├── crdb_internal_idx_expr_1 int as (y + 1) virtual [inaccessible]
+ │    ├── crdb_internal_idx_expr string as (lower(z)) virtual [inaccessible]
  │    └── x int not null
  ├── INVERTED INDEX idx4
- │    ├── crdb_internal_idx_expr_4_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
  │    └── x int not null
  ├── INVERTED INDEX idx5
  │    ├── y int
  │    ├── z string
- │    ├── crdb_internal_idx_expr_5_inverted_key jsonb not null [inverted]
+ │    ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
  │    └── x int not null
  ├── INDEX idx6
- │    ├── crdb_internal_idx_expr_6 int as (x + y) virtual [inaccessible]
+ │    ├── crdb_internal_idx_expr_3 int as (x + y) virtual [inaccessible]
  │    ├── y int
  │    ├── x int not null
  │    ├── z string (storing)
  │    └── WHERE v > 1
  └── INVERTED INDEX idx7
-      ├── crdb_internal_idx_expr_7 int as (x + y) virtual [inaccessible]
-      ├── crdb_internal_idx_expr_8_inverted_key jsonb not null [inverted]
+      ├── crdb_internal_idx_expr_3 int as (x + y) virtual [inaccessible]
+      ├── crdb_internal_idx_expr_2_inverted_key jsonb not null [inverted]
       ├── x int not null
       └── WHERE v > 1

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":546,"Routine":"dropIndexByName","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":560,"Routine":"dropIndexByName","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only


### PR DESCRIPTION
Previously, an inaccessible virtual computed column was created for each
expression in an index. When indexes shared duplicate expressions,
duplicate columns would be created. This could prevent the optimizer
from generating optimal query plans in some cases, and evaluating and
writing to these columns created duplicate work during execution.

Now, existing expression index columns are reused when creating
expression indexes. These columns are only dropped when there are no
indexes which contain them.

This commit also disallows duplicate expressions in an expression index.
This is backward incompatible, but there is no use case for such an
index, so they likely do not exist in the wild.

Release note (sql change): Expression indexes can now longer have
duplicate expressions.