### PR TITLE
dev: make sure we inherit `stdout` and `stderr` when appropriate

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=18
+DEV_VERSION=19
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/io/exec/exec.go
+++ b/pkg/cmd/dev/io/exec/exec.go
@@ -185,11 +185,14 @@ func (e *Exec) commandContextInheritingStdStreamsImpl(
 	}
 	e.logger.Print(command)
 
-	_, err := e.Next(command, func(outTrace, errTrace io.Writer) (string, error) {
+	_, err := e.Next(command, func(_, _ io.Writer) (string, error) {
 		cmd := exec.CommandContext(ctx, name, args...)
+		// NB: In this function we specifically want to inherit the
+		// standard IO streams, so we are not going to capture the
+		// `outTrace` or `errTrace`.
 		cmd.Stdin = os.Stdin
-		cmd.Stdout = io.MultiWriter(e.stdout, outTrace)
-		cmd.Stderr = io.MultiWriter(e.stderr, errTrace)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		cmd.Dir = e.dir
 		cmd.Env = env
 


### PR DESCRIPTION
Otherwise `bazel build`/`test` output will be ugly (won't be colored/
use `ncurses`/etc.)

Release note: None