### PR TITLE
span: remove INVERTED check from builder

### DIFF
--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -224,8 +224,7 @@ func (s *Builder) UnconstrainedSpans() (roachpb.Spans, error) {
 // appendSpansFromConstraintSpan converts a constraint.Span to one or more
 // roachpb.Spans and appends them to the provided spans. It appends multiple
 // spans in the case that multiple, non-adjacent column families should be
-// scanned. The forDelete parameter indicates whether these spans will be used
-// for row deletion.
+// scanned.
 func (s *Builder) appendSpansFromConstraintSpan(
 	appendTo roachpb.Spans, cs *constraint.Span, splitter Splitter,
 ) (roachpb.Spans, error) {
@@ -261,9 +260,8 @@ func (s *Builder) appendSpansFromConstraintSpan(
 		return rowenc.SplitRowKeyIntoFamilySpans(appendTo, span.Key, splitter.neededFamilies), nil
 	}
 
-	// We need to advance the end key if it is inclusive or the index is
-	// inverted.
-	if cs.EndBoundary() == constraint.IncludeBoundary || s.index.GetType() == descpb.IndexDescriptor_INVERTED {
+	// We need to advance the end key if it is inclusive.
+	if cs.EndBoundary() == constraint.IncludeBoundary {
 		span.EndKey = span.EndKey.PrefixEnd()
 	}
 


### PR DESCRIPTION
This check has been carried over since we first added support for JSON
indexes; at that point inverted spans were always single key and thus
had inclusive boundaries.

The check as it stands now is incorrect - there is no reason why we
should always treat an end key as inclusive for an inverted index. In
practice, the only current cases where we might have an exclusive end
key are with geospatial queries, where the spans are not "tight"
anyway (i.e.  false positives are allowed). This might change in the
future though, e.g. if we add support for range queries for JSON
elements.

Release note: None