### PR TITLE
changefeedccl: allow users to alter the sink URI of an existing changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -118,6 +118,10 @@ const (
 	OptKafkaSinkConfig   = `kafka_sink_config`
 	OptWebhookSinkConfig = `webhook_sink_config`
 
+	// OptSink allows users to alter the Sink URI of an existing changefeed.
+	// Note that this option is only allowed for alter changefeed statements.
+	OptSink = `sink`
+
 	SinkParamCACert                 = `ca_cert`
 	SinkParamClientCert             = `client_cert`
 	SinkParamClientKey              = `client_key`
@@ -237,3 +241,14 @@ var NoLongerExperimental = map[string]string{
 // AlterChangefeedUnsupportedOptions are changefeed options that we do not allow
 // users to alter
 var AlterChangefeedUnsupportedOptions = makeStringSet(OptCursor, OptInitialScan, OptNoInitialScan)
+
+// AlterChangefeedOptionExpectValues is used to parse alter changefeed options
+// using PlanHookState.TypeAsStringOpts().
+var AlterChangefeedOptionExpectValues = func() map[string]sql.KVStringOptValidate {
+	alterChangefeedOptions := make(map[string]sql.KVStringOptValidate, len(ChangefeedOptionExpectValues)+1)
+	for key, value := range ChangefeedOptionExpectValues {
+		alterChangefeedOptions[key] = value
+	}
+	alterChangefeedOptions[OptSink] = sql.KVStringOptRequireValue
+	return alterChangefeedOptions
+}()


### PR DESCRIPTION
changefeedccl: allow users to alter the sink URI of
an existing changefeed

References #75895

In this PR, we introduce the capability to alter
the sink URI of an existing changefeed. This
can be achieved by executing the following
statement:

ALTER CHANGEFEED <job_id> SET sink = '<sink_uri>'

Note that the sink type cannot be altered. That is,
the sink type must be the same type that was chosen
when the changefeed was initially created.

Release note (enterprise change): Users may now alter
the sink URI of an existing changefeed. This can be
achieved by executing the following statement:

ALTER CHANGEFEED <job_id> SET sink = '<sink_uri>'

Where the sink type of the new sink must match the
sink type of the old sink that was chosen at the
creation of the changefeed.