### PR TITLE
colbuilder: use the correct eval context for aggregate functions

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -828,7 +828,7 @@ func NewColOperator(
 				Input:      inputs[0].Root,
 				InputTypes: inputTypes,
 				Spec:       aggSpec,
-				EvalCtx:    flowCtx.EvalCtx,
+				EvalCtx:    evalCtx,
 			}
 			newAggArgs.Constructors, newAggArgs.ConstArguments, newAggArgs.OutputTypes, err = colexecagg.ProcessAggregations(
 				evalCtx, args.ExprHelper.SemaCtx, aggSpec.Aggregations, inputTypes,


### PR DESCRIPTION
Previously, we made a copy of the eval context when instantiating
aggregators (because we modify the context), but we forgot to use it one
spot, so this commit fixes things. The bug was introduced in
3dad24ea3497c13789043b78c20309774fe218a7 which is only present on 22.1
branch.

Release note: None