### PR TITLE
kvserver: consider VOTER_INCOMING for lease transfer even if current …

### DIFF
--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -2030,20 +2030,12 @@ func replicaMayNeedSnapshot(raftStatus *raft.Status, replica roachpb.ReplicaDesc
 }
 
 // excludeReplicasInNeedOfSnapshots filters out the `replicas` that may be in
-// need of a raft snapshot. If this function is called with the `raftStatus` of
-// a non-raft leader replica, an empty slice is returned.
+// need of a raft snapshot. VOTER_INCOMING replicas are not filtered out.
+// Other replicas may be filtered out if this function is called with the
+// `raftStatus` of a non-raft leader replica.
 func excludeReplicasInNeedOfSnapshots(
 	ctx context.Context, raftStatus *raft.Status, replicas []roachpb.ReplicaDescriptor,
 ) []roachpb.ReplicaDescriptor {
-	if raftStatus == nil || len(raftStatus.Progress) == 0 {
-		log.VEventf(
-			ctx,
-			5,
-			"raft leader not collocated with the leaseholder; will not produce any lease transfer targets",
-		)
-		return []roachpb.ReplicaDescriptor{}
-	}
-
 	filled := 0
 	for _, repl := range replicas {
 		if replicaMayNeedSnapshot(raftStatus, repl) {


### PR DESCRIPTION
…leaseholder isn't the Raft leader

This was previously done as part of https://github.com/cockroachdb/cockroach/pull/74077
but a check for leader-leaseholder collocation was missed by that patch. This check is removed
in this PR, as this case is already covered by replicaMayNeedSnapshot.

With this PR, restoreTPCCInc/nodes=10 passed 85 times in a row.

In future PRs, we will make the error returned by maybeTransferLeaseDuringLeaveJoint retriable by
AdminSplit.

Release note: None