### PR TITLE
kv/kvserver: skip TestReplicaCircuitBreaker_RangeFeed

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -398,6 +398,7 @@ func (s *dummyStream) Send(ev *roachpb.RangeFeedEvent) error {
 // goes as far as actually losing quorum to verify this end-to-end.
 func TestReplicaCircuitBreaker_RangeFeed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 76856, "flaky test")
 	defer log.Scope(t).Close(t)
 	tc := setupCircuitBreakerTest(t)
 	ctx := context.Background()


### PR DESCRIPTION
Refs: #76856

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None