### PR TITLE
pgwire: fix flaky AOST test

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/as_of_system_time
+++ b/pkg/sql/pgwire/testdata/pgtest/as_of_system_time
@@ -1,23 +1,18 @@
 # This test relies on a CoockroachDB-specific feature, so everything
 # is marked as crdb_only.
 
-send crdb_only
-Query {"String": "SELECT pg_sleep(0.1)"}
+only crdb
 ----
 
-until crdb_only
-ReadyForQuery
+let $before_table_timestamp
+Query {"String": "SELECT cluster_logical_timestamp()"}
 ----
-{"Type":"RowDescription","Fields":[{"Name":"pg_sleep","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":16,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
-{"Type":"DataRow","Values":[{"text":"t"}]}
-{"Type":"CommandComplete","CommandTag":"SELECT 1"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
 
-send crdb_only
+send
 Query {"String": "CREATE TABLE tab(a INT8)"}
 ----
 
-until crdb_only
+until
 ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
@@ -25,37 +20,96 @@ ReadyForQuery
 
 # Make sure AOST is handled during Parse. Preparing the statement should
 # fail since the table did not exist in the past.
-send crdb_only
-Parse {"Name": "s0", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '-0.05s'"}
+send
+Parse {"Name": "s0", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '$before_table_timestamp'"}
 Sync
 ----
 
-until crdb_only
+until keepErrMessage
 ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse","Code":"42P01"}
+{"Type":"ErrorResponse","Code":"42P01","Message":"relation \"tab\" does not exist"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-send crdb_only
-Query {"String": "SELECT pg_sleep(0.1)"}
+let $before_data_timestamp
+Query {"String": "SELECT cluster_logical_timestamp()"}
 ----
 
-until crdb_only
-ReadyForQuery
-----
-{"Type":"RowDescription","Fields":[{"Name":"pg_sleep","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":16,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
-{"Type":"DataRow","Values":[{"text":"t"}]}
-{"Type":"CommandComplete","CommandTag":"SELECT 1"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-
-send crdb_only
+send
 Query {"String": "INSERT INTO tab VALUES(1)"}
 ----
 
-until crdb_only
+until
 ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Make sure AOST is handled consistently during Parse/Bind/Execute. This should
+# succeed, but should not be able to read the data that was added to the table.
+send
+Parse {"Name": "historical_stmt", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '$before_data_timestamp'"}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "historical_stmt"}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Make sure AOST is handled consistently during Bind/Execute. This also should
+# not be able to see the data in the table, since this is a historical read.
+send
+Bind {"DestinationPortal": "p2", "PreparedStatement": "historical_stmt"}
+Execute {"Portal": "p2"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+let $after_data_timestamp
+Query {"String": "SELECT cluster_logical_timestamp()"}
+----
+
+# Preparing another statement with the later timestamp should succeed.
+send
+Parse {"Name": "historical_stmt_working", "Query": "SELECT * FROM tab AS OF SYSTEM TIME '$after_data_timestamp'"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "historical_stmt_working"}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# And reusing that statement should work as well.
+send
+Bind {"DestinationPortal": "p4", "PreparedStatement": "historical_stmt_working"}
+Execute {"Portal": "p4"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
+++ b/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
@@ -1,10 +1,6 @@
-# Test binding calls which reference names via either types or oid casts work
-# after a bizarre turn of events whereby we used to set the planner txn to nil.
-# The long and the short of it is that we totally abuse the planner when
-# performing BIND and the fact that it continues to carry a transaction that
-# does not correspond to the connExecutor's transaction is, generally, a big
-# problem. Before the changes made in the commit adding this test, this test
-# would result in a nil pointer panic.
+# Test binding calls which reference names via either types or oid casts work.
+# Before the changes made in the commit adding this test, this test would result
+# in a nil pointer panic, since the txn was not initialized correctly.
 
 # TODO(richardjcai): Support let command similar to logic tests to
 # programmatically get the table id.

--- a/pkg/testutils/pgtest/BUILD.bazel
+++ b/pkg/testutils/pgtest/BUILD.bazel
@@ -13,5 +13,6 @@ go_library(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgproto3_v2//:pgproto3",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/datadriven"
 	"github.com/jackc/pgproto3/v2"
+	"github.com/stretchr/testify/require"
 )
 
 // WalkWithRunningServer walks path for datadriven files and calls RunTest on them.
@@ -45,6 +46,11 @@ func WalkWithNewServer(
 // RunTest executes PGTest commands, connecting to the database specified by
 // addr and user. Supported commands:
 //
+// "let": Run a query that returns a single row with a single column, and
+// save it in the variable named in the command argument. This variable can
+// be used in future "send" commands and is replaced by simple string
+// substitution.
+//
 // "send": Sends messages to a server. Takes a newline-delimited list of
 // pgproto3.FrontendMessage types. Can fill in values by adding a space then
 // a JSON object. No output. Messages with a []byte type (like CopyData) should
@@ -69,9 +75,11 @@ func WalkWithNewServer(
 // happens.
 func RunTest(t *testing.T, path, addr, user string) {
 	p, err := NewPGTest(context.Background(), addr, user)
+
 	if err != nil {
 		t.Fatal(err)
 	}
+	vars := make(map[string]string)
 	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
 		case "only":
@@ -83,12 +91,40 @@ func RunTest(t *testing.T, path, addr, user string) {
 			}
 			return d.Expected
 
+		case "let":
+			require.Len(t, d.CmdArgs, 1, "only one argument permitted for let")
+			require.Truef(t, strings.HasPrefix(d.CmdArgs[0].Key, "$"), "let argument must begin with '$'")
+			lines := strings.Split(d.Input, "\n")
+			require.Len(t, lines, 1, "only one input command permitted for let")
+			require.Truef(t, strings.HasPrefix(lines[0], "Query "), "let must use a Query command")
+			if err := p.SendOneLine(lines[0]); err != nil {
+				t.Fatalf("%s: send %s: %v", d.Pos, lines[0], err)
+			}
+			msgs, err := p.Receive(hasKeepErrMsg(d), &pgproto3.DataRow{}, &pgproto3.ReadyForQuery{})
+			if err != nil {
+				t.Fatalf("%s: %+v", d.Pos, err)
+			}
+			sawData := false
+			for _, msg := range msgs {
+				if dataRow, ok := msg.(*pgproto3.DataRow); ok {
+					require.False(t, sawData, "let Query must return only one row")
+					require.Len(t, dataRow.Values, 1, "let Query must return only one column")
+					sawData = true
+					for _, arg := range d.CmdArgs {
+						vars[arg.Key] = string(dataRow.Values[0])
+					}
+				}
+			}
+			return ""
 		case "send":
 			if (d.HasArg("crdb_only") && !p.isCockroachDB) ||
 				(d.HasArg("noncrdb_only") && p.isCockroachDB) {
 				return d.Expected
 			}
 			for _, line := range strings.Split(d.Input, "\n") {
+				for k, v := range vars {
+					line = strings.ReplaceAll(line, k, v)
+				}
 				if err := p.SendOneLine(line); err != nil {
 					t.Fatalf("%s: send %s: %v", d.Pos, line, err)
 				}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76965

Change the test so it doesn't rely on sleeps, and instead uses
cluster-provided timestamps.

Release note: None