### PR TITLE
server: add store_id to hot ranges response api

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3344,6 +3344,7 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range. | [reserved](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
+| store_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | store_id indicates the Store ID where range is stored. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1832,6 +1832,9 @@
           "type": "string",
           "x-go-name": "SchemaName"
         },
+        "store_id": {
+          "$ref": "#/definitions/StoreID"
+        },
         "table_name": {
           "type": "string",
           "x-go-name": "TableName"

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -435,6 +435,7 @@ type hotRangeInfo struct {
 	IndexName         string           `json:"index_name"`
 	SchemaName        string           `json:"schema_name"`
 	ReplicaNodeIDs    []roachpb.NodeID `json:"replica_node_ids"`
+	StoreID           roachpb.StoreID  `json:"store_id"`
 }
 
 // swagger:operation GET /ranges/hot/ listHotRanges
@@ -514,6 +515,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 				IndexName:         r.IndexName,
 				ReplicaNodeIDs:    r.ReplicaNodeIds,
 				SchemaName:        r.SchemaName,
+				StoreID:           r.StoreID,
 			}
 		}
 		return hotRangeInfos, nil

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1237,6 +1237,12 @@ message HotRangesResponseV2 {
     ];
     // schema_name provides the name of schema (if exists) for table in current range.
     string schema_name = 9;
+    // store_id indicates the Store ID where range is stored.
+    int32 store_id = 10 [
+      (gogoproto.customname) = "StoreID",
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"
+    ];
   }
   // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2244,6 +2244,7 @@ func (s *statusServer) HotRangesV2(
 						IndexName:         indexName,
 						ReplicaNodeIds:    replicaNodeIDs,
 						LeaseholderNodeID: r.LeaseholderNodeID,
+						StoreID:           store.StoreID,
 					})
 				}
 			}


### PR DESCRIPTION
This change extends HotRangesResponseV2 message
to include store ID data. This information can
be useful to investigate cause of hot ranges.

Release note: None

Release justification: bug fixes and low-risk updates to new functionality

Resolves: https://github.com/cockroachdb/cockroach/issues/76160
