### PR TITLE
spanconfigstore: introduce a system span config store

### DIFF
--- a/pkg/spanconfig/BUILD.bazel
+++ b/pkg/spanconfig/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -220,6 +220,7 @@ type StoreWriter interface {
 	//
 	// [1]: Unless dryrun is true. We'll still generate the same {deleted,added}
 	//      lists.
+	// TODO(arul): Get rid of dryrun; we don't make use of it anywhere.
 	Apply(ctx context.Context, dryrun bool, updates ...Update) (
 		deleted []Target, added []Record,
 	)

--- a/pkg/spanconfig/spanconfigstore/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigstore/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "spanconfigstore.go",
         "store.go",
+        "systemspanconfigstore.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore",
     visibility = ["//visibility:public"],
@@ -26,14 +27,17 @@ go_test(
     srcs = [
         "spanconfigstore_test.go",
         "store_test.go",
+        "systemspanconfigstore_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":spanconfigstore"],
     deps = [
+        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/testutils",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // EnabledSetting is a hidden cluster setting to enable the use of the span
@@ -37,13 +38,11 @@ var EnabledSetting = settings.RegisterBoolSetting(
 // update the span configuration state. Internally, it makes use of an interval
 // tree based spanConfigStore to store non-overlapping span configurations that
 // target keyspans. It's safe for concurrent use.
-//
-// TODO(arul): In the future we'll teach this thing about system span
-// configurations as well.
 type Store struct {
 	mu struct {
 		syncutil.RWMutex
-		spanConfigStore *spanConfigStore
+		spanConfigStore       *spanConfigStore
+		systemSpanConfigStore *systemSpanConfigStore
 	}
 
 	// TODO(irfansharif): We're using a static fall back span config here, we
@@ -63,6 +62,7 @@ var _ spanconfig.Store = &Store{}
 func New(fallback roachpb.SpanConfig) *Store {
 	s := &Store{fallback: fallback}
 	s.mu.spanConfigStore = newSpanConfigStore()
+	s.mu.systemSpanConfigStore = newSystemSpanConfigStore()
 	return s
 }
 
@@ -91,9 +91,9 @@ func (s *Store) GetSpanConfigForKey(
 		return roachpb.SpanConfig{}, err
 	}
 	if !found {
-		return s.fallback, nil
+		conf = s.fallback
 	}
-	return conf, nil
+	return s.mu.systemSpanConfigStore.combine(key, conf)
 }
 
 // Apply is part of the spanconfig.StoreWriter interface.
@@ -114,6 +114,7 @@ func (s *Store) Copy(ctx context.Context) *Store {
 
 	clone := New(s.fallback)
 	clone.mu.spanConfigStore = s.mu.spanConfigStore.copy(ctx)
+	clone.mu.systemSpanConfigStore = s.mu.systemSpanConfigStore.copy()
 	return clone
 }
 
@@ -127,10 +128,15 @@ func (s *Store) applyInternal(
 	// a set of updates at once instead of individually, to correctly construct
 	// the deleted/added slices.
 	spanStoreUpdates := make([]spanconfig.Update, 0, len(updates))
+	systemSpanConfigStoreUpdates := make([]spanconfig.Update, 0, len(updates))
 	for _, update := range updates {
-		// TODO(arul): We'll hijack system span configurations here.
-		if update.Target.IsSpanTarget() {
+		switch {
+		case update.Target.IsSpanTarget():
 			spanStoreUpdates = append(spanStoreUpdates, update)
+		case update.Target.IsSystemTarget():
+			systemSpanConfigStoreUpdates = append(systemSpanConfigStoreUpdates, update)
+		default:
+			return nil, nil, errors.AssertionFailedf("unknown target type")
 		}
 	}
 	deletedSpans, addedEntries, err := s.mu.spanConfigStore.apply(dryrun, spanStoreUpdates...)
@@ -148,6 +154,18 @@ func (s *Store) applyInternal(
 			Config: entry.config,
 		})
 	}
+
+	deletedSystemTargets, addedSystemSpanConfigRecords, err := s.mu.systemSpanConfigStore.apply(
+		systemSpanConfigStoreUpdates...,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, systemTarget := range deletedSystemTargets {
+		deleted = append(deleted, spanconfig.MakeTargetFromSystemTarget(systemTarget))
+	}
+	added = append(added, addedSystemSpanConfigRecords...)
+
 	return deleted, added, nil
 }
 
@@ -155,6 +173,10 @@ func (s *Store) applyInternal(
 func (s *Store) Iterate(f func(spanconfig.Record) error) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	// System targets are considered to be less than span targets.
+	if err := s.mu.systemSpanConfigStore.iterate(f); err != nil {
+		return err
+	}
 	return s.mu.spanConfigStore.forEachOverlapping(
 		keys.EverythingSpan,
 		func(s spanConfigEntry) error {

--- a/pkg/spanconfig/spanconfigstore/systemspanconfigstore.go
+++ b/pkg/spanconfig/spanconfigstore/systemspanconfigstore.go
@@ -1,0 +1,187 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigstore
+
+import (
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/errors"
+)
+
+// systemSpanConfigStore is an in-memory data structure to store system span
+// configurations. It is not safe for concurrent use.
+type systemSpanConfigStore struct {
+	store map[spanconfig.SystemTarget]roachpb.SpanConfig
+}
+
+// newSystemSpanConfigStore constructs and returns a new systemSpanConfigStore.
+func newSystemSpanConfigStore() *systemSpanConfigStore {
+	store := systemSpanConfigStore{}
+	store.store = make(map[spanconfig.SystemTarget]roachpb.SpanConfig)
+	return &store
+}
+
+// apply takes an incremental set of system span config updates and applies them
+// to the underlying store. It returns a list of targets deleted/records added.
+//
+// TODO(arul): Even though this is called from spanconfig.Store.Apply, which
+// accepts a dryrun field, we don't accept a a dry run option here because it's
+// unused; instead, we plan on removing it entirely.
+func (s *systemSpanConfigStore) apply(
+	updates ...spanconfig.Update,
+) (deleted []spanconfig.SystemTarget, added []spanconfig.Record, _ error) {
+	if err := s.validateApplyArgs(updates); err != nil {
+		return nil, nil, err
+	}
+
+	for _, update := range updates {
+		if update.Addition() {
+			conf, found := s.store[update.Target.GetSystemTarget()]
+			if found {
+				if conf.Equal(update.Config) {
+					// no-op.
+					continue
+				}
+				deleted = append(deleted, update.Target.GetSystemTarget())
+			}
+
+			s.store[update.Target.GetSystemTarget()] = update.Config
+			added = append(added, spanconfig.Record(update))
+		}
+
+		if update.Deletion() {
+			_, found := s.store[update.Target.GetSystemTarget()]
+			if !found {
+				continue // no-op
+			}
+			delete(s.store, update.Target.GetSystemTarget())
+			deleted = append(deleted, update.Target.GetSystemTarget())
+		}
+	}
+
+	return deleted, added, nil
+}
+
+// combine takes a key and an associated span configuration and combines it with
+// all system span configs that apply to the given key.
+func (s *systemSpanConfigStore) combine(
+	key roachpb.RKey, config roachpb.SpanConfig,
+) (roachpb.SpanConfig, error) {
+	_, tenID, err := keys.DecodeTenantPrefix(roachpb.Key(key))
+	if err != nil {
+		return roachpb.SpanConfig{}, err
+	}
+
+	hostSetOnTenant, err := spanconfig.MakeTenantKeyspaceTarget(
+		roachpb.SystemTenantID, tenID,
+	)
+	if err != nil {
+		return roachpb.SpanConfig{}, err
+	}
+	// Construct a list of system targets that apply to the key given its tenant
+	// prefix. These are:
+	// 1. The system span config that applies over the entire keyspace.
+	// 2. The system span config set by the host over the tenant's keyspace.
+	// 3. The system span config set by the tenant itself over its own keyspace.
+	targets := []spanconfig.SystemTarget{
+		spanconfig.MakeEntireKeyspaceTarget(),
+		hostSetOnTenant,
+	}
+
+	// We only need to do this for secondary tenants; we've already added this
+	// target if tenID == system tenant.
+	if tenID != roachpb.SystemTenantID {
+		target, err := spanconfig.MakeTenantKeyspaceTarget(tenID, tenID)
+		if err != nil {
+			return roachpb.SpanConfig{}, err
+		}
+		targets = append(targets, target)
+	}
+
+	for _, target := range targets {
+		systemSpanConfig, found := s.store[target]
+		if found {
+			config.GCPolicy.ProtectionPolicies = append(
+				config.GCPolicy.ProtectionPolicies, systemSpanConfig.GCPolicy.ProtectionPolicies...,
+			)
+		}
+	}
+	return config, nil
+}
+
+// copy returns a copy of the system span config store.
+func (s *systemSpanConfigStore) copy() *systemSpanConfigStore {
+	clone := newSystemSpanConfigStore()
+	for k := range s.store {
+		clone.store[k] = s.store[k]
+	}
+	return clone
+}
+
+// iterate goes through all system span config entries in sorted order.
+func (s *systemSpanConfigStore) iterate(f func(record spanconfig.Record) error) error {
+	// Iterate through in sorted order.
+	targets := make([]spanconfig.Target, 0, len(s.store))
+	for k := range s.store {
+		targets = append(targets, spanconfig.MakeTargetFromSystemTarget(k))
+	}
+	sort.Sort(spanconfig.Targets(targets))
+
+	for _, target := range targets {
+		if err := f(spanconfig.Record{
+			Target: target,
+			Config: s.store[target.GetSystemTarget()],
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateApplyArgs ensures that updates can be applied to the system span
+// config store. In particular, it checks that the updates target system targets
+// and duplicate targets do not exist.
+func (s *systemSpanConfigStore) validateApplyArgs(updates []spanconfig.Update) error {
+	for _, update := range updates {
+		if !update.Target.IsSystemTarget() {
+			return errors.AssertionFailedf("expected update to system target update")
+		}
+
+		if update.Target.GetSystemTarget().IsReadOnly() {
+			return errors.AssertionFailedf("invalid system target update")
+		}
+	}
+
+	sorted := make([]spanconfig.Update, len(updates))
+	copy(sorted, updates)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Target.Less(sorted[j].Target)
+	})
+	updates = sorted // re-use the same variable
+
+	for i := range updates {
+		if i == 0 {
+			continue
+		}
+
+		if updates[i].Target.Equal(updates[i-1].Target) {
+			return errors.Newf(
+				"found duplicate updates %s and %s",
+				updates[i-1].Target,
+				updates[i].Target,
+			)
+		}
+	}
+	return nil
+}

--- a/pkg/spanconfig/spanconfigstore/systemspanconfigstore_test.go
+++ b/pkg/spanconfig/spanconfigstore/systemspanconfigstore_test.go
@@ -1,0 +1,145 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigstore
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystemSpanConfigStoreCombine tests that we correctly hydrate span
+// configurations with the system span configurations that apply to a given key.
+func TestSystemSpanConfigStoreCombine(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ts := func(nanos int) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: int64(nanos),
+		}
+	}
+	makeSystemSpanConfig := func(nanos int) roachpb.SpanConfig {
+		return roachpb.SpanConfig{
+			GCPolicy: roachpb.GCPolicy{
+				ProtectionPolicies: []roachpb.ProtectionPolicy{
+					{
+						ProtectedTimestamp: ts(nanos),
+					},
+				},
+			},
+		}
+	}
+
+	// Setup:
+	// System span configurations:
+	// Entire Keyspace: 100
+	// System Tenant -> System Tenant: 120
+	// System Tenant -> Ten 10: 150
+	// System Tenant -> Ten 30: 500
+	// Ten 10 -> Ten 10: 200
+	// Ten 20 -> Ten 20: 300
+	//
+	// Span config: 1
+
+	updates := []spanconfig.Update{
+		spanconfig.Addition(
+			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()),
+			makeSystemSpanConfig(100),
+		),
+		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
+				t, roachpb.SystemTenantID, roachpb.SystemTenantID,
+			),
+		),
+			makeSystemSpanConfig(120),
+		),
+		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
+				t, roachpb.SystemTenantID, roachpb.MakeTenantID(10),
+			),
+		),
+			makeSystemSpanConfig(150),
+		),
+		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
+				t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10),
+			),
+		),
+			makeSystemSpanConfig(200),
+		),
+		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
+				t, roachpb.MakeTenantID(20), roachpb.MakeTenantID(20),
+			),
+		),
+			makeSystemSpanConfig(300),
+		),
+		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
+				t, roachpb.SystemTenantID, roachpb.MakeTenantID(30),
+			),
+		),
+			makeSystemSpanConfig(500),
+		),
+	}
+
+	store := newSystemSpanConfigStore()
+
+	_, _, err := store.apply(updates...)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		key          roachpb.RKey
+		expectedPTSs []hlc.Timestamp
+	}{
+		{
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.SystemTenantID), byte('a'))),
+			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(120)},
+		},
+		{
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(10)), byte('a'))),
+			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(150), ts(200)},
+		},
+		{
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(20)), byte('a'))),
+			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(300)},
+		},
+		{
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(30)), byte('a'))),
+			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(500)},
+		},
+		{
+			// Only the system span config over the entire keyspace should apply to
+			// tenant 40.
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(40)), byte('a'))),
+			expectedPTSs: []hlc.Timestamp{ts(1), ts(100)},
+		},
+	} {
+		// Combine with a span config that already has a PTS set on it.
+		conf, err := store.combine(tc.key, makeSystemSpanConfig(1))
+		require.NoError(t, err)
+		require.Equal(t, len(tc.expectedPTSs), len(conf.GCPolicy.ProtectionPolicies))
+		sort.Slice(conf.GCPolicy.ProtectionPolicies, func(i, j int) bool {
+			return conf.GCPolicy.ProtectionPolicies[i].ProtectedTimestamp.Less(
+				conf.GCPolicy.ProtectionPolicies[j].ProtectedTimestamp,
+			)
+		})
+		for i, expPTS := range tc.expectedPTSs {
+			require.Equal(t, expPTS, conf.GCPolicy.ProtectionPolicies[i].ProtectedTimestamp)
+		}
+	}
+}

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs
@@ -1,0 +1,63 @@
+# Test batched operations performed on system span configurations, with
+# batches that combine both system span configurations and regular span configs.
+
+# apply a batch of system span configs + regular configs.
+apply
+set [a,f):A
+set {entire-keyspace}:_ENTIRE
+set {source=1,target=1}:_HOST
+set {source=10,target=10}:_SECONDARY
+----
+added {entire-keyspace}:_ENTIRE
+added {source=1,target=1}:_HOST
+added {source=10,target=10}:_SECONDARY
+added [a,f):A
+
+get key=b
+----
+conf=A_ENTIRE_HOST
+
+
+# Combine a regular span config update with a system span config update and
+# delete.
+apply
+set [c,d):B
+set {entire-keyspace}:_CLUSTER
+delete {source=1,target=1}
+----
+deleted {entire-keyspace}
+deleted {source=1,target=1}
+deleted [a,f)
+added {entire-keyspace}:_CLUSTER
+added [a,c):A
+added [c,d):B
+added [d,f):A
+
+get key=b
+----
+conf=A_CLUSTER
+
+get key=c
+----
+conf=B_CLUSTER
+
+# Combine a regular span config delete with a system span config delete and
+# update.
+
+apply
+delete [c,d)
+delete {entire-keyspace}
+set {source=10,target=10}:_SEC
+----
+deleted {entire-keyspace}
+deleted {source=10,target=10}
+deleted [c,d)
+added {source=10,target=10}:_SEC
+
+get key=b
+----
+conf=A
+
+get key=c
+----
+conf=FALLBACK

--- a/pkg/spanconfig/spanconfigstore/testdata/single/system_span_configs
+++ b/pkg/spanconfig/spanconfigstore/testdata/single/system_span_configs
@@ -1,0 +1,113 @@
+# Test basic operations performed with system span configurations.
+
+apply
+set [a,c):A
+----
+added [a,c):A
+
+apply
+set {entire-keyspace}:_ENTIRE
+----
+added {entire-keyspace}:_ENTIRE
+
+# Check that keys are hydrated correctly.
+get key=b
+----
+conf=A_ENTIRE
+
+get key=c
+----
+conf=FALLBACK_ENTIRE
+
+# Ensure no-ops appear as such.
+apply
+set {entire-keyspace}:_ENTIRE
+----
+
+# Ensure combining system span configs that target a tenant and the entire
+# keyspace both take affect.
+apply
+set {source=1,target=1}:_TENANT
+----
+added {source=1,target=1}:_TENANT
+
+# Check that keys are hydrated correctly.
+get key=b
+----
+conf=A_ENTIRE_TENANT
+
+get key=c
+----
+conf=FALLBACK_ENTIRE_TENANT
+
+# Ensure updates take affect as you'd expect.
+apply
+set {entire-keyspace}:_KEYSPACE
+----
+deleted {entire-keyspace}
+added {entire-keyspace}:_KEYSPACE
+
+get key=c
+----
+conf=FALLBACK_KEYSPACE_TENANT
+
+get key=b
+----
+conf=A_KEYSPACE_TENANT
+
+# Ensure deletion works properly.
+apply
+delete {entire-keyspace}
+----
+deleted {entire-keyspace}
+
+get key=c
+----
+conf=FALLBACK_TENANT
+
+get key=b
+----
+conf=A_TENANT
+
+# Ensure deletion no-ops appear as such.
+apply
+delete {entire-keyspace}
+----
+
+# Ensure updates/deletes to the system span configuration that applies to tenant
+# keyspace also work as expected.
+apply
+set {source=1,target=1}:_HOST
+----
+deleted {source=1,target=1}
+added {source=1,target=1}:_HOST
+
+get key=b
+----
+conf=A_HOST
+
+apply
+delete {source=1,target=1}
+----
+deleted {source=1,target=1}
+
+get key=b
+----
+conf=A
+
+# Add a system span configuration to a secondary tenant; it shouldn't affect
+# hydration of key b which lies in the system tenant's keyspace.
+
+apply
+set {source=1,target=20}:HOST_ON_SECONDARY
+----
+added {source=1,target=20}:HOST_ON_SECONDARY
+
+apply
+set {source=20,target=20}:SECONDARY_ON_SECONDARY
+----
+added {source=20,target=20}:SECONDARY_ON_SECONDARY
+
+get key=b
+----
+conf=A

--- a/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/spanconfig",
         "//pkg/sql/catalog/descpb",
+        "//pkg/util/hlc",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",

--- a/pkg/spanconfig/systemtarget.go
+++ b/pkg/spanconfig/systemtarget.go
@@ -33,7 +33,7 @@ type SystemTarget struct {
 	//
 	// Secondary tenants are only allowed to target their own keyspace. The host
 	// tenant may use this field to target a specific secondary tenant.
-	targetTenantID *roachpb.TenantID
+	targetTenantID roachpb.TenantID
 
 	// systemTargetType indicates the type of the system target. targetTenantID
 	// can only be set if the system target is specific.
@@ -71,7 +71,7 @@ func MakeTenantKeyspaceTarget(
 ) (SystemTarget, error) {
 	t := SystemTarget{
 		sourceTenantID:   sourceTenantID,
-		targetTenantID:   &targetTenantID,
+		targetTenantID:   targetTenantID,
 		systemTargetType: SystemTargetTypeSpecificTenantKeyspace,
 	}
 	return t, t.validate()
@@ -85,19 +85,19 @@ func makeSystemTargetFromProto(proto *roachpb.SystemSpanConfigTarget) (SystemTar
 	case proto.IsSpecificTenantKeyspaceTarget():
 		t = SystemTarget{
 			sourceTenantID:   proto.SourceTenantID,
-			targetTenantID:   &proto.Type.GetSpecificTenantKeyspace().TenantID,
+			targetTenantID:   proto.Type.GetSpecificTenantKeyspace().TenantID,
 			systemTargetType: SystemTargetTypeSpecificTenantKeyspace,
 		}
 	case proto.IsEntireKeyspaceTarget():
 		t = SystemTarget{
 			sourceTenantID:   proto.SourceTenantID,
-			targetTenantID:   nil,
+			targetTenantID:   roachpb.TenantID{},
 			systemTargetType: SystemTargetTypeEntireKeyspace,
 		}
 	case proto.IsAllTenantKeyspaceTargetsSetTarget():
 		t = SystemTarget{
 			sourceTenantID:   proto.SourceTenantID,
-			targetTenantID:   nil,
+			targetTenantID:   roachpb.TenantID{},
 			systemTargetType: SystemTargetTypeAllTenantKeyspaceTargetsSet,
 		}
 	default:
@@ -114,7 +114,7 @@ func (st SystemTarget) toProto() *roachpb.SystemSpanConfigTarget {
 	case SystemTargetTypeAllTenantKeyspaceTargetsSet:
 		systemTargetType = roachpb.NewAllTenantKeyspaceTargetsSetTargetType()
 	case SystemTargetTypeSpecificTenantKeyspace:
-		systemTargetType = roachpb.NewSpecificTenantKeyspaceTargetType(*st.targetTenantID)
+		systemTargetType = roachpb.NewSpecificTenantKeyspaceTargetType(st.targetTenantID)
 	default:
 		panic("unknown system target type")
 	}
@@ -189,7 +189,7 @@ func (st SystemTarget) encode() roachpb.Span {
 func (st SystemTarget) validate() error {
 	switch st.systemTargetType {
 	case SystemTargetTypeAllTenantKeyspaceTargetsSet:
-		if st.targetTenantID != nil {
+		if st.targetTenantID.IsSet() {
 			return errors.AssertionFailedf(
 				"targetTenantID must be unset when targeting everything installed on tenants",
 			)
@@ -198,16 +198,16 @@ func (st SystemTarget) validate() error {
 		if st.sourceTenantID != roachpb.SystemTenantID {
 			return errors.AssertionFailedf("only the host tenant is allowed to target the entire keyspace")
 		}
-		if st.targetTenantID != nil {
+		if st.targetTenantID.IsSet() {
 			return errors.AssertionFailedf("malformed system target for entire keyspace; targetTenantID set")
 		}
 	case SystemTargetTypeSpecificTenantKeyspace:
-		if st.targetTenantID == nil {
+		if !st.targetTenantID.IsSet() {
 			return errors.AssertionFailedf(
 				"malformed system target for specific tenant keyspace; targetTenantID unset",
 			)
 		}
-		if st.sourceTenantID != roachpb.SystemTenantID && st.sourceTenantID != *st.targetTenantID {
+		if st.sourceTenantID != roachpb.SystemTenantID && st.sourceTenantID != st.targetTenantID {
 			return errors.AssertionFailedf(
 				"secondary tenant %s cannot target another tenant with ID %s",
 				st.sourceTenantID,
@@ -222,7 +222,8 @@ func (st SystemTarget) validate() error {
 
 // isEmpty returns true if the receiver is empty.
 func (st SystemTarget) isEmpty() bool {
-	return st.sourceTenantID.Equal(roachpb.TenantID{}) && st.targetTenantID.Equal(nil)
+	return !st.sourceTenantID.IsSet() && !st.targetTenantID.IsSet() &&
+		st.systemTargetType == 0 // unset
 }
 
 // less returns true if the receiver is considered less than the supplied
@@ -258,7 +259,9 @@ func (st SystemTarget) less(ot SystemTarget) bool {
 
 // equal returns true iff the receiver is equal to the supplied system target.
 func (st SystemTarget) equal(ot SystemTarget) bool {
-	return st.sourceTenantID.Equal(ot.sourceTenantID) && st.targetTenantID.Equal(ot.targetTenantID)
+	return st.sourceTenantID.Equal(ot.sourceTenantID) &&
+		st.targetTenantID.Equal(ot.targetTenantID) &&
+		st.systemTargetType == ot.systemTargetType
 }
 
 // String returns a pretty printed version of a system target.

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -11,9 +11,12 @@
 package spanconfig
 
 import (
+	"testing"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // Target specifies the target of an associated span configuration.
@@ -277,4 +280,14 @@ func TestingEntireSpanConfigurationStateTargets() []Target {
 			span: keys.EverythingSpan,
 		},
 	}
+}
+
+// TestingMakeTenantKeyspaceTargetOrFatal is like MakeTenantKeyspaceTarget
+// except it fatals on error.
+func TestingMakeTenantKeyspaceTargetOrFatal(
+	t *testing.T, sourceID roachpb.TenantID, targetID roachpb.TenantID,
+) SystemTarget {
+	target, err := MakeTenantKeyspaceTarget(sourceID, targetID)
+	require.NoError(t, err)
+	return target
 }

--- a/pkg/spanconfig/target_test.go
+++ b/pkg/spanconfig/target_test.go
@@ -26,11 +26,11 @@ import (
 func TestEncodeDecodeSystemTarget(t *testing.T) {
 	for _, testTarget := range []SystemTarget{
 		// Tenant targeting its logical cluster.
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
 		// System tenant targeting its logical cluster.
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		// System tenant targeting a secondary tenant.
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
 		// System tenant targeting the entire keyspace.
 		MakeEntireKeyspaceTarget(),
 	} {
@@ -50,11 +50,11 @@ func TestEncodeDecodeSystemTarget(t *testing.T) {
 func TestTargetToFromProto(t *testing.T) {
 	for _, testSystemTarget := range []SystemTarget{
 		// Tenant targeting its logical cluster.
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
 		// System tenant targeting its logical cluster.
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		// System tenant targeting a secondary tenant.
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
 		// System tenant targeting the entire keyspace.
 		MakeEntireKeyspaceTarget(),
 		// System tenant's read-only target to fetch all system span configurations
@@ -122,28 +122,28 @@ func TestSystemTargetValidation(t *testing.T) {
 	tenant20 := roachpb.MakeTenantID(20)
 	for _, tc := range []struct {
 		sourceTenantID roachpb.TenantID
-		targetTenantID *roachpb.TenantID
+		targetTenantID roachpb.TenantID
 		targetType     systemTargetType
 		expErr         string
 	}{
 		{
 			// Secondary tenants cannot target the system tenant.
 			sourceTenantID: tenant10,
-			targetTenantID: &roachpb.SystemTenantID,
+			targetTenantID: roachpb.SystemTenantID,
 			targetType:     SystemTargetTypeSpecificTenantKeyspace,
 			expErr:         "secondary tenant 10 cannot target another tenant with ID system",
 		},
 		{
 			// Secondary tenants cannot target other secondary tenants.
 			sourceTenantID: tenant10,
-			targetTenantID: &tenant20,
+			targetTenantID: tenant20,
 			targetType:     SystemTargetTypeSpecificTenantKeyspace,
 			expErr:         "secondary tenant 10 cannot target another tenant with ID 20",
 		},
 		{
 			// Secondary tenants cannot target the entire keyspace.
 			sourceTenantID: tenant10,
-			targetTenantID: nil,
+			targetTenantID: roachpb.TenantID{},
 			targetType:     SystemTargetTypeEntireKeyspace,
 			expErr:         "only the host tenant is allowed to target the entire keyspace",
 		},
@@ -151,7 +151,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// Ensure secondary tenants can't target the entire keyspace even if they
 			// set targetTenantID to themselves.
 			sourceTenantID: tenant10,
-			targetTenantID: &tenant10,
+			targetTenantID: tenant10,
 			targetType:     SystemTargetTypeEntireKeyspace,
 			expErr:         "only the host tenant is allowed to target the entire keyspace",
 		},
@@ -159,7 +159,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// System tenant can't set both targetTenantID and target everything
 			// installed on tenants.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: &tenant10,
+			targetTenantID: tenant10,
 			targetType:     SystemTargetTypeAllTenantKeyspaceTargetsSet,
 			expErr:         "targetTenantID must be unset when targeting everything installed",
 		},
@@ -167,7 +167,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// System tenant must fill in a targetTenantID when targeting a specific
 			// tenant.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: nil,
+			targetTenantID: roachpb.TenantID{},
 			targetType:     SystemTargetTypeSpecificTenantKeyspace,
 			expErr:         "malformed system target for specific tenant keyspace; targetTenantID unset",
 		},
@@ -175,7 +175,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// System tenant can't set both targetTenantID and target the entire
 			// keyspace.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: &tenant10,
+			targetTenantID: tenant10,
 			targetType:     SystemTargetTypeEntireKeyspace,
 			expErr:         "malformed system target for entire keyspace; targetTenantID set",
 		},
@@ -183,7 +183,7 @@ func TestSystemTargetValidation(t *testing.T) {
 			// secondary tenant can't set both targetTenantID and target everything
 			// installed on tenants.
 			sourceTenantID: tenant10,
-			targetTenantID: &tenant10,
+			targetTenantID: tenant10,
 			targetType:     SystemTargetTypeAllTenantKeyspaceTargetsSet,
 			expErr:         "targetTenantID must be unset when targeting everything installed",
 		},
@@ -191,39 +191,39 @@ func TestSystemTargetValidation(t *testing.T) {
 		{
 			// System tenant targeting secondary tenant is allowed.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: &tenant20,
+			targetTenantID: tenant20,
 			targetType:     SystemTargetTypeSpecificTenantKeyspace,
 		},
 		{
 			// System tenant targeting the entire keyspace is allowed.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: nil,
+			targetTenantID: roachpb.TenantID{},
 			targetType:     SystemTargetTypeEntireKeyspace,
 		},
 		{
 			// System tenant targeting itself is allowed.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: &roachpb.SystemTenantID,
+			targetTenantID: roachpb.SystemTenantID,
 			targetType:     SystemTargetTypeSpecificTenantKeyspace,
 		},
 		{
 			// Secondary tenant targeting itself is allowed.
 			sourceTenantID: tenant10,
-			targetTenantID: &tenant10,
+			targetTenantID: tenant10,
 			targetType:     SystemTargetTypeSpecificTenantKeyspace,
 		},
 		{
 			// Secondary tenant targeting everything installed on tenants by it is
 			// allowed.
 			sourceTenantID: tenant10,
-			targetTenantID: nil,
+			targetTenantID: roachpb.TenantID{},
 			targetType:     SystemTargetTypeAllTenantKeyspaceTargetsSet,
 		},
 		{
 			// System tenant targeting everything installed on tenants by it is
 			// allowed.
 			sourceTenantID: roachpb.SystemTenantID,
-			targetTenantID: nil,
+			targetTenantID: roachpb.TenantID{},
 			targetType:     SystemTargetTypeAllTenantKeyspaceTargetsSet,
 		},
 	} {
@@ -251,19 +251,19 @@ func TestTargetSortingRandomized(t *testing.T) {
 		MakeTargetFromSystemTarget(MakeAllTenantKeyspaceTargetsSet(roachpb.MakeTenantID(10))),
 		MakeTargetFromSystemTarget(MakeEntireKeyspaceTarget()),
 		MakeTargetFromSystemTarget(
-			makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		),
 		MakeTargetFromSystemTarget(
-			makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
 		),
 		MakeTargetFromSystemTarget(
-			makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(20)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(20)),
 		),
 		MakeTargetFromSystemTarget(
-			makeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(5), roachpb.MakeTenantID(5)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(5), roachpb.MakeTenantID(5)),
 		),
 		MakeTargetFromSystemTarget(
-			makeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
 		),
 		MakeTargetFromSpan(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}),
 		MakeTargetFromSpan(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("d")}),
@@ -289,9 +289,9 @@ func TestTargetSortingRandomized(t *testing.T) {
 func TestSpanTargetsConstructedInSystemSpanConfigKeyspace(t *testing.T) {
 	for _, tc := range []roachpb.Span{
 		MakeEntireKeyspaceTarget().encode(),
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)).encode(),
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID).encode(),
-		makeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)).encode(),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)).encode(),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID).encode(),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)).encode(),
 		{
 			// Extends into from the left
 			Key:    keys.TimeseriesKeyMax,
@@ -310,12 +310,4 @@ func TestSpanTargetsConstructedInSystemSpanConfigKeyspace(t *testing.T) {
 	} {
 		require.Panics(t, func() { MakeTargetFromSpan(tc) })
 	}
-}
-
-func makeTenantKeyspaceTargetOrFatal(
-	t *testing.T, sourceID roachpb.TenantID, targetID roachpb.TenantID,
-) SystemTarget {
-	target, err := MakeTenantKeyspaceTarget(sourceID, targetID)
-	require.NoError(t, err)
-	return target
 }


### PR DESCRIPTION
This patch introduces an in-memory datastructure to keep track of
system span configurations. This thing is consulted every time we fetch
the span configuration for a key to hydrate PTS information. In
particular, when fetching span configurations, we combine PTS
information stored on any system span configurations that may apply to
the given key with the PTS information stored on the key's associated
"regular" span config.

Release note: None