### PR TITLE
backupccl: backup checkpoint files are now versioned and never deleted

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -195,6 +195,7 @@ go_test(
         "//pkg/cloud",
         "//pkg/cloud/amazon",
         "//pkg/cloud/azure",
+        "//pkg/cloud/gcp",
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/clusterversion",
         "//pkg/config",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -9,11 +9,13 @@
 package backupccl
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	cryptorand "crypto/rand"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -51,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -940,7 +943,7 @@ func backupPlanHook(
 			}
 
 			if err := writeBackupManifestCheckpoint(
-				ctx, jobID, backupDetails, &backupManifest, p.ExecCfg(), p.User(),
+				ctx, backupDetails.URI, backupDetails.EncryptionOptions, &backupManifest, p.ExecCfg(), p.User(),
 			); err != nil {
 				return err
 			}
@@ -965,8 +968,9 @@ func backupPlanHook(
 			if err := p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &sj, jobID, plannerTxn, jr); err != nil {
 				return err
 			}
+
 			if err := writeBackupManifestCheckpoint(
-				ctx, jobID, backupDetails, &backupManifest, p.ExecCfg(), p.User(),
+				ctx, backupDetails.URI, backupDetails.EncryptionOptions, &backupManifest, p.ExecCfg(), p.User(),
 			); err != nil {
 				return err
 			}
@@ -1077,26 +1081,114 @@ func getScheduledBackupExecutionArgsFromSchedule(
 	return sj, args, nil
 }
 
+// writeBackupManifestCheckpoint writes a new BACKUP-CHECKPOINT MANIFEST
+// and CHECKSUM file. If it is a pure v22.1 cluster or later, it will write
+// a timestamped BACKUP-CHECKPOINT to the /progress directory.
+// If it is a mixed cluster version, it will write a non timestamped BACKUP-CHECKPOINT
+// to the base directory in order to not break backup jobs that resume
+// on a v21.2 node.
 func writeBackupManifestCheckpoint(
 	ctx context.Context,
-	jobID jobspb.JobID,
-	backupDetails jobspb.BackupDetails,
-	backupManifest *BackupManifest,
+	storageURI string,
+	encryption *jobspb.BackupEncryptionOptions,
+	desc *BackupManifest,
 	execCfg *sql.ExecutorConfig,
 	user security.SQLUsername,
 ) error {
-	defaultStore, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, backupDetails.URI, user)
+	defaultStore, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, storageURI, user)
 	if err != nil {
 		return err
 	}
 	defer defaultStore.Close()
 
-	if err := writeBackupManifest(
-		ctx, execCfg.Settings, defaultStore, tempCheckpointFileNameForJob(jobID),
-		backupDetails.EncryptionOptions, backupManifest,
-	); err != nil {
-		return errors.Wrapf(err, "writing checkpoint file")
+	sort.Sort(BackupFileDescriptors(desc.Files))
+
+	descBuf, err := protoutil.Marshal(desc)
+	if err != nil {
+		return err
 	}
+
+	descBuf, err = compressData(descBuf)
+	if err != nil {
+		return errors.Wrap(err, "compressing backup manifest")
+	}
+
+	if encryption != nil {
+		encryptionKey, err := getEncryptionKey(ctx, encryption, execCfg.Settings, defaultStore.ExternalIOConf())
+		if err != nil {
+			return err
+		}
+		descBuf, err = storageccl.EncryptFile(descBuf, encryptionKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If the cluster is still running on a mixed version, we want to write
+	// to the base directory instead of the progress directory. That way if
+	// an old node resumes a backup, it doesn't have to start over.
+	if !execCfg.Settings.Version.IsActive(ctx, clusterversion.BackupDoesNotOverwriteLatestAndCheckpoint) {
+		// We want to overwrite the latest checkpoint in the base directory,
+		// just write to the non versioned BACKUP-CHECKPOINT file.
+		err = cloud.WriteFile(ctx, defaultStore, backupManifestCheckpointName, bytes.NewReader(descBuf))
+		if err != nil {
+			return err
+		}
+
+		checksum, err := getChecksum(descBuf)
+		if err != nil {
+			return err
+		}
+
+		return cloud.WriteFile(ctx, defaultStore, backupManifestCheckpointName+backupManifestChecksumSuffix, bytes.NewReader(checksum))
+	}
+
+	// We timestamp the checkpoint files in order to enforce write once backups.
+	// When the job goes to read these timestamped files, it will List
+	// the checkpoints and pick the file whose name is lexicographically
+	// sorted to the top. This will be the last checkpoint we write, for
+	// details refer to newTimestampedCheckpointFileName.
+	filename := newTimestampedCheckpointFileName()
+
+	// HTTP storage does not support listing and so we cannot rely on the
+	// above-mentioned List method to return us the latest checkpoint file.
+	// Instead, we will write a checkpoint once with a well-known filename,
+	// and teach the job to always reach for that filename in the face of
+	// a resume. We may lose progress, but this is a cost we are willing
+	// to pay to uphold write-once semantics.
+	if defaultStore.Conf().Provider == roachpb.ExternalStorageProvider_http {
+		// TODO (darryl): We should do this only for file not found or directory
+		// does not exist errors. As of right now we only specifically wrap
+		// ReadFile errors for file not found so this is not possible yet.
+		if r, err := defaultStore.ReadFile(ctx, backupProgressDirectory+"/"+backupManifestCheckpointName); err != nil {
+			// Since we did not find the checkpoint file this is the first time
+			// we are going to write a checkpoint, so write it with the well
+			// known filename.
+			filename = backupManifestCheckpointName
+		} else {
+			err = r.Close(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err = cloud.WriteFile(ctx, defaultStore, backupProgressDirectory+"/"+filename, bytes.NewReader(descBuf))
+	if err != nil {
+		return errors.Wrap(err, "calculating checksum")
+	}
+
+	// Write the checksum file after we've successfully wrote the checkpoint.
+	checksum, err := getChecksum(descBuf)
+	if err != nil {
+		return errors.Wrap(err, "calculating checksum")
+	}
+
+	err = cloud.WriteFile(ctx, defaultStore, backupProgressDirectory+"/"+filename+backupManifestChecksumSuffix, bytes.NewReader(checksum))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"hash/crc32"
@@ -42,6 +43,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/amazon"
+	"github.com/cockroachdb/cockroach/pkg/cloud/azure"
+	"github.com/cockroachdb/cockroach/pkg/cloud/gcp"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // register cloud storage providers
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
@@ -78,6 +81,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -574,7 +578,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 					files = append(files, f)
 				}
 				return err
-			}))
+			}, 0 /*limit*/))
 			full1 = strings.TrimSuffix(files[0], backupManifestName)
 			full2 = strings.TrimSuffix(files[1], backupManifestName)
 
@@ -588,7 +592,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 					subdirFiles = append(subdirFiles, f)
 				}
 				return err
-			}))
+			}, 0 /*limit*/))
 			require.NoError(t, err)
 			subdirFull1 = strings.TrimSuffix(strings.TrimPrefix(subdirFiles[0], "foo"),
 				backupManifestName)
@@ -1547,64 +1551,79 @@ func TestBackupRestoreResume(t *testing.T) {
 	backupTableDesc := desctestutils.TestingGetPublicTableDescriptor(tc.Servers[0].DB(), keys.SystemSQLCodec, "data", "bank")
 
 	t.Run("backup", func(t *testing.T) {
-		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
-		backupStartKey := backupTableDesc.PrimaryIndexSpan(keys.SystemSQLCodec).Key
-		backupEndKey, err := randgen.TestingMakePrimaryIndexKey(backupTableDesc, numAccounts/2)
-		if err != nil {
-			t.Fatal(err)
-		}
-		backupCompletedSpan := roachpb.Span{Key: backupStartKey, EndKey: backupEndKey}
-		mockManifest, err := protoutil.Marshal(&BackupManifest{
-			ClusterID: tc.Servers[0].ClusterID(),
-			Files: []BackupManifest_File{
-				{Path: "garbage-checkpoint", Span: backupCompletedSpan},
-			},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		backupDir := dir + "/backup"
-		if err := os.MkdirAll(backupDir+"/"+backupProgressDirectory, 0755); err != nil {
-			t.Fatal(err)
-		}
-		checkpointFile := backupDir + "/" + backupProgressDirectory + "/" + backupManifestCheckpointName
-		if err := ioutil.WriteFile(checkpointFile, mockManifest, 0644); err != nil {
-			t.Fatal(err)
-		}
-		createAndWaitForJob(
-			t, sqlDB, []descpb.ID{backupTableDesc.GetID()},
-			jobspb.BackupDetails{
-				EndTime: tc.Servers[0].Clock().Now(),
-				URI:     "nodelocal://0/backup",
-			},
-			jobspb.BackupProgress{},
-		)
+		for _, item := range []struct {
+			testName            string
+			checkpointDirectory string
+		}{
+			{testName: "backup-progress-directory", checkpointDirectory: "/" + backupProgressDirectory},
+			{testName: "backup-base-directory", checkpointDirectory: ""},
+		} {
+			item := item
+			t.Run(item.testName, func(t *testing.T) {
+				sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
+				backupStartKey := backupTableDesc.PrimaryIndexSpan(keys.SystemSQLCodec).Key
+				backupEndKey, err := randgen.TestingMakePrimaryIndexKey(backupTableDesc, numAccounts/2)
+				if err != nil {
+					t.Fatal(err)
+				}
+				backupCompletedSpan := roachpb.Span{Key: backupStartKey, EndKey: backupEndKey}
+				mockManifest, err := protoutil.Marshal(&BackupManifest{
+					ClusterID: tc.Servers[0].ClusterID(),
+					Files: []BackupManifest_File{
+						{Path: "garbage-checkpoint", Span: backupCompletedSpan},
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				backupDir := dir + "/backup" + "-" + item.testName
 
-		// If the backup properly took the (incorrect) checkpoint into account, it
-		// won't have tried to re-export any keys within backupCompletedSpan.
-		backupManifestFile := backupDir + "/" + backupManifestName
-		backupManifestBytes, err := ioutil.ReadFile(backupManifestFile)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if isGZipped(backupManifestBytes) {
-			backupManifestBytes, err = decompressData(ctx, nil, backupManifestBytes)
-			require.NoError(t, err)
-		}
-		var backupManifest BackupManifest
-		if err := protoutil.Unmarshal(backupManifestBytes, &backupManifest); err != nil {
-			t.Fatal(err)
-		}
-		for _, file := range backupManifest.Files {
-			if file.Span.Overlaps(backupCompletedSpan) && file.Path != "garbage-checkpoint" {
-				t.Fatalf("backup re-exported checkpointed span %s", file.Span)
-			}
+				if err := os.MkdirAll(backupDir+item.checkpointDirectory, 0755); err != nil {
+					t.Fatal(err)
+				}
+				checkpointFile := backupDir + item.checkpointDirectory + "/" + backupManifestCheckpointName
+				if err := ioutil.WriteFile(checkpointFile, mockManifest, 0644); err != nil {
+					t.Fatal(err)
+				}
+				createAndWaitForJob(
+					t, sqlDB, []descpb.ID{backupTableDesc.GetID()},
+					jobspb.BackupDetails{
+						EndTime: tc.Servers[0].Clock().Now(),
+						URI:     "nodelocal://0/backup" + "-" + item.testName,
+					},
+					jobspb.BackupProgress{},
+				)
+
+				// If the backup properly took the (incorrect) checkpoint into account, it
+				// won't have tried to re-export any keys within backupCompletedSpan.
+				backupManifestFile := backupDir + "/" + backupManifestName
+				backupManifestBytes, err := ioutil.ReadFile(backupManifestFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if isGZipped(backupManifestBytes) {
+					backupManifestBytes, err = decompressData(ctx, nil, backupManifestBytes)
+					require.NoError(t, err)
+				}
+				var backupManifest BackupManifest
+				if err := protoutil.Unmarshal(backupManifestBytes, &backupManifest); err != nil {
+					t.Fatal(err)
+				}
+				for _, file := range backupManifest.Files {
+					if file.Span.Overlaps(backupCompletedSpan) && file.Path != "garbage-checkpoint" {
+						t.Fatalf("backup re-exported checkpointed span %s", file.Span)
+					}
+				}
+			})
 		}
 	})
 
 	t.Run("restore", func(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
-		restoreDir := "nodelocal://0/restore"
+		// We backup into two different directories in the tests above so
+		// as to not intefere with each other. However, they should both be
+		// the same to RESTORE so we arbitrarily pick this directory.
+		restoreDir := "nodelocal://0/restore-backup-progress-directory"
 		sqlDB.Exec(t, `BACKUP DATABASE DATA TO $1`, restoreDir)
 		sqlDB.Exec(t, `CREATE DATABASE restoredb`)
 		restoreDatabaseID := sqlutils.QueryDatabaseID(t, sqlDB.DB, "restoredb")
@@ -9887,4 +9906,201 @@ func TestRestoreOnFailOrCancelAfterPause(t *testing.T) {
 
 	sqlDBRestore.Exec(t, `CANCEL JOB $1`, id)
 	jobutils.WaitForJobToCancel(t, sqlDBRestore, id)
+}
+
+// TestBackupNoOverwriteCheckpoint tests BACKUP to see that it no longer
+// overwrites the checkpoint file in the progress directory.
+func TestBackupNoOverwriteCheckpoint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// The regular interval is a minute which would require us to take a
+	// very large backup in order to get more than one checkpoint. Instead,
+	// lower the interval and change it back to normal after the test.
+	resetCheckpointInterval := TestingShortBackupCheckpointInterval(BackupCheckpointInterval)
+	defer resetCheckpointInterval()
+	var numCheckpointsWritten int
+
+	// Set the testing knob so we count each time we write a checkpoint.
+	params := base.TestClusterArgs{}
+	knobs := base.TestingKnobs{
+		SQLExecutor: &sql.ExecutorTestingKnobs{
+			AfterBackupCheckpoint: func() {
+				numCheckpointsWritten++
+			},
+		},
+	}
+	params.ServerArgs.Knobs = knobs
+
+	// We want the backup to be large enough so that it doesn't finish in
+	// one iteration, which wouldn't test if checkpoints overwrite.
+	const numAccounts = 1000
+	const userfile = "'userfile:///a'"
+	tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
+	defer cleanupFn()
+
+	query := fmt.Sprintf("BACKUP INTO %s", userfile)
+	sqlDB.Exec(t, query)
+
+	// List all the BACKUP-CHECKPOINTS in the progress directory and see
+	// if there are as many as we'd expect if none got overwritten.
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	ctx := context.Background()
+	store, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, "userfile:///a", security.RootUserName())
+	require.NoError(t, err)
+
+	// Find the latest file so we know where the directory is that we want
+	// to list from.
+	r, err := findLatestFile(ctx, store)
+	require.NoError(t, err)
+	latest, err := ioctx.ReadAll(ctx, r)
+	latestFilePath := (string)(latest)
+	require.NoError(t, err)
+	r.Close(ctx)
+
+	var actualNumCheckpointsWritten int
+	require.NoError(t, store.List(ctx, latestFilePath+"/progress/", "", func(f string) error {
+		// Don't double count checkpoints as there will be the manifest and
+		// the checksum.
+		if !strings.HasSuffix(f, backupManifestChecksumSuffix) {
+			if strings.HasPrefix(f, backupManifestCheckpointName) {
+				actualNumCheckpointsWritten++
+			}
+		}
+		return nil
+	}, 0 /*limit*/))
+
+	// numCheckpointWritten only accounts for checkpoints written in the
+	// progress loop, each time we Resume we write another checkpoint.
+	// since we can resume one or more times, we only require that it be
+	// greater or equal to the number of checkpoints written + 1.
+	require.GreaterOrEqual(t, numCheckpointsWritten+1, actualNumCheckpointsWritten)
+}
+
+// TestBackupCheckpointInBaseDirectory tests to see that BACKUP-CHECKPOINT
+// manifests are correctly named lexicographically when generated with
+// newTimestampedCheckpointFileName(). We generate multiple files and write
+// them to each storage provider. Then we list checkpoint files, with a
+// limit of 1, to see that the file we get back was indeed the latest one.
+func TestBackupTimestampedCheckpointsAreLexicographical(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	var checkpoints []string
+	numCheckpoints := 5
+
+	for i := 0; i < numCheckpoints; i++ {
+		checkpoints = append(checkpoints, newTimestampedCheckpointFileName())
+		// Occasionally, we call newTimestampedCheckpointFileName() in succession
+		// too fast and the timestamp is the same. So wait for a moment to
+		// avoid that.
+		time.Sleep(time.Millisecond)
+	}
+
+	expectedCheckpoint := checkpoints[numCheckpoints-1]
+	// Shuffle the checkpoints to make sure that the List with limit 1
+	// is independent of order of writing.
+	rand.Shuffle(numCheckpoints, func(i, j int) {
+		checkpoints[i], checkpoints[j] = checkpoints[j], checkpoints[i]
+	})
+
+	const numAccounts = 1000
+	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name string
+	}{
+		{
+			"azure",
+		},
+		{
+			"fileTable",
+		},
+		{
+			"gcs",
+		},
+		{
+			"localFile",
+		},
+		{
+			"s3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var uri string
+			switch tc.name {
+			case "s3":
+				// If environment credentials are not present, we want to
+				// skip the S3 test.
+				accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+				if accessKeyID == "" {
+					skip.IgnoreLint(t, "AWS_ACCESS_KEY_ID env var must be set")
+				}
+				secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+				if secretAccessKey == "" {
+					skip.IgnoreLint(t, "AWS_SECRET_ACCESS_KEY env var must be set")
+				}
+				bucket := os.Getenv("AWS_S3_BUCKET")
+				if bucket == "" {
+					skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
+				}
+
+				uri = amazon.S3URI(bucket, "backup-test-lexicographical",
+					&roachpb.ExternalStorage_S3{AccessKey: accessKeyID, Secret: secretAccessKey, Region: "us-east-1"},
+				)
+			case "azure":
+				account := os.Getenv("AZURE_ACCOUNT_NAME")
+				key := os.Getenv("AZURE_ACCOUNT_KEY")
+				bucket := os.Getenv("AZURE_CONTAINER")
+
+				if account == "" || key == "" || bucket == "" {
+					skip.IgnoreLint(t, "AZURE_ACCOUNT_NAME, AZURE_ACCOUNT_KEY, AZURE_CONTAINER must all be set")
+				}
+
+				uri = fmt.Sprintf("azure://%s/%s?%s=%s&%s=%s",
+					bucket, "backup-test-lexicographical",
+					azure.AzureAccountKeyParam, url.QueryEscape(key),
+					azure.AzureAccountNameParam, url.QueryEscape(account))
+			case "gcs":
+				bucket := os.Getenv("GS_BUCKET")
+				if bucket == "" {
+					skip.IgnoreLint(t, "GS_BUCKET env var must be set")
+				}
+
+				credentials := os.Getenv("GS_JSONKEY")
+				if credentials == "" {
+					skip.IgnoreLint(t, "GS_JSONKEY env var must be set")
+				}
+				encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
+				uri = fmt.Sprintf("gs://%s/%s?%s=%s",
+					bucket,
+					"backup-test-lexicographical",
+					gcp.CredentialsParam,
+					url.QueryEscape(encoded),
+				)
+			case "fileTable":
+				uri = "userfile:///a"
+			case "localFile":
+				uri = "nodelocal://0/a"
+			}
+			store, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, security.RootUserName())
+			require.NoError(t, err)
+			for _, checkpoint := range checkpoints {
+				var desc []byte
+				require.NoError(t, cloud.WriteFile(ctx, store, backupProgressDirectory+"/"+checkpoint, bytes.NewReader(desc)))
+			}
+			require.NoError(t, err)
+			var actual string
+			require.NoError(t, store.List(ctx, "/progress/", "", func(f string) error {
+				actual = f
+				return nil
+			}, 1 /*limit*/))
+			require.Equal(t, expectedCheckpoint, actual)
+			for _, checkpoint := range checkpoints {
+				require.NoError(t, store.Delete(ctx, "/progress/"+checkpoint))
+			}
+		})
+	}
 }

--- a/pkg/ccl/backupccl/incrementals.go
+++ b/pkg/ccl/backupccl/incrementals.go
@@ -83,7 +83,7 @@ func FindPriorBackups(
 			prev = append(prev, p)
 		}
 		return nil
-	}); err != nil {
+	}, 0 /*limit*/); err != nil {
 		return nil, errors.Wrap(err, "reading previous backup layers")
 	}
 	sort.Strings(prev)

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -659,7 +659,7 @@ func listDir(
 	if log.V(1) {
 		log.Infof(ctx, "Listing %s", dir)
 	}
-	return es.List(ctx, dir, "/", lsFn)
+	return es.List(ctx, dir, "/", lsFn, 0 /*limit*/)
 }
 
 // ListFixtures returns the object paths to all fixtures stored in a FixtureConfig.

--- a/pkg/cli/userfile.go
+++ b/pkg/cli/userfile.go
@@ -256,7 +256,7 @@ func runUserFileGet(cmd *cobra.Command, args []string) (resErr error) {
 		}
 		files = append(files, s)
 		return nil
-	}); err != nil {
+	}, 0 /*limit*/); err != nil {
 		return err
 	}
 
@@ -451,7 +451,7 @@ func listUserFile(ctx context.Context, conn clisqlclient.Conn, glob string) ([]s
 		}
 		res = append(res, displayPrefix+s)
 		return nil
-	}); err != nil {
+	}, 0 /*limit*/); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -532,7 +532,7 @@ func deleteUserFile(ctx context.Context, conn clisqlclient.Conn, glob string) ([
 		}
 		deleted = append(deleted, displayRoot+s)
 		return nil
-	}); err != nil {
+	}, 0 /*limit*/); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -78,11 +78,12 @@ type ExternalStorage interface {
 	// List enumerates files within the supplied prefix, calling the passed
 	// function with the name of each file found, relative to the external storage
 	// destination's configured prefix. If the passed function returns a non-nil
-	// error, iteration is stopped it is returned. If delimiter is non-empty names
-	// which have the same prefix, prior to the delimiter, are grouped into a
-	// single result which is that prefix. The order that results are passed to
-	// the callback is undefined.
-	List(ctx context.Context, prefix, delimiter string, fn ListingFn) error
+	// error, iteration is stopped it is returned. Iteration is also stopped
+	// if the number of filenames reaches the limit, 0 is no limit.
+	// If delimiter is non-empty names which have the same prefix, prior
+	// to the delimiter, are grouped into a single result which is that
+	// prefix. The order that results are passed to the callback is undefined.
+	List(ctx context.Context, prefix, delimiter string, fn ListingFn, limit int) error
 
 	// Delete removes the named file from the store.
 	Delete(ctx context.Context, basename string) error

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -180,7 +180,7 @@ func (h *httpStorage) Writer(ctx context.Context, basename string) (io.WriteClos
 	}), nil
 }
 
-func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+func (h *httpStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn, _ int) error {
 	return errors.Mark(errors.New("http storage does not support listing"), cloud.ErrListingUnsupported)
 }
 

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -160,7 +160,7 @@ func (l *localFileStorage) ReadFileAt(
 }
 
 func (l *localFileStorage) List(
-	ctx context.Context, prefix, delim string, fn cloud.ListingFn,
+	ctx context.Context, prefix, delim string, fn cloud.ListingFn, limit int,
 ) error {
 	dest := cloud.JoinPathPreservingTrailingSlash(l.base, prefix)
 
@@ -172,6 +172,7 @@ func (l *localFileStorage) List(
 	// Sort results so that we can group as we go.
 	sort.Strings(res)
 	var prevPrefix string
+	count := 0
 	for _, f := range res {
 		f = strings.TrimPrefix(f, dest)
 		if delim != "" {
@@ -185,6 +186,9 @@ func (l *localFileStorage) List(
 		}
 		if err := fn(f); err != nil {
 			return err
+		}
+		if count++; limit != 0 && count >= limit {
+			return nil
 		}
 	}
 	return nil

--- a/pkg/cloud/nullsink/nullsink_storage.go
+++ b/pkg/cloud/nullsink/nullsink_storage.go
@@ -83,7 +83,7 @@ func (n *nullSinkStorage) Writer(_ context.Context, _ string) (io.WriteCloser, e
 	return nullWriter{}, nil
 }
 
-func (n *nullSinkStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn) error {
+func (n *nullSinkStorage) List(_ context.Context, _, _ string, _ cloud.ListingFn, _ int) error {
 	return nil
 }
 

--- a/pkg/cloud/userfile/filetable/file_table_read_writer.go
+++ b/pkg/cloud/userfile/filetable/file_table_read_writer.go
@@ -932,6 +932,9 @@ func (f *FileToTableSystem) NewFileWriter(
 	//
 	// NB: userfile upload will error out on the client side if a file with the
 	// same name already exists.
+	// TODO (darrylwong): Latest files are still overwritten during backups,
+	// but once backups no longer overwrite them, we will no longer need
+	// this in non mixed clusters.
 	err = f.deleteFileWithoutTxn(ctx, filename, e.ie)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1439,6 +1439,10 @@ type ExecutorTestingKnobs struct {
 		txnID uuid.UUID,
 		txnFingerprintID roachpb.TransactionFingerprintID,
 	)
+
+	// AfterBackupCheckpoint if set will be called after a BACKUP-CHECKPOINT
+	// is written.
+	AfterBackupCheckpoint func()
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -437,7 +437,7 @@ func importPlanHook(
 							expandedFiles = append(expandedFiles, uri.String())
 						}
 						return err
-					}); err != nil {
+					}, 0 /*limit*/); err != nil {
 						return err
 					}
 					if len(expandedFiles) < 1 {

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5744,7 +5744,7 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 					files = append(files, f)
 				}
 				return err
-			}))
+			}, 0 /*limit*/))
 			for i, file := range files {
 				require.Equal(t, file, path.Join(dirName, logSubdir, fmt.Sprintf("%d.log", i)))
 				content, err := store.ReadFile(ctx, file)

--- a/pkg/sql/importer/testutils_test.go
+++ b/pkg/sql/importer/testutils_test.go
@@ -296,7 +296,7 @@ func (es *generatorExternalStorage) Writer(
 }
 
 func (es *generatorExternalStorage) List(
-	ctx context.Context, _, _ string, _ cloud.ListingFn,
+	ctx context.Context, _, _ string, _ cloud.ListingFn, _ int,
 ) error {
 	return errors.New("unsupported")
 }


### PR DESCRIPTION
This change teaches backup and restore to no longer overwrite or delete any checkpoint files,
and instead write a new version side by side with the old, and to read these new versioned
checkpoints. To make sure that older backup chains and mixed clusters are not broken by this change,
we only write to the progress directory if it is not a pure v22.1 or later cluster. This
logic can be removed in a post 22.1 release when we no longer write to the base directory.
This change is so we can in the future, no longer require write access for backups.

Addresses https://github.com/cockroachdb/cockroach/issues/76438

Release Justification: release blocker

Release Note enterprise: Checkpoint files are no longer overwritten and now versioned
and written side by side in the /progress directory. Temporary checkpoint files are
no longer written.

Jira issue: CRDB-14712
Epic CRDB-7586