### PR TITLE
logic: add local-prepared logic test config

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -278,9 +278,12 @@ statement ok
 BEGIN; ALTER TABLE t33361 DROP COLUMN y
 
 query II
-DELETE FROM t33361 RETURNING *; COMMIT
+DELETE FROM t33361 RETURNING *
 ----
 1 3
+
+statement ok
+COMMIT
 
 # Test that delete works with column families (no indexes, so fast path).
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/multi_statement
+++ b/pkg/sql/logictest/testdata/logic_test/multi_statement
@@ -1,3 +1,8 @@
+# LogicTest: !local-prepared
+# We turn off the local-prepared mode because this test depends on
+# multi-statement statements being run in single batches, which is not
+# doable with prepared statements.
+
 statement ok
 CREATE TABLE kv (
   k CHAR PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -383,7 +383,6 @@ USE test_schema;
 query T
 BEGIN;
 SELECT crdb_internal.show_create_all_tables('test_schema');
-COMMIT;
 ----
 CREATE TABLE sc1.t (
     x INT8 NULL,
@@ -397,10 +396,10 @@ CREATE TABLE sc2.t (
 );
 
 query T
+COMMIT;
 BEGIN;
 SELECT * FROM sc1.t;
 SELECT crdb_internal.show_create_all_tables('test_schema');
-COMMIT;
 ----
 CREATE TABLE sc1.t (
     x INT8 NULL,
@@ -412,3 +411,6 @@ CREATE TABLE sc2.t (
     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 );
+
+statement ok
+COMMIT

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -75,6 +75,7 @@ go_library(
         "regexp_cache.go",
         "region.go",
         "rename.go",
+        "replace_scalars.go",
         "returning.go",
         "revoke.go",
         "role_spec.go",

--- a/pkg/sql/sem/tree/replace_scalars.go
+++ b/pkg/sql/sem/tree/replace_scalars.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// ReplaceScalarsWithPlaceholders traverses a statement, replacing scalars with
+// placeholders. It returns the new statement and the list of replaced scalars
+// in order.
+// This is used in tests, not production.
+func ReplaceScalarsWithPlaceholders(s Statement) (Statement, Exprs) {
+	v := &scalarReplacer{}
+	newStmt, _ := walkStmt(v, s)
+	return newStmt, v.scalars
+}
+
+type scalarReplacer struct {
+	scalars Exprs
+}
+
+func (s *scalarReplacer) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
+	switch t := expr.(type) {
+	//case dNull:
+	//	// Don't try to substitute NULL with placeholders, because Go's database/sql
+	//	// needs to know the type of the NULL in order to send it properly.
+	//	return false, expr
+	case Constant, Datum:
+		s.scalars = append(s.scalars, t)
+		return false, &Placeholder{Idx: PlaceholderIdx(len(s.scalars) - 1)}
+	}
+	return true, expr
+}
+
+func (s scalarReplacer) VisitPost(expr Expr) (newNode Expr) {
+	return expr
+}


### PR DESCRIPTION
This commit adds a new mode to the logic test harness that runs every
statement as a prepared statement rather than using the default "simple
query" mode of execution.

Release justification: test change

Release note: None