### PR TITLE
sql: bugfix to DECLARE as prepared statement

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -535,6 +535,7 @@ go_test(
         "show_trace_replica_test.go",
         "sort_test.go",
         "split_test.go",
+        "sql_cursor_test.go",
         "statement_mark_redaction_test.go",
         "table_ref_test.go",
         "table_test.go",

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -30,10 +30,6 @@ import (
 // DeclareCursor implements the DECLARE statement.
 // See https://www.postgresql.org/docs/current/sql-declare.html for details.
 func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (planNode, error) {
-	if p.autoCommit {
-		return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
-	}
-
 	if s.Hold {
 		return nil, unimplemented.NewWithIssue(41412, "DECLARE CURSOR WITH HOLD")
 	}
@@ -44,61 +40,71 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 		return nil, unimplemented.NewWithIssue(41412, "DECLARE SCROLL CURSOR")
 	}
 
-	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
-	cursorName := s.Name.String()
-	if cursor, _ := p.sqlCursors.getCursor(cursorName); cursor != nil {
-		return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", cursorName)
-	}
+	return &delayedNode{
+		name: s.String(),
+		constructor: func(ctx context.Context, p *planner) (_ planNode, _ error) {
+			if p.extendedEvalCtx.TxnImplicit {
+				return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
+			}
 
-	// Try to plan the cursor query to make sure that it's valid.
-	stmt := makeStatement(parser.Statement{AST: s.Select}, ClusterWideID{})
-	pt := planTop{}
-	pt.init(&stmt, &p.instrumentation)
-	opc := &p.optPlanningCtx
-	opc.p.stmt = stmt
-	opc.reset()
+			ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
+			cursorName := s.Name.String()
+			if cursor, _ := p.sqlCursors.getCursor(cursorName); cursor != nil {
+				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", cursorName)
+			}
 
-	memo, err := opc.buildExecMemo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if err := opc.runExecBuilder(
-		&pt,
-		&stmt,
-		newExecFactory(p),
-		memo,
-		p.EvalContext(),
-		p.autoCommit,
-	); err != nil {
-		return nil, err
-	}
-	if pt.flags.IsSet(planFlagContainsMutation) {
-		// Cursors with mutations are invalid.
-		return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-			"DECLARE CURSOR must not contain data-modifying statements in WITH")
-	}
+			// Try to plan the cursor query to make sure that it's valid.
+			stmt := makeStatement(parser.Statement{AST: s.Select}, ClusterWideID{})
+			pt := planTop{}
+			pt.init(&stmt, &p.instrumentation)
+			opc := &p.optPlanningCtx
+			opc.p.stmt = stmt
+			opc.reset()
 
-	statement := s.Select.String()
-	rows, err := ie.QueryIterator(ctx, "sql-cursor", p.txn, statement)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to DECLARE CURSOR")
-	}
-	inputState := p.txn.GetLeafTxnInputState(ctx)
-	cursor := &sqlCursor{
-		InternalRows: rows,
-		readSeqNum:   inputState.ReadSeqNum,
-		txn:          p.txn,
-		statement:    statement,
-		created:      timeutil.Now(),
-	}
-	if err := p.sqlCursors.addCursor(cursorName, cursor); err != nil {
-		// This case shouldn't happen because cursor names are scoped to a session,
-		// and sessions can't have more than one statement running at once. But
-		// let's be diligent and clean up if it somehow does happen anyway.
-		_ = cursor.Close()
-		return nil, err
-	}
-	return newZeroNode(nil /* columns */), nil
+			memo, err := opc.buildExecMemo(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if err := opc.runExecBuilder(
+				&pt,
+				&stmt,
+				newExecFactory(p),
+				memo,
+				p.EvalContext(),
+				p.autoCommit,
+			); err != nil {
+				return nil, err
+			}
+			if pt.flags.IsSet(planFlagContainsMutation) {
+				// Cursors with mutations are invalid.
+				return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+					"DECLARE CURSOR must not contain data-modifying statements in WITH")
+			}
+
+			statement := s.Select.String()
+			itCtx := context.Background()
+			rows, err := ie.QueryIterator(itCtx, "sql-cursor", p.txn, statement)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to DECLARE CURSOR")
+			}
+			inputState := p.txn.GetLeafTxnInputState(ctx)
+			cursor := &sqlCursor{
+				InternalRows: rows,
+				readSeqNum:   inputState.ReadSeqNum,
+				txn:          p.txn,
+				statement:    statement,
+				created:      timeutil.Now(),
+			}
+			if err := p.sqlCursors.addCursor(cursorName, cursor); err != nil {
+				// This case shouldn't happen because cursor names are scoped to a session,
+				// and sessions can't have more than one statement running at once. But
+				// let's be diligent and clean up if it somehow does happen anyway.
+				_ = cursor.Close()
+				return nil, err
+			}
+			return newZeroNode(nil /* columns */), nil
+		},
+	}, nil
 }
 
 var errBackwardScan = pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "cursor can only scan forward")
@@ -219,7 +225,12 @@ func (f fetchNode) Close(ctx context.Context) {
 // CloseCursor implements the FETCH statement.
 // See https://www.postgresql.org/docs/current/sql-close.html for details.
 func (p *planner) CloseCursor(ctx context.Context, n *tree.CloseCursor) (planNode, error) {
-	return newZeroNode(nil /* columns */), p.sqlCursors.closeCursor(n.Name.String())
+	return &delayedNode{
+		name: n.String(),
+		constructor: func(ctx context.Context, p *planner) (planNode, error) {
+			return newZeroNode(nil /* columns */), p.sqlCursors.closeCursor(n.Name.String())
+		},
+	}, nil
 }
 
 type sqlCursor struct {

--- a/pkg/sql/sql_cursor_test.go
+++ b/pkg/sql/sql_cursor_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// Make sure that preparing a DECLARE doesn't cause problems.
+func TestPrepareDeclare(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	defer srv.Stopper().Stop(context.Background())
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	t.Run("prepare_declare_raw_txn", func(t *testing.T) {
+		// Make sure that preparing a DECLARE defers errors until execution.
+		stmt, err := conn.PrepareContext(ctx, "DECLARE foo CURSOR FOR VALUES (1), (2)")
+		require.NoError(t, err)
+
+		_, err = stmt.Exec()
+		require.EqualError(t, err, "pq: DECLARE CURSOR can only be used in transaction blocks")
+
+		// Make sure that we can use our prepared statement from before to
+		// successfully execute a declare cursor within a transaction.
+		// We need to execute a raw BEGIN so that we can reuse our pre-prepared txn.
+		_, err = conn.ExecContext(ctx, "BEGIN TRANSACTION")
+		require.NoError(t, err)
+
+		_, err = stmt.Exec()
+		require.NoError(t, err)
+
+		stmt, err = conn.PrepareContext(ctx, "FETCH 2 foo")
+		require.NoError(t, err)
+		r, err := stmt.Query()
+		require.NoError(t, err)
+		var actual int
+		r.Next()
+		require.NoError(t, r.Scan(&actual))
+		require.Equal(t, 1, actual)
+		more := r.Next()
+		require.Equal(t, true, more)
+		require.NoError(t, r.Scan(&actual))
+		require.Equal(t, 2, actual)
+		more = r.Next()
+		require.Equal(t, false, more)
+		_, err = conn.ExecContext(ctx, "COMMIT")
+		require.NoError(t, err)
+	})
+
+	t.Run("prepare_declare_driver_txn", func(t *testing.T) {
+		// Make sure that we can use the driver-level txn support to do the same thing.
+		tx, err := conn.BeginTx(context.Background(), nil /* opts */)
+		require.NoError(t, err)
+		stmt, err := tx.Prepare("DECLARE foo CURSOR FOR VALUES (1), (2)")
+		require.NoError(t, err)
+		_, err = stmt.Exec()
+		require.NoError(t, err)
+
+		stmt, err = tx.Prepare("FETCH 2 foo")
+		require.NoError(t, err)
+		r, err := stmt.Query()
+		require.NoError(t, err)
+		var actual int
+		r.Next()
+		require.NoError(t, r.Scan(&actual))
+		require.Equal(t, 1, actual)
+		more := r.Next()
+		require.Equal(t, true, more)
+		require.NoError(t, r.Scan(&actual))
+		require.Equal(t, 2, actual)
+		more = r.Next()
+		require.Equal(t, false, more)
+
+		require.NoError(t, tx.Commit())
+	})
+
+	// Make sure that we can use the automatic prepare support (when sending
+	// placeholders) to do the same thing.
+	// TODO (jordan): This currently doesn't work, because we don't fully walk
+	// the tree typechecking expressions when sending a DECLARE through the
+	// optimizer. See issue #77067.
+	// When this limitation is lifted, the rest of this test should be uncommented.
+	t.Run("prepare_declare_placeholder", func(t *testing.T) {
+		_, err = conn.ExecContext(ctx, "DECLARE foo CURSOR FOR SELECT 1 WHERE $1", true)
+		require.Contains(t, err.Error(), "could not determine data type of placeholder")
+
+		skip.WithIssue(t, 77067, "placeholders in DECLARE not supported")
+
+		stmt, err := conn.PrepareContext(ctx, "FETCH 1 foo")
+		require.NoError(t, err)
+		r, err := stmt.Query()
+		require.NoError(t, err)
+		var actual int
+		r.Next()
+		require.NoError(t, r.Scan(&actual))
+		require.Equal(t, 1, actual)
+		more := r.Next()
+		require.Equal(t, false, more)
+	})
+}


### PR DESCRIPTION
Closes #76883 

Previously, preparing a DECLARE CURSOR statement was buggy, leading to
errors and panics.

The reason for this was that the work of creating the cursor was done at
plan-time, rather than execution-time. There were no tests that caught
this, and it was ultimately noticed by a nightly driver test.

Now, this is fixed, and the work to declare the cursor properly happens
at execution time.

Release note: None (the bug was not present in a released version)
Release justification: Bug fixes and low-risk updates to new functionality