### PR TITLE
kvserver: export lock table metadata via concurrency manager

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
     embed = [":concurrency"],
     shard_count = 16,
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvserver/batcheval",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/concurrency/poison",

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -261,6 +261,10 @@ type LockManager interface {
 	// updated or released a lock or range of locks that it previously held.
 	// The Durability field of the lock update struct is ignored.
 	OnLockUpdated(context.Context, *roachpb.LockUpdate)
+
+	// QueryLockTableState gathers detailed metadata on locks tracked in the lock
+	// table that are part of the provided span and key scope, up to provided limits.
+	QueryLockTableState(ctx context.Context, span roachpb.Span, opts QueryLockTableOptions) ([]roachpb.LockStateInfo, QueryLockTableResumeState)
 }
 
 // TransactionManager is concerned with tracking transactions that have their
@@ -445,6 +449,22 @@ type Response = []roachpb.ResponseUnion
 
 // Error is an alias for a roachpb.Error.
 type Error = roachpb.Error
+
+// QueryLockTableOptions bundles the options for the QueryLockTableState function.
+type QueryLockTableOptions struct {
+	KeyScope           spanset.SpanScope
+	MaxLocks           int64
+	TargetBytes        int64
+	IncludeUncontended bool
+}
+
+// QueryLockTableResumeState bundles the return metadata on the pagination of
+// results from the QueryLockTableState function.
+type QueryLockTableResumeState struct {
+	ResumeSpan      *roachpb.Span
+	ResumeReason    roachpb.ResumeReason
+	ResumeNextBytes int64
+}
 
 ///////////////////////////////////
 // Internal Structure Interfaces //
@@ -688,6 +708,9 @@ type lockTable interface {
 	// waiting on locks of finalized transactions and telling the caller via
 	// lockTableGuard.ResolveBeforeEvaluation to resolve a batch of intents.
 	TransactionIsFinalized(*roachpb.Transaction)
+
+	// QueryLockTableState returns detailed metadata on locks managed by the lockTable.
+	QueryLockTableState(span roachpb.Span, opts QueryLockTableOptions) ([]roachpb.LockStateInfo, QueryLockTableResumeState)
 
 	// Metrics returns information about the state of the lockTable.
 	Metrics() LockTableMetrics

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -143,7 +143,7 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	lt := newLockTable(cfg.MaxLockTableSize, timeutil.DefaultTimeSource{})
+	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, timeutil.DefaultTimeSource{})
 	*m = managerImpl{
 		st: cfg.Settings,
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
@@ -507,6 +507,13 @@ func (m *managerImpl) OnLockUpdated(ctx context.Context, up *roachpb.LockUpdate)
 	if err := m.lt.UpdateLocks(up); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
+}
+
+// QueryLockTableState implements the LockManager interface.
+func (m *managerImpl) QueryLockTableState(
+	ctx context.Context, span roachpb.Span, opts QueryLockTableOptions,
+) ([]roachpb.LockStateInfo, QueryLockTableResumeState) {
+	return m.lt.QueryLockTableState(span, opts)
 }
 
 // OnTransactionUpdated implements the TransactionManager interface.

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -169,6 +169,10 @@ type treeMu struct {
 //                 > lockState.mu
 //                 > lockTableGuardImpl.mu
 type lockTableImpl struct {
+	// The ID of the range to which this replica's lock table belongs.
+	// Used to populate results when querying the lock table.
+	rID roachpb.RangeID
+
 	// Is the lockTable enabled? When enabled, the lockTable tracks locks and
 	// allows requests to queue in wait-queues on these locks. When disabled,
 	// no locks or wait-queues are maintained.
@@ -258,13 +262,16 @@ type lockTableImpl struct {
 
 var _ lockTable = &lockTableImpl{}
 
-func newLockTable(maxLocks int64, timeProvider timeutil.TimeSource) *lockTableImpl {
+func newLockTable(
+	maxLocks int64, rangeID roachpb.RangeID, timeProvider timeutil.TimeSource,
+) *lockTableImpl {
 	// Check at 5% intervals of the max count.
 	lockAddMaxLocksCheckInterval := maxLocks / (int64(spanset.NumSpanScope) * 20)
 	if lockAddMaxLocksCheckInterval == 0 {
 		lockAddMaxLocksCheckInterval = 1
 	}
 	lt := &lockTableImpl{
+		rID:          rangeID,
 		maxLocks:     maxLocks,
 		minLocks:     maxLocks / 2,
 		timeProvider: timeProvider,
@@ -1054,6 +1061,99 @@ func (l *lockState) safeFormat(sb *redact.StringBuilder, finalizedTxnCache *txnC
 	}
 	if l.distinguishedWaiter != nil {
 		sb.Printf("   distinguished req: %d\n", redact.Safe(l.distinguishedWaiter.seqNum))
+	}
+}
+
+// collectLockStateInfo converts receiver into exportable LockStateInfo metadata
+// and returns (true, valid LockStateInfo), or (false, empty LockStateInfo) if
+// it was filtered out due to being an empty lock or an uncontended lock (if
+// includeUncontended is false).
+func (l *lockState) collectLockStateInfo(
+	includeUncontended bool, now time.Time,
+) (bool, roachpb.LockStateInfo) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Don't include locks that have neither lock holders, nor reservations, nor
+	// waiting readers/writers.
+	if l.isEmptyLock() {
+		return false, roachpb.LockStateInfo{}
+	}
+
+	// Filter out locks without waiting readers/writers unless explicitly requested.
+	if !includeUncontended && l.waitingReaders.Len() == 0 && l.queuedWriters.Len() == 0 {
+		return false, roachpb.LockStateInfo{}
+	}
+
+	return true, l.lockStateInfo(now)
+}
+
+// lockStateInfo converts receiver to the roachpb.LockStateInfo structure.
+// REQUIRES: l.mu is locked.
+func (l *lockState) lockStateInfo(now time.Time) roachpb.LockStateInfo {
+	var txnHolder *enginepb.TxnMeta
+	durability := lock.Unreplicated
+	if l.holder.locked {
+		if l.holder.holder[lock.Unreplicated].txn != nil {
+			txnHolder = l.holder.holder[lock.Unreplicated].txn
+		} else {
+			txnHolder = l.holder.holder[lock.Replicated].txn
+			durability = lock.Replicated
+		}
+	}
+
+	waiterCount := l.waitingReaders.Len() + l.queuedWriters.Len()
+	hasReservation := l.reservation != nil && l.reservation.txn != nil
+	if hasReservation {
+		waiterCount++
+	}
+	lockWaiters := make([]lock.Waiter, 0, waiterCount)
+
+	// Consider the reservation as the "first waiter" (albeit on an unheld lock).
+	if hasReservation {
+		l.reservation.mu.Lock()
+		lockWaiters = append(lockWaiters, lock.Waiter{
+			WaitingTxn:   l.reservation.txn,
+			ActiveWaiter: true,
+			Strength:     lock.Exclusive,
+			WaitDuration: now.Sub(l.reservation.mu.requestWaitBegin),
+		})
+		l.reservation.mu.Unlock()
+	}
+
+	// Next, add waiting readers before writers as they should run first.
+	for e := l.waitingReaders.Front(); e != nil; e = e.Next() {
+		readerGuard := e.Value.(*lockTableGuardImpl)
+		readerGuard.mu.Lock()
+		lockWaiters = append(lockWaiters, lock.Waiter{
+			WaitingTxn:   readerGuard.txn,
+			ActiveWaiter: false,
+			Strength:     lock.None,
+			WaitDuration: now.Sub(readerGuard.mu.requestWaitBegin),
+		})
+		readerGuard.mu.Unlock()
+	}
+
+	// Lastly, add queued writers in order.
+	for e := l.queuedWriters.Front(); e != nil; e = e.Next() {
+		qg := e.Value.(*queuedGuard)
+		writerGuard := qg.guard
+		writerGuard.mu.Lock()
+		lockWaiters = append(lockWaiters, lock.Waiter{
+			WaitingTxn:   writerGuard.txn,
+			ActiveWaiter: qg.active,
+			Strength:     lock.Exclusive,
+			WaitDuration: now.Sub(writerGuard.mu.requestWaitBegin),
+		})
+		writerGuard.mu.Unlock()
+	}
+
+	return roachpb.LockStateInfo{
+		Key:          l.key,
+		LockHolder:   txnHolder,
+		Durability:   durability,
+		HoldDuration: l.lockHeldDuration(now),
+		Waiters:      lockWaiters,
 	}
 }
 
@@ -2746,6 +2846,71 @@ func (t *lockTableImpl) Clear(disable bool) {
 	// Also clear the finalized txn cache, since it won't be needed any time
 	// soon and consumes memory.
 	t.finalizedTxnCache.clear()
+}
+
+// QueryLockTableState implements the lockTable interface.
+func (t *lockTableImpl) QueryLockTableState(
+	span roachpb.Span, opts QueryLockTableOptions,
+) ([]roachpb.LockStateInfo, QueryLockTableResumeState) {
+	t.enabledMu.RLock()
+	defer t.enabledMu.RUnlock()
+	if !t.enabled {
+		// If not enabled, don't return any locks from the query.
+		return []roachpb.LockStateInfo{}, QueryLockTableResumeState{}
+	}
+
+	// Grab tree snapshot to avoid holding read lock during iteration.
+	var snap btree
+	{
+		tree := &t.locks[opts.KeyScope]
+		tree.mu.RLock()
+		snap = tree.Clone()
+		tree.mu.RUnlock()
+	}
+
+	now := t.timeProvider.Now()
+
+	lockTableState := make([]roachpb.LockStateInfo, 0, snap.Len())
+	resumeState := QueryLockTableResumeState{}
+	var numLocks int64
+	var numBytes int64
+	var nextKey roachpb.Key
+	var nextByteSize int64
+
+	// Iterate over locks and gather metadata.
+	iter := snap.MakeIter()
+	ltRange := &lockState{key: span.Key, endKey: span.EndKey}
+	for iter.FirstOverlap(ltRange); iter.Valid(); iter.NextOverlap(ltRange) {
+		l := iter.Cur()
+
+		if ok, lInfo := l.collectLockStateInfo(opts.IncludeUncontended, now); ok {
+			nextKey = l.key
+			nextByteSize = int64(lInfo.Size())
+			lInfo.RangeID = t.rID
+
+			// Check if adding the lock would exceed our byte or count limits,
+			// though we must ensure we return at least one lock.
+			if len(lockTableState) > 0 && opts.TargetBytes > 0 && (numBytes+nextByteSize) > opts.TargetBytes {
+				resumeState.ResumeReason = roachpb.RESUME_BYTE_LIMIT
+				break
+			} else if len(lockTableState) > 0 && opts.MaxLocks > 0 && numLocks >= opts.MaxLocks {
+				resumeState.ResumeReason = roachpb.RESUME_KEY_LIMIT
+				break
+			}
+
+			lockTableState = append(lockTableState, lInfo)
+			numLocks++
+			numBytes += nextByteSize
+		}
+	}
+
+	// If we need to paginate results, set the continuation key in the ResumeSpan.
+	if resumeState.ResumeReason != 0 {
+		resumeState.ResumeNextBytes = nextByteSize
+		resumeState.ResumeSpan = &roachpb.Span{Key: nextKey, EndKey: span.EndKey}
+	}
+
+	return lockTableState, resumeState
 }
 
 // Metrics implements the lockTable interface.

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanlatch"
@@ -155,6 +156,15 @@ print
 ----
 <state of lock table>
 
+query span=<start>[,<end> | /Max] [max-locks=<int>] [max-bytes=<int>] [uncontended]
+----
+
+ Queries the lockTable over a given span (or over the entire LT if no span
+ provided), returning lock state info up to a maximum number of locks or bytes
+ if provided.  By default only returns contended locks (those with waiters),
+ unless the uncontended option is given.
+
+
 metrics
 ----
 <metrics for lock table>
@@ -178,7 +188,7 @@ func TestLockTableBasic(t *testing.T) {
 			case "new-lock-table":
 				var maxLocks int
 				d.ScanArgs(t, "maxlocks", &maxLocks)
-				ltImpl := newLockTable(int64(maxLocks), testTimeProvider)
+				ltImpl := newLockTable(int64(maxLocks), roachpb.RangeID(3), testTimeProvider)
 				ltImpl.enabled = true
 				ltImpl.enabledSeq = 1
 				ltImpl.minLocks = 0
@@ -563,6 +573,46 @@ func TestLockTableBasic(t *testing.T) {
 			case "print":
 				return lt.String()
 
+			case "query":
+				span := keys.EverythingSpan
+				var maxLocks int
+				var targetBytes int
+				if d.HasArg("span") {
+					var spanStr string
+					d.ScanArgs(t, "span", &spanStr)
+					span = getSpan(t, d, spanStr)
+				}
+				if d.HasArg("max-locks") {
+					d.ScanArgs(t, "max-locks", &maxLocks)
+				}
+				if d.HasArg("max-bytes") {
+					d.ScanArgs(t, "max-bytes", &targetBytes)
+				}
+				scanOpts := QueryLockTableOptions{
+					MaxLocks:           int64(maxLocks),
+					TargetBytes:        int64(targetBytes),
+					IncludeUncontended: d.HasArg("uncontended"),
+				}
+				lockInfos, resumeState := lt.QueryLockTableState(span, scanOpts)
+				var lockInfoBytes int64
+				for _, lockInfo := range lockInfos {
+					lockInfoBytes += int64(lockInfo.Size())
+				}
+
+				var buf strings.Builder
+				fmt.Fprintf(&buf, "num locks: %d, bytes returned: %d, resume reason: %s, resume span: %s",
+					len(lockInfos), lockInfoBytes, resumeState.ResumeReason, resumeState.ResumeSpan)
+				if len(lockInfos) > 0 {
+					fmt.Fprintf(&buf, "\n locks:")
+				}
+				for _, lockInfo := range lockInfos {
+					lockInfoStrLines := strings.Split(redact.Sprintf("%+v", lockInfo).StripMarkers(), "\n")
+					for _, line := range lockInfoStrLines {
+						fmt.Fprintf(&buf, "\n  %s", line)
+					}
+				}
+				return buf.String()
+
 			case "metrics":
 				metrics := lt.Metrics()
 				b, err := yaml.Marshal(&metrics)
@@ -599,7 +649,11 @@ func getSpan(t *testing.T, d *datadriven.TestData, str string) roachpb.Span {
 	if len(parts) > 2 {
 		d.Fatalf(t, "incorrect span format: %s", str)
 	} else if len(parts) == 2 {
-		span.EndKey = roachpb.Key(parts[1])
+		if parts[1] == "/Max" {
+			span.EndKey = roachpb.KeyMax
+		} else {
+			span.EndKey = roachpb.Key(parts[1])
+		}
 	}
 	return span
 }
@@ -646,7 +700,7 @@ func intentsToResolveToStr(toResolve []roachpb.LockUpdate, startOnNewLine bool) 
 }
 
 func TestLockTableMaxLocks(t *testing.T) {
-	lt := newLockTable(5, timeutil.DefaultTimeSource{})
+	lt := newLockTable(5, roachpb.RangeID(3), timeutil.DefaultTimeSource{})
 	lt.minLocks = 0
 	lt.enabled = true
 	var keys []roachpb.Key
@@ -773,7 +827,7 @@ func TestLockTableMaxLocks(t *testing.T) {
 // TestLockTableMaxLocksWithMultipleNotRemovableRefs tests the notRemovable
 // ref counting.
 func TestLockTableMaxLocksWithMultipleNotRemovableRefs(t *testing.T) {
-	lt := newLockTable(2, timeutil.DefaultTimeSource{})
+	lt := newLockTable(2, roachpb.RangeID(3), timeutil.DefaultTimeSource{})
 	lt.minLocks = 0
 	lt.enabled = true
 	var keys []roachpb.Key
@@ -1009,7 +1063,7 @@ type workloadExecutor struct {
 
 func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecutor {
 	const maxLocks = 100000
-	lt := newLockTable(maxLocks, timeutil.DefaultTimeSource{})
+	lt := newLockTable(maxLocks, roachpb.RangeID(3), timeutil.DefaultTimeSource{})
 	lt.enabled = true
 	return &workloadExecutor{
 		lm:           spanlatch.Manager{},
@@ -1572,7 +1626,7 @@ func BenchmarkLockTable(b *testing.B) {
 						var numRequestsWaited uint64
 						var numScanCalls uint64
 						const maxLocks = 100000
-						lt := newLockTable(maxLocks, timeutil.DefaultTimeSource{})
+						lt := newLockTable(maxLocks, roachpb.RangeID(3), timeutil.DefaultTimeSource{})
 						lt.enabled = true
 						env := benchEnv{
 							lm:                &spanlatch.Manager{},
@@ -1612,7 +1666,7 @@ func BenchmarkLockTableMetrics(b *testing.B) {
 	for _, locks := range []int{0, 1 << 0, 1 << 4, 1 << 8, 1 << 12} {
 		b.Run(fmt.Sprintf("locks=%d", locks), func(b *testing.B) {
 			const maxLocks = 100000
-			lt := newLockTable(maxLocks, timeutil.DefaultTimeSource{})
+			lt := newLockTable(maxLocks, roachpb.RangeID(3), timeutil.DefaultTimeSource{})
 			lt.enabled = true
 
 			txn := &enginepb.TxnMeta{ID: uuid.MakeV4()}

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -272,6 +272,14 @@ global: num=5
   holder: txn: 00000000-0000-0000-0000-000000000003, ts: 6.000000000,0, info: repl epoch: 0, seqs: [0]
 local: num=0
 
+query
+----
+num locks: 1, bytes returned: 81, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2s
+
 metrics
 ----
 locks: 5
@@ -698,6 +706,23 @@ topklocksbywaitduration:
   waitingwriters: 1
   waitdurationnanos: 0
   maxwaitdurationnanos: 0
+
+
+query
+----
+num locks: 3, bytes returned: 292, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Replicated duration=2.65s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2.65s
+  range_id=3 key="b" holder=<nil> durability=Unreplicated duration=0s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2.65s
+    waiting_txn:00000000-0000-0000-0000-000000000001 active_waiter:true strength:Exclusive wait_duration:250ms
+  range_id=3 key="c" holder=<nil> durability=Unreplicated duration=0s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:2.65s
+    waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:0s
 
 # 100ms passes between before releasing a
 time-tick ms=100

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -1,0 +1,178 @@
+new-lock-table maxlocks=10000
+----
+
+new-txn txn=txn1 ts=10,1 epoch=0
+----
+
+# req1 will acquire locks for txn1
+
+new-request r=req1 txn=txn1 ts=10,1 spans=r@a,b+w@c,f
+----
+
+scan r=req1
+----
+start-waiting: false
+
+guard-state r=req1
+----
+new: state=doneWaiting
+
+acquire r=req1 k=c durability=u
+----
+global: num=1
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+acquire r=req1 k=e durability=u
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+dequeue r=req1
+----
+global: num=2
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+query span=a,d
+----
+num locks: 0, bytes returned: 0, resume reason: RESUME_UNKNOWN, resume span: <nil>
+
+query span=a,d uncontended
+----
+num locks: 1, bytes returned: 41, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
+
+# req2 is also for txn1 and will not wait for locks that are held by self.
+
+new-request r=req2 txn=txn1 ts=10,2 spans=w@b,d+r@d,g
+----
+
+scan r=req2
+----
+start-waiting: false
+
+acquire r=req2 k=b durability=u
+----
+global: num=3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+dequeue r=req2
+----
+global: num=3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
+
+# make sure query limits work
+
+query span=a,f max-locks=2 uncontended
+----
+num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: {e-f}
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
+  range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
+
+query span=a,f max-bytes=50 uncontended
+----
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
+
+# ensure that we return at least one lock, even if it exceed the limits.
+
+query span=a,f max-bytes=10 uncontended
+----
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
+
+# add transactional write waiters
+
+new-txn txn=txn2 ts=8,12 epoch=0
+----
+
+# req3 from txn2 will conflict with locks on b, c since wants to write to [a, d). But does
+# not conflict with lock on e since wants to read there and the read is at a lower timestamp
+# than the lock.
+new-request r=req3 txn=txn2 ts=8,12 spans=w@a,d+r@d,g
+----
+
+scan r=req3
+----
+start-waiting: true
+
+new-txn txn=txn3 ts=9,1 epoch=0
+----
+
+# req4 from txn3 will conflict with locks on e since wants to write to [d, g).
+new-request r=req4 txn=txn3 ts=9,1 spans=w@d,g
+----
+
+scan r=req4
+----
+start-waiting: true
+
+# 200ms passes after req4 starts waiting
+time-tick ms=200
+----
+
+print
+----
+global: num=3
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,2, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 3, txn: 00000000-0000-0000-0000-000000000002
+   distinguished req: 3
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "e"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+   queued writers:
+    active: true req: 4, txn: 00000000-0000-0000-0000-000000000003
+   distinguished req: 4
+local: num=0
+
+query span=a,/Max max-bytes=100
+----
+num locks: 1, bytes returned: 91, resume reason: RESUME_BYTE_LIMIT, resume span: {e-/Max}
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:200ms
+
+query span=b max-bytes=100
+----
+num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:true strength:Exclusive wait_duration:200ms
+
+query span=e,/Max max-bytes=100
+----
+num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="e" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:200ms


### PR DESCRIPTION
This change adds support for exporting lock table metadata using the
`LockStateInfo` protobuf structure.  The metadata is exposed via the
Concurrency Manager, such that it can be queried during command
evaluation.  While previously we had support for exposing lock table
metrics, this change adds support for capturing and exposing a snapshot
state of the locks actively held (and waited on) in the lock table.

Resolves #74832.

Release note: None

Release justification: New observability for use in visualizing
contention, without changes to existing functionality.