### PR TITLE
status: add locality information, additional lease info, to Ranges endpoint

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1229,6 +1229,7 @@ Support status: [reserved](#support-status)
 | locks_with_wait_queues | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  | [reserved](#support-status) |
 | lock_wait_queue_waiters | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  | [reserved](#support-status) |
 | top_k_locks_by_wait_queue_waiters | [RangeInfo.LockInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo.LockInfo) | repeated |  | [reserved](#support-status) |
+| locality | [Locality](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.Locality) |  |  | [reserved](#support-status) |
 
 
 
@@ -1353,6 +1354,34 @@ only.
 
 
 
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.Locality"></a>
+#### Locality
+
+Locality is an ordered set of key value Tiers that describe a node's
+location. The tier keys should be the same across all nodes.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| tiers | [Tier](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.Tier) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.Tier"></a>
+#### Tier
+
+Tier represents one level of the locality hierarchy.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | Key is the name of tier and should match all other nodes. | [reserved](#support-status) |
+| value | [string](#cockroach.server.serverpb.RaftDebugResponse-string) |  | Value is node specific value corresponding to the key. | [reserved](#support-status) |
+
+
+
+
+
 <a name="cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RaftRangeError"></a>
 #### RaftRangeError
 
@@ -1436,6 +1465,7 @@ Support status: [reserved](#support-status)
 | locks_with_wait_queues | [int64](#cockroach.server.serverpb.RangesResponse-int64) |  |  | [reserved](#support-status) |
 | lock_wait_queue_waiters | [int64](#cockroach.server.serverpb.RangesResponse-int64) |  |  | [reserved](#support-status) |
 | top_k_locks_by_wait_queue_waiters | [RangeInfo.LockInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo.LockInfo) | repeated |  | [reserved](#support-status) |
+| locality | [Locality](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.Locality) |  |  | [reserved](#support-status) |
 
 
 
@@ -1555,6 +1585,34 @@ only.
 | waiters | [int64](#cockroach.server.serverpb.RangesResponse-int64) |  |  | [reserved](#support-status) |
 | waiting_readers | [int64](#cockroach.server.serverpb.RangesResponse-int64) |  |  | [reserved](#support-status) |
 | waiting_writers | [int64](#cockroach.server.serverpb.RangesResponse-int64) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.Locality"></a>
+#### Locality
+
+Locality is an ordered set of key value Tiers that describe a node's
+location. The tier keys should be the same across all nodes.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| tiers | [Tier](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.Tier) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.Tier"></a>
+#### Tier
+
+Tier represents one level of the locality hierarchy.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.RangesResponse-string) |  | Key is the name of tier and should match all other nodes. | [reserved](#support-status) |
+| value | [string](#cockroach.server.serverpb.RangesResponse-string) |  | Value is node specific value corresponding to the key. | [reserved](#support-status) |
 
 
 
@@ -3314,6 +3372,7 @@ Support status: [reserved](#support-status)
 | locks_with_wait_queues | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
 | lock_wait_queue_waiters | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
 | top_k_locks_by_wait_queue_waiters | [RangeInfo.LockInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo.LockInfo) | repeated |  | [reserved](#support-status) |
+| locality | [Locality](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.Locality) |  |  | [reserved](#support-status) |
 
 
 
@@ -3433,6 +3492,34 @@ only.
 | waiters | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
 | waiting_readers | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
 | waiting_writers | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.Locality"></a>
+#### Locality
+
+Locality is an ordered set of key value Tiers that describe a node's
+location. The tier keys should be the same across all nodes.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| tiers | [Tier](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.Tier) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.Tier"></a>
+#### Tier
+
+Tier represents one level of the locality hierarchy.
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [string](#cockroach.server.serverpb.RangeResponse-string) |  | Key is the name of tier and should match all other nodes. | [reserved](#support-status) |
+| value | [string](#cockroach.server.serverpb.RangeResponse-string) |  | Value is node specific value corresponding to the key. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1230,6 +1230,8 @@ Support status: [reserved](#support-status)
 | lock_wait_queue_waiters | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) |  |  | [reserved](#support-status) |
 | top_k_locks_by_wait_queue_waiters | [RangeInfo.LockInfo](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.RangeInfo.LockInfo) | repeated |  | [reserved](#support-status) |
 | locality | [Locality](#cockroach.server.serverpb.RaftDebugResponse-cockroach.server.serverpb.Locality) |  |  | [reserved](#support-status) |
+| is_leaseholder | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| lease_valid | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -1466,6 +1468,8 @@ Support status: [reserved](#support-status)
 | lock_wait_queue_waiters | [int64](#cockroach.server.serverpb.RangesResponse-int64) |  |  | [reserved](#support-status) |
 | top_k_locks_by_wait_queue_waiters | [RangeInfo.LockInfo](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.RangeInfo.LockInfo) | repeated |  | [reserved](#support-status) |
 | locality | [Locality](#cockroach.server.serverpb.RangesResponse-cockroach.server.serverpb.Locality) |  |  | [reserved](#support-status) |
+| is_leaseholder | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| lease_valid | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -3373,6 +3377,8 @@ Support status: [reserved](#support-status)
 | lock_wait_queue_waiters | [int64](#cockroach.server.serverpb.RangeResponse-int64) |  |  | [reserved](#support-status) |
 | top_k_locks_by_wait_queue_waiters | [RangeInfo.LockInfo](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.RangeInfo.LockInfo) | repeated |  | [reserved](#support-status) |
 | locality | [Locality](#cockroach.server.serverpb.RangeResponse-cockroach.server.serverpb.Locality) |  |  | [reserved](#support-status) |
+| is_leaseholder | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| lease_valid | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -448,6 +448,8 @@ message RangeInfo {
   }
   repeated LockInfo top_k_locks_by_wait_queue_waiters = 21 [ (gogoproto.nullable) = false ];
   Locality locality = 22;
+  bool is_leaseholder = 23;
+  bool lease_valid = 24;
 }
 
 message RangesRequest {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -447,6 +447,7 @@ message RangeInfo {
     int64 waiting_writers = 6;
   }
   repeated LockInfo top_k_locks_by_wait_queue_waiters = 21 [ (gogoproto.nullable) = false ];
+  Locality locality = 22;
 }
 
 message RangesRequest {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1962,6 +1962,8 @@ func (s *statusServer) rangesHelper(
 			LockWaitQueueWaiters:        metrics.LockTableMetrics.Waiters,
 			TopKLocksByWaitQueueWaiters: topKLocksByWaiters,
 			Locality:                    &locality,
+			IsLeaseholder:               metrics.Leaseholder,
+			LeaseValid:                  metrics.LeaseValid,
 		}
 	}
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1923,6 +1923,13 @@ func (s *statusServer) rangesHelper(
 			})
 		}
 		qps, _ := rep.QueriesPerSecond()
+		locality := serverpb.Locality{}
+		for _, tier := range rep.GetNodeLocality().Tiers {
+			locality.Tiers = append(locality.Tiers, serverpb.Tier{
+				Key:   tier.Key,
+				Value: tier.Value,
+			})
+		}
 		return serverpb.RangeInfo{
 			Span:          span,
 			RaftState:     raftState,
@@ -1954,6 +1961,7 @@ func (s *statusServer) rangesHelper(
 			LocksWithWaitQueues:         metrics.LockTableMetrics.LocksWithWaitQueues,
 			LockWaitQueueWaiters:        metrics.LockTableMetrics.Waiters,
 			TopKLocksByWaitQueueWaiters: topKLocksByWaiters,
+			Locality:                    &locality,
 		}
 	}
 

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -244,6 +244,11 @@ const rangeTableDisplayList: RangeTableRow[] = [
     display: "Circuit Breaker Error",
     compareToLeader: false,
   },
+  {
+    variable: "locality",
+    display: "Locality Info",
+    compareToLeader: false,
+  },
 ];
 
 const rangeTableEmptyContent: RangeTableCellContent = {
@@ -862,6 +867,12 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
         circuitBreakerError: this.createContent(
           info.state.circuit_breaker_error,
         ),
+        locality: this.contentIf(_.size(info.locality.tiers) > 0, () => ({
+          value: _.map(
+            info.locality.tiers,
+            tier => `${tier.key}: ${tier.value}`,
+          ),
+        })),
       });
     });
 

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -61,6 +61,12 @@ const rangeTableDisplayList: RangeTableRow[] = [
   { variable: "leaseState", display: "Lease State", compareToLeader: true },
   { variable: "leaseHolder", display: "Lease Holder", compareToLeader: true },
   { variable: "leaseEpoch", display: "Lease Epoch", compareToLeader: true },
+  {
+    variable: "isLeaseholder",
+    display: "Is Leaseholder",
+    compareToLeader: false,
+  },
+  { variable: "leaseValid", display: "Lease Valid", compareToLeader: false },
   { variable: "leaseStart", display: "Lease Start", compareToLeader: true },
   {
     variable: "leaseExpiration",
@@ -711,6 +717,8 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
         leaseEpoch: epoch
           ? this.createContent(lease.epoch)
           : rangeTableEmptyContent,
+        isLeaseholder: this.createContent(String(info.is_leaseholder)),
+        leaseValid: this.createContent(String(info.lease_valid)),
         leaseStart: this.contentTimestamp(lease.start, now),
         leaseExpiration: epoch
           ? rangeTableEmptyContent


### PR DESCRIPTION
This PR updates the `Ranges` response and associated UI to
display locality, `is_leaseholder`, and `lease_valid` information.

All these pieces of metadata are easily accessible within the Replica
or the metrics that are generated as part of the process of serving a
`Ranges` request. Since adding this information costs us very
little, and provides valuable info in the context of debugging,
this commit adds both fields to the `RangeInfo` proto included
in the `RangesResponse`.

The commit also surfaces this information in the problem ranges
/ranges UI within DB console.

Looking forwward, we can also provide this information in the
response for the upcoming `TenantRanges` endpoint, which acts as
a wrapper over the existing `Ranges` endpoint.

Release note (ui change); display locality information in problem
ranges and range status. Also display is_leaseholder and lease_valid
information in problem ranges and range status pages.

Release justification: Low risk, high benefit changes to existing functionality