### PR TITLE
kvstreamer: fix a possible deadlock with high concurrency

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/large_keys_test.go
+++ b/pkg/kv/kvclient/kvstreamer/large_keys_test.go
@@ -71,6 +71,12 @@ func TestLargeKeys(t *testing.T) {
 	// here.
 	_, err := db.Exec("SET distsql_workmem='100KiB'")
 	require.NoError(t, err)
+	// To improve the test coverage, occasionally lower the maximum number of
+	// concurrent requests.
+	if rng.Float64() < 0.25 {
+		_, err = db.Exec("SET CLUSTER SETTING kv.streamer.concurrency_limit = $1", rng.Intn(10)+1)
+		require.NoError(t, err)
+	}
 	// In both engines, the index joiner will buffer input rows up to a quarter
 	// of workmem limit, so we have several interesting options for the blob
 	// size:


### PR DESCRIPTION
Previously, it was possible for the `Streamer` to get into a deadlock
situation when async requests have exausted the concurrency limit. This
could happen because:
- the worker coordinator goroutine is holding the budget's mutex when it
is issuing new async requests. When the semaphore is at its limit, the
worker coordinator would block trying to acquire the quota of 1 for
spinning up a new goroutine;
- however, the quota would never open up because all concurrency async
requests could get stuck trying to release some memory back to the
budget.

This is now fixed by teaching the worker coordinator to proactively
check how many requests it can issue (i.e. how much quota it can get
from the semaphore) and issuing no more than that number.

Additionally, a minor change to the concurrency cluster setting is made
to allow only positive values (0 should be prohibited).

Fixes: #76818.
Fixes: #76819.
Fixes: #76820.

Release note: None