### PR TITLE
sql: add SHOW STATISTICS WITH FORECAST

### DIFF
--- a/docs/generated/sql/bnf/show_stats.bnf
+++ b/docs/generated/sql/bnf/show_stats.bnf
@@ -1,2 +1,2 @@
 show_stats_stmt ::=
-	'SHOW' 'STATISTICS' 'FOR' 'TABLE' table_name
+	'SHOW' 'STATISTICS' 'FOR' 'TABLE' table_name opt_with_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -877,7 +877,7 @@ show_sessions_stmt ::=
 	| 'SHOW' 'ALL' opt_cluster 'SESSIONS'
 
 show_stats_stmt ::=
-	'SHOW' 'STATISTICS' 'FOR' 'TABLE' table_name
+	'SHOW' 'STATISTICS' 'FOR' 'TABLE' table_name opt_with_options
 
 show_tables_stmt ::=
 	'SHOW' 'TABLES' 'FROM' name '.' name with_comment

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -87,6 +87,9 @@ const AutoStatsName = "__auto__"
 // during import.
 const ImportStatsName = "__import__"
 
+// ForecastStatsName is the name to use for statistic forecasts.
+const ForecastStatsName = "__forecast__"
+
 // AutomaticJobTypes is a list of automatic job types that currently exist.
 var AutomaticJobTypes = [...]Type{
 	TypeAutoCreateStats,

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -300,8 +300,8 @@ column_names  row_count  distinct_count  null_count
 {a,b,c}       256        64              0
 {a,b}         256        16              0
 {a}           256        4               0
+{b,c}         256        16              0
 {b}           256        4               0
-{c,b}         256        16              0
 {c,d}         256        16              0
 {c}           256        4               0
 {d}           256        4               0
@@ -418,7 +418,7 @@ FROM [SHOW STATISTICS FOR TABLE data]
 ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-s4               {c,b}         256        16              0
+s4               {b,c}         256        16              0
 s4               {c,d}         256        16              0
 s5               {a,b,c,d}     256        256             0
 s5               {a,b,c}       256        64              0
@@ -510,7 +510,7 @@ __auto__         {e}
 __auto__         {e}
 __auto__         {e}
 __auto__         {e}
-s4               {c,b}
+s4               {b,c}
 s4               {c,d}
 
 statement ok
@@ -560,7 +560,7 @@ __auto__         {e}
 __auto__         {e}
 __auto__         {e}
 __auto__         {e}
-s4               {c,b}
+s4               {b,c}
 s4               {c,d}
 s7               {a}
 
@@ -612,7 +612,7 @@ __auto__         {e}
 __auto__         {e}
 __auto__         {e}
 __auto__         {e}
-s4               {c,b}
+s4               {b,c}
 s4               {c,d}
 s8               {a}
 
@@ -669,7 +669,7 @@ __auto__         {d}
 __auto__         {d}
 __auto__         {d}
 s10              {a}
-s4               {c,b}
+s4               {b,c}
 s4               {c,d}
 
 # Stats for column e still exist. (We cannot use SHOW STATISTICS to see them
@@ -1585,11 +1585,11 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
     {
         "avg_size": 0,
         "columns": [
+            "a",
             "sa"
         ],
         "distinct_count": 0,
-        "histo_col_type": "INT8",
-        "histo_version": 2,
+        "histo_col_type": "",
         "name": "aristotle",
         "null_count": 0,
         "row_count": 0
@@ -1597,11 +1597,11 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
     {
         "avg_size": 0,
         "columns": [
-            "a",
             "sa"
         ],
         "distinct_count": 0,
-        "histo_col_type": "",
+        "histo_col_type": "INT8",
+        "histo_version": 2,
         "name": "aristotle",
         "null_count": 0,
         "row_count": 0
@@ -1694,17 +1694,6 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
     },
     {
         "columns": [
-            "sa"
-        ],
-        "distinct_count": 1,
-        "histo_col_type": "INT8",
-        "histo_version": 2,
-        "name": "locke",
-        "null_count": 1,
-        "row_count": 1
-    },
-    {
-        "columns": [
             "a",
             "sa"
         ],
@@ -1712,6 +1701,17 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
         "histo_col_type": "",
         "name": "locke",
         "null_count": 0,
+        "row_count": 1
+    },
+    {
+        "columns": [
+            "sa"
+        ],
+        "distinct_count": 1,
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "name": "locke",
+        "null_count": 1,
         "row_count": 1
     }
 ]
@@ -1767,17 +1767,6 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
     {
         "avg_size": 0,
         "columns": [
-            "rowid"
-        ],
-        "distinct_count": 0,
-        "histo_col_type": "INT8",
-        "histo_version": 2,
-        "null_count": 0,
-        "row_count": 0
-    },
-    {
-        "avg_size": 0,
-        "columns": [
             "a"
         ],
         "distinct_count": 0,
@@ -1800,6 +1789,17 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
     {
         "avg_size": 0,
         "columns": [
+            "rowid"
+        ],
+        "distinct_count": 0,
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 0
+    },
+    {
+        "avg_size": 0,
+        "columns": [
             "a",
             "b"
         ],
@@ -1810,3 +1810,35 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
         "row_count": 0
     }
 ]
+
+# Check that column_names of multi-column stats are always sorted the same way.
+statement ok
+CREATE TABLE u (d INT, c INT, b INT, a INT, PRIMARY KEY (a, b), INDEX (c, d, a, b));
+
+statement ok
+CREATE STATISTICS u_defaults FROM u;
+
+statement ok
+CREATE STATISTICS u_a_b ON a, b FROM u;
+
+statement ok
+CREATE STATISTICS u_b_a ON b, a FROM u;
+
+statement ok
+CREATE STATISTICS u_c_d_b ON c, d, b FROM u;
+
+query TT colnames,rowsort
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE u]
+ORDER BY column_names, statistics_name
+----
+statistics_name  column_names
+u_defaults       {a}
+u_defaults       {b}
+u_b_a            {b,a}
+u_defaults       {c}
+u_defaults       {d}
+u_defaults       {d,c}
+u_defaults       {d,c,a}
+u_c_d_b          {d,c,b}
+u_defaults       {d,c,b,a}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1353,7 +1353,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE all_null]
             }
         ],
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "s",
         "null_count": 0,
         "row_count": 1
@@ -1365,7 +1365,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE all_null]
         ],
         "distinct_count": 1,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "s",
         "null_count": 1,
         "row_count": 1
@@ -1411,7 +1411,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE greeting_stats]
             }
         ],
         "histo_col_type": "test.public.greeting",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "s",
         "null_count": 0,
         "row_count": 1
@@ -1565,7 +1565,7 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
         ],
         "distinct_count": 0,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "aristotle",
         "null_count": 0,
         "row_count": 0
@@ -1577,7 +1577,7 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
         ],
         "distinct_count": 0,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "aristotle",
         "null_count": 0,
         "row_count": 0
@@ -1589,7 +1589,7 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
         ],
         "distinct_count": 0,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "aristotle",
         "null_count": 0,
         "row_count": 0
@@ -1668,7 +1668,7 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
             }
         ],
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "locke",
         "null_count": 0,
         "row_count": 1
@@ -1687,7 +1687,7 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
             }
         ],
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "locke",
         "null_count": 0,
         "row_count": 1
@@ -1698,7 +1698,7 @@ SELECT jsonb_pretty(COALESCE(json_agg(stat), '[]'))
         ],
         "distinct_count": 1,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "name": "locke",
         "null_count": 1,
         "row_count": 1
@@ -1771,7 +1771,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
         ],
         "distinct_count": 0,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "null_count": 0,
         "row_count": 0
     },
@@ -1782,7 +1782,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
         ],
         "distinct_count": 0,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "null_count": 0,
         "row_count": 0
     },
@@ -1793,7 +1793,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE t1]
         ],
         "distinct_count": 0,
         "histo_col_type": "INT8",
-        "histo_version": 1,
+        "histo_version": 2,
         "null_count": 0,
         "row_count": 0
     },

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -616,6 +616,64 @@ s4               {b,c}
 s4               {c,d}
 s8               {a}
 
+# Try forecasting stats.
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE data WITH FORECAST]
+ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {e}
+__auto__         {e}
+__auto__         {e}
+__auto__         {e}
+__auto__         {e}
+__forecast__     {a,b,c,d}
+__forecast__     {a,b,c}
+__forecast__     {a,b}
+__forecast__     {a}
+__forecast__     {b}
+__forecast__     {c}
+__forecast__     {d}
+__forecast__     {e}
+s4               {b,c}
+s4               {c,d}
+s8               {a}
+
 # Test deletion of old non-default stats.
 
 statement ok

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6473,16 +6473,25 @@ session_var_parts:
 // are encoded in JSON format.
 // %SeeAlso: SHOW HISTOGRAM
 show_stats_stmt:
-  SHOW STATISTICS FOR TABLE table_name
+  SHOW STATISTICS FOR TABLE table_name opt_with_options
   {
-    $$.val = &tree.ShowTableStats{Table: $5.unresolvedObjectName()}
+      $$.val = &tree.ShowTableStats{
+        Table:   $5.unresolvedObjectName(),
+        Options: $6.kvOptions(),
+      }
   }
-| SHOW STATISTICS USING JSON FOR TABLE table_name
+| SHOW STATISTICS USING JSON FOR TABLE table_name opt_with_options
   {
     /* SKIP DOC */
-    $$.val = &tree.ShowTableStats{Table: $7.unresolvedObjectName(), UsingJSON: true}
+    $$.val = &tree.ShowTableStats{
+      Table:     $7.unresolvedObjectName(),
+      UsingJSON: true,
+      Options:   $8.kvOptions(),
+    }
   }
 | SHOW STATISTICS error // SHOW HELP: SHOW STATISTICS
+
+
 
 // %Help: SHOW HISTOGRAM - display histogram (experimental)
 // %Category: Experimental

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5490,11 +5490,11 @@ func TestCreateStatsAfterSchemaChange(t *testing.T) {
 	// column w is ordered before column v, since index columns are added first).
 	sqlRun.CheckQueryResultsRetry(t,
 		`SELECT statistics_name, column_names, row_count, distinct_count, null_count
-	  FROM [SHOW STATISTICS FOR TABLE t.test]`,
+	  FROM [SHOW STATISTICS FOR TABLE t.test] ORDER BY column_names::STRING`,
 		[][]string{
 			{"__auto__", "{k}", "0", "0", "0"},
-			{"__auto__", "{w}", "0", "0", "0"},
 			{"__auto__", "{v}", "0", "0", "0"},
+			{"__auto__", "{w}", "0", "0", "0"},
 		})
 
 	// Add a column.

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -727,6 +727,7 @@ func (node *ShowFingerprints) Format(ctx *FmtCtx) {
 type ShowTableStats struct {
 	Table     *UnresolvedObjectName
 	UsingJSON bool
+	Options   KVOptions
 }
 
 // Format implements the NodeFormatter interface.
@@ -737,6 +738,10 @@ func (node *ShowTableStats) Format(ctx *FmtCtx) {
 	}
 	ctx.WriteString("FOR TABLE ")
 	ctx.FormatNode(node.Table)
+	if len(node.Options) > 0 {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(&node.Options)
+	}
 }
 
 // ShowHistogram represents a SHOW HISTOGRAM statement.

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -41,9 +42,24 @@ var showTableStatsJSONColumns = colinfo.ResultColumns{
 	{Name: "statistics", Typ: types.Jsonb},
 }
 
+const showTableStatsOptForecast = "forecast"
+
+var showTableStatsOptValidate = map[string]KVStringOptValidate{
+	showTableStatsOptForecast: KVStringOptRequireNoValue,
+}
+
 // ShowTableStats returns a SHOW STATISTICS statement for the specified table.
 // Privileges: Any privilege on table.
 func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (planNode, error) {
+	optsFn, err := p.TypeAsStringOpts(ctx, n.Options, showTableStatsOptValidate)
+	if err != nil {
+		return nil, err
+	}
+	opts, err := optsFn()
+	if err != nil {
+		return nil, err
+	}
+
 	// We avoid the cache so that we can observe the stats without
 	// taking a lease, like other SHOW commands.
 	desc, err := p.ResolveUncachedTableDescriptorEx(ctx, n.Table, true /*required*/, tree.ResolveRequireTableDesc)
@@ -68,7 +84,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			//    "handle" which can be used with SHOW HISTOGRAM.
 			// TODO(yuzefovich): refactor the code to use the iterator API
 			// (currently it is not possible due to a panic-catcher below).
-			const stmt = `SELECT "statisticID",
+			const stmt = `SELECT
+							"tableID",
+							"statisticID",
 							name,
 							"columnIDs",
 							"createdAt",
@@ -92,7 +110,8 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			}
 
 			const (
-				statIDIdx = iota
+				tableIDIdx = iota
+				statIDIdx
 				nameIdx
 				columnIDsIdx
 				createdAtIdx
@@ -120,6 +139,57 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					}
 				}
 			}()
+
+			if _, withForecast := opts[showTableStatsOptForecast]; withForecast {
+				observed := make([]*stats.TableStatistic, 0, len(rows))
+				for _, row := range rows {
+					// Skip stats on dropped columns.
+					colIDs := row[columnIDsIdx].(*tree.DArray).Array
+					ignoreStatsRowWithDroppedColumn := false
+					for _, colID := range colIDs {
+						cid := descpb.ColumnID(*colID.(*tree.DInt))
+						if _, err := desc.FindColumnWithID(cid); err != nil {
+							if sqlerrors.IsUndefinedColumnError(err) {
+								ignoreStatsRowWithDroppedColumn = true
+								break
+							} else {
+								return nil, err
+							}
+						}
+					}
+					if ignoreStatsRowWithDroppedColumn {
+						continue
+					}
+					stat, err := stats.NewTableStatisticProto(row)
+					if err != nil {
+						return nil, err
+					}
+					obs := &stats.TableStatistic{TableStatisticProto: *stat}
+					if obs.HistogramData != nil && !obs.HistogramData.ColumnType.UserDefined() {
+						if err := stats.DecodeHistogramBuckets(obs); err != nil {
+							return nil, err
+						}
+					}
+					observed = append(observed, obs)
+				}
+
+				// Reverse the list to sort by CreatedAt descending.
+				for i := 0; i < len(observed)/2; i++ {
+					j := len(observed) - i - 1
+					observed[i], observed[j] = observed[j], observed[i]
+				}
+
+				forecasts := stats.ForecastTableStatistics(ctx, p.EvalContext(), observed)
+
+				// Iterate in reverse order to match the ORDER BY "columnIDs".
+				for i := len(forecasts) - 1; i >= 0; i-- {
+					forecastRow, err := tableStatisticProtoToRow(&forecasts[i].TableStatisticProto)
+					if err != nil {
+						return nil, err
+					}
+					rows = append(rows, forecastRow)
+				}
+			}
 
 			v := p.newContainerValuesNode(columns, 0)
 			if n.UsingJSON {
@@ -227,4 +297,38 @@ func statColumnString(desc catalog.TableDescriptor, colID tree.Datum) (colName s
 		return "<unknown>", err
 	}
 	return colDesc.GetName(), nil
+}
+
+func tableStatisticProtoToRow(stat *stats.TableStatisticProto) (tree.Datums, error) {
+	name := tree.DNull
+	if stat.Name != "" {
+		name = tree.NewDString(stat.Name)
+	}
+	columnIDs := tree.NewDArray(types.Int)
+	for _, c := range stat.ColumnIDs {
+		if err := columnIDs.Append(tree.NewDInt(tree.DInt(c))); err != nil {
+			return nil, err
+		}
+	}
+	row := tree.Datums{
+		tree.NewDInt(tree.DInt(stat.TableID)),
+		tree.NewDInt(tree.DInt(stat.StatisticID)),
+		name,
+		columnIDs,
+		&tree.DTimestamp{Time: stat.CreatedAt},
+		tree.NewDInt(tree.DInt(stat.RowCount)),
+		tree.NewDInt(tree.DInt(stat.DistinctCount)),
+		tree.NewDInt(tree.DInt(stat.NullCount)),
+		tree.NewDInt(tree.DInt(stat.AvgSize)),
+	}
+	if stat.HistogramData == nil {
+		row = append(row, tree.DNull)
+	} else {
+		histogram, err := protoutil.Marshal(stat.HistogramData)
+		if err != nil {
+			return nil, err
+		}
+		row = append(row, tree.NewDBytes(tree.DBytes(histogram)))
+	}
+	return row, nil
 }

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -68,7 +68,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			//    "handle" which can be used with SHOW HISTOGRAM.
 			// TODO(yuzefovich): refactor the code to use the iterator API
 			// (currently it is not possible due to a panic-catcher below).
-			stmt := `SELECT "statisticID",
+			const stmt = `SELECT "statisticID",
 							name,
 							"columnIDs",
 							"createdAt",
@@ -79,7 +79,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 							histogram
 						FROM system.table_statistics
 						WHERE "tableID" = $1
-						ORDER BY "createdAt"`
+						ORDER BY "createdAt", "columnIDs", "statisticID"`
 			rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
 				ctx,
 				"read-table-stats",

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "row_sampling.go",
         "simple_linear_regression.go",
         "stats_cache.go",
+        "util.go",
     ],
     embed = [":stats_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     srcs = [
         "automatic_stats.go",
         "delete_stats.go",
+        "forecast.go",
         "histogram.go",
         "json.go",
         "new_stat.go",
@@ -58,6 +59,7 @@ go_library(
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -69,6 +71,7 @@ go_test(
         "automatic_stats_test.go",
         "create_stats_job_test.go",
         "delete_stats_test.go",
+        "forecast_test.go",
         "histogram_test.go",
         "main_test.go",
         "quantile_test.go",

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -810,6 +810,9 @@ func avgRefreshTime(tableStats []*TableStatistic) time.Duration {
 		if !areEqual(stat.ColumnIDs, reference.ColumnIDs) {
 			continue
 		}
+		if stat.CreatedAt.Equal(reference.CreatedAt) {
+			continue
+		}
 		// Stats are sorted with the most recent first.
 		sum += reference.CreatedAt.Sub(stat.CreatedAt)
 		count++

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -1,0 +1,363 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stats
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// minObservationsForForecast is the minimum number of observed statistics
+// required to produce a statistics forecast. Forecasts based on 1 or 2
+// observations will always have R² = 1 (perfect goodness of fit) regardless of
+// the accuracy of the forecast.
+const minObservationsForForecast = 3
+
+// minGoodnessOfFit is the minimum R² (goodness of fit) measurement all
+// predictive models in a forecast must have for us to use the forecast.
+const minGoodnessOfFit = 0.95
+
+// maxForecastDistance is the farthest into the future we can forecast from the
+// latest observed statistics.
+const maxForecastDistance = time.Hour * 24 * 7
+
+// ForecastTableStatistics produces zero or more statistics forecasts based on
+// the given observed statistics. The observed statistics must be ordered by
+// collection time descending, with the latest collected statistics first. The
+// observed statistics may be a mixture of statistics for different sets of
+// columns, but should not contain statistics for any old nonexistent columns.
+//
+// Whether a forecast is produced for a set of columns depends on how well the
+// observed statistics for that set of columns fit a linear regression model.
+// This means a forecast will not necessarily be produced for every set of
+// columns in the table. Any forecasts produced will have the same CreatedAt
+// time, which will be up to a week after the latest observed statistics (and
+// could be in the past, present, or future relative to the current time). Any
+// forecasts produced will not necessarily have the same RowCount or be
+// consistent with the other forecasts produced. (For example, DistinctCount in
+// the forecast for columns {a, b} could very well end up less than
+// DistinctCount in the forecast for column {a}.)
+//
+// ForecastTableStatistics is deterministic: given the same observations it will
+// return the same forecasts.
+//
+// TODO(michae2): Use nil *eval.Context or custom tree.CompareContext instead of
+// taking an evalCtx.
+func ForecastTableStatistics(
+	ctx context.Context, evalCtx tree.CompareContext, observed []*TableStatistic,
+) []*TableStatistic {
+	// Early sanity check. We'll check this again in forecastColumnStatistics.
+	if len(observed) < minObservationsForForecast {
+		return nil
+	}
+
+	// To make forecasts deterministic, we must choose a time to forecast at based
+	// on only the observed statistics. We choose the time of the latest
+	// statistics + the average time between automatic stats collections, which
+	// should be roughly when the next automatic stats collection will occur. To
+	// avoid wildly futuristic predictions we cap this at maxForecastDistance.
+	latest := observed[0].CreatedAt
+	horizon := latest.Add(maxForecastDistance)
+	at := latest.Add(avgRefreshTime(observed))
+	if at.After(horizon) {
+		at = horizon
+	}
+
+	// Group observed statistics by column set, and remove statistics with
+	// inverted histograms.
+	var forecastCols []string
+	observedByCols := make(map[string][]*TableStatistic)
+	for _, stat := range observed {
+		// We don't have a good way to detect inverted statistics right now, so skip
+		// all statistics with histograms of type BYTES. This means we cannot
+		// forecast statistics for normal BYTES columns.
+		// TODO(michae2): Improve this when issue #50655 is fixed.
+		if stat.HistogramData != nil && stat.HistogramData.ColumnType.Family() == types.BytesFamily {
+			continue
+		}
+		colKey := MakeSortedColStatKey(stat.ColumnIDs)
+		obs, ok := observedByCols[colKey]
+		if !ok {
+			forecastCols = append(forecastCols, colKey)
+		}
+		observedByCols[colKey] = append(obs, stat)
+	}
+
+	forecasts := make([]*TableStatistic, 0, len(forecastCols))
+	for _, colKey := range forecastCols {
+		forecast, err := forecastColumnStatistics(
+			ctx, evalCtx, observedByCols[colKey], at, minGoodnessOfFit,
+		)
+		if err != nil {
+			log.VEventf(
+				ctx, 2, "could not forecast statistics for table %v columns %s: %v",
+				observed[0].TableID, redact.SafeString(colKey), err,
+			)
+			continue
+		}
+		forecasts = append(forecasts, forecast)
+	}
+	return forecasts
+}
+
+// forecastColumnStatistics produces a statistics forecast at the given time,
+// based on the given observed statistics. The observed statistics must all be
+// for the same set of columns, must not contain any inverted histograms, must
+// have a single observation per collection time, and must be ordered by
+// collection time descending with the latest collected statistics first. The
+// given time to forecast at can be in the past, present, or future.
+//
+// To create a forecast, we construct a linear regression model over time for
+// each statistic (row count, null count, distinct count, average row size, and
+// histogram). If all models are good fits (i.e. have R² >= minRequiredFit) then
+// we use them to predict the value of each statistic at the given time. If any
+// model except the histogram model is a poor fit (i.e. has R² < minRequiredFit)
+// then we return an error instead of a forecast. If the histogram model is a
+// poor fit we adjust the latest observed histogram to match predicted values.
+//
+// forecastColumnStatistics is deterministic: given the same observations and
+// forecast time, it will return the same forecast.
+func forecastColumnStatistics(
+	ctx context.Context,
+	evalCtx tree.CompareContext,
+	observed []*TableStatistic,
+	at time.Time,
+	minRequiredFit float64,
+) (forecast *TableStatistic, err error) {
+	if len(observed) < minObservationsForForecast {
+		return nil, errors.New("not enough observations to forecast statistics")
+	}
+
+	forecastAt := float64(at.Unix())
+	tableID := observed[0].TableID
+	columnIDs := observed[0].ColumnIDs
+
+	// Gather inputs for our regression models.
+	createdAts := make([]float64, len(observed))
+	rowCounts := make([]float64, len(observed))
+	nullCounts := make([]float64, len(observed))
+	// For distinct counts and avg sizes, we skip over empty table stats and
+	// only-null stats to avoid skew.
+	nonEmptyCreatedAts := make([]float64, 0, len(observed))
+	distinctCounts := make([]float64, 0, len(observed))
+	avgSizes := make([]float64, 0, len(observed))
+	for i, stat := range observed {
+		// Guard against multiple observations with the same collection time, to
+		// avoid skewing the regression models.
+		if i > 0 && observed[i].CreatedAt.Equal(observed[i-1].CreatedAt) {
+			return nil, errors.Newf(
+				"multiple observations with the same collection time %v", observed[i].CreatedAt,
+			)
+		}
+		createdAts[i] = float64(stat.CreatedAt.Unix())
+		rowCounts[i] = float64(stat.RowCount)
+		nullCounts[i] = float64(stat.NullCount)
+		if stat.RowCount-stat.NullCount > 0 {
+			nonEmptyCreatedAts = append(nonEmptyCreatedAts, float64(stat.CreatedAt.Unix()))
+			distinctCounts = append(distinctCounts, float64(stat.DistinctCount))
+			avgSizes = append(avgSizes, float64(stat.AvgSize))
+		}
+	}
+
+	// predict tries to predict the value of the given statistic at forecast time.
+	predict := func(name redact.SafeString, y, createdAts []float64) (float64, error) {
+		yₙ, r2 := float64SimpleLinearRegression(createdAts, y, forecastAt)
+		log.VEventf(
+			ctx, 3, "forecast for table %v columns %v predicted %s %v R² %v",
+			tableID, columnIDs, name, yₙ, r2,
+		)
+		if r2 < minRequiredFit {
+			return yₙ, errors.Newf(
+				"predicted %v R² %v below min required R² %v", name, r2, minRequiredFit,
+			)
+		}
+		// Clamp the predicted value to [0, MaxInt64] and round to nearest integer.
+		if yₙ < 0 {
+			return 0, nil
+		}
+		if yₙ > math.MaxInt64 {
+			return math.MaxInt64, nil
+		}
+		return math.Round(yₙ), nil
+	}
+
+	rowCount, err := predict("RowCount", rowCounts, createdAts)
+	if err != nil {
+		return nil, err
+	}
+	nullCount, err := predict("NullCount", nullCounts, createdAts)
+	if err != nil {
+		return nil, err
+	}
+	var distinctCount, avgSize float64
+	if len(nonEmptyCreatedAts) > 0 {
+		distinctCount, err = predict("DistinctCount", distinctCounts, nonEmptyCreatedAts)
+		if err != nil {
+			return nil, err
+		}
+		avgSize, err = predict("AvgSize", avgSizes, nonEmptyCreatedAts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Adjust predicted statistics for consistency.
+	if nullCount > rowCount {
+		nullCount = rowCount
+	}
+	nonNullRowCount := rowCount - nullCount
+
+	minDistinctCount := float64(0)
+	maxDistinctCount := nonNullRowCount
+	if nonNullRowCount > 0 {
+		minDistinctCount++
+	}
+	if nullCount > 0 {
+		minDistinctCount++
+		maxDistinctCount++
+	}
+	if distinctCount < minDistinctCount {
+		distinctCount = minDistinctCount
+	}
+	if distinctCount > maxDistinctCount {
+		distinctCount = maxDistinctCount
+	}
+	nonNullDistinctCount := distinctCount
+	if nullCount > 0 {
+		nonNullDistinctCount--
+	}
+
+	forecast = &TableStatistic{
+		TableStatisticProto: TableStatisticProto{
+			TableID:       tableID,
+			StatisticID:   0, // TODO(michae2): Add support for SHOW HISTOGRAM.
+			Name:          jobspb.ForecastStatsName,
+			ColumnIDs:     columnIDs,
+			CreatedAt:     at,
+			RowCount:      uint64(rowCount),
+			DistinctCount: uint64(distinctCount),
+			NullCount:     uint64(nullCount),
+			AvgSize:       uint64(avgSize),
+		},
+	}
+
+	// Try to predict a histogram if there was one in the latest observed
+	// stats. If we cannot predict a histogram, we will use the latest observed
+	// histogram. NOTE: If any of the observed histograms were for inverted
+	// indexes this will produce an incorrect histogram.
+	if observed[0].HistogramData != nil {
+		hist, err := predictHistogram(
+			ctx, evalCtx, observed, forecastAt, minRequiredFit, nonNullRowCount,
+		)
+		if err != nil {
+			// If we did not successfully predict a histogram then copy the latest
+			// histogram so we can adjust it.
+			log.VEventf(
+				ctx, 3, "forecast for table %v columns %v: could not predict histogram due to: %v",
+				tableID, columnIDs, err,
+			)
+			hist.buckets = append([]cat.HistogramBucket{}, observed[0].nonNullHistogram().buckets...)
+		}
+
+		// Now adjust for consistency.
+		hist.adjustCounts(evalCtx, nonNullRowCount, nonNullDistinctCount)
+
+		// Finally, convert back to HistogramData.
+		histData, err := hist.toHistogramData(observed[0].HistogramData.ColumnType)
+		if err != nil {
+			return nil, err
+		}
+		forecast.HistogramData = &histData
+		forecast.setHistogramBuckets(hist)
+	}
+
+	return forecast, nil
+}
+
+// predictHistogram tries to predict the histogram at forecast time.
+func predictHistogram(
+	ctx context.Context,
+	evalCtx tree.CompareContext,
+	observed []*TableStatistic,
+	forecastAt float64,
+	minRequiredFit float64,
+	nonNullRowCount float64,
+) (histogram, error) {
+	if observed[0].HistogramData == nil {
+		return histogram{}, errors.New("latest observed stat missing histogram")
+	}
+
+	// Empty table case.
+	if nonNullRowCount < 1 {
+		return histogram{buckets: make([]cat.HistogramBucket, 0)}, nil
+	}
+
+	tableID := observed[0].TableID
+	columnIDs := observed[0].ColumnIDs
+	colType := observed[0].HistogramData.ColumnType
+
+	// Convert histograms to quantile functions. We don't need every observation
+	// to have a histogram, but we do need at least minObservationsForForecast
+	// histograms.
+	createdAts := make([]float64, 0, len(observed))
+	quantiles := make([]quantile, 0, len(observed))
+	for _, stat := range observed {
+		if stat.HistogramData == nil {
+			continue
+		}
+		if !stat.HistogramData.ColumnType.Equivalent(colType) {
+			continue
+		}
+		if !canMakeQuantile(stat.HistogramData.Version, stat.HistogramData.ColumnType) {
+			continue
+		}
+		// Skip empty table stats and only-null stats to avoid skew.
+		if stat.RowCount-stat.NullCount < 1 {
+			continue
+		}
+		q, err := makeQuantile(stat.nonNullHistogram(), float64(stat.RowCount-stat.NullCount))
+		if err != nil {
+			return histogram{}, err
+		}
+		createdAts = append(createdAts, float64(stat.CreatedAt.Unix()))
+		quantiles = append(quantiles, q)
+	}
+
+	if len(quantiles) < minObservationsForForecast {
+		return histogram{}, errors.New("not enough observations to forecast histogram")
+	}
+
+	// Construct a linear regression model of quantile functions over time, and
+	// use it to predict a quantile function at the given time.
+	yₙ, r2 := quantileSimpleLinearRegression(createdAts, quantiles, forecastAt)
+	yₙ = yₙ.fixMalformed()
+	log.VEventf(
+		ctx, 3, "forecast for table %v columns %v predicted quantile %v R² %v",
+		tableID, columnIDs, yₙ, r2,
+	)
+	if r2 < minRequiredFit {
+		return histogram{}, errors.Newf(
+			"predicted histogram R² %v below min required R² %v", r2, minRequiredFit,
+		)
+	}
+
+	// Finally, convert the predicted quantile function back to a histogram.
+	return yₙ.toHistogram(evalCtx, colType, nonNullRowCount)
+}

--- a/pkg/sql/stats/forecast_test.go
+++ b/pkg/sql/stats/forecast_test.go
@@ -1,0 +1,650 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stats
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// TestForecastColumnStatistics calls forecastColumnStatistics with various
+// observed stats.
+func TestForecastColumnStatistics(t *testing.T) {
+	testCases := []struct {
+		observed []*testStat
+		at       uint64
+		err      bool
+		forecast *testStat
+	}{
+		// Error: Too few observations
+		{
+			at:  1,
+			err: true,
+		},
+		// Error: Too few observations
+		{
+			observed: []*testStat{
+				{at: 1, row: 1, dist: 1, null: 0, size: 1},
+			},
+			at:  2,
+			err: true,
+		},
+		// Error: Too few observations
+		{
+			observed: []*testStat{
+				{at: 1, row: 1, dist: 1, null: 0, size: 1},
+				{at: 2, row: 2, dist: 2, null: 0, size: 1},
+			},
+			at:  3,
+			err: true,
+		},
+		// Error: Multiple observations with the same collection time
+		{
+			observed: []*testStat{
+				{at: 1, row: 1, dist: 1, null: 0, size: 1},
+				{at: 2, row: 2, dist: 2, null: 0, size: 1},
+				{at: 2, row: 2, dist: 2, null: 0, size: 1},
+			},
+			at:  3,
+			err: true,
+		},
+		// Constant empty table
+		{
+			observed: []*testStat{
+				{at: 1, row: 0, dist: 0, null: 0, size: 0},
+				{at: 2, row: 0, dist: 0, null: 0, size: 0},
+				{at: 3, row: 0, dist: 0, null: 0, size: 0},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 0, dist: 0, null: 0, size: 0},
+		},
+		// Constant all null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 1, dist: 1, null: 1, size: 0},
+				{at: 2, row: 1, dist: 1, null: 1, size: 0},
+				{at: 3, row: 1, dist: 1, null: 1, size: 0},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 1, dist: 1, null: 1, size: 0},
+		},
+		// Constant all non-null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 0, size: 1},
+				{at: 2, row: 2, dist: 1, null: 0, size: 1},
+				{at: 3, row: 2, dist: 1, null: 0, size: 1},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 2, dist: 1, null: 0, size: 1},
+		},
+		// Constant null and non-null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 9, dist: 4, null: 5, size: 1},
+				{at: 2, row: 9, dist: 4, null: 5, size: 1},
+				{at: 3, row: 9, dist: 4, null: 5, size: 1},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 9, dist: 4, null: 5, size: 1},
+		},
+		// Growing number of null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 7, dist: 2, null: 2, size: 1},
+				{at: 2, row: 7, dist: 2, null: 4, size: 1},
+				{at: 3, row: 7, dist: 2, null: 6, size: 1},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 7, dist: 1, null: 7, size: 1},
+		},
+		// Shrinking number of null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 6, dist: 2, null: 5, size: 0},
+				{at: 2, row: 6, dist: 2, null: 3, size: 0},
+				{at: 3, row: 6, dist: 2, null: 1, size: 0},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 6, dist: 2, null: 0, size: 0},
+		},
+		// Growing number of non-null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 10, dist: 8, null: 3, size: 2},
+				{at: 2, row: 20, dist: 18, null: 3, size: 2},
+				{at: 3, row: 30, dist: 28, null: 3, size: 2},
+				{at: 5, row: 50, dist: 48, null: 3, size: 2},
+			},
+			at:       6,
+			forecast: &testStat{at: 6, row: 60, dist: 58, null: 3, size: 2},
+		},
+		// Shrinking number of non-null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 13, dist: 10, null: 4, size: 11},
+				{at: 2, row: 12, dist: 9, null: 4, size: 11},
+				{at: 5, row: 9, dist: 6, null: 4, size: 11},
+			},
+			at:       9,
+			forecast: &testStat{at: 9, row: 5, dist: 2, null: 4, size: 11},
+		},
+		// Growing number of null and non-null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 4, dist: 3, null: 2, size: 5},
+				{at: 3, row: 5, dist: 2, null: 4, size: 5},
+				{at: 5, row: 6, dist: 1, null: 6, size: 5},
+			},
+			at:       7,
+			forecast: &testStat{at: 7, row: 7, dist: 1, null: 7, size: 5},
+		},
+		// Shrinking number of null and non-null rows
+		{
+			observed: []*testStat{
+				{at: 5, row: 14, dist: 9, null: 4, size: 1},
+				{at: 6, row: 10, dist: 6, null: 3, size: 1},
+				{at: 7, row: 6, dist: 3, null: 2, size: 1},
+			},
+			at:       8,
+			forecast: &testStat{at: 8, row: 2, dist: 2, null: 1, size: 1},
+		},
+		// Growing distinct count
+		{
+			observed: []*testStat{
+				{at: 1, row: 21, dist: 3, null: 2, size: 10},
+				{at: 2, row: 22, dist: 6, null: 2, size: 10},
+				{at: 5, row: 25, dist: 15, null: 2, size: 10},
+				{at: 6, row: 26, dist: 18, null: 2, size: 10},
+				{at: 7, row: 27, dist: 21, null: 2, size: 10},
+			},
+			at:       10,
+			forecast: &testStat{at: 10, row: 30, dist: 29, null: 2, size: 10},
+		},
+		// Shrinking distinct count
+		{
+			observed: []*testStat{
+				{at: 5, row: 25, dist: 15, null: 0, size: 1},
+				{at: 6, row: 25, dist: 10, null: 0, size: 1},
+				{at: 7, row: 25, dist: 5, null: 0, size: 1},
+			},
+			at:       11,
+			forecast: &testStat{at: 11, row: 25, dist: 1, null: 0, size: 1},
+		},
+		// Growing AvgSize
+		{
+			observed: []*testStat{
+				{at: 2, row: 9, dist: 3, null: 0, size: 1},
+				{at: 4, row: 9, dist: 5, null: 0, size: 11},
+				{at: 6, row: 9, dist: 7, null: 0, size: 21},
+			},
+			at:       7,
+			forecast: &testStat{at: 7, row: 9, dist: 8, null: 0, size: 26},
+		},
+		// Shrinking AvgSize
+		{
+			observed: []*testStat{
+				{at: 2, row: 10, dist: 8, null: 0, size: 30},
+				{at: 4, row: 10, dist: 8, null: 0, size: 20},
+				{at: 6, row: 10, dist: 8, null: 0, size: 10},
+			},
+			at:       9,
+			forecast: &testStat{at: 9, row: 10, dist: 8, null: 0, size: 0},
+		},
+		// Growing from empty table
+		{
+			observed: []*testStat{
+				{at: 1, row: 0, dist: 0, null: 0, size: 0},
+				{at: 2, row: 1, dist: 1, null: 0, size: 2},
+				{at: 3, row: 2, dist: 1, null: 0, size: 2},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 3, dist: 1, null: 0, size: 2},
+		},
+		// Shrinking to empty table
+		{
+			observed: []*testStat{
+				{at: 1, row: 3, dist: 1, null: 0, size: 2},
+				{at: 2, row: 2, dist: 1, null: 0, size: 2},
+				{at: 3, row: 1, dist: 1, null: 0, size: 2},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 0, dist: 0, null: 0, size: 2},
+		},
+		// Error: RowCount bad fit
+		{
+			observed: []*testStat{
+				{at: 1, row: 7, dist: 1, null: 1, size: 1},
+				{at: 2, row: 9, dist: 2, null: 2, size: 2},
+				{at: 3, row: 5, dist: 3, null: 3, size: 3},
+			},
+			at:  4,
+			err: true,
+		},
+		// Error: NullCount bad fit
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 2, size: 1},
+				{at: 2, row: 4, dist: 2, null: 0, size: 2},
+				{at: 3, row: 6, dist: 3, null: 3, size: 3},
+			},
+			at:  4,
+			err: true,
+		},
+		// Error: DistinctCount bad fit
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 0, size: 1},
+				{at: 2, row: 4, dist: 2, null: 0, size: 2},
+				{at: 3, row: 6, dist: 5, null: 0, size: 3},
+			},
+			at:  4,
+			err: true,
+		},
+		// Error: AvgSize bad fit
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 0, size: 1},
+				{at: 2, row: 4, dist: 2, null: 0, size: 2},
+				{at: 3, row: 6, dist: 5, null: 0, size: 3},
+			},
+			at:  4,
+			err: true,
+		},
+		// Skip only-null stats for DistinctCount
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 2, size: 1},
+				{at: 2, row: 4, dist: 2, null: 2, size: 2},
+				{at: 3, row: 6, dist: 5, null: 2, size: 3},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 8, dist: 7, null: 2, size: 4},
+		},
+		// Skip only-null stats for AvgSize
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 2, size: 0},
+				{at: 2, row: 4, dist: 2, null: 2, size: 7},
+				{at: 3, row: 6, dist: 3, null: 2, size: 6},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 8, dist: 4, null: 2, size: 5},
+		},
+		// Histogram, constant empty table
+		{
+			observed: []*testStat{
+				{at: 1, row: 0, dist: 0, null: 0, size: 0, hist: testHistogram{}},
+				{at: 2, row: 0, dist: 0, null: 0, size: 0, hist: testHistogram{}},
+				{at: 3, row: 0, dist: 0, null: 0, size: 0, hist: testHistogram{}},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 0, dist: 0, null: 0, size: 0, hist: testHistogram{}},
+		},
+		// Histogram, constant all null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 1, dist: 1, null: 1, size: 0, hist: testHistogram{}},
+				{at: 2, row: 1, dist: 1, null: 1, size: 0, hist: testHistogram{}},
+				{at: 3, row: 1, dist: 1, null: 1, size: 0, hist: testHistogram{}},
+			},
+			at:       4,
+			forecast: &testStat{at: 4, row: 1, dist: 1, null: 1, size: 0, hist: testHistogram{}},
+		},
+		// Histogram, constant all non-null rows
+		{
+			observed: []*testStat{
+				{at: 1, row: 2, dist: 1, null: 0, size: 1, hist: testHistogram{{2, 0, 0, 99}}},
+				{at: 2, row: 2, dist: 1, null: 0, size: 1, hist: testHistogram{{2, 0, 0, 99}}},
+				{at: 3, row: 2, dist: 1, null: 0, size: 1, hist: testHistogram{{2, 0, 0, 99}}},
+			},
+			at: 4,
+			forecast: &testStat{
+				at: 4, row: 2, dist: 1, null: 0, size: 1, hist: testHistogram{{2, 0, 0, 99}},
+			},
+		},
+		// Histogram, constant null and non-null rows
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 9, dist: 4, null: 5, size: 1,
+					hist: testHistogram{{2, 0, 0, 99}, {1, 1, 1, 119}},
+				},
+				{
+					at: 2, row: 9, dist: 4, null: 5, size: 1,
+					hist: testHistogram{{2, 0, 0, 99}, {1, 1, 1, 119}},
+				},
+				{
+					at: 3, row: 9, dist: 4, null: 5, size: 1,
+					hist: testHistogram{{2, 0, 0, 99}, {1, 1, 1, 119}},
+				},
+			},
+			at: 4,
+			forecast: &testStat{
+				at: 4, row: 9, dist: 4, null: 5, size: 1,
+				hist: testHistogram{{2, 0, 0, 99}, {1, 1, 1, 119}},
+			},
+		},
+		// Histogram, growing number of null and non-null rows
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 4, dist: 3, null: 2, size: 5,
+					hist: testHistogram{{1, 0, 0, 9000}, {1, 0, 0, 10000}},
+				},
+				{
+					at: 3, row: 5, dist: 2, null: 4, size: 5,
+					hist: testHistogram{{1, 0, 0, 10000}},
+				},
+				{
+					at: 5, row: 6, dist: 1, null: 6, size: 5,
+					hist: testHistogram{},
+				},
+			},
+			at: 7,
+			forecast: &testStat{
+				at: 7, row: 7, dist: 1, null: 7, size: 5,
+				hist: testHistogram{},
+			},
+		},
+		// Histogram, shrinking number of null and non-null rows
+		{
+			observed: []*testStat{
+				{
+					at: 5, row: 14, dist: 9, null: 4, size: 1,
+					hist: testHistogram{{0, 0, 0, 30}, {1, 9, 7, 40}},
+				},
+				{
+					at: 6, row: 10, dist: 6, null: 3, size: 1,
+					hist: testHistogram{{0, 0, 0, 30}, {1, 6, 4, 40}},
+				},
+				{
+					at: 7, row: 6, dist: 3, null: 2, size: 1,
+					hist: testHistogram{{0, 0, 0, 30}, {1, 3, 1, 40}},
+				},
+			},
+			at: 8,
+			forecast: &testStat{
+				at: 8, row: 2, dist: 2, null: 1, size: 1,
+				hist: testHistogram{{1, 0, 0, 40}},
+			},
+		},
+		// Histogram, growing distinct count
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 21, dist: 3, null: 2, size: 10,
+					hist: testHistogram{{0, 0, 0, 85}, {19, 0, 0, 100}},
+				},
+				{
+					at: 2, row: 22, dist: 6, null: 2, size: 10,
+					hist: testHistogram{{0, 0, 0, 85}, {17, 3, 3, 100}},
+				},
+				{
+					at: 5, row: 25, dist: 15, null: 2, size: 10,
+					hist: testHistogram{{0, 0, 0, 85}, {11, 12, 12, 100}},
+				},
+				{
+					at: 6, row: 26, dist: 18, null: 2, size: 10,
+					hist: testHistogram{{0, 0, 0, 85}, {9, 15, 15, 100}},
+				},
+				{
+					at: 7, row: 27, dist: 21, null: 2, size: 10,
+					hist: testHistogram{{0, 0, 0, 85}, {7, 18, 18, 100}},
+				},
+			},
+			at: 10,
+			forecast: &testStat{
+				at: 10, row: 30, dist: 29, null: 2, size: 10,
+				hist: testHistogram{{0, 0, 0, 85}, {1, 27, 27, 100}},
+			},
+		},
+		// Histogram, shrinking distinct count
+		{
+			observed: []*testStat{
+				{
+					at: 5, row: 25, dist: 15, null: 0, size: 1,
+					hist: testHistogram{{7, 0, 0, 404}, {0, 18, 14, 500}},
+				},
+				{
+					at: 6, row: 25, dist: 10, null: 0, size: 1,
+					hist: testHistogram{{10, 0, 0, 404}, {0, 15, 9, 500}},
+				},
+				{
+					at: 7, row: 25, dist: 5, null: 0, size: 1,
+					hist: testHistogram{{13, 0, 0, 404}, {0, 12, 4, 500}},
+				},
+			},
+			at: 11,
+			forecast: &testStat{
+				at: 11, row: 25, dist: 1, null: 0, size: 1,
+				hist: testHistogram{{25, 0, 0, 404}},
+			},
+		},
+		// Histogram, growing from empty table
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 0, dist: 0, null: 0, size: 0,
+					hist: testHistogram{},
+				},
+				{
+					at: 2, row: 1, dist: 1, null: 0, size: 2,
+					hist: testHistogram{{1, 0, 0, -2345}},
+				},
+				{
+					at: 3, row: 2, dist: 1, null: 0, size: 2,
+					hist: testHistogram{{2, 0, 0, -2345}},
+				},
+			},
+			at: 4,
+			forecast: &testStat{
+				at: 4, row: 3, dist: 1, null: 0, size: 2,
+				hist: testHistogram{{3, 0, 0, -2345}},
+			},
+		},
+		// Histogram, shrinking to empty table
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 3, dist: 1, null: 0, size: 2,
+					hist: testHistogram{{3, 0, 0, 1700}},
+				},
+				{
+					at: 2, row: 2, dist: 1, null: 0, size: 2,
+					hist: testHistogram{{2, 0, 0, 1700}},
+				},
+				{
+					at: 3, row: 1, dist: 1, null: 0, size: 2,
+					hist: testHistogram{{1, 0, 0, 1700}},
+				},
+			},
+			at: 4,
+			forecast: &testStat{
+				at: 4, row: 0, dist: 0, null: 0, size: 2,
+				hist: testHistogram{},
+			},
+		},
+		// Histogram, skip only-null stats
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 3, dist: 1, null: 3, size: 2,
+					hist: testHistogram{},
+				},
+				{
+					at: 2, row: 5, dist: 2, null: 3, size: 2,
+					hist: testHistogram{{1, 0, 0, 200}, {0, 1, 1, 800}},
+				},
+				{
+					at: 3, row: 7, dist: 3, null: 3, size: 2,
+					hist: testHistogram{{2, 0, 0, 200}, {0, 2, 2, 800}},
+				},
+				{
+					at: 4, row: 9, dist: 4, null: 3, size: 2,
+					hist: testHistogram{{3, 0, 0, 200}, {0, 3, 3, 800}},
+				},
+			},
+			at: 5,
+			forecast: &testStat{
+				at: 5, row: 11, dist: 5, null: 3, size: 2,
+				hist: testHistogram{{4, 0, 0, 200}, {1, 3, 2, 800}},
+			},
+		},
+		// Histogram, constant numbers but changing shape
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 16, dist: 7, null: 0, size: 1,
+					hist: testHistogram{{1, 0, 0, 14}, {2, 6, 2, 15}, {1, 6, 2, 16}},
+				},
+				{
+					at: 2, row: 16, dist: 7, null: 0, size: 1,
+					hist: testHistogram{{1, 0, 0, 14}, {2, 6, 2, 14.75}, {1, 6, 2, 18}},
+				},
+				{
+					at: 3, row: 16, dist: 7, null: 0, size: 1,
+					hist: testHistogram{{1, 0, 0, 14}, {2, 6, 2, 14.5}, {1, 6, 2, 20}},
+				},
+				{
+					at: 4, row: 16, dist: 7, null: 0, size: 1,
+					hist: testHistogram{{1, 0, 0, 14}, {2, 6, 2, 14.25}, {1, 6, 2, 22}},
+				},
+			},
+			at: 5,
+			forecast: &testStat{
+				at: 5, row: 16, dist: 7, null: 0, size: 1,
+				hist: testHistogram{{9, 0, 0, 14}, {1, 6, 5, 24}},
+			},
+		},
+		// Histogram, too few observations
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 10, dist: 2, null: 0, size: 1,
+				},
+				{
+					at: 2, row: 20, dist: 2, null: 0, size: 1,
+					hist: testHistogram{{10, 0, 0, 100}, {10, 0, 0, 200}},
+				},
+				{
+					at: 3, row: 30, dist: 2, null: 0, size: 1,
+					hist: testHistogram{{15, 0, 0, 100}, {15, 0, 0, 300}},
+				},
+			},
+			at: 4,
+			forecast: &testStat{
+				at: 4, row: 40, dist: 2, null: 0, size: 1,
+				hist: testHistogram{{20, 0, 0, 100}, {20, 0, 0, 300}},
+			},
+		},
+		// Histogram, bad fit
+		{
+			observed: []*testStat{
+				{
+					at: 1, row: 10, dist: 2, null: 0, size: 1,
+					hist: testHistogram{{5, 0, 0, 50}, {5, 0, 0, 100}},
+				},
+				{
+					at: 2, row: 20, dist: 2, null: 0, size: 1,
+					hist: testHistogram{{10, 0, 0, 50}, {10, 0, 0, 200}},
+				},
+				{
+					at: 3, row: 30, dist: 2, null: 0, size: 1,
+					hist: testHistogram{{15, 0, 0, 50}, {15, 0, 0, 301}},
+				},
+			},
+			at: 4,
+			forecast: &testStat{
+				at: 4, row: 40, dist: 2, null: 0, size: 1,
+				hist: testHistogram{{20, 0, 0, 50}, {20, 0, 0, 301}},
+			},
+		},
+	}
+	ctx := context.Background()
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+
+			// Set up observed TableStatistics in CreatedAt desc order.
+			observed := make([]*TableStatistic, len(tc.observed))
+			for j := range tc.observed {
+				observed[len(observed)-j-1] = tc.observed[j].toTableStatistic("testStat", i)
+			}
+			expected := tc.forecast.toTableStatistic(jobspb.ForecastStatsName, i)
+			at := testStatTime(tc.at)
+
+			forecast, err := forecastColumnStatistics(ctx, evalCtx, observed, at, 1)
+			if err != nil {
+				if !tc.err {
+					t.Errorf("test case %d unexpected forecastColumnStatistics err: %v", i, err)
+				}
+				return
+			}
+			if tc.err {
+				t.Errorf("test case %d expected forecastColumnStatistics err, was:\n%s", i, forecast)
+				return
+			}
+			if !reflect.DeepEqual(forecast, expected) {
+				t.Errorf("test case %d incorrect forecast\n%s\nexpected\n%s", i, forecast, expected)
+			}
+		})
+	}
+}
+
+type testStat struct {
+	at, row, dist, null, size uint64
+	hist                      testHistogram
+}
+
+func (ts *testStat) toTableStatistic(name string, tableID int) *TableStatistic {
+	if ts == nil {
+		return nil
+	}
+	stat := &TableStatistic{
+		TableStatisticProto: TableStatisticProto{
+			TableID:       catid.DescID(tableID),
+			StatisticID:   0,
+			Name:          name,
+			ColumnIDs:     []descpb.ColumnID{1},
+			CreatedAt:     testStatTime(ts.at),
+			RowCount:      ts.row,
+			DistinctCount: ts.dist,
+			NullCount:     ts.null,
+			AvgSize:       ts.size,
+		},
+	}
+	if ts.hist != nil {
+		hist := ts.hist.toHistogram()
+		histData, err := hist.toHistogramData(types.Float)
+		if err != nil {
+			panic(err)
+		}
+		stat.HistogramData = &histData
+		stat.setHistogramBuckets(hist)
+	}
+	return stat
+}
+
+func testStatTime(at uint64) time.Time {
+	return timeutil.Unix(int64(at), 0)
+}

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -45,7 +45,7 @@ type HistogramVersion uint32
 //
 // ATTENTION: When updating this field, add a brief description of what
 // changed to the version history below.
-const histVersion HistogramVersion = 1
+const histVersion HistogramVersion = 2
 
 /*
 
@@ -53,7 +53,14 @@ const histVersion HistogramVersion = 1
 
 Please add new entries at the top.
 
+- Version: 2
+- Introduced in 22.2.
+- String columns indexed by an inverted (trigram) index now have two sets of
+  statistics created by each statistics collection: one with the normal STRING
+  histogram, and one with the inverted BYTES histogram.
+
 - Version: 1
+- Introduced in 21.2.
 - The histogram creation logic was changed so the number of distinct values in
   the histogram matched the estimated distinct count from the HyperLogLog sketch.
 

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -81,7 +80,7 @@ Please add new entries at the top.
 // HistogramData.HistogramData_Bucket is non-nil, otherwise a nil
 // []cat.HistogramBucket.
 func EquiDepthHistogram(
-	evalCtx *eval.Context,
+	compareCtx tree.CompareContext,
 	colType *types.T,
 	samples tree.Datums,
 	numRows, distinctCount int64,
@@ -109,7 +108,7 @@ func EquiDepthHistogram(
 	}
 
 	sort.Slice(samples, func(i, j int) bool {
-		return samples[i].Compare(evalCtx, samples[j]) < 0
+		return samples[i].Compare(compareCtx, samples[j]) < 0
 	})
 	numBuckets := maxBuckets
 	if maxBuckets > numSamples {
@@ -130,7 +129,7 @@ func EquiDepthHistogram(
 		// numLess is the number of samples less than upper (in this bucket).
 		numLess := 0
 		for ; numLess < numSamplesInBucket-1; numLess++ {
-			if c := samples[i+numLess].Compare(evalCtx, upper); c == 0 {
+			if c := samples[i+numLess].Compare(compareCtx, upper); c == 0 {
 				break
 			} else if c > 0 {
 				return HistogramData{}, nil, errors.AssertionFailedf("%+v", "samples not sorted")
@@ -138,7 +137,7 @@ func EquiDepthHistogram(
 		}
 		// Advance the boundary of the bucket to cover all samples equal to upper.
 		for ; i+numSamplesInBucket < numSamples; numSamplesInBucket++ {
-			if samples[i+numSamplesInBucket].Compare(evalCtx, upper) != 0 {
+			if samples[i+numSamplesInBucket].Compare(compareCtx, upper) != 0 {
 				break
 			}
 		}
@@ -149,7 +148,7 @@ func EquiDepthHistogram(
 		// count.
 		numEq := float64(numSamplesInBucket-numLess) * float64(numRows) / float64(numSamples)
 		numRange := float64(numLess) * float64(numRows) / float64(numSamples)
-		distinctRange := estimatedDistinctValuesInRange(evalCtx, numRange, lowerBound, upper)
+		distinctRange := estimatedDistinctValuesInRange(compareCtx, numRange, lowerBound, upper)
 
 		i += numSamplesInBucket
 		h.buckets = append(h.buckets, cat.HistogramBucket{
@@ -159,10 +158,10 @@ func EquiDepthHistogram(
 			UpperBound:    upper,
 		})
 
-		lowerBound = getNextLowerBound(evalCtx, upper)
+		lowerBound = getNextLowerBound(compareCtx, upper)
 	}
 
-	h.adjustCounts(evalCtx, float64(numRows), float64(distinctCount))
+	h.adjustCounts(compareCtx, float64(numRows), float64(distinctCount))
 	histogramData, err := h.toHistogramData(colType)
 	return histogramData, h.buckets, err
 }
@@ -175,7 +174,9 @@ type histogram struct {
 // to equal the total row count and estimated distinct count. The total row
 // count and estimated distinct count should not include NULL values, and the
 // histogram should not contain any buckets for NULL values.
-func (h *histogram) adjustCounts(evalCtx *eval.Context, rowCountTotal, distinctCountTotal float64) {
+func (h *histogram) adjustCounts(
+	compareCtx tree.CompareContext, rowCountTotal, distinctCountTotal float64,
+) {
 	// Empty table cases.
 	if rowCountTotal <= 0 || distinctCountTotal <= 0 {
 		h.buckets = make([]cat.HistogramBucket, 0)
@@ -241,7 +242,7 @@ func (h *histogram) adjustCounts(evalCtx *eval.Context, rowCountTotal, distinctC
 		maxDistinctCountRange := float64(math.MaxInt64)
 		lowerBound := h.buckets[0].UpperBound
 		upperBound := h.buckets[len(h.buckets)-1].UpperBound
-		if maxDistinct, ok := tree.MaxDistinctCount(evalCtx, lowerBound, upperBound); ok {
+		if maxDistinct, ok := tree.MaxDistinctCount(compareCtx, lowerBound, upperBound); ok {
 			// Subtract number of buckets to account for the upper bounds of the
 			// buckets, along with the current range distinct count which has already
 			// been accounted for.
@@ -260,7 +261,7 @@ func (h *histogram) adjustCounts(evalCtx *eval.Context, rowCountTotal, distinctC
 			for i := 1; i < len(h.buckets); i++ {
 				lowerBound := h.buckets[i-1].UpperBound
 				upperBound := h.buckets[i].UpperBound
-				maxDistRange, countable := maxDistinctRange(evalCtx, lowerBound, upperBound)
+				maxDistRange, countable := maxDistinctRange(compareCtx, lowerBound, upperBound)
 
 				inc := avgRemPerBucket
 				if countable {
@@ -286,7 +287,7 @@ func (h *histogram) adjustCounts(evalCtx *eval.Context, rowCountTotal, distinctC
 	remDistinctCount = distinctCountTotal - distinctCountRange - distinctCountEq
 	if remDistinctCount > 0 {
 		h.addOuterBuckets(
-			evalCtx, remDistinctCount, &rowCountEq, &distinctCountEq, &rowCountRange, &distinctCountRange,
+			compareCtx, remDistinctCount, &rowCountEq, &distinctCountEq, &rowCountRange, &distinctCountRange,
 		)
 	}
 
@@ -311,29 +312,29 @@ func (h *histogram) adjustCounts(evalCtx *eval.Context, rowCountTotal, distinctC
 // also increments the counters rowCountEq, distinctCountEq, rowCountRange, and
 // distinctCountRange as needed.
 func (h *histogram) addOuterBuckets(
-	evalCtx *eval.Context,
+	compareCtx tree.CompareContext,
 	remDistinctCount float64,
 	rowCountEq, distinctCountEq, rowCountRange, distinctCountRange *float64,
 ) {
 	var maxDistinctCountExtraBuckets float64
 	var addedMin, addedMax bool
 	var newBuckets int
-	if !h.buckets[0].UpperBound.IsMin(evalCtx) {
-		if minVal, ok := h.buckets[0].UpperBound.Min(evalCtx); ok {
+	if !h.buckets[0].UpperBound.IsMin(compareCtx) {
+		if minVal, ok := h.buckets[0].UpperBound.Min(compareCtx); ok {
 			lowerBound := minVal
 			upperBound := h.buckets[0].UpperBound
-			maxDistRange, _ := maxDistinctRange(evalCtx, lowerBound, upperBound)
+			maxDistRange, _ := maxDistinctRange(compareCtx, lowerBound, upperBound)
 			maxDistinctCountExtraBuckets += maxDistRange
 			h.buckets = append([]cat.HistogramBucket{{UpperBound: minVal}}, h.buckets...)
 			addedMin = true
 			newBuckets++
 		}
 	}
-	if !h.buckets[len(h.buckets)-1].UpperBound.IsMax(evalCtx) {
-		if maxVal, ok := h.buckets[len(h.buckets)-1].UpperBound.Max(evalCtx); ok {
+	if !h.buckets[len(h.buckets)-1].UpperBound.IsMax(compareCtx) {
+		if maxVal, ok := h.buckets[len(h.buckets)-1].UpperBound.Max(compareCtx); ok {
 			lowerBound := h.buckets[len(h.buckets)-1].UpperBound
 			upperBound := maxVal
-			maxDistRange, _ := maxDistinctRange(evalCtx, lowerBound, upperBound)
+			maxDistRange, _ := maxDistinctRange(compareCtx, lowerBound, upperBound)
 			maxDistinctCountExtraBuckets += maxDistRange
 			h.buckets = append(h.buckets, cat.HistogramBucket{UpperBound: maxVal})
 			addedMax = true
@@ -379,7 +380,7 @@ func (h *histogram) addOuterBuckets(
 	for _, i := range bucIndexes {
 		lowerBound := h.buckets[i-1].UpperBound
 		upperBound := h.buckets[i].UpperBound
-		maxDistRange, countable := maxDistinctRange(evalCtx, lowerBound, upperBound)
+		maxDistRange, countable := maxDistinctRange(compareCtx, lowerBound, upperBound)
 
 		inc := avgRemPerBucket
 		if countable && h.buckets[0].UpperBound.ResolvedType().Family() == types.EnumFamily {
@@ -447,23 +448,23 @@ func (h histogram) String() string {
 // equal to numRange. If they are countable, we can estimate the distinct count
 // based on the total number of distinct values in the range.
 func estimatedDistinctValuesInRange(
-	evalCtx *eval.Context, numRange float64, lowerBound, upperBound tree.Datum,
+	compareCtx tree.CompareContext, numRange float64, lowerBound, upperBound tree.Datum,
 ) float64 {
 	if numRange == 0 {
 		return 0
 	}
-	rangeUpperBound, ok := upperBound.Prev(evalCtx)
+	rangeUpperBound, ok := upperBound.Prev(compareCtx)
 	if !ok {
 		rangeUpperBound = upperBound
 	}
-	if maxDistinct, ok := tree.MaxDistinctCount(evalCtx, lowerBound, rangeUpperBound); ok {
+	if maxDistinct, ok := tree.MaxDistinctCount(compareCtx, lowerBound, rangeUpperBound); ok {
 		return expectedDistinctCount(numRange, float64(maxDistinct))
 	}
 	return numRange
 }
 
-func getNextLowerBound(evalCtx *eval.Context, currentUpperBound tree.Datum) tree.Datum {
-	nextLowerBound, ok := currentUpperBound.Next(evalCtx)
+func getNextLowerBound(compareCtx tree.CompareContext, currentUpperBound tree.Datum) tree.Datum {
+	nextLowerBound, ok := currentUpperBound.Next(compareCtx)
 	if !ok {
 		nextLowerBound = currentUpperBound
 	}
@@ -474,9 +475,9 @@ func getNextLowerBound(evalCtx *eval.Context, currentUpperBound tree.Datum) tree
 // range, excluding both lowerBound and upperBound. Returns countable=true if
 // the returned value is countable.
 func maxDistinctRange(
-	evalCtx *eval.Context, lowerBound, upperBound tree.Datum,
+	compareCtx tree.CompareContext, lowerBound, upperBound tree.Datum,
 ) (_ float64, countable bool) {
-	if maxDistinct, ok := tree.MaxDistinctCount(evalCtx, lowerBound, upperBound); ok {
+	if maxDistinct, ok := tree.MaxDistinctCount(compareCtx, lowerBound, upperBound); ok {
 		// Remove 2 for the upper and lower boundaries.
 		if maxDistinct < 2 {
 			return 0, true

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -311,6 +311,9 @@ func (h *histogram) adjustCounts(
 		adjustmentFactorDistinctRange = (distinctCountTotal - distinctCountEq) / distinctCountRange
 	}
 	adjustmentFactorRowCount := rowCountTotal / (rowCountRange + rowCountEq)
+	// TODO(michae2): Consider moving this section above the sections adjusting
+	// NumEq and NumRange for distinct counts. This would help the adjustments be
+	// less surprising in some cases.
 	for i := range h.buckets {
 		h.buckets[i].DistinctRange *= adjustmentFactorDistinctRange
 		h.buckets[i].NumRange *= adjustmentFactorRowCount

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -173,6 +173,9 @@ func EquiDepthHistogram(
 	return histogramData, h.buckets, err
 }
 
+// histogram is a decoded HistogramData with datums for upper bounds. We use
+// nil buckets for error cases, and non-nil zero-length buckets for histograms
+// on empty tables.
 type histogram struct {
 	buckets []cat.HistogramBucket
 }

--- a/pkg/sql/stats/histogram.proto
+++ b/pkg/sql/stats/histogram.proto
@@ -20,7 +20,8 @@ import "gogoproto/gogo.proto";
 import "sql/types/types.proto";
 
 // HistogramData encodes the data for a histogram, which captures the
-// distribution of values on a specific column.
+// distribution of values on a specific column. A histogram on an empty table
+// is represented by a non-nil HistogramData with non-nil zero-length Buckets.
 message HistogramData {
   message Bucket {
     // The estimated number of values that are equal to upper_bound.
@@ -53,7 +54,8 @@ message HistogramData {
   sql.sem.types.T column_type = 2;
 
   // Histogram buckets. Note that NULL values are excluded from the
-  // histogram.
+  // histogram. For an empty table (or a table with all NULL values) Buckets
+  // will have zero length.
   repeated Bucket buckets = 1 [(gogoproto.nullable) = false];
 
   // Version of the logic used to construct this histogram. See histogram.go

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -315,6 +315,28 @@ func TestAdjustCounts(t *testing.T) {
 		distinctCount float64
 		expected      []cat.HistogramBucket
 	}{
+		{ // Empty histogram already matching empty table.
+			expected: make([]cat.HistogramBucket, 0),
+		},
+		{ // Empty histogram not matching rowCount.
+			rowCount:      1,
+			distinctCount: 1,
+			expected:      make([]cat.HistogramBucket, 0),
+		},
+		{ // One empty bucket already matching counts.
+			h: []cat.HistogramBucket{
+				{UpperBound: d(0)},
+			},
+			expected: make([]cat.HistogramBucket, 0),
+		},
+		{ // One empty bucket not matching rowCount.
+			h: []cat.HistogramBucket{
+				{UpperBound: d(0)},
+			},
+			rowCount:      1,
+			distinctCount: 1,
+			expected:      make([]cat.HistogramBucket, 0),
+		},
 		{ // One bucket already matching counts.
 			h: []cat.HistogramBucket{
 				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: d(1)},
@@ -453,6 +475,54 @@ func TestAdjustCounts(t *testing.T) {
 				{NumRange: 4.29, NumEq: 0.95, DistinctRange: 4.5, UpperBound: d(1)},
 				{NumRange: 8.57, NumEq: 1.9, DistinctRange: 8, UpperBound: d(10)},
 				{NumRange: 4.29, NumEq: 0, DistinctRange: 4.5, UpperBound: d(math.MaxInt64)},
+			},
+		},
+		{ // Two buckets already matching counts, 0 NumEq.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 7, NumEq: 0, DistinctRange: 5, UpperBound: d(10)},
+			},
+			rowCount:      7,
+			distinctCount: 5,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 7, NumEq: 0, DistinctRange: 5, UpperBound: d(10)},
+			},
+		},
+		{ // Two buckets matching distinctCount but not rowCount, 0 NumEq.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 7, NumEq: 0, DistinctRange: 5, UpperBound: d(10)},
+			},
+			rowCount:      14,
+			distinctCount: 5,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 14, NumEq: 0, DistinctRange: 5, UpperBound: d(10)},
+			},
+		},
+		{ // Two buckets matching rowCount but not distinctCount, 0 NumEq.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 7, NumEq: 0, DistinctRange: 5, UpperBound: d(10)},
+			},
+			rowCount:      7,
+			distinctCount: 6,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 7, NumEq: 0, DistinctRange: 6, UpperBound: d(10)},
+			},
+		},
+		{ // Two buckets matching neither count, 0 NumEq.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 4000, NumEq: 0, DistinctRange: 3, UpperBound: d(10)},
+			},
+			rowCount:      6000,
+			distinctCount: 2,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(1)},
+				{NumRange: 6000, NumEq: 0, DistinctRange: 2, UpperBound: d(10)},
 			},
 		},
 		{ // Two buckets with floats.

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -568,6 +568,51 @@ func TestAdjustCounts(t *testing.T) {
 				{NumRange: 50, NumEq: 0, DistinctRange: 32.5, UpperBound: f(200)},
 			},
 		},
+		{ // Adjust a leading bucket to zero.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: f(52)},
+				{NumRange: 1, NumEq: 10, DistinctRange: 1, UpperBound: f(62)},
+			},
+			rowCount:      1,
+			distinctCount: 1,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: f(62)},
+			},
+		},
+		{ // Adjust a trailing bucket to zero.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 10, DistinctRange: 0, UpperBound: f(42)},
+				{NumRange: 1, NumEq: 0, DistinctRange: 1, UpperBound: f(52)},
+			},
+			rowCount:      1,
+			distinctCount: 1,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: f(42)},
+			},
+		},
+		{ // Adjust a middle bucket to zero.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 10, DistinctRange: 0, UpperBound: f(42)},
+				{NumRange: 1, NumEq: 0, DistinctRange: 1, UpperBound: f(52)},
+				{NumRange: 0, NumEq: 10, DistinctRange: 0, UpperBound: f(62)},
+			},
+			rowCount:      1,
+			distinctCount: 1,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: .5, DistinctRange: 0, UpperBound: f(42)},
+				{NumRange: 0, NumEq: .5, DistinctRange: 0, UpperBound: f(62)},
+			},
+		},
+		{ // Adjust all buckets to zero.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 10, DistinctRange: 0, UpperBound: f(42)},
+				{NumRange: 0, NumEq: 10, DistinctRange: 0, UpperBound: f(52)},
+				{NumRange: 0, NumEq: 10, DistinctRange: 0, UpperBound: f(62)},
+			},
+			rowCount:      0,
+			distinctCount: 0,
+			expected:      []cat.HistogramBucket{},
+		},
 	}
 
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())

--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -234,7 +233,7 @@ func makeQuantile(hist histogram, rowCount float64) (quantile, error) {
 // row count. It returns an error if the conversion fails. The quantile must be
 // well-formed before calling toHistogram.
 func (q quantile) toHistogram(
-	evalCtx *eval.Context, colType *types.T, rowCount float64,
+	compareCtx tree.CompareContext, colType *types.T, rowCount float64,
 ) (histogram, error) {
 	if len(q) < 2 || q[0].p != 0 || q[len(q)-1].p != 1 {
 		return histogram{}, errors.AssertionFailedf("invalid quantile: %v", q)
@@ -286,7 +285,7 @@ func (q quantile) toHistogram(
 
 		// Calculate DistinctRange for this bucket now that NumRange is finalized.
 		distinctRange := estimatedDistinctValuesInRange(
-			evalCtx, currentBucket.NumRange, currentLowerBound, currentUpperBound,
+			compareCtx, currentBucket.NumRange, currentLowerBound, currentUpperBound,
 		)
 		if !isValidCount(distinctRange) {
 			return errors.AssertionFailedf("invalid histogram DistinctRange: %v", distinctRange)
@@ -306,7 +305,7 @@ func (q quantile) toHistogram(
 		if err != nil {
 			return histogram{}, err
 		}
-		cmp, err := upperBound.CompareError(evalCtx, currentUpperBound)
+		cmp, err := upperBound.CompareError(compareCtx, currentUpperBound)
 		if err != nil {
 			return histogram{}, err
 		}
@@ -326,7 +325,7 @@ func (q quantile) toHistogram(
 			if !isValidCount(numRange) {
 				return histogram{}, errors.AssertionFailedf("invalid histogram NumRange: %v", numRange)
 			}
-			currentLowerBound = getNextLowerBound(evalCtx, currentUpperBound)
+			currentLowerBound = getNextLowerBound(compareCtx, currentUpperBound)
 			currentUpperBound = upperBound
 			currentBucket = cat.HistogramBucket{
 				NumEq:         0,

--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -104,12 +104,17 @@ var zeroQuantile = quantile{{p: 0, v: 0}, {p: 1, v: 0}}
 // If you are introducing a new histogram version, please check whether
 // makeQuantile and quantile.toHistogram need to change, and then increase the
 // hard-coded number here.
-const _ uint = 1 - uint(histVersion)
+const _ uint = 2 - uint(histVersion)
 
 // canMakeQuantile returns true if a quantile function can be created for a
-// histogram of the given type.
+// histogram of the given type. Note that by not supporting BYTES we rule out
+// creating quantile functions for histograms of inverted columns.
 // TODO(michae2): Add support for DECIMAL, TIME, TIMETZ, and INTERVAL.
-func canMakeQuantile(colType *types.T) bool {
+func canMakeQuantile(version HistogramVersion, colType *types.T) bool {
+	if version > 2 {
+		return false
+	}
+
 	if colType.UserDefined() {
 		return false
 	}

--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -246,7 +246,7 @@ func (q quantile) toHistogram(
 
 	// Empty table case.
 	if rowCount < 1 {
-		return histogram{}, nil
+		return histogram{buckets: make([]cat.HistogramBucket, 0)}, nil
 	}
 
 	hist := histogram{buckets: make([]cat.HistogramBucket, 0, len(q)-1)}

--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -283,6 +283,8 @@ func (q quantile) toHistogram(
 			// Steal from NumRange so that NumEq is at least 1, if it wouldn't make
 			// NumRange 0. This makes the histogram look more like something
 			// EquiDepthHistogram would produce.
+			// TODO(michae2): Consider removing this logic if statistics_builder
+			// doesn't need it.
 			currentBucket.NumRange -= 1 - numEq
 			numEq = 1
 		}

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -441,7 +441,7 @@ func TestQuantileToHistogram(t *testing.T) {
 		{
 			qfun: zeroQuantile,
 			rows: 0,
-			hist: nil,
+			hist: testHistogram{},
 		},
 		{
 			qfun: zeroQuantile,

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -70,10 +70,12 @@ func TestRandomQuantileRoundTrip(t *testing.T) {
 // randHist makes a random histogram of the specified type, with [1, 200]
 // buckets. Not all types are supported. Every bucket will have NumEq > 0 but
 // could have NumRange == 0.
-func randHist(evalCtx *eval.Context, colType *types.T, rng *rand.Rand) (histogram, float64) {
+func randHist(
+	compareCtx tree.CompareContext, colType *types.T, rng *rand.Rand,
+) (histogram, float64) {
 	numBuckets := rng.Intn(200) + 1
 	buckets := make([]cat.HistogramBucket, numBuckets)
-	bounds := randBounds(evalCtx, colType, rng, numBuckets)
+	bounds := randBounds(compareCtx, colType, rng, numBuckets)
 	buckets[0].NumEq = float64(rng.Intn(100) + 1)
 	buckets[0].UpperBound = bounds[0]
 	rowCount := buckets[0].NumEq
@@ -97,9 +99,9 @@ func randHist(evalCtx *eval.Context, colType *types.T, rng *rand.Rand) (histogra
 	}
 	// Set DistinctRange in all buckets.
 	for i := 1; i < len(buckets); i++ {
-		lowerBound := getNextLowerBound(evalCtx, buckets[i-1].UpperBound)
+		lowerBound := getNextLowerBound(compareCtx, buckets[i-1].UpperBound)
 		buckets[i].DistinctRange = estimatedDistinctValuesInRange(
-			evalCtx, buckets[i].NumRange, lowerBound, buckets[i].UpperBound,
+			compareCtx, buckets[i].NumRange, lowerBound, buckets[i].UpperBound,
 		)
 	}
 	return histogram{buckets: buckets}, rowCount
@@ -109,7 +111,9 @@ func randHist(evalCtx *eval.Context, colType *types.T, rng *rand.Rand) (histogra
 // type. Not all types are supported. This differs from randgen.RandDatum in
 // that it generates no "interesting" Datums, and differs from
 // randgen.RandDatumSimple in that it generates distinct Datums without repeats.
-func randBounds(evalCtx *eval.Context, colType *types.T, rng *rand.Rand, num int) tree.Datums {
+func randBounds(
+	compareCtx tree.CompareContext, colType *types.T, rng *rand.Rand, num int,
+) tree.Datums {
 	datums := make(tree.Datums, num)
 
 	// randInts creates an ordered slice of num distinct random ints in the closed

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -44,7 +44,7 @@ func TestRandomQuantileRoundTrip(t *testing.T) {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	rng, seed := randutil.NewTestRand()
 	for _, colType := range colTypes {
-		if canMakeQuantile(colType) {
+		if canMakeQuantile(histVersion, colType) {
 			for i := 0; i < 5; i++ {
 				t.Run(fmt.Sprintf("%v/%v", colType.Name(), i), func(t *testing.T) {
 					hist, rowCount := randHist(evalCtx, colType, rng)

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -265,7 +265,7 @@ func (sr *SampleReservoir) copyRow(
 			dst[i].Datum = truncateDatum(evalCtx, dst[i].Datum, maxBytesPerSample)
 			afterSize = dst[i].Size()
 		} else {
-			dst[i].Datum = deepCopyDatum(evalCtx, dst[i].Datum)
+			dst[i].Datum = deepCopyDatum(dst[i].Datum)
 		}
 
 		// Perform memory accounting.
@@ -351,7 +351,7 @@ func truncateString(s string, maxBytes int) string {
 // Note: this function is currently only called for key-encoded datums. Update
 // the calling function if there is a need to call this for value-encoded
 // datums as well.
-func deepCopyDatum(evalCtx *eval.Context, d tree.Datum) tree.Datum {
+func deepCopyDatum(d tree.Datum) tree.Datum {
 	switch t := d.(type) {
 	case *tree.DString:
 		return tree.NewDString(deepCopyString(string(*t)))
@@ -365,7 +365,7 @@ func deepCopyDatum(evalCtx *eval.Context, d tree.Datum) tree.Datum {
 
 	case *tree.DOidWrapper:
 		return &tree.DOidWrapper{
-			Wrapped: deepCopyDatum(evalCtx, t.Wrapped),
+			Wrapped: deepCopyDatum(t.Wrapped),
 			Oid:     t.Oid,
 		}
 

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -487,11 +487,10 @@ const (
 	statsLen
 )
 
-// parseStats converts the given datums to a TableStatistic object. It might
-// need to run a query to get user defined type metadata.
-func (sc *TableStatisticsCache) parseStats(
-	ctx context.Context, datums tree.Datums,
-) (*TableStatistic, error) {
+// NewTableStatisticProto converts a row of datums from system.table_statistics
+// into a TableStatisticsProto. Note that any user-defined types in the
+// HistogramData will be unresolved.
+func NewTableStatisticProto(datums tree.Datums) (*TableStatisticProto, error) {
 	if datums == nil || datums.Len() == 0 {
 		return nil, nil
 	}
@@ -528,16 +527,14 @@ func (sc *TableStatisticsCache) parseStats(
 	}
 
 	// Extract datum values.
-	res := &TableStatistic{
-		TableStatisticProto: TableStatisticProto{
-			TableID:       descpb.ID((int32)(*datums[tableIDIndex].(*tree.DInt))),
-			StatisticID:   (uint64)(*datums[statisticsIDIndex].(*tree.DInt)),
-			CreatedAt:     datums[createdAtIndex].(*tree.DTimestamp).Time,
-			RowCount:      (uint64)(*datums[rowCountIndex].(*tree.DInt)),
-			DistinctCount: (uint64)(*datums[distinctCountIndex].(*tree.DInt)),
-			NullCount:     (uint64)(*datums[nullCountIndex].(*tree.DInt)),
-			AvgSize:       (uint64)(*datums[avgSizeIndex].(*tree.DInt)),
-		},
+	res := &TableStatisticProto{
+		TableID:       descpb.ID((int32)(*datums[tableIDIndex].(*tree.DInt))),
+		StatisticID:   (uint64)(*datums[statisticsIDIndex].(*tree.DInt)),
+		CreatedAt:     datums[createdAtIndex].(*tree.DTimestamp).Time,
+		RowCount:      (uint64)(*datums[rowCountIndex].(*tree.DInt)),
+		DistinctCount: (uint64)(*datums[distinctCountIndex].(*tree.DInt)),
+		NullCount:     (uint64)(*datums[nullCountIndex].(*tree.DInt)),
+		AvgSize:       (uint64)(*datums[avgSizeIndex].(*tree.DInt)),
 	}
 	columnIDs := datums[columnIDsIndex].(*tree.DArray)
 	res.ColumnIDs = make([]descpb.ColumnID, len(columnIDs.Array))
@@ -555,7 +552,21 @@ func (sc *TableStatisticsCache) parseStats(
 		); err != nil {
 			return nil, err
 		}
+	}
+	return res, nil
+}
 
+// parseStats converts the given datums to a TableStatistic object. It might
+// need to run a query to get user defined type metadata.
+func (sc *TableStatisticsCache) parseStats(
+	ctx context.Context, datums tree.Datums,
+) (*TableStatistic, error) {
+	tsp, err := NewTableStatisticProto(datums)
+	if err != nil {
+		return nil, err
+	}
+	res := &TableStatistic{TableStatisticProto: *tsp}
+	if res.HistogramData != nil {
 		// Hydrate the type in case any user defined types are present.
 		// There are cases where typ is nil, so don't do anything if so.
 		if typ := res.HistogramData.ColumnType; typ != nil && typ.UserDefined() {
@@ -671,7 +682,7 @@ func (sc *TableStatisticsCache) getTableStatsFromDB(
 ) ([]*TableStatistic, error) {
 	const getTableStatisticsStmt = `
 SELECT
-  "tableID",
+	"tableID",
 	"statisticID",
 	name,
 	"columnIDs",

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -636,7 +636,7 @@ func DecodeHistogramBuckets(tabStat *TableStatistic) error {
 func (sc *TableStatisticsCache) getTableStatsFromDB(
 	ctx context.Context, tableID descpb.ID,
 ) ([]*TableStatistic, error) {
-	getTableStatisticsStmt := `
+	const getTableStatisticsStmt = `
 SELECT
   "tableID",
 	"statisticID",
@@ -650,8 +650,10 @@ SELECT
 	histogram
 FROM system.table_statistics
 WHERE "tableID" = $1
-ORDER BY "createdAt" DESC
+ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
 `
+	// TODO(michae2): Add an index on system.table_statistics (tableID, createdAt,
+	// columnIDs, statisticID).
 
 	it, err := sc.SQLExecutor.QueryIterator(
 		ctx, "get-table-statistics", nil /* txn */, getTableStatisticsStmt, tableID,

--- a/pkg/sql/stats/table_statistic.proto
+++ b/pkg/sql/stats/table_statistic.proto
@@ -45,7 +45,14 @@ message TableStatisticProto {
   uint64 distinct_count = 7;
   // The number of rows that have a NULL in all of the columns in ColumnIDs.
   uint64 null_count = 8;
-  // Histogram (if available)
+  // Histogram (if available). A nil HistogramData is used for:
+  // - regular stats, GenerateHistogram=false (i.e. no histogram collected)
+  // - inverted stats, no inverted index  (i.e. no histogram collected)
+  // - inverted stats, yes inverted index, empty table
+  // - inverted stats, yes inverted index, all NULL values
+  // A non-nil HistogramData with len(Buckets) == 0 is used for:
+  // - regular stats, GenerateHistogram=true, empty table
+  // - regular stats, GenerateHistogram=true, all NULL values
   HistogramData histogram_data = 9;
   // The average row size of the columns in ColumnIDs.
   uint64 avg_size = 10;

--- a/pkg/sql/stats/util.go
+++ b/pkg/sql/stats/util.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stats
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// MakeSortedColStatKey constructs a unique key representing cols that can be
+// used as the key in a map, and also sorts cols as a side-effect.
+func MakeSortedColStatKey(cols []descpb.ColumnID) string {
+	var colSet util.FastIntSet
+	for _, c := range cols {
+		colSet.Add(int(c))
+	}
+	// We've already done the work to order the column set, so might as well make
+	// cols match that ordering now instead of sorting it later.
+	var i int
+	colSet.ForEach(func(c int) {
+		cols[i] = descpb.ColumnID(c)
+		i++
+	})
+	return colSet.String()
+}


### PR DESCRIPTION
**sql/stats: replace eval.Context with tree.CompareContext**

Most uses of eval.Context in the sql/stats package can actually be
tree.CompareContext instead, so make the replacement.

Release note: None

**sql/stats: bump histogram version to 2**

In 22.2 as of 963deb8 we support multiple histograms for trigram-
indexed strings. Let's bump the histogram version for this change, as we
may want to know whether multiple histograms are possible for a given
row in system.table_statistics.

(I suspect that during upgrades to 22.2 the 22.1 statistics builder will
choke on these statistics, so maybe we should also backport a version
check to 22.1.)

Also update avgRefreshTime to work correctly in multiple-histogram
cases.

Release note: None

**sql/stats: teach histogram.adjustCounts to remove empty buckets**

Sometimes when adjusting counts down we end up with empty buckets in the
histogram. They don't hurt anything, but they take up some memory (and
some brainpower when examining test results). So, teach adjustCounts to
remove them.

Release note: None

**sql/stats: always use non-nil buckets for empty-table histograms**

After 82b5926 I've been using the convention that nil histogram
buckets = no histogram, and non-nil-zero-length histogram buckets =
histogram on empty table. This is mostly useful for testing but is also
important for forecasting histograms.

Fix a spot that wasn't following this convention.

Also, add some empty-table testcases and some other testcases for
histogram.adjustCounts.

Release note: None

**sql/stats: make ordering of SHOW STATISTICS more deterministic**

Make two changes to produce more deterministic SHOW STATISTICS output:

1. Sort column IDs when creating statistics. We already use `FastIntSet`
   in both create_stats.go and statistics_builder.go to ignore ordering
   when gathering statistics by column set, but the column ordering from
   CREATE STATISTICS leaks into `system.table_statistics` and can affect
   SQL on that table, such as SHOW STATISTICS and various internal
   DELETE statements.

2. Order by column IDs and statistic IDs when reading from
   `system.table_statistics` in both SHOW STATISTICS and the stats
   cache. This will ensure SHOW STATISTICS always produces the same
   output, and shows us rows in the same order as the stats cache sees
   them (well, reverse order of the stats cache).

Release note (sql change): Make SHOW STATISTICS output more
deterministic.

**sql/stats: forecast table statistics**

Add function to forecast table statistics based on observed statistics.
These forecasts are based on linear regression models over time. For
each set of columns with statistics, we construct a linear regression
model over time for each statistic (row count, null count, distinct
count, average row size, and histogram). If all models are good fits
then we produce a statistics forecast for the set of columns.

Assists: #79872

Release note: None

**sql: add SHOW STATISTICS WITH FORECAST**

Add a new WITH FORECAST option to SHOW STATISTICS which calculates and
displays forecasted statistics along with the existing table statistics.

Also, forbid injecting forecasted stats.

Assists: #79872

Release note (sql change): Add a new WITH FORECAST option to SHOW
STATISTICS which calculates and displays forecasted statistics along
with the existing table statistics.