### PR TITLE
release-21.2: changefeedccl: mark kvcoord sendError as retryable

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord:with-mocks",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/liveness/livenesspb",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
@@ -128,6 +129,68 @@ func TestChangefeedBasics(t *testing.T) {
 
 	// NB running TestChangefeedBasics, which includes a DELETE, with
 	// cloudStorageTest is a regression test for #36994.
+}
+
+// TestChangefeedSendError validates that SendErrors do not fail the changefeed
+// as they can occur in normal situations such as a cluster update
+func TestChangefeedSendError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (0)`)
+
+		knobs := f.Server().TestingKnobs().
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		// Allow triggering a single sendError
+		sendErrorCh := make(chan error, 1)
+		knobs.FeedKnobs.OnRangeFeedValue = func(_ roachpb.KeyValue) error {
+			select {
+			case err := <-sendErrorCh:
+				return err
+			default:
+				return nil
+			}
+		}
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		defer closeFeed(t, foo)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
+		sendErrorCh <- kvcoord.TestNewSendError("test sendError")
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (3)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (4)`)
+
+		// Changefeed should've been retried due to the SendError
+		registry := f.Server().JobRegistry().(*jobs.Registry)
+		sli, err := registry.MetricsStruct().Changefeed.(*Metrics).getSLIMetrics(defaultSLIScope)
+		require.NoError(t, err)
+		retryCounter := sli.ErrorRetries
+		testutils.SucceedsSoon(t, func() error {
+			if retryCounter.Value() < 1 {
+				return fmt.Errorf("no retry has occurred")
+			}
+			return nil
+		})
+
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"after": {"a": 0}}`,
+			`foo: [1]->{"after": {"a": 1}}`,
+			`foo: [2]->{"after": {"a": 2}}`,
+			`foo: [3]->{"after": {"a": 3}}`,
+			`foo: [4]->{"after": {"a": 4}}`,
+		})
+	}
+
+	t.Run(`enterprise`, enterpriseTest(testFn))
+	t.Run(`cloudstorage`, cloudStorageTest(testFn))
+	t.Run(`kafka`, kafkaTest(testFn))
+	t.Run(`webhook`, webhookTest(testFn))
 }
 
 func TestChangefeedBasicConfluentKafka(t *testing.T) {
@@ -376,8 +439,8 @@ func TestChangefeedFullTableName(t *testing.T) {
 			assertPayloads(t, foo, []string{`d.public.foo: [1]->{"after": {"a": 1, "b": "a"}}`})
 		})
 	}
-	//TODO(zinger): Plumb this option through to all encoders so it works in sinkless mode
-	//t.Run(`sinkless`, sinklessTest(testFn))
+	// TODO(zinger): Plumb this option through to all encoders so it works in sinkless mode
+	// t.Run(`sinkless`, sinklessTest(testFn))
 	t.Run(`enterprise`, enterpriseTest(testFn))
 	t.Run(`kafka`, kafkaTest(testFn))
 	t.Run(`webhook`, webhookTest(testFn))

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -88,6 +88,11 @@ func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
 			switch t := e.GetValue().(type) {
 			case *roachpb.RangeFeedValue:
 				kv := roachpb.KeyValue{Key: t.Key, Value: t.Value}
+				if p.cfg.Knobs.OnRangeFeedValue != nil {
+					if err := p.cfg.Knobs.OnRangeFeedValue(kv); err != nil {
+						return err
+					}
+				}
 				var prevVal roachpb.Value
 				if p.cfg.WithDiff {
 					prevVal = t.PrevValue

--- a/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
@@ -8,12 +8,16 @@
 
 package kvfeed
 
-import "github.com/cockroachdb/cockroach/pkg/kv"
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
 
 // TestingKnobs are the testing knobs for kvfeed.
 type TestingKnobs struct {
 	// BeforeScanRequest is a callback invoked before issuing Scan request.
 	BeforeScanRequest func(b *kv.Batch)
+	OnRangeFeedValue  func(kv roachpb.KeyValue) error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2256,6 +2256,11 @@ func newSendError(msg string) error {
 	return sendError{message: msg}
 }
 
+// TestNewSendError creates a new sendError for the purpose of unit tests
+func TestNewSendError(msg string) error {
+	return newSendError(msg)
+}
+
 func (s sendError) Error() string {
 	return "failed to send RPC: " + s.message
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: mark kvcoord sendError as retryable" (#75517)
  * 1/1 commits from "changefeedccl: Fix data race in a test." (#77006)

Please see individual PRs for details.

/cc @cockroachdb/release
