### PR TITLE
jobs: Slow down schedulers when running large cluster.

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/gossip",
         "//pkg/jobs/jobspb",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/scheduledjobs/BUILD.bazel
+++ b/pkg/scheduledjobs/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/gossip",
         "//pkg/kv",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/security",

--- a/pkg/scheduledjobs/env.go
+++ b/pkg/scheduledjobs/env.go
@@ -12,6 +12,7 @@ package scheduledjobs
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -46,6 +47,7 @@ type JobExecutionConfig struct {
 	Settings         *cluster.Settings
 	InternalExecutor sqlutil.InternalExecutor
 	DB               *kv.DB
+	Gossip           gossip.OptionalGossip
 	// TestingKnobs is *jobs.TestingKnobs; however we cannot depend
 	// on jobs package due to circular dependencies.
 	TestingKnobs base.ModuleTestingKnobs

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1222,6 +1222,7 @@ func (s *SQLServer) preStart(
 			Settings:         s.execCfg.Settings,
 			InternalExecutor: s.internalExecutor,
 			DB:               s.execCfg.DB,
+			Gossip:           s.execCfg.Gossip,
 			TestingKnobs:     knobs.JobsTestingKnobs,
 			PlanHookMaker: func(opName string, txn *kv.Txn, user security.SQLUsername) (interface{}, func()) {
 				// This is a hack to get around a Go package dependency cycle. See comment


### PR DESCRIPTION
Job scheduler runs on every node by default.  The pace of the scheduler
is controlled via the `jobs.scheduler.pace` setting.  However, because
each node executes scheduler independently, if the scheduler runs
in a large cluster, then it is possible that scheduler logic will execute
much more frequently than what's implied by the scheduler pace setting.
For example, in a 30 node cluster, with scheduler pace set to 1 minute, it is
expected that a scheduler runs, on average, every 2 seconds.
This escalation in scheduler frequency is problematic because if schedules
take some time to execute (i.e. plan their transaction), another instance
of scheduler may start execution, thus blocking behind previusly running instances.
This may lead to a large number of transaction restart errors, built up of
intents, as well as hot spots (i.e. all schedulers reading few schedules).

This PR introduce a new setting `jobs.scheduler.max_target_frequency` which
attempts to put a target frequency of scheduler exectution in a cluster.
It accomplishes this by proprtionally increasing scheduler pace setting as the
cluster size grows.

Release Notes (enterprise change): Job schedulers scales better as
the cluster size increases.