### PR TITLE
log: Set content type header for http sink

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -333,7 +333,8 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 				// The sink was not accepting entries at this level. Nothing to do.
 				continue
 			}
-			if err := s.sink.output(bufs.b[i].Bytes(), sinkOutputOptions{extraFlush: extraFlush, forceSync: isFatal}); err != nil {
+			format := formatParsers[s.formatter.formatterName()]
+			if err := s.sink.output(bufs.b[i].Bytes(), sinkOutputOptions{extraFlush: extraFlush, forceSync: isFatal, format: format}); err != nil {
 				if !s.criticality {
 					// An error on this sink is not critical. Just report
 					// the error and move on.

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -375,6 +375,7 @@ func newFluentSinkInfo(c logconfig.FluentSinkConfig) (*sinkInfo, error) {
 
 func newHTTPSinkInfo(c logconfig.HTTPSinkConfig) (*sinkInfo, error) {
 	info := &sinkInfo{}
+
 	if err := info.applyConfig(c.CommonSinkConfig); err != nil {
 		return nil, err
 	}

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -12,7 +12,6 @@ package log
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,7 +37,7 @@ import (
 func testBase(
 	t *testing.T,
 	defaults logconfig.HTTPDefaults,
-	fn func(body string) error,
+	fn func(header http.Header, body string) error,
 	hangServer bool,
 	deadline time.Duration,
 ) {
@@ -68,7 +68,7 @@ func testBase(
 			<-cancelCh
 		} else {
 			// The test is expecting some message via a predicate.
-			if err := fn(string(buf)); err != nil {
+			if err := fn(r.Header, string(buf)); err != nil {
 				// non-failing, in case there are extra log messages generated
 				t.Log(err)
 			} else {
@@ -175,7 +175,7 @@ func TestMessageReceived(t *testing.T) {
 		DisableKeepAlives: &tb,
 	}
 
-	testFn := func(body string) error {
+	testFn := func(_ http.Header, body string) error {
 		t.Log(body)
 		if !strings.Contains(body, `"message":"hello world"`) {
 			return errors.New("Log message not found in request")
@@ -204,4 +204,72 @@ func TestHTTPSinkTimeout(t *testing.T) {
 	}
 
 	testBase(t, defaults, nil /* testFn */, true /* hangServer */, 500*time.Millisecond)
+}
+
+// TestHTTPSinkContentTypeJSON verifies that the HTTP sink content type
+// header is set to `application/json` when the format is json.
+func TestHTTPSinkContentTypeJSON(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	address := "http://localhost" // testBase appends the port
+	timeout := 5 * time.Second
+	tb := true
+	format := "json"
+	expectedContentType := "application/json"
+	defaults := logconfig.HTTPDefaults{
+		Address: &address,
+		Timeout: &timeout,
+
+		// We need to disable keepalives otherwise the HTTP server in the
+		// test will let an async goroutine run waiting for more requests.
+		DisableKeepAlives: &tb,
+		CommonSinkConfig: logconfig.CommonSinkConfig{
+			Format: &format,
+		},
+	}
+
+	testFn := func(header http.Header, body string) error {
+		t.Log(body)
+		contentType := header.Get("Content-Type")
+		if contentType != expectedContentType {
+			return errors.Newf("mismatched content type: expected %s, got %s")
+		}
+		return nil
+	}
+
+	testBase(t, defaults, testFn, false /* hangServer */, time.Duration(0))
+}
+
+// TestHTTPSinkContentTypePlainText verifies that the HTTP sink content type
+// header is set to `text/plain` when the format is json.
+func TestHTTPSinkContentTypePlainText(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	address := "http://localhost" // testBase appends the port
+	timeout := 5 * time.Second
+	tb := true
+	format := "crdb-v1"
+	expectedContentType := "text/plain"
+	defaults := logconfig.HTTPDefaults{
+		Address: &address,
+		Timeout: &timeout,
+
+		// We need to disable keepalives otherwise the HTTP server in the
+		// test will let an async goroutine run waiting for more requests.
+		DisableKeepAlives: &tb,
+		CommonSinkConfig: logconfig.CommonSinkConfig{
+			Format: &format,
+		},
+	}
+
+	testFn := func(header http.Header, body string) error {
+		t.Log(body)
+		contentType := header.Get("Content-Type")
+		if contentType != expectedContentType {
+			return errors.Newf("mismatched content type: expected %s, got %s")
+		}
+		return nil
+	}
+
+	testBase(t, defaults, testFn, false /* hangServer */, time.Duration(0))
 }

--- a/pkg/util/log/sinks.go
+++ b/pkg/util/log/sinks.go
@@ -31,6 +31,8 @@ type sinkOutputOptions struct {
 	// forceSync forces synchronous operation of this output operation.
 	// That is, it will block until the output has been handled.
 	forceSync bool
+	// format specifies the log entry format (e.g. json etc.).
+	format string
 }
 
 // logSink abstracts the destination of logging events, after all


### PR DESCRIPTION
The content type header for the output of HTTP log sink
is always set to text/plain irrespective of the log format.
If the log format is JSON, we should set the content
type to be application/json.

Release note (bug fix): The content type header for the
HTTP log sink is set to application/json if the format of
the log output is JSON.