### PR TITLE
roachtest: skip scbench

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -87,6 +87,7 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 		Name:    name,
 		Owner:   registry.OwnerSQLSchema,
 		Cluster: r.MakeClusterSpec(b.Nodes),
+		Skip:    "https://github.com/cockroachdb/cockroach/issues/56230",
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/56230.

I don't usually go around skipping other team's tests, but this one
regularly times out, occupying a cluster for 10h, and possibly
contributing to timeouts of the roachtest suite as a whole.

Looking at the failure issue it's also clear that the owning team is not
deriving any signal whatsoever from this test at the moment.

Release note: None
