### PR TITLE
opt: remove redundant arbiter indexes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -205,8 +205,6 @@ vectorized: true
               row 0, expr 1: '4321'
               row 0, expr 2: gen_random_uuid()
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -221,7 +219,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, part)
 │ auto commit
-│ arbiter indexes: t_gen_random_uuid_pkey
 │ arbiter constraints: t_gen_random_uuid_pkey
 │
 └── • render
@@ -240,43 +237,28 @@ vectorized: true
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • distinct
+        └── • lookup join (anti)
             │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
             │ estimated row count: 0 (missing stats)
-            │ distinct on: crdb_internal_user_id_shard_16_cast, user_id_default
-            │ nulls are distinct
+            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+            │ equality cols are key
+            │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • lookup join (anti)
+            └── • render
                 │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                │ equality cols are key
-                │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ estimated row count: 1
+                │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                │ render column2: column2
+                │ render val_cast: val_cast
+                │ render user_id_default: user_id_default
                 │
-                └── • lookup join (anti)
-                    │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                    │ equality: (column2, crdb_internal_user_id_shard_16_cast, user_id_default) = (part,crdb_internal_user_id_shard_16,user_id)
-                    │ equality cols are key
-                    │
-                    └── • render
-                        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
-                        │ estimated row count: 1
-                        │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
-                        │ render column2: column2
-                        │ render val_cast: val_cast
-                        │ render user_id_default: user_id_default
-                        │
-                        └── • values
-                              columns: (column2, val_cast, user_id_default)
-                              size: 3 columns, 1 row
-                              row 0, expr 0: 'seattle'
-                              row 0, expr 1: '4321'
-                              row 0, expr 2: gen_random_uuid()
+                └── • values
+                      columns: (column2, val_cast, user_id_default)
+                      size: 3 columns, 1 row
+                      row 0, expr 0: 'seattle'
+                      row 0, expr 1: '4321'
+                      row 0, expr 2: gen_random_uuid()
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -291,7 +273,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, part)
 │ auto commit
-│ arbiter indexes: t_gen_random_uuid_pkey
 │ arbiter constraints: t_gen_random_uuid_pkey
 │
 └── • render
@@ -310,48 +291,35 @@ vectorized: true
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • distinct
+        └── • lookup join (anti)
             │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
             │ estimated row count: 0 (missing stats)
-            │ distinct on: crdb_internal_user_id_shard_16_cast, column2, user_id_default
-            │ nulls are distinct
+            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+            │ equality cols are key
+            │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • lookup join (anti)
+            └── • render
                 │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                │ equality cols are key
-                │ lookup condition: ((user_id_default = user_id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                │ estimated row count: 2
+                │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                │ render column2: column2
+                │ render val_cast: val_cast
+                │ render user_id_default: user_id_default
                 │
-                └── • lookup join (anti)
-                    │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                    │ equality: (column2, crdb_internal_user_id_shard_16_cast, user_id_default) = (part,crdb_internal_user_id_shard_16,user_id)
-                    │ equality cols are key
+                └── • render
+                    │ columns: (user_id_default, column2, val_cast)
+                    │ estimated row count: 2
+                    │ render user_id_default: gen_random_uuid()
+                    │ render column2: column2
+                    │ render val_cast: val_cast
                     │
-                    └── • render
-                        │ columns: (crdb_internal_user_id_shard_16_cast, column2, val_cast, user_id_default)
-                        │ estimated row count: 2
-                        │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
-                        │ render column2: column2
-                        │ render val_cast: val_cast
-                        │ render user_id_default: user_id_default
-                        │
-                        └── • render
-                            │ columns: (user_id_default, column2, val_cast)
-                            │ estimated row count: 2
-                            │ render user_id_default: gen_random_uuid()
-                            │ render column2: column2
-                            │ render val_cast: val_cast
-                            │
-                            └── • values
-                                  columns: (val_cast, column2)
-                                  size: 2 columns, 2 rows
-                                  row 0, expr 0: '4321'
-                                  row 0, expr 1: 'seattle'
-                                  row 1, expr 0: '8765'
-                                  row 1, expr 1: 'new york'
+                    └── • values
+                          columns: (val_cast, column2)
+                          size: 2 columns, 2 rows
+                          row 0, expr 0: '4321'
+                          row 0, expr 1: 'seattle'
+                          row 1, expr 0: '8765'
+                          row 1, expr 1: 'new york'
 
 subtest test_uniqueness_check_pk
 
@@ -419,8 +387,6 @@ vectorized: true
                           columns: (crdb_internal_id_shard_16_cast, column1, column2, check1, check2)
                           label: buffer 1
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -435,7 +401,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
 │ auto commit
-│ arbiter indexes: t_unique_hash_pk_pkey
 │ arbiter constraints: t_unique_hash_pk_pkey
 │
 └── • render
@@ -447,32 +412,24 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
     │
-    └── • lookup join (anti)
+    └── • cross join (anti)
         │ columns: (column1, column2, crdb_internal_id_shard_16_cast)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • cross join (anti)
-            │ columns: (column1, column2, crdb_internal_id_shard_16_cast)
-            │ estimated row count: 0 (missing stats)
-            │
-            ├── • values
-            │     columns: (column1, column2, crdb_internal_id_shard_16_cast)
-            │     size: 3 columns, 1 row
-            │     row 0, expr 0: 4321
-            │     row 0, expr 1: 'seattle'
-            │     row 0, expr 2: 9
-            │
-            └── • scan
-                  columns: (crdb_internal_id_shard_16, id, part)
-                  estimated row count: 1 (missing stats)
-                  table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                  spans: /"seattle"/9/4321/0
+        ├── • values
+        │     columns: (column1, column2, crdb_internal_id_shard_16_cast)
+        │     size: 3 columns, 1 row
+        │     row 0, expr 0: 4321
+        │     row 0, expr 1: 'seattle'
+        │     row 0, expr 2: 9
+        │
+        └── • scan
+              columns: (id)
+              estimated row count: 1 (missing stats)
+              table: t_unique_hash_pk@t_unique_hash_pk_pkey
+              spans: /"new york"/9/4321/0 /"seattle"/9/4321/0
+              parallel
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -487,7 +444,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, part)
 │ auto commit
-│ arbiter indexes: t_unique_hash_pk_pkey
 │ arbiter constraints: t_unique_hash_pk_pkey
 │
 └── • render
@@ -499,40 +455,27 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
     │
-    └── • distinct
+    └── • lookup join (anti)
         │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: crdb_internal_id_shard_16_cast, column1, column2
-        │ nulls are distinct
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • lookup join (anti)
+        └── • render
             │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
-            │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-            │ equality cols are key
-            │ lookup condition: ((column1 = id) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ estimated row count: 2
+            │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+            │ render column1: column1
+            │ render column2: column2
             │
-            └── • lookup join (anti)
-                │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ equality: (column2, crdb_internal_id_shard_16_cast, column1) = (part,crdb_internal_id_shard_16,id)
-                │ equality cols are key
-                │
-                └── • render
-                    │ columns: (crdb_internal_id_shard_16_cast, column1, column2)
-                    │ estimated row count: 2
-                    │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
-                    │ render column1: column1
-                    │ render column2: column2
-                    │
-                    └── • values
-                          columns: (column1, column2)
-                          size: 2 columns, 2 rows
-                          row 0, expr 0: 4321
-                          row 0, expr 1: 'seattle'
-                          row 1, expr 0: 8765
-                          row 1, expr 1: 'new york'
+            └── • values
+                  columns: (column1, column2)
+                  size: 2 columns, 2 rows
+                  row 0, expr 0: 4321
+                  row 0, expr 1: 'seattle'
+                  row 1, expr 0: 8765
+                  row 1, expr 1: 'new york'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id, part) VALUES (4321, 'seattle') ON CONFLICT (id) DO NOTHING;
@@ -1069,8 +1012,6 @@ vectorized: true
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_cast, check1, check2)
                           label: buffer 1
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -1085,7 +1026,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
 │ auto commit
-│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │
 └── • render
@@ -1105,44 +1045,29 @@ vectorized: true
         │ equality cols are key
         │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • lookup join (anti)
+        └── • cross join (anti)
             │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
             │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-            │ equality cols are key
-            │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
             │
-            └── • lookup join (anti)
-                │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ equality: (column3, crdb_internal_email_shard_16_cast, column2) = (part,crdb_internal_email_shard_16,email)
-                │ equality cols are key
+            ├── • values
+            │     columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 4321
+            │     row 0, expr 1: 'some_email'
+            │     row 0, expr 2: 'seattle'
+            │     row 0, expr 3: 13
+            │
+            └── • project
+                │ columns: ()
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • cross join (anti)
-                    │ columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
-                    │ estimated row count: 0 (missing stats)
-                    │
-                    ├── • values
-                    │     columns: (column1, column2, column3, crdb_internal_email_shard_16_cast)
-                    │     size: 4 columns, 1 row
-                    │     row 0, expr 0: 4321
-                    │     row 0, expr 1: 'some_email'
-                    │     row 0, expr 2: 'seattle'
-                    │     row 0, expr 3: 13
-                    │
-                    └── • project
-                        │ columns: ()
-                        │ estimated row count: 1 (missing stats)
-                        │
-                        └── • scan
-                              columns: (id, part)
-                              estimated row count: 1 (missing stats)
-                              table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                              spans: /"seattle"/4321/0
+                └── • scan
+                      columns: (id)
+                      estimated row count: 1 (missing stats)
+                      table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                      spans: /"new york"/4321/0 /"seattle"/4321/0
+                      parallel
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -1157,7 +1082,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_sec_key(id, email, part, crdb_internal_email_shard_16)
 │ auto commit
-│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │
 └── • render
@@ -1170,57 +1094,37 @@ vectorized: true
     │ render column3: column3
     │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
     │
-    └── • distinct
+    └── • lookup join (anti)
         │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: crdb_internal_email_shard_16_cast, column2, column3
-        │ nulls are distinct
+        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+        │ equality cols are key
+        │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
             │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@idx_uniq_hash_email
+            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
             │ equality cols are key
-            │ lookup condition: ((column2 = email) AND (part IN ('new york', 'seattle'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
             │
-            └── • lookup join (anti)
+            └── • render
                 │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                │ equality cols are key
-                │ lookup condition: (column1 = id) AND (part IN ('new york', 'seattle'))
+                │ estimated row count: 2
+                │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+                │ render column1: column1
+                │ render column2: column2
+                │ render column3: column3
                 │
-                └── • lookup join (anti)
-                    │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                    │ equality: (column3, column1) = (part,id)
-                    │ equality cols are key
-                    │
-                    └── • lookup join (anti)
-                        │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
-                        │ estimated row count: 0 (missing stats)
-                        │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                        │ equality: (column3, crdb_internal_email_shard_16_cast, column2) = (part,crdb_internal_email_shard_16,email)
-                        │ equality cols are key
-                        │
-                        └── • render
-                            │ columns: (crdb_internal_email_shard_16_cast, column1, column2, column3)
-                            │ estimated row count: 2
-                            │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
-                            │ render column1: column1
-                            │ render column2: column2
-                            │ render column3: column3
-                            │
-                            └── • values
-                                  columns: (column1, column2, column3)
-                                  size: 3 columns, 2 rows
-                                  row 0, expr 0: 4321
-                                  row 0, expr 1: 'some_email'
-                                  row 0, expr 2: 'seattle'
-                                  row 1, expr 0: 8765
-                                  row 1, expr 1: 'another_email'
-                                  row 1, expr 2: 'new york'
+                └── • values
+                      columns: (column1, column2, column3)
+                      size: 3 columns, 2 rows
+                      row 0, expr 0: 4321
+                      row 0, expr 1: 'some_email'
+                      row 0, expr 2: 'seattle'
+                      row 1, expr 0: 8765
+                      row 1, expr 1: 'another_email'
+                      row 1, expr 2: 'new york'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email, part) VALUES (4321, 'some_email', 'seattle') ON CONFLICT (email) DO NOTHING;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -214,8 +214,6 @@ vectorized: true
               row 0, expr 1: gen_random_uuid()
               row 0, expr 2: 'ap-southeast-2'
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -230,7 +228,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, crdb_region)
 │ auto commit
-│ arbiter indexes: t_gen_random_uuid_pkey
 │ arbiter constraints: t_gen_random_uuid_pkey
 │
 └── • render
@@ -249,50 +246,35 @@ vectorized: true
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • distinct
+        └── • lookup join (anti)
             │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
             │ estimated row count: 0 (missing stats)
-            │ distinct on: crdb_internal_user_id_shard_16_cast, user_id_default
-            │ nulls are distinct
+            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+            │ equality cols are key
+            │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 1 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                │ equality: (crdb_region_default, crdb_internal_user_id_shard_16_cast, user_id_default) = (crdb_region,crdb_internal_user_id_shard_16,user_id)
                 │ equality cols are key
+                │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
                 │
-                └── • lookup join (anti)
+                └── • render
                     │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                    │ equality cols are key
-                    │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                    │ estimated row count: 1
+                    │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                    │ render val_cast: val_cast
+                    │ render user_id_default: user_id_default
+                    │ render crdb_region_default: crdb_region_default
                     │
-                    └── • lookup join (anti)
-                        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                        │ estimated row count: 1 (missing stats)
-                        │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                        │ equality cols are key
-                        │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                        │
-                        └── • render
-                            │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                            │ estimated row count: 1
-                            │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
-                            │ render val_cast: val_cast
-                            │ render user_id_default: user_id_default
-                            │ render crdb_region_default: crdb_region_default
-                            │
-                            └── • values
-                                  columns: (val_cast, user_id_default, crdb_region_default)
-                                  size: 3 columns, 1 row
-                                  row 0, expr 0: '4321'
-                                  row 0, expr 1: gen_random_uuid()
-                                  row 0, expr 2: 'ap-southeast-2'
+                    └── • values
+                          columns: (val_cast, user_id_default, crdb_region_default)
+                          size: 3 columns, 1 row
+                          row 0, expr 0: '4321'
+                          row 0, expr 1: gen_random_uuid()
+                          row 0, expr 2: 'ap-southeast-2'
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -307,7 +289,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_gen_random_uuid(crdb_internal_user_id_shard_16, user_id, val, crdb_region)
 │ auto commit
-│ arbiter indexes: t_gen_random_uuid_pkey
 │ arbiter constraints: t_gen_random_uuid_pkey
 │
 └── • render
@@ -326,53 +307,40 @@ vectorized: true
         │ distinct on: user_id_default
         │ nulls are distinct
         │
-        └── • distinct
+        └── • lookup join (anti)
             │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
             │ estimated row count: 0 (missing stats)
-            │ distinct on: crdb_internal_user_id_shard_16_cast, user_id_default
-            │ nulls are distinct
+            │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
+            │ equality cols are key
+            │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                │ estimated row count: 0 (missing stats)
+                │ estimated row count: 2 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                │ equality: (crdb_region_default, crdb_internal_user_id_shard_16_cast, user_id_default) = (crdb_region,crdb_internal_user_id_shard_16,user_id)
                 │ equality cols are key
+                │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
                 │
-                └── • lookup join (anti)
+                └── • render
                     │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                    │ equality cols are key
-                    │ lookup condition: ((user_id_default = user_id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                    │ estimated row count: 2
+                    │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
+                    │ render val_cast: val_cast
+                    │ render user_id_default: user_id_default
+                    │ render crdb_region_default: crdb_region_default
                     │
-                    └── • lookup join (anti)
-                        │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                        │ estimated row count: 2 (missing stats)
-                        │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
-                        │ equality cols are key
-                        │ lookup condition: ((user_id_default = user_id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_user_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+                    └── • render
+                        │ columns: (user_id_default, crdb_region_default, val_cast)
+                        │ estimated row count: 2
+                        │ render user_id_default: gen_random_uuid()
+                        │ render crdb_region_default: 'ap-southeast-2'
+                        │ render val_cast: val_cast
                         │
-                        └── • render
-                            │ columns: (crdb_internal_user_id_shard_16_cast, val_cast, user_id_default, crdb_region_default)
-                            │ estimated row count: 2
-                            │ render crdb_internal_user_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16), NULL::INT4)
-                            │ render val_cast: val_cast
-                            │ render user_id_default: user_id_default
-                            │ render crdb_region_default: crdb_region_default
-                            │
-                            └── • render
-                                │ columns: (user_id_default, crdb_region_default, val_cast)
-                                │ estimated row count: 2
-                                │ render user_id_default: gen_random_uuid()
-                                │ render crdb_region_default: 'ap-southeast-2'
-                                │ render val_cast: val_cast
-                                │
-                                └── • values
-                                      columns: (val_cast)
-                                      size: 1 column, 2 rows
-                                      row 0, expr 0: '4321'
-                                      row 1, expr 0: '8765'
+                        └── • values
+                              columns: (val_cast)
+                              size: 1 column, 2 rows
+                              row 0, expr 0: '4321'
+                              row 1, expr 0: '8765'
 
 subtest test_uniqueness_check_pk
 
@@ -435,11 +403,6 @@ vectorized: true
                           columns: (crdb_internal_id_shard_16_cast, column1, crdb_region_default, check1, check2)
                           label: buffer 1
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT DO NOTHING;
 ----
@@ -451,7 +414,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
 │ auto commit
-│ arbiter indexes: t_unique_hash_pk_pkey
 │ arbiter constraints: t_unique_hash_pk_pkey
 │
 └── • render
@@ -463,32 +425,35 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
     │
-    └── • lookup join (anti)
+    └── • cross join (anti)
         │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
         │ estimated row count: 0 (missing stats)
-        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-        │ equality cols are key
-        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • cross join (anti)
-            │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
-            │ estimated row count: 0 (missing stats)
+        ├── • values
+        │     columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+        │     size: 3 columns, 1 row
+        │     row 0, expr 0: 4321
+        │     row 0, expr 1: 'ap-southeast-2'
+        │     row 0, expr 2: 9
+        │
+        └── • union all
+            │ columns: (id)
+            │ estimated row count: 1 (missing stats)
+            │ limit: 1
             │
-            ├── • values
-            │     columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
-            │     size: 3 columns, 1 row
-            │     row 0, expr 0: 4321
-            │     row 0, expr 1: 'ap-southeast-2'
-            │     row 0, expr 2: 9
+            ├── • scan
+            │     columns: (id)
+            │     estimated row count: 1 (missing stats)
+            │     table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │     spans: /"@"/9/4321/0
             │
             └── • scan
-                  columns: (crdb_internal_id_shard_16, id, crdb_region)
+                  columns: (id)
                   estimated row count: 1 (missing stats)
                   table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                  spans: /"@"/9/4321/0
+                  spans: /"\x80"/9/4321/0 /"\xc0"/9/4321/0
+                  parallel
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -503,7 +468,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_pk(crdb_internal_id_shard_16, id, crdb_region)
 │ auto commit
-│ arbiter indexes: t_unique_hash_pk_pkey
 │ arbiter constraints: t_unique_hash_pk_pkey
 │
 └── • render
@@ -515,56 +479,32 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
     │
-    └── • distinct
-        │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
+    └── • lookup join (anti)
+        │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: column1, crdb_internal_id_shard_16_cast
-        │ nulls are distinct
+        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+        │ equality cols are key
+        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • project
-            │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_cast)
-            │ estimated row count: 0 (missing stats)
+        └── • lookup join (anti)
+            │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+            │ estimated row count: 2 (missing stats)
+            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
+            │ equality cols are key
+            │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
-            └── • lookup join (anti)
-                │ columns: ("lookup_join_const_col_@12", column1, crdb_region_default, crdb_internal_id_shard_16_cast)
-                │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                │ equality: (lookup_join_const_col_@12, crdb_internal_id_shard_16_cast, column1) = (crdb_region,crdb_internal_id_shard_16,id)
-                │ equality cols are key
+            └── • render
+                │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
+                │ estimated row count: 2
+                │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
+                │ render crdb_region_default: 'ap-southeast-2'
+                │ render column1: column1
                 │
-                └── • render
-                    │ columns: ("lookup_join_const_col_@12", column1, crdb_region_default, crdb_internal_id_shard_16_cast)
-                    │ estimated row count: 0 (missing stats)
-                    │ render lookup_join_const_col_@12: 'ap-southeast-2'
-                    │ render column1: column1
-                    │ render crdb_region_default: crdb_region_default
-                    │ render crdb_internal_id_shard_16_cast: crdb_internal_id_shard_16_cast
-                    │
-                    └── • lookup join (anti)
-                        │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
-                        │ estimated row count: 0 (missing stats)
-                        │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                        │ equality cols are key
-                        │ lookup condition: ((column1 = id) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                        │
-                        └── • lookup join (anti)
-                            │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
-                            │ estimated row count: 2 (missing stats)
-                            │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
-                            │ equality cols are key
-                            │ lookup condition: ((column1 = id) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_id_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
-                            │
-                            └── • render
-                                │ columns: (crdb_internal_id_shard_16_cast, crdb_region_default, column1)
-                                │ estimated row count: 2
-                                │ render crdb_internal_id_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16), NULL::INT4)
-                                │ render crdb_region_default: 'ap-southeast-2'
-                                │ render column1: column1
-                                │
-                                └── • values
-                                      columns: (column1)
-                                      size: 1 column, 2 rows
-                                      row 0, expr 0: 4321
-                                      row 1, expr 0: 8765
+                └── • values
+                      columns: (column1)
+                      size: 1 column, 2 rows
+                      row 0, expr 0: 4321
+                      row 1, expr 0: 8765
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_pk (id) VALUES (4321) ON CONFLICT (id) DO NOTHING;
@@ -1131,11 +1071,6 @@ vectorized: true
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast, check1, check2)
                           label: buffer 1
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
-# TODO (mgartner): there is a lookup join with lookup condition checking every
-# single shard. This is unnecessary and could be improved by having the shard
-# number calculated instead of looking at all possible shards.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT DO NOTHING;
 ----
@@ -1147,7 +1082,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
 │ auto commit
-│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │
 └── • render
@@ -1167,44 +1101,40 @@ vectorized: true
         │ equality cols are key
         │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
         │
-        └── • lookup join (anti)
+        └── • cross join (anti)
             │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
             │ estimated row count: 0 (missing stats)
-            │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-            │ equality cols are key
-            │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
             │
-            └── • lookup join (anti)
-                │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                │ equality: (crdb_region_default, crdb_internal_email_shard_16_cast, column2) = (crdb_region,crdb_internal_email_shard_16,email)
-                │ equality cols are key
+            ├── • values
+            │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 4321
+            │     row 0, expr 1: 'some_email'
+            │     row 0, expr 2: 'ap-southeast-2'
+            │     row 0, expr 3: 13
+            │
+            └── • project
+                │ columns: ()
+                │ estimated row count: 1 (missing stats)
                 │
-                └── • cross join (anti)
-                    │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
-                    │ estimated row count: 0 (missing stats)
+                └── • union all
+                    │ columns: (id)
+                    │ estimated row count: 1 (missing stats)
+                    │ limit: 1
                     │
-                    ├── • values
-                    │     columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_cast)
-                    │     size: 4 columns, 1 row
-                    │     row 0, expr 0: 4321
-                    │     row 0, expr 1: 'some_email'
-                    │     row 0, expr 2: 'ap-southeast-2'
-                    │     row 0, expr 3: 13
+                    ├── • scan
+                    │     columns: (id)
+                    │     estimated row count: 1 (missing stats)
+                    │     table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                    │     spans: /"@"/4321/0
                     │
-                    └── • project
-                        │ columns: ()
-                        │ estimated row count: 1 (missing stats)
-                        │
-                        └── • scan
-                              columns: (id, crdb_region)
-                              estimated row count: 1 (missing stats)
-                              table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                              spans: /"@"/4321/0
+                    └── • scan
+                          columns: (id)
+                          estimated row count: 1 (missing stats)
+                          table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                          spans: /"\x80"/4321/0 /"\xc0"/4321/0
+                          parallel
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 # TODO (mgartner): there is a lookup join with lookup condition checking every
 # single shard. This is unnecessary and could be improved by having the shard
 # number calculated instead of looking at all possible shards.
@@ -1219,7 +1149,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_unique_hash_sec_key(id, email, crdb_region, crdb_internal_email_shard_16)
 │ auto commit
-│ arbiter indexes: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │ arbiter constraints: t_unique_hash_sec_key_pkey, idx_uniq_hash_email
 │
 └── • render
@@ -1232,64 +1161,42 @@ vectorized: true
     │ render crdb_region_default: crdb_region_default
     │ render crdb_internal_email_shard_16_cast: crdb_internal_email_shard_16_cast
     │
-    └── • distinct
+    └── • lookup join (anti)
         │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: crdb_internal_email_shard_16_cast, column2
-        │ nulls are distinct
+        │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+        │ equality cols are key
+        │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
             │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
-            │ lookup condition: ((column2 = email) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+            │ lookup condition: ((column2 = email) AND (crdb_region IN ('ca-central-1', 'us-east-1'))) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
-                │ estimated row count: 0 (missing stats)
-                │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
+                │ estimated row count: 2 (missing stats)
+                │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
-                │ lookup condition: (column1 = id) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │ lookup condition: ((column2 = email) AND (crdb_region = 'ap-southeast-2')) AND (crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
                 │
-                └── • lookup join (anti)
+                └── • render
                     │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: t_unique_hash_sec_key@idx_uniq_hash_email
-                    │ equality: (crdb_region_default, crdb_internal_email_shard_16_cast, column2) = (crdb_region,crdb_internal_email_shard_16,email)
-                    │ equality cols are key
+                    │ estimated row count: 2
+                    │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
+                    │ render crdb_region_default: 'ap-southeast-2'
+                    │ render column1: column1
+                    │ render column2: column2
                     │
-                    └── • hash join (right anti)
-                        │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
-                        │ estimated row count: 0 (missing stats)
-                        │ equality: (id) = (column1)
-                        │ left cols are key
-                        │
-                        ├── • project
-                        │   │ columns: (id)
-                        │   │ estimated row count: 333 (missing stats)
-                        │   │
-                        │   └── • scan
-                        │         columns: (id, crdb_region)
-                        │         estimated row count: 333 (missing stats)
-                        │         table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
-                        │         spans: /"@"-/"@"/PrefixEnd
-                        │
-                        └── • render
-                            │ columns: (crdb_internal_email_shard_16_cast, crdb_region_default, column1, column2)
-                            │ estimated row count: 2
-                            │ render crdb_internal_email_shard_16_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16), NULL::INT4)
-                            │ render crdb_region_default: 'ap-southeast-2'
-                            │ render column1: column1
-                            │ render column2: column2
-                            │
-                            └── • values
-                                  columns: (column1, column2)
-                                  size: 2 columns, 2 rows
-                                  row 0, expr 0: 4321
-                                  row 0, expr 1: 'some_email'
-                                  row 1, expr 0: 8765
-                                  row 1, expr 1: 'another_email'
+                    └── • values
+                          columns: (column1, column2)
+                          size: 2 columns, 2 rows
+                          row 0, expr 0: 4321
+                          row 0, expr 1: 'some_email'
+                          row 1, expr 0: 8765
+                          row 1, expr 1: 'another_email'
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_unique_hash_sec_key (id, email) VALUES (4321, 'some_email') ON CONFLICT (email) DO NOTHING;

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -329,6 +329,56 @@ ORDER BY pk LIMIT 5] OFFSET 2
           spans: /"\xc0"-/"\xc0"/PrefixEnd
           limit: 5
 
+# Test that the synthesized UNIQUE WITHOUT INDEX constraints do not cause
+# lookups into redundant arbiters.
+query T
+SELECT * FROM [
+  EXPLAIN INSERT INTO regional_by_row_table (crdb_region, pk, pk2, a, b)
+  VALUES ('ca-central-1', 7, 7, 8, 9) ON CONFLICT DO NOTHING
+] OFFSET 2
+----
+·
+• insert
+│ into: regional_by_row_table(pk, pk2, a, b, j, crdb_region)
+│ auto commit
+│ arbiter constraints: regional_by_row_table_pkey, regional_by_row_table_b_key, uniq_idx
+│
+└── • render
+    │
+    └── • distinct
+        │ distinct on: arbiter_uniq_idx_distinct
+        │ nulls are distinct
+        │
+        └── • render
+            │
+            └── • lookup join (anti)
+                │ table: regional_by_row_table@uniq_idx (partial index)
+                │ lookup condition: (column4 = a) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                │ pred: column5 > 0
+                │
+                └── • lookup join (anti)
+                    │ table: regional_by_row_table@regional_by_row_table_b_key
+                    │ equality cols are key
+                    │ lookup condition: (column5 = b) AND (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1'))
+                    │
+                    └── • cross join (anti)
+                        │
+                        ├── • values
+                        │     size: 6 columns, 1 row
+                        │
+                        └── • union all
+                            │ limit: 1
+                            │
+                            ├── • scan
+                            │     missing stats
+                            │     table: regional_by_row_table@regional_by_row_table_pkey
+                            │     spans: [/'ap-southeast-2'/7 - /'ap-southeast-2'/7]
+                            │
+                            └── • scan
+                                  missing stats
+                                  table: regional_by_row_table@regional_by_row_table_pkey
+                                  spans: [/'ca-central-1'/7 - /'ca-central-1'/7] [/'us-east-1'/7 - /'us-east-1'/7]
+
 # Tests for locality optimized search.
 
 # Split the table into 3 regions and change the leaseholders to be "local"
@@ -2417,7 +2467,7 @@ FROM
                         regional_by_row_table_as4@a_idx
                     WHERE
                         a
-                        IN (1, 2, 4, 5, 6, 8, 10, 11, 12, 14, 15, 16, 17, 18, 
+                        IN (1, 2, 4, 5, 6, 8, 10, 11, 12, 14, 15, 16, 17, 18,
                             18, 19, 22, 23, 24, 25, 28, 30, 33, 34, 39, 40)
                     LIMIT
                         5
@@ -2479,7 +2529,7 @@ FROM
             regional_by_row_table_as4@a_idx
         WHERE
             a
-            IN (1, 2, 4, 5, 6, 8, 10, 11, 12, 14, 15, 16, 17, 18, 
+            IN (1, 2, 4, 5, 6, 8, 10, 11, 12, 14, 15, 16, 17, 18,
                 18, 19, 22, 23, 24, 25, 28, 30, 33, 34, 39, 40)
         LIMIT
             5
@@ -2522,7 +2572,7 @@ FROM
             regional_by_row_table_as4@a_idx
         WHERE
             a
-            IN (1, 2, 4, 5, 6, 8, 10, 11, 12, 14, 15, 16, 17, 18, 
+            IN (1, 2, 4, 5, 6, 8, 10, 11, 12, 14, 15, 16, 17, 18,
                 18, 19, 22, 23, 24, 25, 28, 30, 33, 34, 39, 40)
         LIMIT
             5

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -246,7 +246,8 @@ vectorized: true
           spans: /6/1234/0
           locking strength: for update
 
-# TODO(mgartner): We should be able to perform the UPSERT fast path in this case, because the shard column is a function of the other PK columns.
+# TODO(mgartner): We should be able to perform the UPSERT fast path in this
+# case, because the shard column is a function of the other PK columns.
 query T
 EXPLAIN (VERBOSE) UPSERT INTO t_hash_indexed VALUES (4321, 8765);
 ----
@@ -351,9 +352,6 @@ vectorized: true
                       spans: /1/4321/0
                       locking strength: for update
 
-# TODO (issue #75498): The `lookup join` in this test output is unnecessary
-# since we're using unique without index on (a) as an arbiter and using the
-# original hash sharded index as an arbiter is totally redundant.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT DO NOTHING
 ----
@@ -365,7 +363,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_hash_indexed(crdb_internal_a_shard_8, a, b)
 │ auto commit
-│ arbiter indexes: t_hash_indexed_pkey
 │ arbiter constraints: t_hash_indexed_pkey
 │
 └── • render
@@ -376,40 +373,22 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_a_shard_8_cast: crdb_internal_a_shard_8_cast
     │
-    └── • project
+    └── • cross join (anti)
         │ columns: (column1, column2, crdb_internal_a_shard_8_cast)
         │ estimated row count: 0 (missing stats)
         │
-        └── • lookup join (anti)
-            │ columns: (crdb_internal_a_shard_8_eq, column1, column2, crdb_internal_a_shard_8_cast)
-            │ table: t_hash_indexed@t_hash_indexed_pkey
-            │ equality: (crdb_internal_a_shard_8_eq, column1) = (crdb_internal_a_shard_8,a)
-            │ equality cols are key
-            │
-            └── • render
-                │ columns: (crdb_internal_a_shard_8_eq, column1, column2, crdb_internal_a_shard_8_cast)
-                │ estimated row count: 0 (missing stats)
-                │ render crdb_internal_a_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 8)
-                │ render column1: column1
-                │ render column2: column2
-                │ render crdb_internal_a_shard_8_cast: crdb_internal_a_shard_8_cast
-                │
-                └── • cross join (anti)
-                    │ columns: (column1, column2, crdb_internal_a_shard_8_cast)
-                    │ estimated row count: 0 (missing stats)
-                    │
-                    ├── • values
-                    │     columns: (column1, column2, crdb_internal_a_shard_8_cast)
-                    │     size: 3 columns, 1 row
-                    │     row 0, expr 0: 4321
-                    │     row 0, expr 1: 8765
-                    │     row 0, expr 2: 1
-                    │
-                    └── • scan
-                          columns: (crdb_internal_a_shard_8, a)
-                          estimated row count: 1 (missing stats)
-                          table: t_hash_indexed@t_hash_indexed_pkey
-                          spans: /1/4321/0
+        ├── • values
+        │     columns: (column1, column2, crdb_internal_a_shard_8_cast)
+        │     size: 3 columns, 1 row
+        │     row 0, expr 0: 4321
+        │     row 0, expr 1: 8765
+        │     row 0, expr 2: 1
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1 (missing stats)
+              table: t_hash_indexed@t_hash_indexed_pkey
+              spans: /1/4321/0
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT (a) DO NOTHING
@@ -758,8 +737,6 @@ vectorized: true
                               row 1, expr 0: 333
                               row 1, expr 1: 444
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT DO NOTHING
 ----
@@ -771,7 +748,7 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_hash_indexed(a, b, crdb_internal_b_shard_8)
 │ auto commit
-│ arbiter indexes: t_hash_indexed_pkey, idx_t_hash_indexed
+│ arbiter indexes: t_hash_indexed_pkey
 │ arbiter constraints: idx_t_hash_indexed
 │
 └── • render
@@ -800,36 +777,27 @@ vectorized: true
                 │ render column2: column2
                 │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
                 │
-                └── • lookup join (anti)
+                └── • cross join (anti)
                     │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
                     │ estimated row count: 0 (missing stats)
-                    │ table: t_hash_indexed@idx_t_hash_indexed
-                    │ equality: (crdb_internal_b_shard_8_cast, column2) = (crdb_internal_b_shard_8,b)
-                    │ equality cols are key
                     │
-                    └── • cross join (anti)
-                        │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
-                        │ estimated row count: 0 (missing stats)
+                    ├── • values
+                    │     columns: (column1, column2, crdb_internal_b_shard_8_cast)
+                    │     size: 3 columns, 1 row
+                    │     row 0, expr 0: 4321
+                    │     row 0, expr 1: 8765
+                    │     row 0, expr 2: 3
+                    │
+                    └── • project
+                        │ columns: ()
+                        │ estimated row count: 1 (missing stats)
                         │
-                        ├── • values
-                        │     columns: (column1, column2, crdb_internal_b_shard_8_cast)
-                        │     size: 3 columns, 1 row
-                        │     row 0, expr 0: 4321
-                        │     row 0, expr 1: 8765
-                        │     row 0, expr 2: 3
-                        │
-                        └── • project
-                            │ columns: ()
-                            │ estimated row count: 1 (missing stats)
-                            │
-                            └── • scan
-                                  columns: (a)
-                                  estimated row count: 1 (missing stats)
-                                  table: t_hash_indexed@t_hash_indexed_pkey
-                                  spans: /4321/0
+                        └── • scan
+                              columns: (a)
+                              estimated row count: 1 (missing stats)
+                              table: t_hash_indexed@t_hash_indexed_pkey
+                              spans: /4321/0
 
-# TODO (issue #75498): we're using unique without index on (a) as an arbiter and
-# using the original hash sharded index as an arbiter is not necessary.
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (111, 222), (333, 444) ON CONFLICT DO NOTHING
 ----
@@ -841,7 +809,7 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: t_hash_indexed(a, b, crdb_internal_b_shard_8)
 │ auto commit
-│ arbiter indexes: t_hash_indexed_pkey, idx_t_hash_indexed
+│ arbiter indexes: t_hash_indexed_pkey
 │ arbiter constraints: idx_t_hash_indexed
 │
 └── • render
@@ -852,58 +820,38 @@ vectorized: true
     │ render column2: column2
     │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
     │
-    └── • distinct
+    └── • lookup join (anti)
         │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
         │ estimated row count: 0 (missing stats)
-        │ distinct on: column2, crdb_internal_b_shard_8_cast
-        │ nulls are distinct
+        │ table: t_hash_indexed@t_hash_indexed_pkey
+        │ equality: (column1) = (a)
+        │ equality cols are key
         │
         └── • project
             │ columns: (column1, column2, crdb_internal_b_shard_8_cast)
             │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
-                │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_cast)
+                │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_cast, column1, column2)
                 │ table: t_hash_indexed@idx_t_hash_indexed
                 │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
                 │ equality cols are key
                 │
                 └── • render
-                    │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_cast)
-                    │ estimated row count: 0 (missing stats)
+                    │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_cast, column1, column2)
+                    │ estimated row count: 2
                     │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
+                    │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
                     │ render column1: column1
                     │ render column2: column2
-                    │ render crdb_internal_b_shard_8_cast: crdb_internal_b_shard_8_cast
                     │
-                    └── • lookup join (anti)
-                        │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
-                        │ estimated row count: 0 (missing stats)
-                        │ table: t_hash_indexed@t_hash_indexed_pkey
-                        │ equality: (column1) = (a)
-                        │ equality cols are key
-                        │
-                        └── • lookup join (anti)
-                            │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
-                            │ estimated row count: 0 (missing stats)
-                            │ table: t_hash_indexed@idx_t_hash_indexed
-                            │ equality: (crdb_internal_b_shard_8_cast, column2) = (crdb_internal_b_shard_8,b)
-                            │ equality cols are key
-                            │
-                            └── • render
-                                │ columns: (crdb_internal_b_shard_8_cast, column1, column2)
-                                │ estimated row count: 2
-                                │ render crdb_internal_b_shard_8_cast: crdb_internal.assignment_cast(mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8), NULL::INT4)
-                                │ render column1: column1
-                                │ render column2: column2
-                                │
-                                └── • values
-                                      columns: (column1, column2)
-                                      size: 2 columns, 2 rows
-                                      row 0, expr 0: 111
-                                      row 0, expr 1: 222
-                                      row 1, expr 0: 333
-                                      row 1, expr 1: 444
+                    └── • values
+                          columns: (column1, column2)
+                          size: 2 columns, 2 rows
+                          row 0, expr 0: 111
+                          row 0, expr 1: 222
+                          row 1, expr 0: 333
+                          row 1, expr 1: 444
 
 query T
 EXPLAIN (VERBOSE) INSERT INTO t_hash_indexed VALUES (4321, 8765) ON CONFLICT (b) DO NOTHING

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -914,7 +914,6 @@ vectorized: true
 │ estimated row count: 0 (missing stats)
 │ into: uniq_enum(r, s, i, j)
 │ auto commit
-│ arbiter indexes: uniq_enum_pkey, uniq_enum_r_s_j_key
 │ arbiter constraints: unique_i, unique_s_j
 │
 └── • render
@@ -929,42 +928,28 @@ vectorized: true
     └── • lookup join (anti)
         │ columns: (column1, column2, column3, column4)
         │ estimated row count: 0 (missing stats)
-        │ table: uniq_enum@uniq_enum_r_s_j_key
+        │ table: uniq_enum@uniq_enum_pkey
         │ equality cols are key
-        │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
+        │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
         │
         └── • lookup join (anti)
             │ columns: (column1, column2, column3, column4)
             │ estimated row count: 0 (missing stats)
-            │ table: uniq_enum@uniq_enum_pkey
+            │ table: uniq_enum@uniq_enum_r_s_j_key
             │ equality cols are key
-            │ lookup condition: (column3 = i) AND (r IN ('us-east', 'us-west', 'eu-west'))
+            │ lookup condition: ((column2 = s) AND (column4 = j)) AND (r IN ('us-east', 'us-west', 'eu-west'))
             │
-            └── • lookup join (anti)
-                │ columns: (column1, column2, column3, column4)
-                │ estimated row count: 0 (missing stats)
-                │ table: uniq_enum@uniq_enum_pkey
-                │ equality: (column1, column3) = (r,i)
-                │ equality cols are key
-                │
-                └── • lookup join (anti)
-                    │ columns: (column1, column2, column3, column4)
-                    │ estimated row count: 0 (missing stats)
-                    │ table: uniq_enum@uniq_enum_r_s_j_key
-                    │ equality: (column1, column2, column4) = (r,s,j)
-                    │ equality cols are key
-                    │
-                    └── • values
-                          columns: (column1, column2, column3, column4)
-                          size: 4 columns, 2 rows
-                          row 0, expr 0: 'us-west'
-                          row 0, expr 1: 'foo'
-                          row 0, expr 2: 1
-                          row 0, expr 3: 1
-                          row 1, expr 0: 'us-east'
-                          row 1, expr 1: 'bar'
-                          row 1, expr 2: 2
-                          row 1, expr 3: 2
+            └── • values
+                  columns: (column1, column2, column3, column4)
+                  size: 4 columns, 2 rows
+                  row 0, expr 0: 'us-west'
+                  row 0, expr 1: 'foo'
+                  row 0, expr 2: 1
+                  row 0, expr 3: 1
+                  row 1, expr 0: 'us-east'
+                  row 1, expr 1: 'bar'
+                  row 1, expr 2: 2
+                  row 1, expr 3: 2
 
 # None of the inserted values have nulls.
 query T

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -578,12 +578,12 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *InsertExpr:
+		f.formatArbiterIndexes(tp, t.ArbiterIndexes, t.Table)
+		f.formatArbiterConstraints(tp, t.ArbiterConstraints, t.Table)
 		if !f.HasFlags(ExprFmtHideColumns) {
 			if len(colList) == 0 {
 				tp.Child("columns: <none>")
 			}
-			f.formatArbiterIndexes(tp, t.ArbiterIndexes, t.Table)
-			f.formatArbiterConstraints(tp, t.ArbiterConstraints, t.Table)
 			f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
@@ -604,13 +604,13 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *UpsertExpr:
+		f.formatArbiterIndexes(tp, t.ArbiterIndexes, t.Table)
+		f.formatArbiterConstraints(tp, t.ArbiterConstraints, t.Table)
 		if !f.HasFlags(ExprFmtHideColumns) {
 			if len(colList) == 0 {
 				tp.Child("columns: <none>")
 			}
 			if t.CanaryCol != 0 {
-				f.formatArbiterIndexes(tp, t.ArbiterIndexes, t.Table)
-				f.formatArbiterConstraints(tp, t.ArbiterConstraints, t.Table)
 				f.formatColList(e, tp, "canary column:", opt.ColList{t.CanaryCol})
 				f.formatOptionalColList(e, tp, "fetch columns:", t.FetchCols)
 				f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -532,8 +532,8 @@ ON CONFLICT (a) DO
 UPDATE SET b=2
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_a_key
+ ├── columns: <none>
  ├── canary column: a:15(int)
  ├── fetch columns: a:15(int) b:16(int) c:17(int) rowid:18(int)
  ├── insert-mapping:

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -245,8 +245,8 @@ SELECT z::int FROM xyz
 ON CONFLICT (v) DO UPDATE SET v=1
 ----
 upsert uv
- ├── columns: <none>
  ├── arbiter indexes: uv_v_key
+ ├── columns: <none>
  ├── canary column: u:12(int)
  ├── fetch columns: u:12(int) v:13(int)
  ├── insert-mapping:
@@ -329,8 +329,8 @@ SELECT * FROM mno
 ON CONFLICT (n, o) DO UPDATE SET o = 5
 ----
 upsert mno
- ├── columns: <none>
  ├── arbiter indexes: mno_n_o_key
+ ├── columns: <none>
  ├── canary column: m:11(int)
  ├── fetch columns: m:11(int) n:12(int) o:13(int)
  ├── insert-mapping:

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -725,8 +725,8 @@ SELECT i, i, i, i FROM (SELECT * FROM a WHERE EXISTS(SELECT * FROM a) AND k>0)
 ON CONFLICT (c1) DO UPDATE SET c3=1
 ----
 upsert nullablecols
- ├── columns: <none>
  ├── arbiter indexes: nullablecols_c1_key
+ ├── columns: <none>
  ├── canary column: rowid:24
  ├── fetch columns: c1:21 c2:22 c3:23 rowid:24
  ├── insert-mapping:
@@ -943,8 +943,8 @@ SELECT y FROM xy WHERE y=0
 ON CONFLICT (x) DO NOTHING
 ----
 insert xy
- ├── columns: <none>
  ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── y:6 => x:1
  │    └── y_default:9 => y:2
@@ -985,8 +985,8 @@ SELECT y FROM xy WHERE y=0
 ON CONFLICT (x) DO UPDATE SET y=1
 ----
 upsert xy
- ├── columns: <none>
  ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
  ├── canary column: x:10
  ├── fetch columns: x:10 y:11
  ├── insert-mapping:
@@ -1041,8 +1041,8 @@ SELECT y FROM xy WHERE y IS NULL
 ON CONFLICT (x) DO NOTHING
 ----
 insert xy
- ├── columns: <none>
  ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── y:6 => x:1
  │    └── y_default:9 => y:2
@@ -1084,8 +1084,8 @@ SELECT y FROM xy WHERE y IS NULL
 ON CONFLICT (x) DO UPDATE SET y=1
 ----
 upsert xy
- ├── columns: <none>
  ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
  ├── canary column: x:10
  ├── fetch columns: x:10 y:11
  ├── insert-mapping:
@@ -1141,8 +1141,8 @@ SELECT 1, b, 2 FROM abc
 ON CONFLICT (a, b, c) DO UPDATE SET a=1
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_pkey
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 b:14 c:15
  ├── insert-mapping:
@@ -1192,8 +1192,8 @@ SELECT NULL, b, c FROM abc WHERE b=1
 ON CONFLICT (a, b, c) DO UPDATE SET c=2
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_pkey
+ ├── columns: <none>
  ├── canary column: a:12
  ├── fetch columns: a:12 b:13 c:14
  ├── insert-mapping:
@@ -1664,8 +1664,8 @@ INSERT INTO a (k, i, s) SELECT 1, i, 'foo' FROM a WHERE i = 1
 ON CONFLICT (s, i) DO NOTHING
 ----
 insert a
- ├── columns: <none>
  ├── arbiter indexes: si_idx
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── "?column?":15 => k:1
  │    ├── i:9 => i:2
@@ -1761,8 +1761,8 @@ INSERT INTO a (k, i, s) SELECT 1, i, 'foo' FROM a WHERE i = 1
 ON CONFLICT (s, i) DO UPDATE SET f=1.1
 ----
 upsert a
- ├── columns: <none>
  ├── arbiter indexes: si_idx
+ ├── columns: <none>
  ├── canary column: s:22
  ├── fetch columns: k:19 i:20 f:21 s:22 j:23
  ├── insert-mapping:
@@ -2105,8 +2105,8 @@ INSERT INTO a (k, s, i) VALUES (1, NULL, NULL), (1, NULL, NULL)
 ON CONFLICT (s, i) DO NOTHING
 ----
 insert a
- ├── columns: <none>
  ├── arbiter indexes: si_idx
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => k:1
  │    ├── column3:10 => i:2
@@ -2144,8 +2144,8 @@ INSERT INTO a (k, s, i) VALUES (1, NULL, NULL), (1, NULL, NULL)
 ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
- ├── columns: <none>
  ├── arbiter indexes: si_idx
+ ├── columns: <none>
  ├── canary column: s:16
  ├── fetch columns: k:13 i:14 f:15 s:16 j:17
  ├── insert-mapping:
@@ -2195,8 +2195,8 @@ INSERT INTO a (k, s, i) VALUES (1, 'foo', 1), (2, 'bar', 2), (3, 'foo', 1)
 ON CONFLICT (s, i) DO UPDATE SET f=1.0
 ----
 upsert a
- ├── columns: <none>
  ├── arbiter indexes: si_idx
+ ├── columns: <none>
  ├── canary column: s:16
  ├── fetch columns: k:13 i:14 f:15 s:16 j:17
  ├── insert-mapping:
@@ -2263,8 +2263,8 @@ INSERT INTO a (k, s, i, f) VALUES (1, 'foo', 1, 1.0), (2, 'bar', 2, 2.0), (3, 'f
 ON CONFLICT DO NOTHING
 ----
 insert a
- ├── columns: <none>
  ├── arbiter indexes: a_pkey si_idx fi_idx
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => k:1
  │    ├── column3:10 => i:2
@@ -2322,8 +2322,8 @@ INSERT INTO a (k, s, f) VALUES (1, 'foo', 1.0), (2, 'bar', 2.0), (3, 'foo', 1.0)
 ON CONFLICT DO NOTHING
 ----
 insert a
- ├── columns: <none>
  ├── arbiter indexes: a_pkey si_idx fi_idx
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => k:1
  │    ├── i_default:11 => i:2
@@ -2409,8 +2409,8 @@ INSERT INTO a (k, s, i, f) VALUES (unique_rowid(), 'foo', 1, 1.0), (unique_rowid
 ON CONFLICT DO NOTHING
 ----
 insert a
- ├── columns: <none>
  ├── arbiter indexes: a_pkey si_idx fi_idx
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => k:1
  │    ├── column3:10 => i:2
@@ -2488,8 +2488,8 @@ INSERT INTO a (k, s, i) SELECT i, 'foo', i FROM a
 ON CONFLICT (s, i) DO NOTHING
 ----
 insert a
- ├── columns: <none>
  ├── arbiter indexes: si_idx
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── i:9 => k:1
  │    ├── i:9 => i:2

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2244,8 +2244,8 @@ norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 UPSERT INTO partial_indexes (a, d) VALUES (1, 2)
 ----
 upsert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 d:14
  ├── insert-mapping:
@@ -2301,8 +2301,8 @@ norm expect-not=PruneMutationFetchCols
 UPSERT INTO partial_indexes (a, b, d) VALUES (1, 2, 3)
 ----
 upsert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14
  ├── insert-mapping:
@@ -2360,8 +2360,8 @@ norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 INSERT INTO partial_indexes (a, d) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET d = 3
 ----
 upsert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 d:14
  ├── insert-mapping:
@@ -2418,8 +2418,8 @@ norm expect-not=PruneMutationFetchCols
 INSERT INTO partial_indexes (a, d) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b = 3, d = 4
 ----
 upsert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14
  ├── insert-mapping:
@@ -2613,8 +2613,8 @@ norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 UPSERT INTO virt_partial_idx (a, d) VALUES (1, 2)
 ----
 upsert virt_partial_idx
- ├── columns: <none>
  ├── arbiter indexes: virt_partial_idx_pkey
+ ├── columns: <none>
  ├── canary column: a:12
  ├── fetch columns: a:12 d:16
  ├── insert-mapping:
@@ -2684,8 +2684,8 @@ norm expect-not=PruneMutationFetchCols
 UPSERT INTO virt_partial_idx (a, b, d) VALUES (1, 2, 3)
 ----
 upsert virt_partial_idx
- ├── columns: <none>
  ├── arbiter indexes: virt_partial_idx_pkey
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 b:14 v:15 c:16 d:17
  ├── insert-mapping:
@@ -2758,8 +2758,8 @@ norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 INSERT INTO virt_partial_idx (a, d) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET d = 3
 ----
 upsert virt_partial_idx
- ├── columns: <none>
  ├── arbiter indexes: virt_partial_idx_pkey
+ ├── columns: <none>
  ├── canary column: a:12
  ├── fetch columns: a:12 d:16
  ├── insert-mapping:
@@ -2830,8 +2830,8 @@ norm expect-not=PruneMutationFetchCols
 INSERT INTO virt_partial_idx (a, d) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b = 3, d = 4
 ----
 upsert virt_partial_idx
- ├── columns: <none>
  ├── arbiter indexes: virt_partial_idx_pkey
+ ├── columns: <none>
  ├── canary column: a:12
  ├── fetch columns: a:12 b:13 v:14 c:15 d:16
  ├── insert-mapping:
@@ -3103,8 +3103,8 @@ norm expect=PruneMutationInputCols
 INSERT INTO a (k, s) VALUES (1, 'foo') ON CONFLICT (k) DO UPDATE SET i=a.i+1
 ----
 upsert a
- ├── columns: <none>
  ├── arbiter indexes: a_pkey
+ ├── columns: <none>
  ├── canary column: k:11
  ├── fetch columns: k:11 i:12 f:13 s:14
  ├── insert-mapping:
@@ -3216,8 +3216,8 @@ norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 UPSERT INTO family (a, b) VALUES (1, 2)
 ----
 upsert family
- ├── columns: <none>
  ├── arbiter indexes: family_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12
  ├── insert-mapping:
@@ -3324,8 +3324,8 @@ norm expect=(PruneMutationFetchCols,PruneMutationInputCols)
 INSERT INTO family VALUES (1, 2, 3, 4) ON CONFLICT (a) DO UPDATE SET d=10
 ----
 upsert family
- ├── columns: <none>
  ├── arbiter indexes: family_pkey
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 c:15 d:16
  ├── insert-mapping:
@@ -3375,8 +3375,8 @@ norm expect=(PruneMutationInputCols)
 INSERT INTO mutation VALUES (1, 2, 3) ON CONFLICT (a) DO UPDATE SET b=10
 ----
 upsert mutation
- ├── columns: <none>
  ├── arbiter indexes: mutation_pkey
+ ├── columns: <none>
  ├── canary column: a:12
  ├── fetch columns: a:12 b:13 c:14 d:15 e:16
  ├── insert-mapping:
@@ -3532,8 +3532,8 @@ norm
 UPSERT INTO checks (a, c, d) VALUES (1, 3, 4)
 ----
 upsert checks
- ├── columns: <none>
  ├── arbiter indexes: checks_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14
  ├── insert-mapping:
@@ -3756,8 +3756,8 @@ norm expect=PruneMutationInputCols
 INSERT INTO uniq_fk_parent VALUES (2, 1) ON CONFLICT (k) DO UPDATE SET c = 1
 ----
 upsert uniq_fk_parent
- ├── columns: <none>
  ├── arbiter indexes: uniq_fk_parent_pkey
+ ├── columns: <none>
  ├── canary column: uniq_fk_parent.k:11
  ├── fetch columns: uniq_fk_parent.k:11 uniq_fk_parent.b:13 uniq_fk_parent.c:14
  ├── insert-mapping:
@@ -3868,8 +3868,8 @@ norm expect=PruneMutationInputCols
 INSERT INTO uniq_fk_parent VALUES (1) ON CONFLICT (k) DO UPDATE SET d = 1
 ----
 upsert uniq_fk_parent
- ├── columns: <none>
  ├── arbiter indexes: uniq_fk_parent_pkey
+ ├── columns: <none>
  ├── canary column: uniq_fk_parent.k:10
  ├── fetch columns: uniq_fk_parent.k:10 uniq_fk_parent.d:14
  ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/arbiter_set.go
+++ b/pkg/sql/opt/optbuilder/arbiter_set.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
 )
 
 // arbiterSet represents a set of arbiters. Unique indexes or constraints can be
@@ -136,5 +137,132 @@ func (a *arbiterSet) ForEach(
 		}
 
 		f(uniqueConstraint.Name(), conflictOrds, pred, canaryOrd)
+	})
+}
+
+// removeIndex removes an index arbiter from the set.
+func (a *arbiterSet) removeIndex(idx cat.IndexOrdinal) {
+	a.indexes.Remove(idx)
+}
+
+// minArbiterSet represents a set of arbiters. It differs from arbiterSet by
+// automatically removing arbiter indexes that are made redundant by arbiter
+// unique constraints. It is only useful when an ON CONFLICT statement specifies
+// no columns or constraints. For example, consider the table and statement:
+//
+//   CREATE TABLE t (
+//     a INT,
+//     b INT,
+//     UNIQUE INDEX a_b_key (a, b),
+//     UNIQUE WITHOUT INDEX b_key (b)
+//   )
+//
+//   INSERT INTO t VALUES (1, 2) ON CONFLICT DO NOTHING
+//
+// There is no need to use both a_b_key and b_key as arbiters for the INSERT
+// statement because any conflict in a_b_key will also be a conflict in b_key.
+// Only b_key is required to be an arbiter.
+//
+// Special care is taken with partial indexes and unique constraints. An arbiter
+// index is only made redundant by a unique constraint if they are both
+// non-partial, or their partial predicates are identical. Note that in the
+// future, we could probably be smarter about this by using implication (see
+// partialidx.Implicator) to remove arbiter indexes that have predicates that do
+// not exactly match a unique constraint predicate.
+//
+// Note that minArbiterSet does not currently remove arbiter indexes that are
+// made redundant by other arbiter indexes, nor does it remove arbiter unique
+// constraints made redundant by other arbiter unique constraints. These cases
+// would only occur if a user created redundant unique indexes or unique
+// constraints, and the extra arbiters can be easily removed by removing the
+// redundant indexes and constraints from the table. The minArbiterSet is
+// designed to remove arbiter indexes that are made redundant by UNIQUE WITHOUT
+// INDEX constraints that are synthesized for partitioned and hash-sharded
+// indexes, which the user has no control over.
+type minArbiterSet struct {
+	as arbiterSet
+
+	// addUniqueConstraintCalled is set to true when addUniqueConstraint is
+	// called. When true, AddIndex will panic to avoid undefined behavior.
+	addUniqueConstraintCalled bool
+
+	// indexConflictOrdsCache caches the conflict column sets of arbiter indexes
+	// in the set.
+	indexConflictOrdsCache map[cat.IndexOrdinal]util.FastIntSet
+}
+
+// makeMinArbiterSet returns an initialized arbiterSet.
+func makeMinArbiterSet(mb *mutationBuilder) minArbiterSet {
+	return minArbiterSet{
+		as: makeArbiterSet(mb),
+	}
+}
+
+// AddIndex adds an index arbiter to the set. Panics if called after
+// AddUniqueConstraint has been called.
+func (m *minArbiterSet) AddIndex(idx cat.IndexOrdinal) {
+	if m.addUniqueConstraintCalled {
+		panic(errors.AssertionFailedf("cannot call AddIndex after AddUniqueConstraint"))
+	}
+	m.as.AddIndex(idx)
+}
+
+// AddUniqueConstraint adds a unique constraint arbiter to the set. If the
+// unique constraint makes an index redundant, the index is removed from the
+// set.
+func (m *minArbiterSet) AddUniqueConstraint(uniq cat.UniqueOrdinal) {
+	m.addUniqueConstraintCalled = true
+	m.as.AddUniqueConstraint(uniq)
+
+	uniqueConstraint := m.as.mb.tab.Unique(uniq)
+	if idx, ok := m.findRedundantIndex(uniqueConstraint); ok {
+		m.as.removeIndex(idx)
+		delete(m.indexConflictOrdsCache, idx)
+	}
+}
+
+// ArbiterSet converts the minArbiterSet to an arbiterSet.
+func (m *minArbiterSet) ArbiterSet() arbiterSet {
+	return m.as
+}
+
+// findRedundantIndex returns the first arbiter index which is made redundant by
+// the unique constraint. An arbiter index is redundant if both of the following
+// hold:
+//
+//   1. Its conflict columns are a super set of the given conflict columns.
+//   2. The index and unique constraint are both non-partial, or have the same
+//      partial predicate.
+//
+func (m *minArbiterSet) findRedundantIndex(
+	uniq cat.UniqueConstraint,
+) (_ cat.IndexOrdinal, ok bool) {
+	m.initCache()
+	// If there is only one arbiter index, check if it is made redundant by
+	// the unique constraint.
+	conflictOrds := getUniqueConstraintOrdinals(m.as.mb.tab, uniq)
+	pred, _ := uniq.Predicate()
+	// Find the first arbiter index that is made redundant by the unique
+	// constraint.
+	for i, indexConflictOrds := range m.indexConflictOrdsCache {
+		indexPred, _ := m.as.mb.tab.Index(i).Predicate()
+		if pred == indexPred && conflictOrds.SubsetOf(indexConflictOrds) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// initCache initializes the index conflict columns cache.
+func (m *minArbiterSet) initCache() {
+	// Do nothing if the cache has already been initialized.
+	if m.indexConflictOrdsCache != nil {
+		return
+	}
+	// Cache each index's conflict columns.
+	m.indexConflictOrdsCache = make(map[cat.IndexOrdinal]util.FastIntSet, m.as.indexes.Len())
+	m.as.indexes.ForEach(func(i int) {
+		index := m.as.mb.tab.Index(i)
+		m.indexConflictOrdsCache[i] = getIndexLaxKeyOrdinals(index)
 	})
 }

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -85,7 +85,11 @@ func (mb *mutationBuilder) findArbiters(onConflict *tree.OnConflict) arbiterSet 
 			}
 		}
 		// Found nothing, we have to return an error.
-		panic(pgerror.Newf(pgcode.UndefinedObject, "constraint %q for table %q does not exist", onConflict.Constraint, mb.tab.Name()))
+		panic(pgerror.Newf(
+			pgcode.UndefinedObject,
+			"constraint %q for table %q does not exist",
+			onConflict.Constraint, mb.tab.Name(),
+		))
 	}
 	// We have to infer an arbiter set.
 	var ords util.FastIntSet
@@ -111,11 +115,13 @@ func partialIndexArbiterError(onConflict *tree.OnConflict, tableName tree.Name) 
 	return errors.WithHint(
 		pgerror.Newf(
 			pgcode.WrongObjectType,
-			"unique constraint %q for table %q is partial, so cannot be used as an arbiter via the ON CONSTRAINT syntax",
+			"unique constraint %q for table %q is partial, "+
+				"so it cannot be used as an arbiter via the ON CONSTRAINT syntax",
 			onConflict.Constraint,
 			tableName,
 		),
-		"use the ON CONFLICT (columns...) WHERE <predicate> form to select this partial unique constraint as an arbiter",
+		"use the ON CONFLICT (columns...) WHERE <predicate> form "+
+			"to select this partial unique constraint as an arbiter",
 	)
 }
 
@@ -148,11 +154,12 @@ func partialIndexArbiterError(onConflict *tree.OnConflict, tableName tree.Name) 
 func (mb *mutationBuilder) inferArbitersFromConflictOrds(
 	conflictOrds util.FastIntSet, arbiterPredicate tree.Expr,
 ) arbiterSet {
-	arbiters := makeArbiterSet(mb)
-
 	// If conflictOrds is empty, then all unique indexes and unique without
 	// index constraints are arbiters.
 	if conflictOrds.Empty() {
+		// Use a minArbiterSet which automatically removes arbiter indexes that
+		// are made redundant by arbiter unique constraints.
+		arbiters := makeMinArbiterSet(mb)
 		for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
 			if mb.tab.Index(idx).IsUnique() {
 				arbiters.AddIndex(idx)
@@ -163,9 +170,10 @@ func (mb *mutationBuilder) inferArbitersFromConflictOrds(
 				arbiters.AddUniqueConstraint(uc)
 			}
 		}
-		return arbiters
+		return arbiters.ArbiterSet()
 	}
 
+	arbiters := makeArbiterSet(mb)
 	h := &mb.arbiterPredicateHelper
 	h.init(mb, arbiterPredicate)
 	for idx, idxCount := 0, mb.tab.IndexCount(); idx < idxCount; idx++ {
@@ -214,10 +222,6 @@ func (mb *mutationBuilder) inferArbitersFromConflictOrds(
 		uniqueConstraint := mb.tab.Unique(uc)
 		if !uniqueConstraint.WithoutIndex() {
 			// Unique constraints with an index were handled above.
-			continue
-		}
-
-		if uniqueConstraint.ColumnCount() != conflictOrds.Len() {
 			continue
 		}
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -36,8 +36,8 @@ build
 INSERT INTO child VALUES (100, 1), (200, 1) ON CONFLICT DO NOTHING
 ----
 insert child
- ├── columns: <none>
  ├── arbiter indexes: child_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:5 => c:1
  │    └── column2:6 => child.p:2

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -65,8 +65,8 @@ build
 UPSERT INTO c1(c) VALUES (100), (200)
 ----
 upsert c1
- ├── columns: <none>
  ├── arbiter indexes: c1_pkey
+ ├── columns: <none>
  ├── canary column: c:9
  ├── fetch columns: c:9 c1.p:10 i:11
  ├── insert-mapping:
@@ -152,8 +152,8 @@ build
 INSERT INTO c1 VALUES (100, 1), (200, 1) ON CONFLICT (c) DO UPDATE SET p = excluded.p + 1
 ----
 upsert c1
- ├── columns: <none>
  ├── arbiter indexes: c1_pkey
+ ├── columns: <none>
  ├── canary column: c:9
  ├── fetch columns: c:9 c1.p:10 i:11
  ├── insert-mapping:
@@ -212,8 +212,8 @@ build
 INSERT INTO c1 SELECT u, v FROM uv ON CONFLICT (c) DO UPDATE SET i = c1.c + 1
 ----
 upsert c1
- ├── columns: <none>
  ├── arbiter indexes: c1_pkey
+ ├── columns: <none>
  ├── canary column: c:12
  ├── fetch columns: c:12 c1.p:13 i:14
  ├── insert-mapping:
@@ -276,8 +276,8 @@ build
 INSERT INTO c2 VALUES (1), (2) ON CONFLICT (c) DO UPDATE SET c = 1
 ----
 upsert c2
- ├── columns: <none>
  ├── arbiter indexes: c2_pkey
+ ├── columns: <none>
  ├── canary column: c2.c:5
  ├── fetch columns: c2.c:5
  ├── insert-mapping:
@@ -359,8 +359,8 @@ build
 UPSERT INTO c3(c) VALUES (100), (200)
 ----
 upsert c3
- ├── columns: <none>
  ├── arbiter indexes: c3_pkey
+ ├── columns: <none>
  ├── canary column: c:7
  ├── fetch columns: c:7 c3.p:8
  ├── insert-mapping:
@@ -417,8 +417,8 @@ build
 INSERT INTO c4 SELECT x, y, z FROM xyzw ON CONFLICT (a) DO UPDATE SET other = 1
 ----
 upsert c4
- ├── columns: <none>
  ├── arbiter indexes: c4_a_key
+ ├── columns: <none>
  ├── canary column: c:13
  ├── fetch columns: c:13 c4.a:14 c4.other:15
  ├── insert-mapping:
@@ -477,8 +477,8 @@ build
 INSERT INTO c4 SELECT x, y, z FROM xyzw ON CONFLICT (a) DO UPDATE SET a = 5
 ----
 upsert c4
- ├── columns: <none>
  ├── arbiter indexes: c4_a_key
+ ├── columns: <none>
  ├── canary column: c:13
  ├── fetch columns: c:13 c4.a:14 c4.other:15
  ├── insert-mapping:
@@ -629,8 +629,8 @@ build
 UPSERT INTO cpq(c,p) SELECT x,y FROM xyzw
 ----
 upsert cpq
- ├── columns: <none>
  ├── arbiter indexes: cpq_pkey
+ ├── columns: <none>
  ├── canary column: c:16
  ├── fetch columns: c:16 cpq.p:17 cpq.q:18 cpq.other:19
  ├── insert-mapping:
@@ -696,8 +696,8 @@ build
 UPSERT INTO cpq(c) SELECT x FROM xyzw
 ----
 upsert cpq
- ├── columns: <none>
  ├── arbiter indexes: cpq_pkey
+ ├── columns: <none>
  ├── canary column: c:17
  ├── fetch columns: c:17 cpq.p:18 cpq.q:19 cpq.other:20
  ├── insert-mapping:
@@ -801,8 +801,8 @@ build
 INSERT INTO cpq VALUES (1), (2) ON CONFLICT (c) DO UPDATE SET p = 10
 ----
 upsert cpq
- ├── columns: <none>
  ├── arbiter indexes: cpq_pkey
+ ├── columns: <none>
  ├── canary column: c:11
  ├── fetch columns: c:11 cpq.p:12 cpq.q:13 cpq.other:14
  ├── insert-mapping:
@@ -930,8 +930,8 @@ build
 UPSERT INTO cmulti(a,b,c) SELECT x,y,z FROM xyzw
 ----
 upsert cmulti
- ├── columns: <none>
  ├── arbiter indexes: cmulti_pkey
+ ├── columns: <none>
  ├── canary column: cmulti.a:15
  ├── fetch columns: cmulti.a:15 cmulti.b:16 cmulti.c:17 d:18
  ├── insert-mapping:
@@ -1028,8 +1028,8 @@ build
 UPSERT INTO p1 VALUES (1, 1), (2, 2)
 ----
 upsert p1
- ├── columns: <none>
  ├── arbiter indexes: p1_pkey
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 other:8
  ├── insert-mapping:
@@ -1064,8 +1064,8 @@ build
 INSERT INTO p1 VALUES (100, 1), (200, 1) ON CONFLICT (p) DO UPDATE SET p = excluded.p + 1
 ----
 upsert p1
- ├── columns: <none>
  ├── arbiter indexes: p1_pkey
+ ├── columns: <none>
  ├── canary column: p1.p:7
  ├── fetch columns: p1.p:7 other:8
  ├── insert-mapping:
@@ -1125,8 +1125,8 @@ build
 INSERT INTO p1 VALUES (100, 1), (200, 1) ON CONFLICT (p) DO UPDATE SET other = p1.other + 1
 ----
 upsert p1
- ├── columns: <none>
  ├── arbiter indexes: p1_pkey
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 other:8
  ├── insert-mapping:
@@ -1173,8 +1173,8 @@ build
 UPSERT INTO p2 VALUES (1, 1), (2, 2)
 ----
 upsert p2
- ├── columns: <none>
  ├── arbiter indexes: p2_pkey
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 p2.fk:8
  ├── insert-mapping:
@@ -1230,8 +1230,8 @@ build
 INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (p) DO UPDATE SET p = excluded.p + 1
 ----
 upsert p2
- ├── columns: <none>
  ├── arbiter indexes: p2_pkey
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 fk:8
  ├── insert-mapping:
@@ -1271,8 +1271,8 @@ build
 INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (p) DO UPDATE SET fk = excluded.fk + 1
 ----
 upsert p2
- ├── columns: <none>
  ├── arbiter indexes: p2_pkey
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 p2.fk:8
  ├── insert-mapping:
@@ -1333,8 +1333,8 @@ build
 INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (fk) DO UPDATE SET p = excluded.p + 1
 ----
 upsert p2
- ├── columns: <none>
  ├── arbiter indexes: p2_fk_key
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 fk:8
  ├── insert-mapping:
@@ -1372,8 +1372,8 @@ build
 INSERT INTO p2 VALUES (1, 1), (2, 2) ON CONFLICT (fk) DO UPDATE SET fk = excluded.fk + 1
 ----
 upsert p2
- ├── columns: <none>
  ├── arbiter indexes: p2_fk_key
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 p2.fk:8
  ├── insert-mapping:
@@ -1434,8 +1434,8 @@ build
 UPSERT INTO p2(p) VALUES (1), (2)
 ----
 upsert p2
- ├── columns: <none>
  ├── arbiter indexes: p2_pkey
+ ├── columns: <none>
  ├── canary column: p:7
  ├── fetch columns: p:7 fk:8
  ├── insert-mapping:
@@ -1475,8 +1475,8 @@ build
 UPSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2)
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_pkey
+ ├── columns: <none>
  ├── canary column: k:11
  ├── fetch columns: k:11 pq.p:12 pq.q:13 pq.other:14
  ├── insert-mapping:
@@ -1564,8 +1564,8 @@ build
 UPSERT INTO pq (k) VALUES (1), (2)
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_pkey
+ ├── columns: <none>
  ├── canary column: k:9
  ├── fetch columns: k:9 p:10 q:11 other:12
  ├── insert-mapping:
@@ -1605,8 +1605,8 @@ build
 UPSERT INTO pq (k,q) VALUES (1, 1), (2, 2)
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_pkey
+ ├── columns: <none>
  ├── canary column: k:10
  ├── fetch columns: k:10 pq.p:11 pq.q:12 pq.other:13
  ├── insert-mapping:
@@ -1696,8 +1696,8 @@ build
 INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (p,q) DO UPDATE SET k = pq.k + 1
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_p_q_key
+ ├── columns: <none>
  ├── canary column: k:11
  ├── fetch columns: k:11 p:12 q:13 other:14
  ├── insert-mapping:
@@ -1742,8 +1742,8 @@ build
 INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (p,q) DO UPDATE SET p = pq.p + 1
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_p_q_key
+ ├── columns: <none>
  ├── canary column: k:11
  ├── fetch columns: k:11 pq.p:12 pq.q:13 pq.other:14
  ├── insert-mapping:
@@ -1835,8 +1835,8 @@ build
 INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (k) DO UPDATE SET other = 5
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_pkey
+ ├── columns: <none>
  ├── canary column: k:11
  ├── fetch columns: k:11 p:12 q:13 other:14
  ├── insert-mapping:
@@ -1882,8 +1882,8 @@ build
 INSERT INTO pq VALUES (1, 1, 1, 1), (2, 2, 2, 2) ON CONFLICT (k) DO UPDATE SET q = 5
 ----
 upsert pq
- ├── columns: <none>
  ├── arbiter indexes: pq_pkey
+ ├── columns: <none>
  ├── canary column: k:11
  ├── fetch columns: k:11 pq.p:12 pq.q:13 pq.other:14
  ├── insert-mapping:
@@ -2001,8 +2001,8 @@ build
 UPSERT INTO tab2 VALUES (1,NULL,NULL), (2,2,2)
 ----
 upsert tab2
- ├── columns: <none>
  ├── arbiter indexes: tab2_pkey
+ ├── columns: <none>
  ├── canary column: c:9
  ├── fetch columns: c:9 tab2.d:10 tab2.e:11
  ├── insert-mapping:
@@ -2075,8 +2075,8 @@ build
 INSERT INTO tab2 VALUES (1,1,1) ON CONFLICT (c) DO UPDATE SET e = tab2.e + 1
 ----
 upsert tab2
- ├── columns: <none>
  ├── arbiter indexes: tab2_pkey
+ ├── columns: <none>
  ├── canary column: c:9
  ├── fetch columns: c:9 tab2.d:10 tab2.e:11
  ├── insert-mapping:
@@ -2154,8 +2154,8 @@ build
 INSERT INTO tab2 VALUES (1,1,1) ON CONFLICT (e) DO UPDATE SET d = tab2.d + 1
 ----
 upsert tab2
- ├── columns: <none>
  ├── arbiter indexes: tab2_e_key
+ ├── columns: <none>
  ├── canary column: c:9
  ├── fetch columns: c:9 tab2.d:10 e:11
  ├── insert-mapping:
@@ -2227,8 +2227,8 @@ build
 UPSERT INTO self SELECT x, y, z, w FROM xyzw
 ----
 upsert self
- ├── columns: <none>
  ├── arbiter indexes: self_pkey
+ ├── columns: <none>
  ├── canary column: self.a:14
  ├── fetch columns: self.a:14 self.b:15 self.c:16 self.d:17
  ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -227,8 +227,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -310,8 +310,8 @@ UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -400,8 +400,8 @@ INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UP
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_p_q_key
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -612,8 +612,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -823,8 +823,8 @@ UPSERT INTO parent_assn_cast (p, p2) VALUES (1.23, 4.56)
 ----
 root
  ├── upsert parent_assn_cast
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_assn_cast_pkey
+ │    ├── columns: <none>
  │    ├── canary column: p:9
  │    ├── fetch columns: p:9 p2:10
  │    ├── insert-mapping:
@@ -906,8 +906,8 @@ INSERT INTO parent_assn_cast (p, p2) VALUES (1.23, 4.56) ON CONFLICT (p) DO UPDA
 ----
 root
  ├── upsert parent_assn_cast
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_assn_cast_pkey
+ │    ├── columns: <none>
  │    ├── canary column: p:9
  │    ├── fetch columns: p:9 p2:10
  │    ├── insert-mapping:
@@ -1189,8 +1189,8 @@ UPSERT INTO parent_multi_partial VALUES (1), (2)
 ----
 root
  ├── upsert parent_multi_partial
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_partial_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:8
  │    ├── fetch columns: pk:8 p:9 q:10
  │    ├── insert-mapping:
@@ -1604,8 +1604,8 @@ INSERT INTO parent_diff_type VALUES (0) ON CONFLICT (p) DO UPDATE SET p = 1
 ----
 root
  ├── upsert parent_diff_type
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_diff_type_pkey
+ │    ├── columns: <none>
  │    ├── canary column: p:5
  │    ├── fetch columns: p:5
  │    ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -357,8 +357,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -492,8 +492,8 @@ UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -630,8 +630,8 @@ INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UP
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_p_q_key
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -855,8 +855,8 @@ UPSERT INTO parent_assn_cast (p, p2) VALUES (1, 2)
 ----
 root
  ├── upsert parent_assn_cast
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_assn_cast_pkey
+ │    ├── columns: <none>
  │    ├── canary column: p:7
  │    ├── fetch columns: p:7 p2:8
  │    ├── insert-mapping:
@@ -935,8 +935,8 @@ INSERT INTO parent_assn_cast (p, p2) VALUES (1, 2) ON CONFLICT (p) DO UPDATE SET
 ----
 root
  ├── upsert parent_assn_cast
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_assn_cast_pkey
+ │    ├── columns: <none>
  │    ├── canary column: p:7
  │    ├── fetch columns: p:7 p2:8
  │    ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -279,8 +279,8 @@ UPSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -383,8 +383,8 @@ UPSERT INTO parent_multi(pk, p) VALUES (1, 10), (2, 20)
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_pkey
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:
@@ -490,8 +490,8 @@ INSERT INTO parent_multi VALUES (1, 10, 10), (2, 20, 20) ON CONFLICT (p,q) DO UP
 ----
 root
  ├── upsert parent_multi
- │    ├── columns: <none>
  │    ├── arbiter indexes: parent_multi_p_q_key
+ │    ├── columns: <none>
  │    ├── canary column: pk:9
  │    ├── fetch columns: pk:9 p:10 q:11
  │    ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -54,8 +54,8 @@ build
 UPSERT INTO kj VALUES (1, '{"a": 2}')
 ----
 upsert kj
- ├── columns: <none>
  ├── arbiter indexes: kj_pkey
+ ├── columns: <none>
  ├── canary column: k:8
  ├── fetch columns: k:8 j:9
  ├── insert-mapping:
@@ -87,8 +87,8 @@ build
 INSERT INTO kj VALUES (1, '{"a": 2}') ON CONFLICT (k) DO NOTHING
 ----
 insert kj
- ├── columns: <none>
  ├── arbiter indexes: kj_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => k:1
  │    └── column2:7 => j:2
@@ -112,8 +112,8 @@ build
 INSERT INTO kj VALUES (1, '{"a": 2}') ON CONFLICT (k) DO UPDATE SET j = '{"a": 3}'
 ----
 upsert kj
- ├── columns: <none>
  ├── arbiter indexes: kj_pkey
+ ├── columns: <none>
  ├── canary column: k:8
  ├── fetch columns: k:8 j:9
  ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -592,8 +592,8 @@ build
 INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT DO NOTHING
 ----
 insert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_pkey partial_indexes_b_c_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -659,8 +659,8 @@ build
 INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT (b, c) DO UPDATE SET b = partial_indexes.b + 1, c = 'baz'
 ----
 upsert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_b_c_key
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 c:11
  ├── insert-mapping:
@@ -724,8 +724,8 @@ build
 UPSERT INTO partial_indexes VALUES (2, 1, 'bar')
 ----
 upsert partial_indexes
- ├── columns: <none>
  ├── arbiter indexes: partial_indexes_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 c:11
  ├── insert-mapping:
@@ -791,8 +791,8 @@ build
 INSERT INTO comp VALUES (2, 1, 'Foo') ON CONFLICT DO NOTHING
 ----
 insert comp
- ├── columns: <none>
  ├── arbiter indexes: comp_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
@@ -850,8 +850,8 @@ build
 INSERT INTO comp VALUES (2, 1, 'Foo') ON CONFLICT (a) DO UPDATE SET b = comp.b + 1, c = 'Bar'
 ----
 upsert comp
- ├── columns: <none>
  ├── arbiter indexes: comp_pkey
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 b:14 c:15 d:16 e:17
  ├── insert-mapping:
@@ -937,8 +937,8 @@ build
 UPSERT INTO comp VALUES (2, 1, 'Foo')
 ----
 upsert comp
- ├── columns: <none>
  ├── arbiter indexes: comp_pkey
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 b:14 c:15 d:16 e:17
  ├── insert-mapping:
@@ -1010,8 +1010,8 @@ build
 INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey uniq_b_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1079,8 +1079,8 @@ build
 INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_b_key u2
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1174,8 +1174,8 @@ build
 INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter indexes: u3
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1230,8 +1230,8 @@ opt
 INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' AND c = 'bar' DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter indexes: u4
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => a:1
  │    ├── column2:7 => b:2
@@ -1270,8 +1270,8 @@ build
 INSERT INTO uniq VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE c = 'foo' DO UPDATE SET b = 10
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_b_key
+ ├── columns: <none>
  ├── canary column: a:10
  ├── fetch columns: a:10 b:11 c:12
  ├── insert-mapping:
@@ -1341,8 +1341,8 @@ ON CONFLICT (partial_index_put1) WHERE partial_index_put1 > 0 AND partial_index_
 DO UPDATE SET partial_index_put1 = 10, partial_index_del1 = 20
 ----
 upsert ambig
- ├── columns: <none>
  ├── arbiter indexes: ambig_partial_index_put1_key
+ ├── columns: <none>
  ├── canary column: rowid:15
  ├── fetch columns: ambig.partial_index_put1:12 ambig.partial_index_del1:13 ambig.check1:14 rowid:15
  ├── insert-mapping:
@@ -1432,8 +1432,8 @@ build
 INSERT INTO comp VALUES (1, 1, 'bar') ON CONFLICT DO NOTHING
 ----
 insert comp
- ├── columns: <none>
  ├── arbiter indexes: comp_pkey u1
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
@@ -1544,8 +1544,8 @@ build
 INSERT INTO comp VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE d = 'foo' AND e = 'bar' DO NOTHING
 ----
 insert comp
- ├── columns: <none>
  ├── arbiter indexes: u1 u2
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
@@ -1681,8 +1681,8 @@ build
 INSERT INTO comp VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE d = 'foo' AND e = 'bar' DO NOTHING
 ----
 insert comp
- ├── columns: <none>
  ├── arbiter indexes: u3
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
@@ -1761,8 +1761,8 @@ build
 INSERT INTO comp VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE d = 'foo' DO UPDATE SET b = 10
 ----
 upsert comp
- ├── columns: <none>
  ├── arbiter indexes: u1
+ ├── columns: <none>
  ├── canary column: a:14
  ├── fetch columns: a:14 b:15 c:16 d:17 e:18
  ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -1755,7 +1755,7 @@ error (0A000): unimplemented: there are multiple unique or exclusion constraints
 build
 INSERT INTO comp VALUES (1, 1, 'bar') ON CONFLICT ON CONSTRAINT u1 DO UPDATE SET b = 10
 ----
-error (42809): unique constraint "u1" for table "comp" is partial, so cannot be used as an arbiter via the ON CONSTRAINT syntax
+error (42809): unique constraint "u1" for table "comp" is partial, so it cannot be used as an arbiter via the ON CONSTRAINT syntax
 
 build
 INSERT INTO comp VALUES (1, 1, 'bar') ON CONFLICT (b) WHERE d = 'foo' DO UPDATE SET b = 10

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -1013,7 +1013,7 @@ error (42P10): there is no unique or exclusion constraint matching the ON CONFLI
 build
 INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT ON CONSTRAINT unique_a DO NOTHING
 ----
-error (42809): unique constraint "unique_a" for table "uniq_partial" is partial, so cannot be used as an arbiter via the ON CONSTRAINT syntax
+error (42809): unique constraint "unique_a" for table "uniq_partial" is partial, so it cannot be used as an arbiter via the ON CONSTRAINT syntax
 
 # On conflict clause references unique without index constraint.
 build

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -257,9 +257,9 @@ build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey uniq_v_key
  ├── arbiter constraints: unique_w unique_x_y
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => k:1
  │    ├── column2:9 => v:2
@@ -346,8 +346,8 @@ build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (w) DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter constraints: unique_w
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => uniq.k:1
  │    ├── column2:9 => uniq.v:2
@@ -402,8 +402,8 @@ build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT ON CONSTRAINT unique_w DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter constraints: unique_w
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => uniq.k:1
  │    ├── column2:9 => uniq.v:2
@@ -950,9 +950,9 @@ build
 INSERT INTO uniq_partial VALUES (1, 2, 3), (2, 2, 3) ON CONFLICT DO NOTHING
 ----
 insert uniq_partial
- ├── columns: <none>
  ├── arbiter indexes: uniq_partial_pkey
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => k:1
  │    ├── column2:7 => a:2
@@ -1020,8 +1020,8 @@ build
 INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT (a) WHERE b > 0 DO NOTHING
 ----
 insert uniq_partial
- ├── columns: <none>
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => k:1
  │    ├── column2:7 => a:2
@@ -1373,8 +1373,8 @@ INSERT INTO uniq_partial_constraint_and_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 10 DO NOTHING
 ----
 insert uniq_partial_constraint_and_index
- ├── columns: <none>
  ├── arbiter indexes: uniq_partial_constraint_and_index_a_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => uniq_partial_constraint_and_index.k:1
  │    ├── column2:7 => uniq_partial_constraint_and_index.a:2
@@ -1445,8 +1445,8 @@ INSERT INTO uniq_constraint_and_partial_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 0 DO NOTHING
 ----
 insert uniq_constraint_and_partial_index
- ├── columns: <none>
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => k:1
  │    ├── column2:7 => a:2
@@ -1489,9 +1489,9 @@ INSERT INTO uniq_partial_constraint_and_partial_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 10 DO NOTHING
 ----
 insert uniq_partial_constraint_and_partial_index
- ├── columns: <none>
  ├── arbiter indexes: uniq_partial_constraint_and_partial_index_a_key
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => k:1
  │    ├── column2:7 => a:2

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -18,8 +18,8 @@ build
 UPSERT INTO uniq VALUES (1, 1, 1, 1, 1), (2, 2, 2, 2, 2)
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey
+ ├── columns: <none>
  ├── canary column: uniq.k:13
  ├── fetch columns: uniq.k:13 uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  ├── insert-mapping:
@@ -105,8 +105,8 @@ build
 UPSERT INTO uniq (k, v, w) VALUES (1, 1, 1), (2, 2, 2)
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey
+ ├── columns: <none>
  ├── canary column: uniq.k:13
  ├── fetch columns: uniq.k:13 uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  ├── insert-mapping:
@@ -198,8 +198,8 @@ build
 UPSERT INTO uniq (k, w, x) VALUES (1, NULL, 1), (2, NULL, NULL)
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey
+ ├── columns: <none>
  ├── canary column: uniq.k:13
  ├── fetch columns: uniq.k:13 uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  ├── insert-mapping:
@@ -291,8 +291,8 @@ build
 UPSERT INTO uniq SELECT k, v, w FROM other
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey
+ ├── columns: <none>
  ├── canary column: uniq.k:18
  ├── fetch columns: uniq.k:18 uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
  ├── insert-mapping:
@@ -385,8 +385,8 @@ build
 INSERT INTO uniq VALUES (100, 1), (200, 1) ON CONFLICT (k) DO UPDATE SET w = excluded.w + 1
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey
+ ├── columns: <none>
  ├── canary column: uniq.k:12
  ├── fetch columns: uniq.k:12 uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16
  ├── insert-mapping:
@@ -481,8 +481,8 @@ build
 INSERT INTO uniq SELECT k, v FROM other ON CONFLICT (k) DO UPDATE SET w = uniq.k + 1
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey
+ ├── columns: <none>
  ├── canary column: uniq.k:18
  ├── fetch columns: uniq.k:18 uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
  ├── insert-mapping:
@@ -576,8 +576,8 @@ build
 INSERT INTO uniq VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (w) DO UPDATE SET w = 10
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter constraints: unique_w
+ ├── columns: <none>
  ├── canary column: uniq.k:13
  ├── fetch columns: uniq.k:13 uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  ├── insert-mapping:
@@ -673,8 +673,8 @@ build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT (x, y) DO UPDATE SET v = 10
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter constraints: unique_x_y
+ ├── columns: <none>
  ├── canary column: uniq.k:13
  ├── fetch columns: uniq.k:13 uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  ├── insert-mapping:
@@ -903,8 +903,8 @@ build
 INSERT INTO uniq_overlaps_pk VALUES (100, 10, 1, 1), (200, 20, 2, 2) ON CONFLICT (a) DO UPDATE SET a = 10
 ----
 upsert uniq_overlaps_pk
- ├── columns: <none>
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── canary column: uniq_overlaps_pk.a:11
  ├── fetch columns: uniq_overlaps_pk.a:11 uniq_overlaps_pk.b:12 uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
  ├── insert-mapping:
@@ -1007,8 +1007,8 @@ build
 INSERT INTO uniq_overlaps_pk VALUES (1, 2, 3, 4) ON CONFLICT (c, d) DO UPDATE SET b = 10
 ----
 upsert uniq_overlaps_pk
- ├── columns: <none>
  ├── arbiter constraints: unique_c_d
+ ├── columns: <none>
  ├── canary column: uniq_overlaps_pk.a:11
  ├── fetch columns: uniq_overlaps_pk.a:11 uniq_overlaps_pk.b:12 uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
  ├── insert-mapping:
@@ -1103,8 +1103,8 @@ build
 UPSERT INTO uniq_hidden_pk (a, b, d) VALUES (1, 1, 1), (2, 2, 2)
 ----
 upsert uniq_hidden_pk
- ├── columns: <none>
  ├── arbiter indexes: uniq_hidden_pk_pkey
+ ├── columns: <none>
  ├── canary column: uniq_hidden_pk.rowid:17
  ├── fetch columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17
  ├── insert-mapping:
@@ -1296,8 +1296,8 @@ build
 INSERT INTO uniq_hidden_pk VALUES (1, 2, 3, 4) ON CONFLICT (a, b, d) DO UPDATE SET a = 10
 ----
 upsert uniq_hidden_pk
- ├── columns: <none>
  ├── arbiter constraints: unique_a_b_d
+ ├── columns: <none>
  ├── canary column: uniq_hidden_pk.rowid:17
  ├── fetch columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17
  ├── insert-mapping:
@@ -1427,8 +1427,8 @@ build
 UPSERT INTO uniq_fk_parent (a) VALUES (1)
 ----
 upsert uniq_fk_parent
- ├── columns: <none>
  ├── arbiter indexes: uniq_fk_parent_pkey
+ ├── columns: <none>
  ├── canary column: uniq_fk_parent.rowid:8
  ├── fetch columns: uniq_fk_parent.a:7 uniq_fk_parent.rowid:8
  ├── insert-mapping:
@@ -1537,8 +1537,8 @@ build
 INSERT INTO t VALUES (1) ON CONFLICT (i) WHERE i > 0 DO UPDATE SET i = 2
 ----
 upsert t
- ├── columns: <none>
  ├── arbiter constraints: i2
+ ├── columns: <none>
  ├── canary column: t.rowid:8
  ├── fetch columns: t.i:7 t.rowid:8
  ├── insert-mapping:
@@ -1610,8 +1610,8 @@ build
 INSERT INTO uniq VALUES (1, 2, 3, 4, 5) ON CONFLICT ON CONSTRAINT unique_w DO UPDATE SET v=1
 ----
 upsert uniq
- ├── columns: <none>
  ├── arbiter constraints: unique_w
+ ├── columns: <none>
  ├── canary column: uniq.k:13
  ├── fetch columns: uniq.k:13 uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
  ├── insert-mapping:
@@ -1777,8 +1777,8 @@ build
 INSERT INTO uniq_partial VALUES (100, 10, 1), (200, 20, 2) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = 10
 ----
 upsert uniq_partial
- ├── columns: <none>
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── canary column: uniq_partial.k:10
  ├── fetch columns: uniq_partial.k:10 uniq_partial.a:11 uniq_partial.b:12
  ├── insert-mapping:
@@ -1879,8 +1879,8 @@ INSERT INTO uniq_partial_constraint_and_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 10 DO UPDATE SET a = 10
 ----
 upsert uniq_partial_constraint_and_index
- ├── columns: <none>
  ├── arbiter indexes: uniq_partial_constraint_and_index_a_key
+ ├── columns: <none>
  ├── canary column: uniq_partial_constraint_and_index.k:10
  ├── fetch columns: uniq_partial_constraint_and_index.k:10 uniq_partial_constraint_and_index.a:11 uniq_partial_constraint_and_index.b:12
  ├── insert-mapping:
@@ -1959,8 +1959,8 @@ INSERT INTO uniq_constraint_and_partial_index VALUES (1, 1, 1)
 ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = 10
 ----
 upsert uniq_constraint_and_partial_index
- ├── columns: <none>
  ├── arbiter constraints: unique_a
+ ├── columns: <none>
  ├── canary column: uniq_constraint_and_partial_index.k:10
  ├── fetch columns: uniq_constraint_and_partial_index.k:10 uniq_constraint_and_partial_index.a:11 uniq_constraint_and_partial_index.b:12
  ├── insert-mapping:
@@ -2057,8 +2057,8 @@ build
 UPSERT INTO uniq_computed_pk (i, s, d) VALUES (1, 'a', 1.0), (2, 'b', 2.0)
 ----
 upsert uniq_computed_pk
- ├── columns: <none>
  ├── arbiter indexes: uniq_computed_pk_pkey
+ ├── columns: <none>
  ├── canary column: uniq_computed_pk.c_i_expr:18
  ├── fetch columns: uniq_computed_pk.i:15 uniq_computed_pk.s:16 uniq_computed_pk.d:17 uniq_computed_pk.c_i_expr:18 uniq_computed_pk.c_s:19 uniq_computed_pk.c_d:20 uniq_computed_pk.c_d_expr:21
  ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -1859,7 +1859,7 @@ error (42P10): there is no unique or exclusion constraint matching the ON CONFLI
 build
 INSERT INTO uniq_partial VALUES (1, 2, 3) ON CONFLICT ON CONSTRAINT unique_a DO UPDATE SET a = 2
 ----
-error (42809): unique constraint "unique_a" for table "uniq_partial" is partial, so cannot be used as an arbiter via the ON CONSTRAINT syntax
+error (42809): unique constraint "unique_a" for table "uniq_partial" is partial, so it cannot be used as an arbiter via the ON CONSTRAINT syntax
 
 exec-ddl
 CREATE TABLE uniq_partial_constraint_and_index (

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -122,8 +122,8 @@ ON CONFLICT (a) DO
 UPDATE SET a=5
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_a_key
+ ├── columns: <none>
  ├── canary column: a:14
  ├── fetch columns: a:14 b:15 c:16 rowid:17
  ├── insert-mapping:
@@ -263,8 +263,8 @@ UPDATE SET b=10
 WHERE abc.a>0
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_a_key
+ ├── columns: <none>
  ├── canary column: a:14
  ├── fetch columns: a:14 b:15 c:16 rowid:17
  ├── insert-mapping:
@@ -418,8 +418,8 @@ ON CONFLICT (a) DO
 UPDATE SET a=tab.a*excluded.a
 ----
 upsert abc [as=tab]
- ├── columns: <none>
  ├── arbiter indexes: abc_a_key
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 rowid:14
  ├── insert-mapping:
@@ -483,8 +483,8 @@ ON CONFLICT (c, b) DO
 UPDATE SET a=5
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_b_c_key
+ ├── columns: <none>
  ├── canary column: rowid:14
  ├── fetch columns: a:11 b:12 c:13 rowid:14
  ├── insert-mapping:
@@ -577,8 +577,8 @@ VALUES (1, 2, 3), (4, 5, 6)
 ON CONFLICT DO NOTHING
 ----
 insert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey xyz_y_z_key xyz_z_y_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => x:1
  │    ├── column2:7 => y:2
@@ -635,8 +635,8 @@ VALUES (1, 2, 3), (4, 5, 6)
 ON CONFLICT (y, z) DO NOTHING
 ----
 insert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_y_z_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => x:1
  │    ├── column2:7 => y:2
@@ -664,8 +664,8 @@ INSERT INTO uniq VALUES ('x2', 'y1', 'z2'), ('x2', 'y2', 'z2'), ('x2', 'y2', 'z2
 ON CONFLICT DO NOTHING
 ----
 insert uniq
- ├── columns: <none>
  ├── arbiter indexes: uniq_pkey uniq_y_key uniq_z_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:6 => x:1
  │    ├── column2:7 => y:2
@@ -817,8 +817,8 @@ ON CONFLICT (a) DO
 UPDATE SET (b, a)=(SELECT x, y+excluded.b FROM xyz WHERE x=excluded.a)
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_a_key
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 rowid:14
  ├── insert-mapping:
@@ -895,8 +895,8 @@ ON CONFLICT (a) DO
 UPDATE SET a=DEFAULT, b=DEFAULT
 ----
 upsert abc
- ├── columns: <none>
  ├── arbiter indexes: abc_a_key
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 rowid:14
  ├── insert-mapping:
@@ -966,8 +966,8 @@ ON CONFLICT (m) DO
 UPDATE SET m=mutation.m+1
 ----
 upsert mutation
- ├── columns: <none>
  ├── arbiter indexes: mutation_pkey
+ ├── columns: <none>
  ├── canary column: m:12
  ├── fetch columns: m:12 n:13 o:14 p:15 q:16
  ├── insert-mapping:
@@ -1037,8 +1037,8 @@ build
 UPSERT INTO xyz VALUES (1)
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:8
  ├── fetch columns: x:8 y:9 z:10
  ├── insert-mapping:
@@ -1159,8 +1159,8 @@ build
 UPSERT INTO xyz (z, x, y) VALUES (1, 2, 3)
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:9
  ├── fetch columns: x:9 y:10 z:11
  ├── insert-mapping:
@@ -1214,8 +1214,8 @@ build
 UPSERT INTO checks (a, b, c) VALUES (1, 2, 3)
 ----
 upsert checks
- ├── columns: <none>
  ├── arbiter indexes: checks_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14
  ├── insert-mapping:
@@ -1272,8 +1272,8 @@ build
 UPSERT INTO mutation (m, n) VALUES (1, 2)
 ----
 upsert mutation
- ├── columns: <none>
  ├── arbiter indexes: mutation_pkey
+ ├── columns: <none>
  ├── canary column: m:12
  ├── fetch columns: m:12 n:13 o:14 p:15 q:16
  ├── insert-mapping:
@@ -1330,8 +1330,8 @@ build
 UPSERT INTO mutation VALUES (1, 2)
 ----
 upsert mutation
- ├── columns: <none>
  ├── arbiter indexes: mutation_pkey
+ ├── columns: <none>
  ├── canary column: m:12
  ├── fetch columns: m:12 n:13 o:14 p:15 q:16
  ├── insert-mapping:
@@ -1397,8 +1397,8 @@ build
 INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b=3, c=4
 ----
 upsert checks
- ├── columns: <none>
  ├── arbiter indexes: checks_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14
  ├── insert-mapping:
@@ -1470,8 +1470,8 @@ build
 INSERT INTO checks (a, b) VALUES (1, 2) ON CONFLICT (a) DO NOTHING
 ----
 insert checks
- ├── columns: <none>
  ├── arbiter indexes: checks_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:7 => a:1
  │    ├── column2:8 => b:2
@@ -1521,8 +1521,8 @@ build
 UPSERT INTO checks (a, b) VALUES (1, 2)
 ----
 upsert checks
- ├── columns: <none>
  ├── arbiter indexes: checks_pkey
+ ├── columns: <none>
  ├── canary column: a:11
  ├── fetch columns: a:11 b:12 c:13 d:14
  ├── insert-mapping:
@@ -1588,8 +1588,8 @@ SELECT a, b FROM abc
 ON CONFLICT (a) DO UPDATE SET a=excluded.a, b=(SELECT x FROM xyz WHERE x=checks.a)
 ----
 upsert checks
- ├── columns: <none>
  ├── arbiter indexes: checks_pkey
+ ├── columns: <none>
  ├── canary column: checks.a:15
  ├── fetch columns: checks.a:15 checks.b:16 checks.c:17 d:18
  ├── insert-mapping:
@@ -1674,8 +1674,8 @@ SELECT a, b, c FROM abc ORDER BY a
 ON CONFLICT (z, y) DO UPDATE SET y=5
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_y_z_key
+ ├── columns: <none>
  ├── canary column: x:12
  ├── fetch columns: x:12 y:13 z:14
  ├── insert-mapping:
@@ -1724,8 +1724,8 @@ build
 UPSERT INTO decimals (a, b) VALUES (1.1, ARRAY[0.95])
 ----
 upsert decimals
- ├── columns: <none>
  ├── arbiter indexes: decimals_pkey
+ ├── columns: <none>
  ├── canary column: a:15
  ├── fetch columns: a:15 b:16 c:17 d:18
  ├── insert-mapping:
@@ -1804,8 +1804,8 @@ build
 UPSERT INTO decimals (a) VALUES (1.1)
 ----
 upsert decimals
- ├── columns: <none>
  ├── arbiter indexes: decimals_pkey
+ ├── columns: <none>
  ├── canary column: a:14
  ├── fetch columns: a:14 b:15 c:16 d:17
  ├── insert-mapping:
@@ -1882,8 +1882,8 @@ assign-placeholders-build query-args=(1.1)
 UPSERT INTO decimals (a) VALUES ($1)
 ----
 upsert decimals
- ├── columns: <none>
  ├── arbiter indexes: decimals_pkey
+ ├── columns: <none>
  ├── canary column: a:14
  ├── fetch columns: a:14 b:15 c:16 d:17
  ├── insert-mapping:
@@ -1962,8 +1962,8 @@ ON CONFLICT (a)
 DO UPDATE SET b=ARRAY[0.99]
 ----
 upsert decimals
- ├── columns: <none>
  ├── arbiter indexes: decimals_pkey
+ ├── columns: <none>
  ├── canary column: a:15
  ├── fetch columns: a:15 b:16 c:17 d:18
  ├── insert-mapping:
@@ -2054,8 +2054,8 @@ ON CONFLICT (a)
 DO UPDATE SET b=$3
 ----
 upsert decimals
- ├── columns: <none>
  ├── arbiter indexes: decimals_pkey
+ ├── columns: <none>
  ├── canary column: a:15
  ├── fetch columns: a:15 b:16 c:17 d:18
  ├── insert-mapping:
@@ -2144,8 +2144,8 @@ build
 UPSERT INTO assn_cast (k, c, qc, i, s) VALUES (1.0::DECIMAL, ' ', 'foo', '1', 2)
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:22
  ├── fetch columns: k:22 c:23 qc:24 i:25 s:26 d:27 d_comp:28
  ├── insert-mapping:
@@ -2229,8 +2229,8 @@ assign-placeholders-build query-args=(1.0, ' ', 'foo', '1')
 UPSERT INTO assn_cast (k, c, qc, i) VALUES ($1::DECIMAL, $2, $3, $4)
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:21
  ├── fetch columns: k:21 c:22 qc:23 i:24 s:25 d:26 d_comp:27
  ├── insert-mapping:
@@ -2313,8 +2313,8 @@ build
 INSERT INTO assn_cast (k, c, qc, i, s) VALUES (1.0::DECIMAL, ' ', 'foo', '1', 2) ON CONFLICT DO NOTHING
 ----
 insert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── k_cast:15 => k:1
  │    ├── c_cast:16 => c:2
@@ -2382,8 +2382,8 @@ INSERT INTO assn_cast (k, c, qc, i, s) VALUES (1.0::DECIMAL, 'a', 'b', 1, 'c')
 ON CONFLICT (k) DO UPDATE SET c = ' ', qc = 'foo', i = '1', s = 2
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:21
  ├── fetch columns: k:21 c:22 qc:23 i:24 s:25 d:26 d_comp:27
  ├── insert-mapping:
@@ -2485,8 +2485,8 @@ build
 UPSERT INTO assn_cast (k, i) VALUES (1, DEFAULT)
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:19
  ├── fetch columns: k:19 c:20 qc:21 i:22 s:23 d:24 d_comp:25
  ├── insert-mapping:
@@ -2567,8 +2567,8 @@ build
 INSERT INTO assn_cast (k, i) VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET i = DEFAULT
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:18
  ├── fetch columns: k:18 c:19 qc:20 i:21 s:22 d:23 d_comp:24
  ├── insert-mapping:
@@ -2655,8 +2655,8 @@ build
 UPSERT INTO assn_cast (k, d) VALUES (1, 1.45::DECIMAL(10, 2))
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:20
  ├── fetch columns: k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26
  ├── insert-mapping:
@@ -2739,8 +2739,8 @@ assign-placeholders-build query-args=(1.45::DECIMAL(10, 2))
 UPSERT INTO assn_cast (k, d) VALUES (1, $1)
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:20
  ├── fetch columns: k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26
  ├── insert-mapping:
@@ -2823,8 +2823,8 @@ build
 INSERT INTO assn_cast (k, d) VALUES (1, 1.45::DECIMAL(10, 2)) ON CONFLICT DO NOTHING
 ----
 insert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:10 => k:1
  │    ├── c_default:13 => c:2
@@ -2894,8 +2894,8 @@ build
 INSERT INTO assn_cast (k, d) VALUES (1, 1.45) ON CONFLICT (k) DO UPDATE SET d = 2.67::DECIMAL(10, 2)
 ----
 upsert assn_cast
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_pkey
+ ├── columns: <none>
  ├── canary column: k:20
  ├── fetch columns: k:20 c:21 qc:22 i:23 s:24 d:25 d_comp:26
  ├── insert-mapping:
@@ -2997,8 +2997,8 @@ build
 INSERT INTO assn_cast_on_update (k, i) VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET i = 3
 ----
 upsert assn_cast_on_update
- ├── columns: <none>
  ├── arbiter indexes: assn_cast_on_update_pkey
+ ├── columns: <none>
  ├── canary column: k:12
  ├── fetch columns: k:12 i:13 d:14 d2:15 d_comp:16
  ├── insert-mapping:
@@ -3143,8 +3143,8 @@ build
 UPSERT INTO on_update_bare (a) VALUES (1)
 ----
 upsert on_update_bare
- ├── columns: <none>
  ├── arbiter indexes: on_update_bare_pkey
+ ├── columns: <none>
  ├── canary column: a:7
  ├── fetch columns: a:7 v:8
  ├── insert-mapping:
@@ -3198,8 +3198,8 @@ build
 UPSERT INTO on_update_with_default (a, b) VALUES (1, 2)
 ----
 upsert on_update_with_default
- ├── columns: <none>
  ├── arbiter indexes: on_update_with_default_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 v:11
  ├── insert-mapping:
@@ -3247,8 +3247,8 @@ ON CONFLICT (a) DO
 UPDATE SET (a, v) = (5, 4)
 ----
 upsert on_update_with_default
- ├── columns: <none>
  ├── arbiter indexes: on_update_with_default_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 v:11
  ├── insert-mapping:
@@ -3298,8 +3298,8 @@ ON CONFLICT (a) DO
 UPDATE SET a=5
 ----
 upsert on_update_with_default
- ├── columns: <none>
  ├── arbiter indexes: on_update_with_default_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 v:11
  ├── insert-mapping:
@@ -3374,8 +3374,8 @@ build
 UPSERT INTO generated_as_identity (a) VALUES (2)
 ----
 upsert generated_as_identity
- ├── columns: <none>
  ├── arbiter indexes: generated_as_identity_pkey
+ ├── columns: <none>
  ├── canary column: rowid:14
  ├── fetch columns: a:11 b:12 c:13 rowid:14
  ├── insert-mapping:
@@ -3426,8 +3426,8 @@ build
 UPSERT INTO generated_as_identity (a, c) VALUES (3, 30)
 ----
 upsert generated_as_identity
- ├── columns: <none>
  ├── arbiter indexes: generated_as_identity_pkey
+ ├── columns: <none>
  ├── canary column: rowid:14
  ├── fetch columns: a:11 b:12 c:13 rowid:14
  ├── insert-mapping:
@@ -3478,8 +3478,8 @@ ON CONFLICT ON CONSTRAINT xyz_pkey DO
 UPDATE SET x=5
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:9
  ├── fetch columns: x:9 y:10 z:11
  ├── insert-mapping:
@@ -3527,8 +3527,8 @@ ON CONFLICT ON CONSTRAINT xyz_y_z_key DO
 UPDATE SET x=5
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_y_z_key
+ ├── columns: <none>
  ├── canary column: x:9
  ├── fetch columns: x:9 y:10 z:11
  ├── insert-mapping:
@@ -3575,8 +3575,8 @@ ON CONFLICT ON CONSTRAINT xyz_z_y_key DO
 UPDATE SET x=5
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_z_y_key
+ ├── columns: <none>
  ├── canary column: x:9
  ├── fetch columns: x:9 y:10 z:11
  ├── insert-mapping:

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -3623,3 +3623,521 @@ ON CONFLICT ON CONSTRAINT no_such_constraint DO
 UPDATE SET x=5
 ----
 error (42704): constraint "no_such_constraint" for table "xyz" does not exist
+
+exec-ddl
+CREATE TABLE min_arbiters (
+  a INT,
+  b INT,
+  c INT,
+  UNIQUE WITHOUT INDEX (b),
+  UNIQUE WITHOUT INDEX (c) WHERE a > 0
+)
+----
+
+exec-ddl
+CREATE UNIQUE INDEX redundant ON min_arbiters (a, b)
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      └── upsert-distinct-on
+           ├── project
+           │    ├── upsert-distinct-on
+           │    │    ├── upsert-distinct-on
+           │    │    │    ├── anti-join (hash)
+           │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    │    ├── project
+           │    │    │    │    │    │    │    ├── values
+           │    │    │    │    │    │    │    │    └── (1,)
+           │    │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │    │         ├── NULL::INT8
+           │    │    │    │    │    │    │         └── unique_rowid()
+           │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │         └── rowid_default = rowid
+           │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── b_default = b
+           │    │    │    │    ├── select
+           │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── a > 0
+           │    │    │    │    └── filters
+           │    │    │    │         ├── b_default = c
+           │    │    │    │         └── column1 > 0
+           │    │    │    └── aggregations
+           │    │    │         ├── first-agg
+           │    │    │         │    └── column1
+           │    │    │         └── first-agg
+           │    │    │              └── b_default
+           │    │    └── aggregations
+           │    │         ├── first-agg
+           │    │         │    └── column1
+           │    │         └── first-agg
+           │    │              └── rowid_default
+           │    └── projections
+           │         └── (column1 > 0) OR NULL::BOOL
+           └── aggregations
+                ├── first-agg
+                │    └── column1
+                └── first-agg
+                     └── rowid_default
+
+exec-ddl
+DROP INDEX redundant
+----
+
+exec-ddl
+CREATE UNIQUE INDEX redundant ON min_arbiters (a, b, c)
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      └── upsert-distinct-on
+           ├── project
+           │    ├── upsert-distinct-on
+           │    │    ├── upsert-distinct-on
+           │    │    │    ├── anti-join (hash)
+           │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    │    ├── project
+           │    │    │    │    │    │    │    ├── values
+           │    │    │    │    │    │    │    │    └── (1,)
+           │    │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │    │         ├── NULL::INT8
+           │    │    │    │    │    │    │         └── unique_rowid()
+           │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │         └── rowid_default = rowid
+           │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── b_default = b
+           │    │    │    │    ├── select
+           │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         └── a > 0
+           │    │    │    │    └── filters
+           │    │    │    │         ├── b_default = c
+           │    │    │    │         └── column1 > 0
+           │    │    │    └── aggregations
+           │    │    │         ├── first-agg
+           │    │    │         │    └── column1
+           │    │    │         └── first-agg
+           │    │    │              └── b_default
+           │    │    └── aggregations
+           │    │         ├── first-agg
+           │    │         │    └── column1
+           │    │         └── first-agg
+           │    │              └── rowid_default
+           │    └── projections
+           │         └── (column1 > 0) OR NULL::BOOL
+           └── aggregations
+                ├── first-agg
+                │    └── column1
+                └── first-agg
+                     └── rowid_default
+
+exec-ddl
+DROP INDEX redundant
+----
+
+exec-ddl
+CREATE UNIQUE INDEX redundant ON min_arbiters (b, c) WHERE a > 0
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      ├── project
+      │    └── upsert-distinct-on
+      │         ├── project
+      │         │    ├── upsert-distinct-on
+      │         │    │    ├── upsert-distinct-on
+      │         │    │    │    ├── anti-join (hash)
+      │         │    │    │    │    ├── anti-join (hash)
+      │         │    │    │    │    │    ├── anti-join (hash)
+      │         │    │    │    │    │    │    ├── project
+      │         │    │    │    │    │    │    │    ├── values
+      │         │    │    │    │    │    │    │    │    └── (1,)
+      │         │    │    │    │    │    │    │    └── projections
+      │         │    │    │    │    │    │    │         ├── NULL::INT8
+      │         │    │    │    │    │    │    │         └── unique_rowid()
+      │         │    │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │    │    │    │    │         └── redundant: filters
+      │         │    │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │         └── rowid_default = rowid
+      │         │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │    │    │    │         └── redundant: filters
+      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── b_default = b
+      │         │    │    │    │    ├── select
+      │         │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │    │    │    │         └── redundant: filters
+      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── a > 0
+      │         │    │    │    │    └── filters
+      │         │    │    │    │         ├── b_default = c
+      │         │    │    │    │         └── column1 > 0
+      │         │    │    │    └── aggregations
+      │         │    │    │         ├── first-agg
+      │         │    │    │         │    └── column1
+      │         │    │    │         └── first-agg
+      │         │    │    │              └── b_default
+      │         │    │    └── aggregations
+      │         │    │         ├── first-agg
+      │         │    │         │    └── column1
+      │         │    │         └── first-agg
+      │         │    │              └── rowid_default
+      │         │    └── projections
+      │         │         └── (column1 > 0) OR NULL::BOOL
+      │         └── aggregations
+      │              ├── first-agg
+      │              │    └── column1
+      │              └── first-agg
+      │                   └── rowid_default
+      └── projections
+           └── column1 > 0
+
+exec-ddl
+DROP INDEX redundant
+----
+
+exec-ddl
+CREATE UNIQUE INDEX redundant ON min_arbiters (b, c) WHERE a > 0
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      ├── project
+      │    └── upsert-distinct-on
+      │         ├── project
+      │         │    ├── upsert-distinct-on
+      │         │    │    ├── upsert-distinct-on
+      │         │    │    │    ├── anti-join (hash)
+      │         │    │    │    │    ├── anti-join (hash)
+      │         │    │    │    │    │    ├── anti-join (hash)
+      │         │    │    │    │    │    │    ├── project
+      │         │    │    │    │    │    │    │    ├── values
+      │         │    │    │    │    │    │    │    │    └── (1,)
+      │         │    │    │    │    │    │    │    └── projections
+      │         │    │    │    │    │    │    │         ├── NULL::INT8
+      │         │    │    │    │    │    │    │         └── unique_rowid()
+      │         │    │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │    │    │    │    │         └── redundant: filters
+      │         │    │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    └── filters
+      │         │    │    │    │    │    │         └── rowid_default = rowid
+      │         │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │    │    │    │         └── redundant: filters
+      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── b_default = b
+      │         │    │    │    │    ├── select
+      │         │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │    │    │    │         └── redundant: filters
+      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    └── filters
+      │         │    │    │    │    │         └── a > 0
+      │         │    │    │    │    └── filters
+      │         │    │    │    │         ├── b_default = c
+      │         │    │    │    │         └── column1 > 0
+      │         │    │    │    └── aggregations
+      │         │    │    │         ├── first-agg
+      │         │    │    │         │    └── column1
+      │         │    │    │         └── first-agg
+      │         │    │    │              └── b_default
+      │         │    │    └── aggregations
+      │         │    │         ├── first-agg
+      │         │    │         │    └── column1
+      │         │    │         └── first-agg
+      │         │    │              └── rowid_default
+      │         │    └── projections
+      │         │         └── (column1 > 0) OR NULL::BOOL
+      │         └── aggregations
+      │              ├── first-agg
+      │              │    └── column1
+      │              └── first-agg
+      │                   └── rowid_default
+      └── projections
+           └── column1 > 0
+
+exec-ddl
+DROP INDEX redundant
+----
+
+exec-ddl
+CREATE UNIQUE INDEX not_redundant ON min_arbiters (b, c) WHERE a > 10
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey not_redundant
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      ├── project
+      │    └── upsert-distinct-on
+      │         ├── project
+      │         │    ├── upsert-distinct-on
+      │         │    │    ├── project
+      │         │    │    │    └── upsert-distinct-on
+      │         │    │    │         ├── project
+      │         │    │    │         │    ├── upsert-distinct-on
+      │         │    │    │         │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    │    │    │    ├── project
+      │         │    │    │         │    │    │    │    │    │    │    ├── values
+      │         │    │    │         │    │    │    │    │    │    │    │    └── (1,)
+      │         │    │    │         │    │    │    │    │    │    │    └── projections
+      │         │    │    │         │    │    │    │    │    │    │         ├── NULL::INT8
+      │         │    │    │         │    │    │    │    │    │    │         └── unique_rowid()
+      │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │    │    │         └── rowid_default = rowid
+      │         │    │    │         │    │    │    │    │    ├── select
+      │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │    │    │         └── a > 10
+      │         │    │    │         │    │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │    │         ├── b_default = b
+      │         │    │    │         │    │    │    │    │         ├── b_default = c
+      │         │    │    │         │    │    │    │    │         └── column1 > 10
+      │         │    │    │         │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │         └── b_default = b
+      │         │    │    │         │    │    │    ├── select
+      │         │    │    │         │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │         └── a > 0
+      │         │    │    │         │    │    │    └── filters
+      │         │    │    │         │    │    │         ├── b_default = c
+      │         │    │    │         │    │    │         └── column1 > 0
+      │         │    │    │         │    │    └── aggregations
+      │         │    │    │         │    │         ├── first-agg
+      │         │    │    │         │    │         │    └── column1
+      │         │    │    │         │    │         └── first-agg
+      │         │    │    │         │    │              └── b_default
+      │         │    │    │         │    └── projections
+      │         │    │    │         │         └── (column1 > 10) OR NULL::BOOL
+      │         │    │    │         └── aggregations
+      │         │    │    │              ├── first-agg
+      │         │    │    │              │    └── column1
+      │         │    │    │              └── first-agg
+      │         │    │    │                   └── rowid_default
+      │         │    │    └── aggregations
+      │         │    │         ├── first-agg
+      │         │    │         │    └── column1
+      │         │    │         └── first-agg
+      │         │    │              └── rowid_default
+      │         │    └── projections
+      │         │         └── (column1 > 0) OR NULL::BOOL
+      │         └── aggregations
+      │              ├── first-agg
+      │              │    └── column1
+      │              └── first-agg
+      │                   └── rowid_default
+      └── projections
+           └── column1 > 10
+
+exec-ddl
+DROP INDEX not_redundant
+----
+
+exec-ddl
+CREATE UNIQUE INDEX not_redundant ON min_arbiters (a, b) WHERE c > 0
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey not_redundant
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      ├── project
+      │    └── upsert-distinct-on
+      │         ├── project
+      │         │    ├── upsert-distinct-on
+      │         │    │    ├── project
+      │         │    │    │    └── upsert-distinct-on
+      │         │    │    │         ├── project
+      │         │    │    │         │    ├── upsert-distinct-on
+      │         │    │    │         │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    │    │    ├── anti-join (hash)
+      │         │    │    │         │    │    │    │    │    │    ├── project
+      │         │    │    │         │    │    │    │    │    │    │    ├── values
+      │         │    │    │         │    │    │    │    │    │    │    │    └── (1,)
+      │         │    │    │         │    │    │    │    │    │    │    └── projections
+      │         │    │    │         │    │    │    │    │    │    │         ├── NULL::INT8
+      │         │    │    │         │    │    │    │    │    │    │         └── unique_rowid()
+      │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │    │    │         └── rowid_default = rowid
+      │         │    │    │         │    │    │    │    │    ├── select
+      │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │    │    │         └── c > 0
+      │         │    │    │         │    │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │    │         ├── column1 = a
+      │         │    │    │         │    │    │    │    │         ├── b_default = b
+      │         │    │    │         │    │    │    │    │         └── b_default > 0
+      │         │    │    │         │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │         └── b_default = b
+      │         │    │    │         │    │    │    ├── select
+      │         │    │    │         │    │    │    │    ├── scan min_arbiters
+      │         │    │    │         │    │    │    │    │    └── partial index predicates
+      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    └── filters
+      │         │    │    │         │    │    │    │         └── a > 0
+      │         │    │    │         │    │    │    └── filters
+      │         │    │    │         │    │    │         ├── b_default = c
+      │         │    │    │         │    │    │         └── column1 > 0
+      │         │    │    │         │    │    └── aggregations
+      │         │    │    │         │    │         ├── first-agg
+      │         │    │    │         │    │         │    └── column1
+      │         │    │    │         │    │         └── first-agg
+      │         │    │    │         │    │              └── b_default
+      │         │    │    │         │    └── projections
+      │         │    │    │         │         └── (b_default > 0) OR NULL::BOOL
+      │         │    │    │         └── aggregations
+      │         │    │    │              └── first-agg
+      │         │    │    │                   └── rowid_default
+      │         │    │    └── aggregations
+      │         │    │         ├── first-agg
+      │         │    │         │    └── column1
+      │         │    │         └── first-agg
+      │         │    │              └── rowid_default
+      │         │    └── projections
+      │         │         └── (column1 > 0) OR NULL::BOOL
+      │         └── aggregations
+      │              ├── first-agg
+      │              │    └── column1
+      │              └── first-agg
+      │                   └── rowid_default
+      └── projections
+           └── b_default > 0
+
+exec-ddl
+DROP INDEX not_redundant
+----
+
+exec-ddl
+CREATE UNIQUE INDEX not_redundant ON min_arbiters (a, c)
+----
+
+build format=hide-all
+INSERT INTO min_arbiters (a) VALUES (1) ON CONFLICT DO NOTHING
+----
+insert min_arbiters
+ ├── arbiter indexes: min_arbiters_pkey not_redundant
+ ├── arbiter constraints: unique_b unique_c
+ └── project
+      └── upsert-distinct-on
+           ├── project
+           │    ├── upsert-distinct-on
+           │    │    ├── upsert-distinct-on
+           │    │    │    ├── upsert-distinct-on
+           │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    │    │    ├── anti-join (hash)
+           │    │    │    │    │    │    │    │    ├── project
+           │    │    │    │    │    │    │    │    │    ├── values
+           │    │    │    │    │    │    │    │    │    │    └── (1,)
+           │    │    │    │    │    │    │    │    │    └── projections
+           │    │    │    │    │    │    │    │    │         ├── NULL::INT8
+           │    │    │    │    │    │    │    │    │         └── unique_rowid()
+           │    │    │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │    │    │         └── rowid_default = rowid
+           │    │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │    │         ├── column1 = a
+           │    │    │    │    │    │    │         └── b_default = c
+           │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │         └── b_default = b
+           │    │    │    │    │    ├── select
+           │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── filters
+           │    │    │    │    │    │         └── a > 0
+           │    │    │    │    │    └── filters
+           │    │    │    │    │         ├── b_default = c
+           │    │    │    │    │         └── column1 > 0
+           │    │    │    │    └── aggregations
+           │    │    │    │         ├── first-agg
+           │    │    │    │         │    └── column1
+           │    │    │    │         └── first-agg
+           │    │    │    │              └── b_default
+           │    │    │    └── aggregations
+           │    │    │         └── first-agg
+           │    │    │              └── rowid_default
+           │    │    └── aggregations
+           │    │         ├── first-agg
+           │    │         │    └── column1
+           │    │         └── first-agg
+           │    │              └── rowid_default
+           │    └── projections
+           │         └── (column1 > 0) OR NULL::BOOL
+           └── aggregations
+                ├── first-agg
+                │    └── column1
+                └── first-agg
+                     └── rowid_default

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -713,8 +713,8 @@ build
 UPSERT INTO t(a) VALUES (1)
 ----
 upsert t
- ├── columns: <none>
  ├── arbiter indexes: t_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 v:11
  ├── insert-mapping:
@@ -858,8 +858,8 @@ build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO NOTHING
 ----
 insert t_idx2
- ├── columns: <none>
  ├── arbiter indexes: t_idx2_w_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
@@ -907,8 +907,8 @@ build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT DO NOTHING
 ----
 insert t_idx2
- ├── columns: <none>
  ├── arbiter indexes: t_idx2_pkey t_idx2_w_key
+ ├── columns: <none>
  ├── insert-mapping:
  │    ├── column1:8 => a:1
  │    ├── column2:9 => b:2
@@ -984,8 +984,8 @@ build
 INSERT INTO t VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET a=t.v+1
 ----
 upsert t
- ├── columns: <none>
  ├── arbiter indexes: t_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 v:11
  ├── insert-mapping:
@@ -1042,8 +1042,8 @@ build
 INSERT INTO t VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET a=excluded.v+1
 ----
 upsert t
- ├── columns: <none>
  ├── arbiter indexes: t_pkey
+ ├── columns: <none>
  ├── canary column: a:9
  ├── fetch columns: a:9 b:10 v:11
  ├── insert-mapping:
@@ -1100,8 +1100,8 @@ build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO UPDATE SET c=10
 ----
 upsert t_idx2
- ├── columns: <none>
  ├── arbiter indexes: t_idx2_w_key
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 b:14 c:15 v:16 w:17
  ├── insert-mapping:
@@ -1171,8 +1171,8 @@ build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO UPDATE SET c=t_idx2.v+1
 ----
 upsert t_idx2
- ├── columns: <none>
  ├── arbiter indexes: t_idx2_w_key
+ ├── columns: <none>
  ├── canary column: a:13
  ├── fetch columns: a:13 b:14 c:15 v:16 w:17
  ├── insert-mapping:

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -471,8 +471,8 @@ opt
 UPSERT INTO t64570 VALUES (10, 10, 10)
 ----
 upsert t64570
- ├── columns: <none>
  ├── arbiter indexes: t64570_pkey
+ ├── columns: <none>
  ├── canary column: x:9
  ├── fetch columns: x:9 y:10 v:11
  ├── insert-mapping:

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1265,8 +1265,8 @@ UPSERT INTO Transactions (dealerid, isbuy, date, accountname, customername, oper
 VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C26-B72D-C524A9D537DD')
 ----
 upsert transactions
- ├── columns: <none>
  ├── arbiter indexes: transactionsprimarykey
+ ├── columns: <none>
  ├── canary column: dealerid:19
  ├── fetch columns: dealerid:19 isbuy:20 date:21 accountname:22 customername:23 operationid:24 version:25
  ├── insert-mapping:
@@ -1321,8 +1321,8 @@ SELECT
 FROM updates
 ----
 upsert transactiondetails
- ├── columns: <none>
  ├── arbiter indexes: detailsprimarykey
+ ├── columns: <none>
  ├── canary column: transactiondetails.dealerid:21
  ├── fetch columns: transactiondetails.dealerid:21 transactiondetails.isbuy:22 transactiondetails.transactiondate:23 transactiondetails.cardid:24 quantity:25 sellprice:26 buyprice:27 transactiondetails.version:28
  ├── insert-mapping:

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1270,8 +1270,8 @@ UPSERT INTO Transactions (dealerid, isbuy, date, accountname, customername, oper
 VALUES (1, FALSE, '2020-03-01', 'the-account', 'the-customer', '70F03EB1-4F58-4C26-B72D-C524A9D537DD')
 ----
 upsert transactions
- ├── columns: <none>
  ├── arbiter indexes: transactionsprimarykey
+ ├── columns: <none>
  ├── canary column: dealerid:22
  ├── fetch columns: dealerid:22 isbuy:23 date:24 accountname:25 customername:26 operationid:27 version:28 olddate:29 extra:30
  ├── insert-mapping:
@@ -1328,8 +1328,8 @@ SELECT
 FROM updates
 ----
 upsert transactiondetails
- ├── columns: <none>
  ├── arbiter indexes: detailsprimarykey
+ ├── columns: <none>
  ├── canary column: transactiondetails.dealerid:25
  ├── fetch columns: transactiondetails.dealerid:25 transactiondetails.isbuy:26 transactiondetails.transactiondate:27 transactiondetails.cardid:28 quantity:29 sellprice:30 buyprice:31 transactiondetails.version:32 discount:33 transactiondetails.extra:34
  ├── insert-mapping:

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2731,8 +2731,8 @@ opt expect=SplitGroupByScanIntoUnionScans
 INSERT INTO xyz SELECT a, b, c FROM regional ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:15
  ├── fetch columns: x:15 y:16 z:17
  ├── insert-mapping:
@@ -2797,8 +2797,8 @@ INSERT INTO xyz SELECT a, b, c FROM regional WHERE b > 5
 ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:15
  ├── fetch columns: x:15 y:16 z:17
  ├── insert-mapping:
@@ -3056,8 +3056,8 @@ opt expect=EliminateIndexJoinOrProjectInsideGroupBy
 INSERT INTO xyz SELECT a, a, b FROM abcd WHERE c > 0 ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:13
  ├── fetch columns: x:13 y:14 z:15
  ├── insert-mapping:
@@ -3107,8 +3107,8 @@ opt expect=EliminateIndexJoinOrProjectInsideGroupBy
 INSERT INTO xyz SELECT c, c, b FROM abcd WHERE d = 1 ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
 upsert xyz
- ├── columns: <none>
  ├── arbiter indexes: xyz_pkey
+ ├── columns: <none>
  ├── canary column: x:13
  ├── fetch columns: x:13 y:14 z:15
  ├── insert-mapping:


### PR DESCRIPTION
We select all unique indexes and unique constraints as arbiters for
`INSERT .. ON CONFLICT` statements without explicit conflict columns or
constraints. In some cases, unique constraint arbiters make unique index
arbiters redundant, which results in query plans that perform
unnecessary work to check for conflicts. Most notably, redundant unique
indexes are chosen as arbiters for both partitioned and hash-sharded
indexes which synthesize `UNIQUE WITHOUT INDEX` constraints.

For example, consider the table and statement which mimics a
simplified hash-sharded index:

    CREATE TABLE t (
        a INT,
        shard_a INT,
        UNIQUE INDEX shard_a_a_key (shard_a, a),
        UNIQUE WITHOUT INDEX a_key (a)
    )

    INSERT INTO t VALUES (1, 2) ON CONFLICT DO NOTHING

There is no need to use both `shard_a_a_key` and `a_key` as arbiters for
the `INSERT` statement because any conflict in `shard_a_a_key` will also
be a conflict in `a_key`. Only `a_key` is required to be an arbiter.

This commit removes these redundant arbiter indexes, which improves
query plans.

Fixes #75498

Release note (performance improvement): The optimizer produces more
efficient query plans for `INSERT .. ON CONFLICT` statements that do not
have explicit conflict columns or constraints and are performed on
partitioned tables.