### PR TITLE
storage: add some `MVCCKey` and `Timestamp` utility functions

### DIFF
--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -156,6 +156,12 @@ func EncodeMVCCKeyToBuf(buf []byte, key MVCCKey) []byte {
 	return buf
 }
 
+// EncodeMVCCKeyPrefix encodes an MVCC user key (without timestamp) into its
+// Pebble prefix representation.
+func EncodeMVCCKeyPrefix(key roachpb.Key) []byte {
+	return EncodeMVCCKey(MVCCKey{Key: key})
+}
+
 // encodeMVCCKeyToBuf encodes an MVCCKey into its Pebble representation to the
 // target buffer, which must have the correct size.
 func encodeMVCCKeyToBuf(buf []byte, key MVCCKey, keyLen int) {
@@ -185,10 +191,10 @@ func encodeMVCCTimestamp(ts hlc.Timestamp) []byte {
 	return buf
 }
 
-// encodeMVCCTimestampSuffix encodes an MVCC timestamp into its Pebble
+// EncodeMVCCTimestampSuffix encodes an MVCC timestamp into its Pebble
 // representation, including the length suffix but excluding the sentinel byte.
 // This is equivalent to the Pebble suffix.
-func encodeMVCCTimestampSuffix(ts hlc.Timestamp) []byte {
+func EncodeMVCCTimestampSuffix(ts hlc.Timestamp) []byte {
 	tsLen := encodedMVCCTimestampLength(ts)
 	if tsLen == 0 {
 		return nil

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -61,6 +61,23 @@ func (k MVCCKey) Next() MVCCKey {
 	}
 }
 
+// Compare returns -1 if this key is less than the given key, 0 if they're
+// equal, or 1 if this is greater. Comparison is by key,timestamp, where larger
+// timestamps sort before smaller ones except empty ones which sort first (like
+// elsewhere in MVCC).
+func (k MVCCKey) Compare(o MVCCKey) int {
+	if c := k.Key.Compare(o.Key); c != 0 {
+		return c
+	}
+	if k.Timestamp.IsEmpty() && !o.Timestamp.IsEmpty() {
+		return -1
+	} else if !k.Timestamp.IsEmpty() && o.Timestamp.IsEmpty() {
+		return 1
+	} else {
+		return -k.Timestamp.Compare(o.Timestamp) // timestamps sort in reverse
+	}
+}
+
 // Less compares two keys.
 func (k MVCCKey) Less(l MVCCKey) bool {
 	if c := k.Key.Compare(l.Key); c != 0 {

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -109,7 +109,7 @@ func TestEncodeDecodeMVCCKeyAndTimestamp(t *testing.T) {
 				expectTS = nil
 			}
 
-			encodedTS := encodeMVCCTimestampSuffix(tc.ts)
+			encodedTS := EncodeMVCCTimestampSuffix(tc.ts)
 			require.Equal(t, expectTS, encodedTS)
 
 			decodedTS, err := decodeMVCCTimestampSuffix(encodedTS)

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -93,7 +93,7 @@ func TestMVCCKeyCompare(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeMVCCKeyAndTimestamp(t *testing.T) {
+func TestEncodeDecodeMVCCKeyAndTimestampWithLength(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testcases := map[string]struct {
@@ -127,10 +127,19 @@ func TestEncodeDecodeMVCCKeyAndTimestamp(t *testing.T) {
 
 			encoded := EncodeMVCCKey(mvccKey)
 			require.Equal(t, expect, encoded)
+			require.Equal(t, len(encoded), encodedMVCCKeyLength(mvccKey))
+			require.Equal(t, len(encoded),
+				encodedMVCCKeyPrefixLength(mvccKey.Key)+encodedMVCCTimestampSuffixLength(mvccKey.Timestamp))
 
 			decoded, err := DecodeMVCCKey(encoded)
 			require.NoError(t, err)
 			require.Equal(t, mvccKey, decoded)
+
+			// Test EncodeMVCCKeyPrefix.
+			expectPrefix, err := hex.DecodeString(tc.encoded[:2*len(tc.key)+2])
+			require.NoError(t, err)
+			require.Equal(t, expectPrefix, EncodeMVCCKeyPrefix(roachpb.Key(tc.key)))
+			require.Equal(t, len(expectPrefix), encodedMVCCKeyPrefixLength(roachpb.Key(tc.key)))
 
 			// Test encode/decodeMVCCTimestampSuffix too, since we can trivially do so.
 			expectTS, err := hex.DecodeString(tc.encoded[2*len(tc.key)+2:])
@@ -141,6 +150,7 @@ func TestEncodeDecodeMVCCKeyAndTimestamp(t *testing.T) {
 
 			encodedTS := EncodeMVCCTimestampSuffix(tc.ts)
 			require.Equal(t, expectTS, encodedTS)
+			require.Equal(t, len(encodedTS), encodedMVCCTimestampSuffixLength(tc.ts))
 
 			decodedTS, err := decodeMVCCTimestampSuffix(encodedTS)
 			require.NoError(t, err)
@@ -153,6 +163,7 @@ func TestEncodeDecodeMVCCKeyAndTimestamp(t *testing.T) {
 
 			encodedTS = encodeMVCCTimestamp(tc.ts)
 			require.Equal(t, expectTS, encodedTS)
+			require.Equal(t, len(encodedTS), encodedMVCCTimestampLength(tc.ts))
 
 			decodedTS, err = decodeMVCCTimestamp(encodedTS)
 			require.NoError(t, err)

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -63,6 +63,36 @@ func TestMVCCKeys(t *testing.T) {
 	}
 }
 
+func TestMVCCKeyCompare(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	a1 := MVCCKey{roachpb.Key("a"), hlc.Timestamp{Logical: 1}}
+	a2 := MVCCKey{roachpb.Key("a"), hlc.Timestamp{Logical: 2}}
+	b0 := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 0}}
+	b1 := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 1}}
+	b2 := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 2}}
+
+	testcases := map[string]struct {
+		a      MVCCKey
+		b      MVCCKey
+		expect int
+	}{
+		"equal":               {a1, a1, 0},
+		"key lt":              {a1, b1, -1},
+		"key gt":              {b1, a1, 1},
+		"time lt":             {a2, a1, -1}, // MVCC timestamps sort in reverse order
+		"time gt":             {a1, a2, 1},  // MVCC timestamps sort in reverse order
+		"empty time lt set":   {b0, b1, -1}, // empty MVCC timestamps sort before non-empty
+		"set time gt empty":   {b1, b0, 1},  // empty MVCC timestamps sort before non-empty
+		"key time precedence": {a1, b2, -1}, // a before b, but 2 before 1; key takes precedence
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.a.Compare(tc.b))
+		})
+	}
+}
+
 func TestEncodeDecodeMVCCKeyAndTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1126,7 +1126,7 @@ func TestPebbleMVCCTimeIntervalCollector(t *testing.T) {
 	finishAndCheck(22, 26)
 	// Using the same suffix for all keys in a block results in an interval of
 	// width one (inclusive lower bound to exclusive upper bound).
-	suffix := encodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 42, Logical: 1})
+	suffix := EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 42, Logical: 1})
 	require.NoError(t, collector.UpdateKeySuffixes(
 		nil /* old prop */, nil /* old suffix */, suffix,
 	))
@@ -1138,7 +1138,7 @@ func TestPebbleMVCCTimeIntervalCollector(t *testing.T) {
 	key[sentinelPos] = '\xff'
 	require.Error(t, collector.UpdateKeySuffixes(nil, nil, key))
 	// Case 2: malformed bare suffix (too short).
-	suffix = encodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 42, Logical: 1})[1:]
+	suffix = EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 42, Logical: 1})[1:]
 	require.Error(t, collector.UpdateKeySuffixes(nil, nil, suffix))
 }
 

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -247,8 +247,8 @@ func UpdateSSTTimestamps(
 			opts,
 			sstOut,
 			MakeIngestionWriterOptions(ctx, st),
-			encodeMVCCTimestampSuffix(from),
-			encodeMVCCTimestampSuffix(to),
+			EncodeMVCCTimestampSuffix(from),
+			EncodeMVCCTimestampSuffix(to),
 			concurrency,
 		); err != nil {
 			return nil, err

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -54,6 +54,22 @@ func (t Timestamp) LessEq(s Timestamp) bool {
 	return t.WallTime < s.WallTime || (t.WallTime == s.WallTime && t.Logical <= s.Logical)
 }
 
+// Compare returns -1 if this timestamp is lesser than the given timestamp, 1 if
+// it is greater, and 0 if they are equal.
+func (t Timestamp) Compare(s Timestamp) int {
+	if t.WallTime > s.WallTime {
+		return 1
+	} else if t.WallTime < s.WallTime {
+		return -1
+	} else if t.Logical > s.Logical {
+		return 1
+	} else if t.Logical < s.Logical {
+		return -1
+	} else {
+		return 0
+	}
+}
+
 // String implements the fmt.Stringer interface.
 func (t Timestamp) String() string {
 	// The following code was originally written as


### PR DESCRIPTION
These came out of the reverted MVCC range tombstone work, may as well get them in.

See individual commits for details.