### PR TITLE
batcheval: add setting to reject non-MVCC `AddSSTable`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -47,6 +48,16 @@ var AddSSTableRewriteConcurrency = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
+// AddSSTableRequireAtRequestTimestamp will reject any AddSSTable requests that
+// aren't sent with SSTTimestampToRequestTimestamp. This can be used to verify
+// that all callers have been migrated to use SSTTimestampToRequestTimestamp.
+var AddSSTableRequireAtRequestTimestamp = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.bulk_io_write.sst_require_at_request_timestamp.enabled",
+	"rejects addsstable requests that don't write at the request timestamp",
+	false,
+)
+
 var forceRewrite = util.ConstantWithMetamorphicTestBool("addsst-rewrite-forced", false)
 
 // EvalAddSSTable evaluates an AddSSTable command. For details, see doc comment
@@ -66,6 +77,14 @@ func EvalAddSSTable(
 	ctx, span = tracing.ChildSpan(ctx, fmt.Sprintf("AddSSTable [%s,%s)", start.Key, end.Key))
 	defer span.Finish()
 	log.Eventf(ctx, "evaluating AddSSTable [%s,%s)", start.Key, end.Key)
+
+	// Reject AddSSTable requests not writing at the request timestamp if requested.
+	if cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.MVCCAddSSTable) &&
+		AddSSTableRequireAtRequestTimestamp.Get(&cArgs.EvalCtx.ClusterSettings().SV) &&
+		sstToReqTS.IsEmpty() {
+		return result.Result{}, errors.AssertionFailedf(
+			"AddSSTable requests must set SSTTimestampToRequestTimestamp")
+	}
 
 	// Under the race detector, check that the SST contents satisfy AddSSTable
 	// requirements. We don't always do this otherwise, due to the cost.


### PR DESCRIPTION
This patch adds a cluster setting
`kv.bulk_io_write.sst_require_at_request_timestamp.enabled` (default
`false`), which will reject all non-MVCC `AddSSTable` requests (i.e.
without `SSTTimestampToRequestTimestamp` set).

This can be used to verify that all callers send MVCC-compliant
`AddSSTable` requests, for example when testing streaming replication or
in preparation for 22.2. It is not enabled by default, since that would
require multiple migrations to ensure all callers were in fact using
`SSTTimestampToRequestTimestamp` (which is new in this release), and
would prevent falling back to the old index backfiller in case bugs are
discovered.

Release note: None