### PR TITLE
release: setup for post-blockers cmd

### DIFF
--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -3,11 +3,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "release_lib",
     srcs = [
+        "blockers.go",
         "git.go",
         "jira.go",
         "mail.go",
         "main.go",
         "metadata.go",
+        "pick_sha.go",
         "templates.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",

--- a/pkg/cmd/release/blockers.go
+++ b/pkg/cmd/release/blockers.go
@@ -1,0 +1,78 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	envSMTPUser     = "SMTP_USER"
+	envSMTPPassword = "SMTP_PASSWORD"
+	envGithubToken  = "GITHUB_TOKEN"
+	releaseSeries   = "release-series"
+	smtpUser        = "smtp-user"
+	smtpHost        = "smtp-host"
+	smtpPort        = "smtp-port"
+	emailAddresses  = "to"
+	dryRun          = "dry-run"
+)
+
+var blockersFlags = struct {
+	releaseSeries  string
+	smtpUser       string
+	smtpHost       string
+	smtpPort       int
+	emailAddresses []string
+	dryRun         bool
+}{}
+
+var postReleaseSeriesBlockersCmd = &cobra.Command{
+	Use:   "post-blockers",
+	Short: "Post blockers against release series",
+	Long:  "Fetch post blockers against release series",
+	RunE:  fetchReleaseSeriesBlockers,
+}
+
+func init() {
+	// TODO: improve flag usage comments
+	postReleaseSeriesBlockersCmd.Flags().StringVar(&blockersFlags.releaseSeries, releaseSeries, "", "major release series")
+	postReleaseSeriesBlockersCmd.Flags().StringVar(&blockersFlags.smtpUser, smtpUser, os.Getenv(envSMTPUser), "SMTP user name")
+	postReleaseSeriesBlockersCmd.Flags().StringVar(&blockersFlags.smtpHost, smtpHost, "", "SMTP host")
+	postReleaseSeriesBlockersCmd.Flags().IntVar(&blockersFlags.smtpPort, smtpPort, 0, "SMTP port")
+	postReleaseSeriesBlockersCmd.Flags().StringArrayVar(&blockersFlags.emailAddresses, emailAddresses, []string{}, "email addresses")
+	postReleaseSeriesBlockersCmd.Flags().BoolVar(&blockersFlags.dryRun, dryRun, false, "use dry run Jira project for issues")
+
+	_ = postReleaseSeriesBlockersCmd.MarkFlagRequired(releaseSeries)
+	_ = postReleaseSeriesBlockersCmd.MarkFlagRequired(smtpUser)
+	_ = postReleaseSeriesBlockersCmd.MarkFlagRequired(smtpHost)
+	_ = postReleaseSeriesBlockersCmd.MarkFlagRequired(smtpPort)
+	_ = postReleaseSeriesBlockersCmd.MarkFlagRequired(emailAddresses)
+}
+
+func fetchReleaseSeriesBlockers(_ *cobra.Command, _ []string) error {
+	smtpPassword := os.Getenv(envSMTPPassword)
+	if smtpPassword == "" {
+		return fmt.Errorf("%s environment variable should be set", envSMTPPassword)
+	}
+	githubToken := os.Getenv(envGithubToken)
+	if githubToken == "" {
+		return fmt.Errorf("%s environment variable should be set", envGithubToken)
+	}
+
+	// TODO(celia): fetch blockers and send out email
+	fmt.Println("TODO(celia): fetch blockers and send out email")
+
+	return nil
+}

--- a/pkg/cmd/release/git.go
+++ b/pkg/cmd/release/git.go
@@ -183,8 +183,8 @@ func findCandidateCommits(prevRelease string, releaseSeries string) ([]string, e
 func findHealthyBuild(potentialRefs []string) (buildInfo, error) {
 	for _, ref := range potentialRefs {
 		fmt.Println("Fetching release qualification metadata for", ref)
-		meta, err := getBuildInfo(context.Background(), qualifyBucket,
-			fmt.Sprintf("%s/%s.json", qualifyObjectPrefix, ref))
+		meta, err := getBuildInfo(context.Background(), pickSHAFlags.qualifyBucket,
+			fmt.Sprintf("%s/%s.json", pickSHAFlags.qualifyObjectPrefix, ref))
 		if err != nil {
 			// TODO: retry if error is not 404
 			fmt.Println("no metadata qualification for", ref, err)

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -10,149 +10,17 @@
 
 package main
 
-import (
-	"context"
-	"fmt"
-	"html/template"
-	"os"
+import "github.com/spf13/cobra"
 
-	"github.com/spf13/cobra"
-)
-
-var (
-	qualifyBucket       string
-	qualifyObjectPrefix string
-	releaseBucket       string
-	releaseObjectPrefix string
-	releaseSeries       string
-	smtpUser            string
-	smtpPassword        string
-	smtpHost            string
-	smtpPort            int
-	emailAddresses      []string
-	jiraUsername        string
-	jiraToken           string
-	dryRun              bool
-)
+var rootCmd = &cobra.Command{Use: "release"}
 
 func main() {
-	if err := run(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		panic(err)
 	}
 }
 
-func run() error {
-	smtpPassword = os.Getenv("SMTP_PASSWORD")
-	if smtpPassword == "" {
-		return fmt.Errorf("SMTP_PASSWORD environment variable should be set")
-	}
-	jiraUsername = os.Getenv("JIRA_USERNAME")
-	if jiraUsername == "" {
-		return fmt.Errorf("JIRA_USERNAME environment variable should be set")
-	}
-	jiraToken = os.Getenv("JIRA_TOKEN")
-	if jiraToken == "" {
-		return fmt.Errorf("JIRA_TOKEN environment variable should be set")
-	}
-
-	cmdPickSHA := &cobra.Command{
-		Use:   "pick-sha",
-		Short: "Pick release git SHA for a particular version and communicate the choice via Jira and email",
-		// TODO: improve Long description
-		Long: "Pick release git SHA for a particular version and communicate the choice via Jira and email",
-		RunE: pickSHA,
-	}
-	// TODO: improve flag usage comments
-	cmdPickSHA.Flags().StringVar(&qualifyBucket, "qualify-bucket", "", "release qualification metadata GCS bucket")
-	cmdPickSHA.Flags().StringVar(&qualifyObjectPrefix, "qualify-object-prefix", "",
-		"release qualification object prefix")
-	cmdPickSHA.Flags().StringVar(&releaseBucket, "release-bucket", "", "release candidates metadata GCS bucket")
-	cmdPickSHA.Flags().StringVar(&releaseObjectPrefix, "release-object-prefix", "", "release candidate object prefix")
-	cmdPickSHA.Flags().StringVar(&releaseSeries, "release-series", "", "major release series")
-	cmdPickSHA.Flags().StringVar(&smtpUser, "smtp-user", os.Getenv("SMTP_USER"), "SMTP user name")
-	cmdPickSHA.Flags().StringVar(&smtpHost, "smtp-host", "", "SMTP host")
-	cmdPickSHA.Flags().IntVar(&smtpPort, "smtp-port", 0, "SMTP port")
-	cmdPickSHA.Flags().StringArrayVar(&emailAddresses, "to", []string{}, "email addresses")
-	cmdPickSHA.Flags().BoolVar(&dryRun, "dry-run", false, "use dry run Jira project for issues")
-	requiredFlags := []string{
-		"qualify-bucket",
-		"qualify-object-prefix",
-		"release-bucket",
-		"release-object-prefix",
-		"release-series",
-		"smtp-user",
-		"smtp-host",
-		"smtp-port",
-		"to",
-	}
-	for _, flag := range requiredFlags {
-		if err := cmdPickSHA.MarkFlagRequired(flag); err != nil {
-			return err
-		}
-	}
-	// TODO: improve rootCmd description
-	rootCmd := &cobra.Command{Use: "release"}
-	rootCmd.AddCommand(cmdPickSHA)
-	if err := rootCmd.Execute(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func pickSHA(_ *cobra.Command, _ []string) error {
-	nextRelease, err := findNextRelease(releaseSeries)
-	if err != nil {
-		return fmt.Errorf("cannot find next release: %w", err)
-	}
-	// TODO: improve stdout message
-	fmt.Println("Previous version:", nextRelease.prevReleaseVersion)
-	fmt.Println("Next version:", nextRelease.nextReleaseVersion)
-	fmt.Println("Release SHA:", nextRelease.buildInfo.SHA)
-
-	// TODO: before copying check if it's already there and bail if exists, can be forced by -f
-	releaseInfoPath := fmt.Sprintf("%s/%s.json", releaseObjectPrefix, nextRelease.nextReleaseVersion)
-	fmt.Println("Publishing release candidate metadata")
-	if err := publishReleaseCandidateInfo(context.Background(), nextRelease, releaseBucket, releaseInfoPath); err != nil {
-		return fmt.Errorf("cannot publish release metadata: %w", err)
-	}
-
-	fmt.Println("Creating SRE issue")
-	jiraClient, err := newJiraClient(jiraBaseURL, jiraUsername, jiraToken)
-	if err != nil {
-		return fmt.Errorf("cannot create Jira client: %w", err)
-	}
-	sreIssue, err := createSREIssue(jiraClient, nextRelease, dryRun)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Creating tracking issue")
-	trackingIssue, err := createTrackingIssue(jiraClient, nextRelease, sreIssue, dryRun)
-	if err != nil {
-		return fmt.Errorf("cannot create tracking issue: %w", err)
-	}
-	diffURL := template.URL(
-		fmt.Sprintf("https://github.com/cockroachdb/cockroach/compare/%s...%s",
-			nextRelease.prevReleaseVersion,
-			nextRelease.buildInfo.SHA))
-	args := emailArgs{
-		Version:          nextRelease.nextReleaseVersion,
-		SHA:              nextRelease.buildInfo.SHA,
-		TrackingIssue:    trackingIssue.Key,
-		TrackingIssueURL: template.URL(trackingIssue.url()),
-		DiffURL:          diffURL,
-	}
-	opts := smtpOpts{
-		from:     fmt.Sprintf("Justin Beaver <%s>", smtpUser),
-		host:     smtpHost,
-		port:     smtpPort,
-		user:     smtpUser,
-		password: smtpPassword,
-		to:       emailAddresses,
-	}
-	fmt.Println("Sending email")
-	if err := sendmail(args, opts); err != nil {
-		return fmt.Errorf("cannot send email: %w", err)
-	}
-	return nil
+func init() {
+	rootCmd.AddCommand(pickSHACmd)
+	rootCmd.AddCommand(postReleaseSeriesBlockersCmd)
 }

--- a/pkg/cmd/release/pick_sha.go
+++ b/pkg/cmd/release/pick_sha.go
@@ -1,0 +1,143 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var pickSHAFlags = struct {
+	qualifyBucket       string
+	qualifyObjectPrefix string
+	releaseBucket       string
+	releaseObjectPrefix string
+	releaseSeries       string
+	smtpUser            string
+	smtpHost            string
+	smtpPort            int
+	emailAddresses      []string
+	dryRun              bool
+}{}
+
+var pickSHACmd = &cobra.Command{
+	Use:   "pick-sha",
+	Short: "Pick release git SHA for a particular version and communicate the choice via Jira and email",
+	// TODO: improve Long description
+	Long: "Pick release git SHA for a particular version and communicate the choice via Jira and email",
+	RunE: pickSHA,
+}
+
+func init() {
+	// TODO: improve flag usage comments
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.qualifyBucket, "qualify-bucket", "", "release qualification metadata GCS bucket")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.qualifyObjectPrefix, "qualify-object-prefix", "",
+		"release qualification object prefix")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.releaseBucket, "release-bucket", "", "release candidates metadata GCS bucket")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.releaseObjectPrefix, "release-object-prefix", "", "release candidate object prefix")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.releaseSeries, "release-series", "", "major release series")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.smtpUser, "smtp-user", os.Getenv("SMTP_USER"), "SMTP user name")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.smtpHost, "smtp-host", "", "SMTP host")
+	pickSHACmd.Flags().IntVar(&pickSHAFlags.smtpPort, "smtp-port", 0, "SMTP port")
+	pickSHACmd.Flags().StringArrayVar(&pickSHAFlags.emailAddresses, "to", []string{}, "email addresses")
+	pickSHACmd.Flags().BoolVar(&pickSHAFlags.dryRun, "dry-run", false, "use dry run Jira project for issues")
+	requiredFlags := []string{
+		"qualify-bucket",
+		"qualify-object-prefix",
+		"release-bucket",
+		"release-object-prefix",
+		"release-series",
+		"smtp-user",
+		"smtp-host",
+		"smtp-port",
+		"to",
+	}
+	for _, flag := range requiredFlags {
+		if err := pickSHACmd.MarkFlagRequired(flag); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func pickSHA(_ *cobra.Command, _ []string) error {
+	smtpPassword := os.Getenv("SMTP_PASSWORD")
+	if smtpPassword == "" {
+		return fmt.Errorf("SMTP_PASSWORD environment variable should be set")
+	}
+	jiraUsername := os.Getenv("JIRA_USERNAME")
+	if jiraUsername == "" {
+		return fmt.Errorf("JIRA_USERNAME environment variable should be set")
+	}
+	jiraToken := os.Getenv("JIRA_TOKEN")
+	if jiraToken == "" {
+		return fmt.Errorf("JIRA_TOKEN environment variable should be set")
+	}
+
+	nextRelease, err := findNextRelease(pickSHAFlags.releaseSeries)
+	if err != nil {
+		return fmt.Errorf("cannot find next release: %w", err)
+	}
+	// TODO: improve stdout message
+	fmt.Println("Previous version:", nextRelease.prevReleaseVersion)
+	fmt.Println("Next version:", nextRelease.nextReleaseVersion)
+	fmt.Println("Release SHA:", nextRelease.buildInfo.SHA)
+
+	// TODO: before copying check if it's already there and bail if exists, can be forced by -f
+	releaseInfoPath := fmt.Sprintf("%s/%s.json", pickSHAFlags.releaseObjectPrefix, nextRelease.nextReleaseVersion)
+	fmt.Println("Publishing release candidate metadata")
+	if err := publishReleaseCandidateInfo(context.Background(), nextRelease, pickSHAFlags.releaseBucket, releaseInfoPath); err != nil {
+		return fmt.Errorf("cannot publish release metadata: %w", err)
+	}
+
+	fmt.Println("Creating SRE issue")
+	jiraClient, err := newJiraClient(jiraBaseURL, jiraUsername, jiraToken)
+	if err != nil {
+		return fmt.Errorf("cannot create Jira client: %w", err)
+	}
+	sreIssue, err := createSREIssue(jiraClient, nextRelease, pickSHAFlags.dryRun)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Creating tracking issue")
+	trackingIssue, err := createTrackingIssue(jiraClient, nextRelease, sreIssue, pickSHAFlags.dryRun)
+	if err != nil {
+		return fmt.Errorf("cannot create tracking issue: %w", err)
+	}
+	diffURL := template.URL(
+		fmt.Sprintf("https://github.com/cockroachdb/cockroach/compare/%s...%s",
+			nextRelease.prevReleaseVersion,
+			nextRelease.buildInfo.SHA))
+	args := emailArgs{
+		Version:          nextRelease.nextReleaseVersion,
+		SHA:              nextRelease.buildInfo.SHA,
+		TrackingIssue:    trackingIssue.Key,
+		TrackingIssueURL: template.URL(trackingIssue.url()),
+		DiffURL:          diffURL,
+	}
+	opts := smtpOpts{
+		from:     fmt.Sprintf("Justin Beaver <%s>", pickSHAFlags.smtpUser),
+		host:     pickSHAFlags.smtpHost,
+		port:     pickSHAFlags.smtpPort,
+		user:     pickSHAFlags.smtpUser,
+		password: smtpPassword,
+		to:       pickSHAFlags.emailAddresses,
+	}
+	fmt.Println("Sending email")
+	if err := sendmail(args, opts); err != nil {
+		return fmt.Errorf("cannot send email: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
### Summary

This commit does a quick refactor and sets up cobra command infra for the post-blockers command. Actual logic for fetching and posting blockers to an email will happen in a follow-up commit. The intent here is to a minimal refactor so that remaining "Week -1" and "Week 1" can happen in parallel (and avoid merge conflicts).

### Tests

I ran the `pick-sha` command locally with fake parameters to verify no refactor regressions[See Test 1]. Additionally, I ran the `post-blockers` command locally to get expected ("TODO") output[See Test 2].

#### Test 1:
- Ran `pick-sha`, using fake parameters
email`
- Got error (expected): `panic: cannot find next release: cannot find healthy build: no ref found`

```
SMTP_PASSWORD=foo \
JIRA_USERNAME=foo \
JIRA_TOKEN=foo \
bazel run pkg/cmd/release:release \
pick-sha -- \
  --dry-run \
  --release-series=21.1 \
  --smtp-user=foo \
  --smtp-host=smtp.gmail.com \
  --smtp-port=587 \
  --to=celia@cockroachlabs.com \
  --qualify-bucket=foo \
  --qualify-object-prefix=foo \
  --release-bucket=foo \
  --release-object-prefix=foo
```

#### Test 2:
- Ran `post-blockers`, using fake parameters
- Got TODO message (expected): `TODO(celia): fetch blockers and send out 
```
SMTP_PASSWORD=foo \
GITHUB_TOKEN=foo \
bazel run pkg/cmd/release:release \
post-blockers -- \
  --dry-run \
  --release-series=21.1 \
  --smtp-user=foo \
  --smtp-host=smtp.gmail.com \
  --smtp-port=587 \
  --to=celia@cockroachlabs.com

```

Release note: None