### PR TITLE
kv/kvserver: skip TestReplicaCircuitBreaker_Follower_QuorumLoss

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -279,6 +279,7 @@ func TestReplicaCircuitBreaker_Leaseholder_QuorumLoss(t *testing.T) {
 // leases have lots of special casing internally, this is easy to get wrong.
 func TestReplicaCircuitBreaker_Follower_QuorumLoss(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 76781, "flaky test")
 	defer log.Scope(t).Close(t)
 	tc := setupCircuitBreakerTest(t)
 	defer tc.Stopper().Stop(context.Background())


### PR DESCRIPTION
Refs: #76781

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None