### PR TITLE
release-21.2: opt: fetch virtual columns during cascading delete

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -3808,3 +3808,38 @@ INSERT INTO t3 VALUES (1, 1, 1), (2, NULL, 2)
 
 statement ok
 DROP TABLE t3, t1, t2
+
+# Regression test for #76852. Correctly maintain child indexes on virtual
+# columns during a cascading delete.
+statement ok
+CREATE TABLE p76852 (
+  p STRING PRIMARY KEY,
+  i INT
+);
+CREATE TABLE c76852 (
+  b BOOL,
+  v STRING AS (b::STRING) VIRTUAL,
+  p STRING REFERENCES p76852 (p) ON DELETE CASCADE,
+  PRIMARY KEY (p, b),
+  INDEX idx (v)
+);
+
+statement ok
+INSERT INTO p76852 (p, i) VALUES ('foo', 1);
+INSERT INTO c76852 (b, p) VALUES (true, 'foo');
+DELETE FROM p76852 WHERE true;
+
+# Fast path case.
+query B
+SELECT b FROM c76852@idx WHERE b
+----
+
+statement ok
+INSERT INTO p76852 (p, i) VALUES ('foo', 1);
+INSERT INTO c76852 (b, p) VALUES (true, 'foo');
+DELETE FROM p76852 WHERE i = 1;
+
+# Non-fast path case.
+query B
+SELECT b FROM c76852@idx WHERE b
+----

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -286,7 +286,7 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 				includeMutations:       false,
 				includeSystem:          false,
 				includeInverted:        false,
-				includeVirtualComputed: false,
+				includeVirtualComputed: true,
 			}),
 			nil, /* indexFlags */
 			noRowLocking,
@@ -506,16 +506,13 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	// update to the child table. The execution engine requires that the fetch
 	// columns are a superset of the update columns. See the related panic in
 	// execFactory.ConstructUpdate.
-	action := fk.DeleteReferenceAction()
-	fetchVirtualComputedCols := action == tree.SetNull || action == tree.SetDefault
-
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
 			includeMutations:       false,
 			includeSystem:          false,
 			includeInverted:        false,
-			includeVirtualComputed: fetchVirtualComputedCols,
+			includeVirtualComputed: true,
 		}),
 		nil, /* indexFlags */
 		noRowLocking,

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -1005,7 +1005,8 @@ exec-ddl
 CREATE TABLE child_virt (
   c INT PRIMARY KEY,
   p INT REFERENCES parent_virt(p) ON DELETE CASCADE,
-  v INT AS (p) VIRTUAL
+  v INT AS (p) VIRTUAL,
+  v2 STRING AS (c::STRING) VIRTUAL
 )
 ----
 
@@ -1028,17 +1029,24 @@ root
  └── cascade
       └── delete child_virt
            ├── columns: <none>
-           ├── fetch columns: c:12 child_virt.p:13
+           ├── fetch columns: c:13 child_virt.p:14 v:15 v2:16
            └── select
-                ├── columns: c:12!null child_virt.p:13!null
-                ├── scan child_virt
-                │    ├── columns: c:12!null child_virt.p:13
-                │    └── computed column expressions
-                │         └── v:14
-                │              └── child_virt.p:13
+                ├── columns: c:13!null child_virt.p:14!null v:15 v2:16!null
+                ├── project
+                │    ├── columns: v:15 v2:16!null c:13!null child_virt.p:14
+                │    ├── scan child_virt
+                │    │    ├── columns: c:13!null child_virt.p:14
+                │    │    └── computed column expressions
+                │    │         ├── v:15
+                │    │         │    └── child_virt.p:14
+                │    │         └── v2:16
+                │    │              └── c:13::STRING
+                │    └── projections
+                │         ├── child_virt.p:14 [as=v:15]
+                │         └── c:13::STRING [as=v2:16]
                 └── filters
-                     ├── child_virt.p:13 > 1
-                     └── child_virt.p:13 IS DISTINCT FROM CAST(NULL AS INT8)
+                     ├── child_virt.p:14 > 1
+                     └── child_virt.p:14 IS DISTINCT FROM CAST(NULL AS INT8)
 
 # No fast path.
 build-cascades
@@ -1060,17 +1068,24 @@ root
  └── cascade
       └── delete child_virt
            ├── columns: <none>
-           ├── fetch columns: c:12 child_virt.p:13
+           ├── fetch columns: c:13 child_virt.p:14 v:15 v2:16
            └── semi-join (hash)
-                ├── columns: c:12!null child_virt.p:13
-                ├── scan child_virt
-                │    ├── columns: c:12!null child_virt.p:13
-                │    └── computed column expressions
-                │         └── v:14
-                │              └── child_virt.p:13
+                ├── columns: c:13!null child_virt.p:14 v:15 v2:16!null
+                ├── project
+                │    ├── columns: v:15 v2:16!null c:13!null child_virt.p:14
+                │    ├── scan child_virt
+                │    │    ├── columns: c:13!null child_virt.p:14
+                │    │    └── computed column expressions
+                │    │         ├── v:15
+                │    │         │    └── child_virt.p:14
+                │    │         └── v2:16
+                │    │              └── c:13::STRING
+                │    └── projections
+                │         ├── child_virt.p:14 [as=v:15]
+                │         └── c:13::STRING [as=v2:16]
                 ├── with-scan &1
-                │    ├── columns: p:17!null
+                │    ├── columns: p:19!null
                 │    └── mapping:
-                │         └──  parent_virt.p:4 => p:17
+                │         └──  parent_virt.p:4 => p:19
                 └── filters
-                     └── child_virt.p:13 = p:17
+                     └── child_virt.p:14 = p:19


### PR DESCRIPTION
Backport 1/2 commits from #77052.

/cc @cockroachdb/release

---

#### opt: fetch virtual columns during cascading delete

Previously, virtual columns were not always fetched from child tables in
FK relationships during cascading deletes. This prevented the execution
engine from correctly removing KV entries in indexes on virtual columns,
causing index corruption. Virtual columns are now always fetched from
child tables during cascading deletes.

Fixes #76852

Release note (bug fix): A bug has been fixed that could corrupt indexes
containing virtual columns or expressions. The bug only occured when
the index's table had a foreign key reference to another table with an
`ON DELETE CASCADE` action, and a row was deleted in the referenced
table. This bug was present since virtual columns were added in version
21.1.0.

---

Release justification: This commit fixes a bug that corrupts indexes with
virtual columns or expressions.

