### PR TITLE
mon: when creating inherited BytesMonitor don't copy metrics

### DIFF
--- a/pkg/util/mon/BUILD.bazel
+++ b/pkg/util/mon/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],


### PR DESCRIPTION
Previously monitor inherited parameters like name, resource, limits etc
from parent and also included metrics.
This is not good as metrics were updated twice when borrowing resources,
one time by child monitor and again by parent monitor which lead to
misreporting.
This patch removes metrics from inheritance. It is safe to do as metrics
could be safely set to nil. It could lead to some memory that is reserved
by child pool reported as allocated, but it is better than doing x2.

Release note: None

Fixes #76898