### PR TITLE
sql: account for MVCC index backfill process in truncate

### DIFF
--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -374,7 +375,7 @@ func TestInvertedIndexMergeEveryStateWrite(t *testing.T) {
 	var writeMore func() error
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeDescTxn:  func() error { return writeMore() },
+			RunBeforeDescTxn:  func(_ jobspb.JobID) error { return writeMore() },
 			BackfillChunkSize: chunkSize,
 		},
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2343,7 +2343,7 @@ type SchemaChangerTestingKnobs struct {
 
 	// RunBeforeDescTxn runs at the start of every call to
 	// (*schemaChanger).txn.
-	RunBeforeDescTxn func() error
+	RunBeforeDescTxn func(jobID jobspb.JobID) error
 
 	// OldNamesDrainedNotification is called during a schema change,
 	// after all leases on the version of the descriptor with the old
@@ -2392,7 +2392,7 @@ func (sc *SchemaChanger) txn(
 	ctx context.Context, f func(context.Context, *kv.Txn, *descs.Collection) error,
 ) error {
 	if fn := sc.testingKnobs.RunBeforeDescTxn; fn != nil {
-		if err := fn(); err != nil {
+		if err := fn(sc.job.ID()); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7885,7 +7885,7 @@ func TestPauseBeforeRandomDescTxn(t *testing.T) {
 		params.Knobs = base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-				RunBeforeDescTxn: func() error {
+				RunBeforeDescTxn: func(_ jobspb.JobID) error {
 					if atomic.LoadInt32(&shouldCount) == 1 {
 						atomic.AddInt32(&count, 1)
 					}
@@ -7918,7 +7918,7 @@ func TestPauseBeforeRandomDescTxn(t *testing.T) {
 					jobID = id
 					return nil
 				},
-				RunBeforeDescTxn: func() error {
+				RunBeforeDescTxn: func(_ jobspb.JobID) error {
 					if atomic.LoadInt32(&shouldPause) == 0 {
 						return nil
 					}
@@ -7979,5 +7979,87 @@ INSERT INTO t VALUES (1, 1), (2, 2), (3, 3);
 			})
 		}
 	}
+}
 
+func TestTruncateWithIndexAdditionAtEveryStateTransition(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var (
+		s     serverutils.TestTenantInterface
+		sqlDB *gosql.DB
+		kvDB  *kv.DB
+
+		jobID jobspb.JobID
+		count int32
+	)
+	rowCount := 10
+	writeSomeRows := func() error {
+		for i := 0; i < rowCount; i++ {
+			_, err := sqlDB.Exec("INSERT INTO t.test VALUES ($1, $1)", i)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	rng, _ := randutil.NewPseudoRand()
+	truncateAtLim := 14
+	truncateAt := rng.Intn(truncateAtLim) + 1
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			RunBeforeResume: func(id jobspb.JobID) error {
+				if jobID == 0 {
+					jobID = id
+				}
+				return nil
+			},
+			RunBeforeDescTxn: func(id jobspb.JobID) error {
+				if jobID == id {
+					current := int(atomic.AddInt32(&count, 1))
+					if current == truncateAt {
+						t.Logf("running TRUNCATE at txn %d", current)
+						if err := writeSomeRows(); err != nil {
+							return err
+						}
+
+						_, err := sqlDB.Exec("TRUNCATE t.test")
+						if err != nil {
+							return err
+						}
+						truncateAt = -1
+						// Write more rows so that there is something to truncate the next time.
+						return writeSomeRows()
+					}
+				}
+				return nil
+			},
+		},
+	}
+	s, sqlDB, kvDB = serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+	_, err := sqlDB.Exec("CREATE DATABASE t; CREATE TABLE t.test (pk INT PRIMARY KEY, v INT)")
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec("CREATE INDEX ON t.test(v)")
+	require.NoError(t, err)
+
+	txnCount := int(atomic.LoadInt32(&count))
+	require.True(t, txnCount <= truncateAtLim, "schema change ran %d which is larger than the hardcoded limit %d", txnCount, truncateAtLim)
+
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
+	if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, tableDesc.GetID()); err != nil {
+		t.Fatal(err)
+	}
+	testutils.SucceedsSoon(t, func() error {
+		return sqltestutils.CheckTableKeyCountExact(ctx, kvDB, 2*rowCount)
+	})
+	indexes := tableDesc.ActiveIndexes()
+	require.Equal(t, 2, len(indexes))
+	require.Equal(t, descpb.IndexID(4), indexes[0].GetID())
+	require.Equal(t, descpb.IndexID(5), indexes[1].GetID())
 }


### PR DESCRIPTION
This code previously assumed that all table mutations could be made
public. That is no longer true as temporary indexes should never be
made public.

Now, we handle temporary indexes in truncate and ensure they are
garbage collected.

Fixes #76684

Release note: None

Release justification: Fixes a bug that would prevent TRUNCATE in the
presence of an ADD INDEX mutation.