### PR TITLE
bazel: refine `dev generate bazel` skip optimization

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -53,8 +53,8 @@ fi
 
 bazel run //:gazelle
 
-if files_unchanged_from_upstream $(find ./pkg -name '*.proto'); then
-  echo "Skipping generation of protobuf dependencies."
+if files_unchanged_from_upstream $(find ./pkg -name '*.proto') $(find ./pkg -name BUILD.bazel) $(find ./pkg -name '*.bzl') $(find ./docs -name 'BUILD.bazel') $(find ./docs -name '*.bzl'); then
+  echo "Skipping //pkg/gen/genbzl (relevant files are unchanged from upstream)."
 else
   bazel run pkg/gen/genbzl --run_under="cd $PWD && " -- --out-dir pkg/gen
 fi


### PR DESCRIPTION
Without this stuff, a `dev generate bazel` without
`COCKROACH_BAZEL_FORCE_GENERATE=1` resulted in skipping `genbzl`
incorrectly.

Closes https://github.com/cockroachdb/cockroach/issues/76905.

Release note: None