### PR TITLE
ci: a couple tweaks to bazel CI

### DIFF
--- a/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
@@ -25,3 +25,10 @@ if grep TODO DEPS.bzl; then
     exit 1
 fi
 check_workspace_clean "Run \`./dev generate bazel\` to automatically regenerate these."
+
+# Run go mod tidy and ensure nothing changes.
+# NB: If files are missing from any packages then `go mod tidy` will
+# fail. So we need to make sure that `.pb.go` sources are populated.
+bazel run //pkg/gen:go_proto
+bazel run @go_sdk//:bin/go --ui_event_filters=-DEBUG,-info,-stdout,-stderr --noshow_progress mod tidy
+check_workspace_clean "Run \`go mod tidy\` to automatically regenerate these."

--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -4,4 +4,5 @@ set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --config=ci \
-		       test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests
+		                   test //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests -- \
+                                   --profile=/artifacts/profile.gz


### PR DESCRIPTION
* Run `go mod tidy` in Bazel CI.
* When running unit tests, write the profile file to `/artifacts` so it
  can be inspected later if necessary.

Release note: None