### PR TITLE
sql: change index backfill merger to use batch api

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -82,17 +82,6 @@ var indexBackfillBatchSize = settings.RegisterIntSetting(
 	settings.NonNegativeInt, /* validateFn */
 )
 
-// indexBackfillMergeBatchSize is the maximum number of rows we
-// attempt to merge in a single transaction during the merging
-// process.
-var indexBackfillMergeBatchSize = settings.RegisterIntSetting(
-	settings.TenantWritable,
-	"bulkio.index_backfill.merge_batch_size",
-	"the number of rows we merge between temporary and adding indexes in a single batch",
-	1000,
-	settings.NonNegativeInt, /* validateFn */
-)
-
 // columnBackfillBatchSize is the maximum number of rows we update at once when
 // adding or removing columns.
 var columnBackfillBatchSize = settings.RegisterIntSetting(

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -55,14 +55,10 @@ func initIndexBackfillerSpec(
 }
 
 func initIndexBackfillMergerSpec(
-	desc descpb.TableDescriptor,
-	chunkSize int64,
-	addedIndexes []descpb.IndexID,
-	temporaryIndexes []descpb.IndexID,
+	desc descpb.TableDescriptor, addedIndexes []descpb.IndexID, temporaryIndexes []descpb.IndexID,
 ) (execinfrapb.IndexBackfillMergerSpec, error) {
 	return execinfrapb.IndexBackfillMergerSpec{
 		Table:            desc,
-		ChunkSize:        chunkSize,
 		AddedIndexes:     addedIndexes,
 		TemporaryIndexes: temporaryIndexes,
 	}, nil

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -321,5 +321,5 @@ message IndexBackfillMergerSpec {
   repeated roachpb.Span spans = 4 [(gogoproto.nullable) = false];
   repeated int32 span_idx = 5;
 
-  optional int64 chunk_size = 6 [(gogoproto.nullable) = false];
+  // NEXT ID: 8.
 }

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -63,9 +63,8 @@ func (im *IndexBackfillerMergePlanner) plan(
 		evalCtx = createSchemaChangeEvalCtx(ctx, im.execCfg, txn.ReadTimestamp(), descriptors)
 		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn,
 			DistributionTypeSystemTenantOnly)
-		chunkSize := indexBackfillMergeBatchSize.Get(&im.execCfg.Settings.SV)
 
-		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), chunkSize, addedIndexes, temporaryIndexes)
+		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), addedIndexes, temporaryIndexes)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -371,7 +371,7 @@ func NewProcessor(
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
 			return nil, err
 		}
-		return backfill.NewIndexBackfillMerger(flowCtx, *core.IndexBackfillMerger, outputs[0])
+		return backfill.NewIndexBackfillMerger(ctx, flowCtx, *core.IndexBackfillMerger, outputs[0])
 	}
 	return nil, errors.Errorf("unsupported processor core %q", core)
 }


### PR DESCRIPTION
Use Batch API instead of txn.Scan() in order to limit the number of bytes per
batch response in the index backfill merger.

Fixes #76685.

Release note: None