### PR TITLE
sql: fix error handling for AOST clause

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -756,38 +756,42 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 					return err
 				}
 			}
-		} else if p.extendedEvalCtx.AsOfSystemTime.BoundedStaleness {
-			// This has to be a bounded staleness read with nearest_only=True during
-			// a retry. The AOST read timestamps are expected to differ.
-			if p.extendedEvalCtx.AsOfSystemTime.MaxTimestampBound.IsEmpty() {
-				return errors.AssertionFailedf(
-					"expected bounded_staleness set with a max_timestamp_bound",
-				)
+			return nil
+		}
+		if *p.extendedEvalCtx.AsOfSystemTime == *asOf {
+			// In most cases, the AOST timestamps are expected to match.
+			return nil
+		}
+		if p.extendedEvalCtx.AsOfSystemTime.BoundedStaleness {
+			if !p.extendedEvalCtx.AsOfSystemTime.MaxTimestampBound.IsEmpty() {
+				// This has to be a bounded staleness read with nearest_only=True during
+				// a retry. The AOST read timestamps are expected to differ.
+				return nil
 			}
-		} else if *p.extendedEvalCtx.AsOfSystemTime != *asOf {
-			return errors.AssertionFailedf(
-				"cannot specify AS OF SYSTEM TIME with different timestamps",
-			)
+			return errors.AssertionFailedf("expected bounded_staleness set with a max_timestamp_bound")
 		}
-	} else {
-		// If we're in an explicit txn, we allow AOST but only if it matches with
-		// the transaction's timestamp. This is useful for running AOST statements
-		// using the InternalExecutor inside an external transaction; one might want
-		// to do that to force p.avoidLeasedDescriptors to be set below.
-		if asOf.BoundedStaleness {
-			return pgerror.Newf(
-				pgcode.FeatureNotSupported,
-				"cannot use a bounded staleness query in a transaction",
-			)
-		}
-		if readTs := ex.state.getReadTimestamp(); asOf.Timestamp != readTs {
-			err = pgerror.Newf(pgcode.Syntax,
-				"inconsistent AS OF SYSTEM TIME timestamp; expected: %s", readTs)
-			err = errors.WithHint(err, "try SET TRANSACTION AS OF SYSTEM TIME")
-			return err
-		}
-		p.extendedEvalCtx.AsOfSystemTime = asOf
+		return errors.AssertionFailedf(
+			"cannot specify AS OF SYSTEM TIME with different timestamps. expected: %s, got: %s",
+			p.extendedEvalCtx.AsOfSystemTime.Timestamp, asOf.Timestamp,
+		)
 	}
+	// If we're in an explicit txn, we allow AOST but only if it matches with
+	// the transaction's timestamp. This is useful for running AOST statements
+	// using the InternalExecutor inside an external transaction; one might want
+	// to do that to force p.avoidLeasedDescriptors to be set below.
+	if asOf.BoundedStaleness {
+		return pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"cannot use a bounded staleness query in a transaction",
+		)
+	}
+	if readTs := ex.state.getReadTimestamp(); asOf.Timestamp != readTs {
+		err = pgerror.Newf(pgcode.Syntax,
+			"inconsistent AS OF SYSTEM TIME timestamp; expected: %s, got: %s", readTs, asOf.Timestamp)
+		err = errors.WithHint(err, "try SET TRANSACTION AS OF SYSTEM TIME")
+		return err
+	}
+	p.extendedEvalCtx.AsOfSystemTime = asOf
 	return nil
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76979
fixes https://github.com/cockroachdb/cockroach/issues/76978
fixes https://github.com/cockroachdb/cockroach/issues/76977
fixes https://github.com/cockroachdb/cockroach/issues/76975
fixes https://github.com/cockroachdb/cockroach/issues/76787

The AOST clause logic would previously error for any bounded staleness
query that was used in a prepared statement. This is because prepared
statements use an implicit txn, so the same AOST clause has to be
checked multiple times in the txn. A recent commit refactored
the error handling and caused this bug.

Release note: None