### PR TITLE
kvserver: add new errors to IsExpectedRelocateError

### DIFF
--- a/pkg/kv/test_utils.go
+++ b/pkg/kv/test_utils.go
@@ -60,6 +60,8 @@ func IsExpectedRelocateError(err error) bool {
 		"cannot up-replicate to .*; missing gossiped StoreDescriptor",
 		"remote couldn't accept .* snapshot",
 		"cannot add placeholder",
+		"removing leaseholder not allowed since it isn't the Raft leader",
+		"could not find a better lease transfer target for",
 	}
 	pattern := "(" + strings.Join(allowlist, "|") + ")"
 	return testutils.IsError(err, pattern)


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/74077 we introduced
two new transient errors that can be thrown when relocating a range.
This PR adds them to the list of expected errors.

Release note: None