### PR TITLE
sql: fix bug in inverted index creation

### DIFF
--- a/pkg/sql/testdata/index_mutations/delete_preserving_update
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_update
@@ -149,7 +149,13 @@ UPDATE tii SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
 Scan /Table/109/{1-2}
 Put /Table/109/1/1/0 -> /TUPLE/
+Put (delete) /Table/109/2/NULL/1/0
+Put (delete) /Table/109/2/1/1/0
+Put (delete) /Table/109/2/2/1/0
 Put (delete) /Table/109/2/3/1/0
+Put /Table/109/2/NULL/1/0 -> /BYTES/0x0a0103
+Put /Table/109/2/1/1/0 -> /BYTES/0x0a0103
+Put /Table/109/2/2/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/4/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------

--- a/pkg/sql/testdata/index_mutations/delete_preserving_upsert
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_upsert
@@ -158,7 +158,13 @@ UPSERT INTO tii VALUES (1, ARRAY[1, 2, 2, NULL, 4, 4])
 ----
 Scan /Table/109/1/1/0
 Put /Table/109/1/1/0 -> /TUPLE/
+Put (delete) /Table/109/2/NULL/1/0
+Put (delete) /Table/109/2/1/1/0
+Put (delete) /Table/109/2/2/1/0
 Put (delete) /Table/109/2/3/1/0
+Put /Table/109/2/NULL/1/0 -> /BYTES/0x0a0103
+Put /Table/109/2/1/1/0 -> /BYTES/0x0a0103
+Put /Table/109/2/2/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/4/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------


### PR DESCRIPTION
When updating an inverted index, we calculate all index entries for
the old values and new values with the intent of issuing a Delete
for every old entry and a Put for every new entry. To try to save on
work, the updater looks for Del's that are followed by identical Put's
and removes both from the set of index entries to process.

This de-duplication is incorrect for temporary indexes used in the
mvcc-compatible index backfilling process. Consider the following:

```
t1: Write of k=1, v={"a": 1}
t2: CREATE INDEX (i2 is in BACKFILLING, i3 (temporary) is in DELETE_ONLY)
t3: i3 moves to DELETE_AND_WRITE_ONLY
t4: AddSSTable backfill into i2
t5: i2 moves to DELETE_ONLY
```

At this point, `i2` contains 1 inverted entry for k=1. and i3 is
empty. Now, say an update is issued:

```
t6: Write of k=1, v={"a": 1, "b": 2}
```

Index `i2` is in DELETE_ONLY. The delete path has no deduplication
logic, so we just see the delete for a key that looks something like

```
Del /Table/106/2/"a"/1/1/0
```

But, `i3` is in DELETE_AND_WRITE ONLY, so both the delete _and the
associated write_ is elided, so instead of:

```
Put /Table/106/3/"a"/1/1/0
Put (delete) /Table/106/3/"a"/1/1/0
Put /Table/106/3/"b"/2/1/0
```

it only sees a single Put:

```
Put /Table/106/3/"b"/2/1/0
```

Thus, we now have an empty `i2` and a single entry in `i3`.  When we
go to merge i3 into i2, we will get our single entry. But, we are
supposed to have two entries.  When we eventually try to validate `i2`,
it will fail because of the missing entry.

To account for this, we skip de-duplication on temporary indexes.

Release note: None