### PR TITLE
sql: add bucket count limit for hash sharded index

### DIFF
--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -13,7 +13,6 @@ package tabledesc
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 
@@ -239,7 +238,8 @@ func EvalShardBucketCount(
 	}
 
 	var buckets int64
-	const invalidBucketCountMsg = `BUCKET_COUNT must be a 32-bit integer greater than 1, got %v`
+	const maxBucketAllowed = 2048
+	const invalidBucketCountMsg = `hash sharded index bucket count must be in range [2, 2048], got %v`
 	// If shardBuckets is not specified, use default bucket count from cluster setting.
 	if legacyBucketNotGiven && paramVal == nil {
 		buckets = catconstants.DefaultHashShardedIndexBucketCount.Get(&evalCtx.Settings.SV)
@@ -262,7 +262,7 @@ func EvalShardBucketCount(
 	if buckets < 2 {
 		return 0, pgerror.Newf(pgcode.InvalidParameterValue, invalidBucketCountMsg, buckets)
 	}
-	if buckets > math.MaxInt32 {
+	if buckets > maxBucketAllowed {
 		return 0, pgerror.Newf(pgcode.InvalidParameterValue, invalidBucketCountMsg, buckets)
 	}
 	return int32(buckets), nil

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -11,13 +11,13 @@ sharded_primary  CREATE TABLE public.sharded_primary (
                  CONSTRAINT sharded_primary_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
 )
 
-statement error pgcode 22023 BUCKET_COUNT must be a 32-bit integer greater than 1, got -1
+statement error pgcode 22023 hash sharded index bucket count must be in range \[2, 2048\], got -1
 CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=-1))
 
-statement error pgcode 22023 BUCKET_COUNT must be a 32-bit integer greater than 1, got 1099511627776
-CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=1099511627776))
+statement error pgcode 22023 hash sharded index bucket count must be in range \[2, 2048\], got 999999999
+CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=999999999))
 
-statement error pgcode 22023 BUCKET_COUNT must be a 32-bit integer greater than 1, got 1
+statement error pgcode 22023 hash sharded index bucket count must be in range \[2, 2048\], got 1
 CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=1))
 
 statement error expected BUCKET_COUNT expression to have type int, but '2.32' has type decimal


### PR DESCRIPTION
Fixes #77000

Release note (sql change): Previously we only require the bucket
count a positive Int32 integer (greater than 1). Now it's limited
to inclusive range of [2, 2048].