### PR TITLE
opt: fetch virtual columns during cascading delete

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3835,3 +3835,38 @@ NOTICE: type of foreign key column "parent_id" (int4) is not identical to refere
 
 statement ok
 DROP DATABASE db_type_test
+
+# Regression test for #76852. Correctly maintain child indexes on virtual
+# columns during a cascading delete.
+statement ok
+CREATE TABLE p76852 (
+  p STRING PRIMARY KEY,
+  i INT
+);
+CREATE TABLE c76852 (
+  b BOOL,
+  v STRING AS (b::STRING) VIRTUAL,
+  p STRING REFERENCES p76852 (p) ON DELETE CASCADE,
+  PRIMARY KEY (p, b),
+  INDEX idx (v)
+);
+
+statement ok
+INSERT INTO p76852 (p, i) VALUES ('foo', 1);
+INSERT INTO c76852 (b, p) VALUES (true, 'foo');
+DELETE FROM p76852 WHERE true;
+
+# Fast path case.
+query B
+SELECT b FROM c76852@idx WHERE b
+----
+
+statement ok
+INSERT INTO p76852 (p, i) VALUES ('foo', 1);
+INSERT INTO c76852 (b, p) VALUES (true, 'foo');
+DELETE FROM p76852 WHERE i = 1;
+
+# Non-fast path case.
+query B
+SELECT b FROM c76852@idx WHERE b
+----

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -284,10 +284,9 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 		mb.fetchScope = b.buildScan(
 			b.addTable(cb.childTable, &mb.alias),
 			tableOrdinals(cb.childTable, columnKinds{
-				includeMutations:       false,
-				includeSystem:          false,
-				includeInverted:        false,
-				includeVirtualComputed: true,
+				includeMutations: false,
+				includeSystem:    false,
+				includeInverted:  false,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,
@@ -503,17 +502,12 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	bindingProps *props.Relational,
 	oldValues opt.ColList,
 ) (outScope *scope) {
-	// We must fetch virtual computed columns for cascades that result in an
-	// update to the child table. The execution engine requires that the fetch
-	// columns are a superset of the update columns. See the related panic in
-	// execFactory.ConstructUpdate.
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
-			includeMutations:       false,
-			includeSystem:          false,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: false,
+			includeSystem:    false,
+			includeInverted:  false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -744,16 +738,12 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 	oldValues opt.ColList,
 	newValues opt.ColList,
 ) (outScope *scope) {
-	// We must fetch virtual computed columns for cascades. The execution engine
-	// requires that the fetch columns are a superset of the update columns. See
-	// the related panic in execFactory.ConstructUpdate.
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
-			includeMutations:       false,
-			includeSystem:          false,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: false,
+			includeSystem:    false,
+			includeInverted:  false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -287,7 +287,7 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 				includeMutations:       false,
 				includeSystem:          false,
 				includeInverted:        false,
-				includeVirtualComputed: false,
+				includeVirtualComputed: true,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,
@@ -507,16 +507,13 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	// update to the child table. The execution engine requires that the fetch
 	// columns are a superset of the update columns. See the related panic in
 	// execFactory.ConstructUpdate.
-	action := fk.DeleteReferenceAction()
-	fetchVirtualComputedCols := action == tree.SetNull || action == tree.SetDefault
-
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
 			includeMutations:       false,
 			includeSystem:          false,
 			includeInverted:        false,
-			includeVirtualComputed: fetchVirtualComputedCols,
+			includeVirtualComputed: true,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -282,10 +282,9 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	mb.fetchScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: true,
+			includeSystem:    true,
+			includeInverted:  false,
 		}),
 		indexFlags,
 		noRowLocking,
@@ -398,10 +397,9 @@ func (mb *mutationBuilder) buildInputForDelete(
 	mb.fetchScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: true,
+			includeSystem:    true,
+			includeInverted:  false,
 		}),
 		indexFlags,
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -287,10 +287,9 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 	fetchScope := mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       false,
-			includeSystem:          false,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: false,
+			includeSystem:    false,
+			includeInverted:  false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -373,10 +372,9 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 	mb.fetchScope = mb.b.buildScan(
 		mb.b.addTable(mb.tab, &mb.alias),
 		tableOrdinals(mb.tab, columnKinds{
-			includeMutations:       true,
-			includeSystem:          true,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: true,
+			includeSystem:    true,
+			includeInverted:  false,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,
@@ -581,10 +579,9 @@ func (h *arbiterPredicateHelper) tableScope() *scope {
 	if h.tableScopeLazy == nil {
 		h.tableScopeLazy = h.mb.b.buildScan(
 			h.tabMeta, tableOrdinals(h.tabMeta.Table, columnKinds{
-				includeMutations:       false,
-				includeSystem:          false,
-				includeInverted:        false,
-				includeVirtualComputed: true,
+				includeMutations: false,
+				includeSystem:    false,
+				includeInverted:  false,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -399,10 +399,9 @@ func (h *uniqueCheckHelper) buildInsertionCheck() memo.UniqueChecksItem {
 func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, ordinals []int) {
 	tabMeta := h.mb.b.addTable(h.mb.tab, tree.NewUnqualifiedTableName(h.mb.tab.Name()))
 	ordinals = tableOrdinals(tabMeta.Table, columnKinds{
-		includeMutations:       false,
-		includeSystem:          false,
-		includeInverted:        false,
-		includeVirtualComputed: true,
+		includeMutations: false,
+		includeSystem:    false,
+		includeInverted:  false,
 	})
 	return h.mb.b.buildScan(
 		tabMeta,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -115,10 +115,9 @@ func (b *Builder) buildDataSource(
 			return b.buildScan(
 				tabMeta,
 				tableOrdinals(t, columnKinds{
-					includeMutations:       false,
-					includeSystem:          true,
-					includeInverted:        false,
-					includeVirtualComputed: true,
+					includeMutations: false,
+					includeSystem:    true,
+					includeInverted:  false,
 				}),
 				indexFlags, locking, inScope,
 			)
@@ -399,10 +398,9 @@ func (b *Builder) buildScanFromTableRef(
 		ordinals = resolveNumericColumnRefs(tab, ref.Columns)
 	} else {
 		ordinals = tableOrdinals(tab, columnKinds{
-			includeMutations:       false,
-			includeSystem:          true,
-			includeInverted:        false,
-			includeVirtualComputed: true,
+			includeMutations: false,
+			includeSystem:    true,
+			includeInverted:  false,
 		})
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -1005,7 +1005,8 @@ exec-ddl
 CREATE TABLE child_virt (
   c INT PRIMARY KEY,
   p INT REFERENCES parent_virt(p) ON DELETE CASCADE,
-  v INT AS (p) VIRTUAL
+  v INT AS (p) VIRTUAL,
+  v2 STRING AS (c::STRING) VIRTUAL
 )
 ----
 
@@ -1028,17 +1029,24 @@ root
  └── cascade
       └── delete child_virt
            ├── columns: <none>
-           ├── fetch columns: c:12 child_virt.p:13
+           ├── fetch columns: c:13 child_virt.p:14 v:15 v2:16
            └── select
-                ├── columns: c:12!null child_virt.p:13!null
-                ├── scan child_virt
-                │    ├── columns: c:12!null child_virt.p:13
-                │    └── computed column expressions
-                │         └── v:14
-                │              └── child_virt.p:13
+                ├── columns: c:13!null child_virt.p:14!null v:15 v2:16!null
+                ├── project
+                │    ├── columns: v:15 v2:16!null c:13!null child_virt.p:14
+                │    ├── scan child_virt
+                │    │    ├── columns: c:13!null child_virt.p:14
+                │    │    └── computed column expressions
+                │    │         ├── v:15
+                │    │         │    └── child_virt.p:14
+                │    │         └── v2:16
+                │    │              └── c:13::STRING
+                │    └── projections
+                │         ├── child_virt.p:14 [as=v:15]
+                │         └── c:13::STRING [as=v2:16]
                 └── filters
-                     ├── child_virt.p:13 > 1
-                     └── child_virt.p:13 IS DISTINCT FROM CAST(NULL AS INT8)
+                     ├── child_virt.p:14 > 1
+                     └── child_virt.p:14 IS DISTINCT FROM CAST(NULL AS INT8)
 
 # No fast path.
 build-cascades
@@ -1060,17 +1068,24 @@ root
  └── cascade
       └── delete child_virt
            ├── columns: <none>
-           ├── fetch columns: c:12 child_virt.p:13
+           ├── fetch columns: c:13 child_virt.p:14 v:15 v2:16
            └── semi-join (hash)
-                ├── columns: c:12!null child_virt.p:13
-                ├── scan child_virt
-                │    ├── columns: c:12!null child_virt.p:13
-                │    └── computed column expressions
-                │         └── v:14
-                │              └── child_virt.p:13
+                ├── columns: c:13!null child_virt.p:14 v:15 v2:16!null
+                ├── project
+                │    ├── columns: v:15 v2:16!null c:13!null child_virt.p:14
+                │    ├── scan child_virt
+                │    │    ├── columns: c:13!null child_virt.p:14
+                │    │    └── computed column expressions
+                │    │         ├── v:15
+                │    │         │    └── child_virt.p:14
+                │    │         └── v2:16
+                │    │              └── c:13::STRING
+                │    └── projections
+                │         ├── child_virt.p:14 [as=v:15]
+                │         └── c:13::STRING [as=v2:16]
                 ├── with-scan &1
-                │    ├── columns: p:17!null
+                │    ├── columns: p:19!null
                 │    └── mapping:
-                │         └──  parent_virt.p:4 => p:17
+                │         └──  parent_virt.p:4 => p:19
                 └── filters
-                     └── child_virt.p:13 = p:17
+                     └── child_virt.p:14 = p:19

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -708,9 +708,6 @@ type columnKinds struct {
 
 	// If true, include inverted index columns.
 	includeInverted bool
-
-	// If true, include virtual computed columns.
-	includeVirtualComputed bool
 }
 
 // tableOrdinals returns a slice of ordinals that correspond to table columns of
@@ -727,7 +724,7 @@ func tableOrdinals(tab cat.Table, k columnKinds) []int {
 	ordinals := make([]int, 0, n)
 	for i := 0; i < n; i++ {
 		col := tab.Column(i)
-		if shouldInclude[col.Kind()] && (k.includeVirtualComputed || !col.IsVirtualComputed()) {
+		if shouldInclude[col.Kind()] {
 			ordinals = append(ordinals, i)
 		}
 	}


### PR DESCRIPTION
#### opt: fetch virtual columns during cascading delete

Previously, virtual columns were not always fetched from child tables in
FK relationships during cascading deletes. This prevented the execution
engine from correctly removing KV entries in indexes on virtual columns,
causing index corruption. Virtual columns are now always fetched from
child tables during cascading deletes.

Fixes #76852

Release note (bug fix): A bug has been fixed that could corrupt indexes
containing virtual columns or expressions. The bug only occured when
the index's table had a foreign key reference to another table with an
`ON DELETE CASCADE` action, and a row was deleted in the referenced
table. This bug was present since virtual columns were added in version
21.1.0.

#### opt: remove includeVirtualComputed field from columnKinds

The `columnKinds.includeVirtualComputed` column field is always `true`,
so there is no need for it. It has been removed.

Release note: None
