### PR TITLE
bulk: rename `WriteAtRequestTimestamp` parameters

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -114,7 +114,7 @@ func MakeBulkAdder(
 			disallowShadowingBelow: opts.DisallowShadowingBelow,
 			splitAfter:             opts.SplitAndScatterAfter,
 			batchTS:                opts.BatchTimestamp,
-			writeAtBatchTS:         opts.WriteAtRequestTime,
+			writeAtBatchTS:         opts.WriteAtBatchTimestamp,
 		},
 		timestamp:           timestamp,
 		curBufferSize:       opts.MinBufferSize,

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -537,9 +537,9 @@ func AddSSTable(
 				if writeAtBatchTs {
 					var writeTs hlc.Timestamp
 					// This will fail if the range has split but we'll check for that below.
-					writeTs, err = db.AddSSTableAtBatchTimestamp(ctx, item.start, item.end, item.sstBytes, false, /* disallowConflicts */
-						!item.disallowShadowingBelow.IsEmpty(), item.disallowShadowingBelow, &item.stats,
-						ingestAsWriteBatch, batchTs)
+					writeTs, err = db.AddSSTableAtBatchTimestamp(ctx, item.start, item.end, item.sstBytes,
+						false /* disallowConflicts */, !item.disallowShadowingBelow.IsEmpty(),
+						item.disallowShadowingBelow, &item.stats, ingestAsWriteBatch, batchTs)
 					if err == nil {
 						maxTs.Forward(writeTs)
 					}

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -68,9 +68,11 @@ type BulkAdderOptions struct {
 	// actually applied to each key).
 	BatchTimestamp hlc.Timestamp
 
-	// WriteAtRequestTime is used to set the corresponding field when sending
-	// constructed SSTables to AddSSTable. See roachpb.AddSSTableRequest.
-	WriteAtRequestTime bool
+	// WriteAtBatchTimestamp will rewrite the SST to use the batch timestamp, even
+	// if it gets pushed to a different timestamp on the server side. All SST MVCC
+	// timestamps must equal BatchTimestamp. See
+	// roachpb.AddSSTableRequest.SSTTimestampToRequestTimestamp.
+	WriteAtBatchTimestamp bool
 
 	// InitialSplitsIfUnordered specifies a number of splits to make before the
 	// first flush of the buffer if the contents of that buffer were unsorted.

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -39,18 +39,18 @@ func initColumnBackfillerSpec(
 func initIndexBackfillerSpec(
 	desc descpb.TableDescriptor,
 	writeAsOf, readAsOf hlc.Timestamp,
-	writeAtRequestTimestamp bool,
+	writeAtBatchTimestamp bool,
 	chunkSize int64,
 	indexesToBackfill []descpb.IndexID,
 ) (execinfrapb.BackfillerSpec, error) {
 	return execinfrapb.BackfillerSpec{
-		Table:                   desc,
-		WriteAsOf:               writeAsOf,
-		WriteAtRequestTimestamp: writeAtRequestTimestamp,
-		ReadAsOf:                readAsOf,
-		Type:                    execinfrapb.BackfillerSpec_Index,
-		ChunkSize:               chunkSize,
-		IndexesToBackfill:       indexesToBackfill,
+		Table:                 desc,
+		WriteAsOf:             writeAsOf,
+		WriteAtBatchTimestamp: writeAtBatchTimestamp,
+		ReadAsOf:              readAsOf,
+		Type:                  execinfrapb.BackfillerSpec_Index,
+		ChunkSize:             chunkSize,
+		IndexesToBackfill:     indexesToBackfill,
 	}, nil
 }
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -75,14 +75,14 @@ message BackfillerSpec {
 
   optional int32 initial_splits = 11 [(gogoproto.nullable) = false];
 
-  // WriteAtRequestTimestamp controls the corresponding AddSSTable request
-  // option which updates all MVCC timestamps in the SST to the request
-  // timestamp, even if the request gets pushed. This ensures the writes
-  // comply with the timestamp cache and closed timestamp.
+  // WriteAtBatchTimestamp will write the SST MVCC timestamps at the batch
+  // timestamp, even if the request gets pushed server-side. This ensures the
+  // writes comply with the timestamp cache and closed timestamp. See also
+  // AddSSTableRequest.SSTTimestampToRequestTimestamp.
   //
   // Note that older nodes do not respect this flag so callers should
   // check MVCCAddSSTable before setting this option.
-  optional bool write_at_request_timestamp = 12 [(gogoproto.nullable) = false];
+  optional bool write_at_batch_timestamp = 12 [(gogoproto.nullable) = false];
 }
 
 // JobProgress identifies the job to report progress on. This reporting

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -334,13 +334,13 @@ func ingestKvs(
 	defer span.Finish()
 
 	writeTS := hlc.Timestamp{WallTime: spec.WalltimeNanos}
-	writeAtRequestTime := true
+	writeAtBatchTimestamp := true
 	if !importAtNow.Get(&flowCtx.Cfg.Settings.SV) {
 		log.Warningf(ctx, "ingesting import data with raw timestamps due to cluster setting")
-		writeAtRequestTime = false
+		writeAtBatchTimestamp = false
 	} else if !flowCtx.Cfg.Settings.Version.IsActive(ctx, clusterversion.MVCCAddSSTable) {
 		log.Warningf(ctx, "ingesting import data with raw timestamps due to cluster version")
-		writeAtRequestTime = false
+		writeAtBatchTimestamp = false
 	}
 
 	flushSize := func() int64 { return bulk.IngestFileSize(flowCtx.Cfg.Settings) }
@@ -365,7 +365,7 @@ func ingestKvs(
 		StepBufferSize:           stepSize,
 		SSTSize:                  flushSize,
 		InitialSplitsIfUnordered: int(spec.InitialSplits),
-		WriteAtRequestTime:       writeAtRequestTime,
+		WriteAtBatchTimestamp:    writeAtBatchTimestamp,
 	})
 	if err != nil {
 		return nil, err
@@ -383,7 +383,7 @@ func ingestKvs(
 		StepBufferSize:           stepSize,
 		SSTSize:                  flushSize,
 		InitialSplitsIfUnordered: int(spec.InitialSplits),
-		WriteAtRequestTime:       writeAtRequestTime,
+		WriteAtBatchTimestamp:    writeAtBatchTimestamp,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -200,7 +200,7 @@ func (ib *indexBackfiller) ingestIndexEntries(
 		SkipDuplicates:           ib.ContainsInvertedIndex(),
 		BatchTimestamp:           ib.spec.ReadAsOf,
 		InitialSplitsIfUnordered: int(ib.spec.InitialSplits),
-		WriteAtRequestTime:       ib.spec.WriteAtRequestTimestamp,
+		WriteAtBatchTimestamp:    ib.spec.WriteAtBatchTimestamp,
 	}
 	adder, err := ib.flowCtx.Cfg.BulkAdder(ctx, ib.flowCtx.Cfg.DB, ib.spec.WriteAsOf, opts)
 	if err != nil {


### PR DESCRIPTION
This renames a couple of parameters from `WriteAtRequestTimestamp` to
`WriteAtBatchTimestamp`, for consistency with other parameters.

Release note: None