### PR TITLE
changefeedccl: enable changefeeds on multiple column families

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -49,6 +49,7 @@ const (
 	OptCompression              = `compression`
 	OptSchemaChangeEvents       = `schema_change_events`
 	OptSchemaChangePolicy       = `schema_change_policy`
+	OptSplitColumnFamilies      = `split_column_families`
 	OptProtectDataFromGCOnPause = `protect_data_from_gc_on_pause`
 	OptWebhookAuthHeader        = `webhook_auth_header`
 	OptWebhookClientTimeout     = `webhook_client_timeout`
@@ -178,6 +179,7 @@ var ChangefeedOptionExpectValues = map[string]sql.KVStringOptValidate{
 	OptCompression:              sql.KVStringOptRequireValue,
 	OptSchemaChangeEvents:       sql.KVStringOptRequireValue,
 	OptSchemaChangePolicy:       sql.KVStringOptRequireValue,
+	OptSplitColumnFamilies:      sql.KVStringOptRequireNoValue,
 	OptInitialScan:              sql.KVStringOptRequireNoValue,
 	OptNoInitialScan:            sql.KVStringOptRequireNoValue,
 	OptProtectDataFromGCOnPause: sql.KVStringOptRequireNoValue,
@@ -203,7 +205,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEnvelope,
 	OptFormat, OptFullTableName,
 	OptKeyInValue, OptTopicInValue,
 	OptResolvedTimestamps, OptUpdatedTimestamps,
-	OptMVCCTimestamps, OptDiff,
+	OptMVCCTimestamps, OptDiff, OptSplitColumnFamilies,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
 	OptInitialScan, OptNoInitialScan,

--- a/pkg/ccl/changefeedccl/changefeedbase/validate.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/validate.go
@@ -16,7 +16,9 @@ import (
 
 // ValidateTable validates that a table descriptor can be watched by a CHANGEFEED.
 func ValidateTable(
-	targets []jobspb.ChangefeedTargetSpecification, tableDesc catalog.TableDescriptor,
+	targets []jobspb.ChangefeedTargetSpecification,
+	tableDesc catalog.TableDescriptor,
+	opts map[string]string,
 ) error {
 	var t jobspb.ChangefeedTargetSpecification
 	var found bool
@@ -48,10 +50,16 @@ func ValidateTable(
 	if tableDesc.IsSequence() {
 		return errors.Errorf(`CHANGEFEED cannot target sequences: %s`, tableDesc.GetName())
 	}
-	if len(tableDesc.GetFamilies()) != 1 {
+	if t.Type == jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY && len(tableDesc.GetFamilies()) != 1 {
 		return errors.Errorf(
-			`CHANGEFEEDs are currently supported on tables with exactly 1 column family: %s has %d`,
+			`CHANGEFEED created on a table with a single column family (%s) cannot now target a table with %d families.`,
 			tableDesc.GetName(), len(tableDesc.GetFamilies()))
+	}
+	_, columnFamiliesOpt := opts[OptSplitColumnFamilies]
+	if !columnFamiliesOpt && len(tableDesc.GetFamilies()) != 1 {
+		return errors.Errorf(
+			`CHANGEFEED targeting a table (%s) with multiple column families requires WITH %s and will emit multiple events per row.`,
+			tableDesc.GetName(), OptSplitColumnFamilies)
 	}
 
 	if tableDesc.Dropped() {
@@ -78,6 +86,12 @@ func WarningsForTable(
 				)
 			}
 		}
+	}
+	if tableDesc.NumFamilies() > 1 {
+		warnings = append(warnings,
+			errors.Errorf("Table %s has %d underlying column families. Messages will be emitted separately for each family.",
+				tableDesc.GetName(), tableDesc.NumFamilies(),
+			))
 	}
 	return warnings
 }

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -53,6 +53,9 @@ type encodeRow struct {
 	// tableDesc is a TableDescriptor for the table containing `datums`.
 	// It's valid for interpreting the row at `updated`.
 	tableDesc catalog.TableDescriptor
+	// familyID indicates which column family is populated on this row.
+	// It's valid for interpreting the row at `updated`.
+	familyID descpb.FamilyID
 	// prevDatums is the old value of a changed table row. The field is set
 	// to nil if the before value for changes was not requested (OptDiff).
 	prevDatums rowenc.EncDatumRow
@@ -61,6 +64,8 @@ type encodeRow struct {
 	// prevTableDesc is a TableDescriptor for the table containing `prevDatums`.
 	// It's valid for interpreting the row at `updated.Prev()`.
 	prevTableDesc catalog.TableDescriptor
+	// prevFamilyID indicates which column family is populated in prevDatums.
+	prevFamilyID descpb.FamilyID
 }
 
 // Encoder turns a row into a serialized changefeed key, value, or resolved
@@ -186,9 +191,23 @@ func (e *jsonEncoder) encodeKeyRaw(row encodeRow) ([]interface{}, error) {
 func (e *jsonEncoder) encodeTopicRaw(row encodeRow) (interface{}, error) {
 	descID := row.tableDesc.GetID()
 	// use the target list since row.tableDesc.GetName() will not have fully qualified names
-	for _, topic := range e.targets {
-		if topic.TableID == descID {
-			return topic.StatementTimeName, nil
+	for _, target := range e.targets {
+		if target.TableID == descID {
+			switch target.Type {
+			case jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY:
+				return target.StatementTimeName, nil
+			case jobspb.ChangefeedTargetSpecification_EACH_FAMILY:
+				family, err := row.tableDesc.FindFamilyByID(row.familyID)
+				if err != nil {
+					return nil, err
+				}
+				return fmt.Sprintf("%s.%s", target.StatementTimeName, family.Name), nil
+			case jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY:
+				// Not implemented yet
+			default:
+				// fall through to error
+			}
+			return nil, errors.AssertionFailedf("Found a matching target with unimplemented type %s", target.Type)
 		}
 	}
 	return nil, fmt.Errorf("table with name %s and descriptor ID %d not found in changefeed target list",
@@ -203,48 +222,64 @@ func (e *jsonEncoder) EncodeValue(_ context.Context, row encodeRow) ([]byte, err
 
 	var after map[string]interface{}
 	if !row.deleted {
-		columns := row.tableDesc.PublicColumns()
+		family, err := row.tableDesc.FindFamilyByID(row.familyID)
+		if err != nil {
+			return nil, err
+		}
+		include := make(map[descpb.ColumnID]struct{}, len(family.ColumnIDs))
+		var yes struct{}
+		for _, colID := range family.ColumnIDs {
+			include[colID] = yes
+		}
 		after = make(map[string]interface{})
-		for i, col := range columns {
-			if col.IsVirtual() && e.virtualColumnVisibility == string(changefeedbase.OptVirtualColumnsOmitted) {
-				continue
-			}
-			datum := row.datums[i]
-			if err := datum.EnsureDecoded(col.GetType(), &e.alloc); err != nil {
-				return nil, err
-			}
-			var err error
-			after[col.GetName()], err = tree.AsJSON(
-				datum.Datum,
-				sessiondatapb.DataConversionConfig{},
-				time.UTC,
-			)
-			if err != nil {
-				return nil, err
+		for i, col := range row.tableDesc.PublicColumns() {
+			_, inFamily := include[col.GetID()]
+			virtual := col.IsVirtual() && e.virtualColumnVisibility == string(changefeedbase.OptVirtualColumnsNull)
+			if inFamily || virtual {
+				datum := row.datums[i]
+				if err := datum.EnsureDecoded(col.GetType(), &e.alloc); err != nil {
+					return nil, err
+				}
+				after[col.GetName()], err = tree.AsJSON(
+					datum.Datum,
+					sessiondatapb.DataConversionConfig{},
+					time.UTC,
+				)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
 
 	var before map[string]interface{}
 	if row.prevDatums != nil && !row.prevDeleted {
-		columns := row.prevTableDesc.PublicColumns()
+		family, err := row.prevTableDesc.FindFamilyByID(row.prevFamilyID)
+		if err != nil {
+			return nil, err
+		}
+		include := make(map[descpb.ColumnID]struct{})
+		var yes struct{}
+		for _, colID := range family.ColumnIDs {
+			include[colID] = yes
+		}
 		before = make(map[string]interface{})
-		for i, col := range columns {
-			if col.IsVirtual() && e.virtualColumnVisibility == string(changefeedbase.OptVirtualColumnsOmitted) {
-				continue
-			}
-			datum := row.prevDatums[i]
-			if err := datum.EnsureDecoded(col.GetType(), &e.alloc); err != nil {
-				return nil, err
-			}
-			var err error
-			before[col.GetName()], err = tree.AsJSON(
-				datum.Datum,
-				sessiondatapb.DataConversionConfig{},
-				time.UTC,
-			)
-			if err != nil {
-				return nil, err
+		for i, col := range row.prevTableDesc.PublicColumns() {
+			_, inFamily := include[col.GetID()]
+			virtual := col.IsVirtual() && e.virtualColumnVisibility == string(changefeedbase.OptVirtualColumnsNull)
+			if inFamily || virtual {
+				datum := row.prevDatums[i]
+				if err := datum.EnsureDecoded(col.GetType(), &e.alloc); err != nil {
+					return nil, err
+				}
+				before[col.GetName()], err = tree.AsJSON(
+					datum.Datum,
+					sessiondatapb.DataConversionConfig{},
+					time.UTC,
+				)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -342,12 +377,12 @@ type confluentAvroEncoder struct {
 	resolvedCache map[string]confluentRegisteredEnvelopeSchema
 }
 
-type tableIDAndVersion uint64
-type tableIDAndVersionPair [2]tableIDAndVersion // [before, after]
-
-func makeTableIDAndVersion(id descpb.ID, version descpb.DescriptorVersion) tableIDAndVersion {
-	return tableIDAndVersion(id)<<32 + tableIDAndVersion(version)
+type tableIDAndVersion struct {
+	tableID  descpb.ID
+	version  descpb.DescriptorVersion
+	familyID descpb.FamilyID
 }
+type tableIDAndVersionPair [2]tableIDAndVersion // [before, after]
 
 type confluentRegisteredKeySchema struct {
 	schema     *avroDataRecord
@@ -424,19 +459,35 @@ func newConfluentAvroEncoder(
 
 // Get the raw SQL-formatted string for a table name
 // and apply full_table_name and avro_schema_prefix options
-func (e *confluentAvroEncoder) rawTableName(desc catalog.TableDescriptor) string {
-	for _, spec := range e.targets {
-		if spec.TableID == desc.GetID() {
-			return e.schemaPrefix + spec.StatementTimeName
+func (e *confluentAvroEncoder) rawTableName(
+	desc catalog.TableDescriptor, familyID descpb.FamilyID,
+) (string, error) {
+	for _, target := range e.targets {
+		if target.TableID == desc.GetID() {
+			switch target.Type {
+			case jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY:
+				return e.schemaPrefix + target.StatementTimeName, nil
+			case jobspb.ChangefeedTargetSpecification_EACH_FAMILY:
+				family, err := desc.FindFamilyByID(familyID)
+				if err != nil {
+					return "", err
+				}
+				return fmt.Sprintf("%s%s.%s", e.schemaPrefix, target.StatementTimeName, family.Name), nil
+			case jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY:
+				// Not implemented yet
+			default:
+				// fall through to error
+			}
+			return "", errors.AssertionFailedf("Found a matching target with unimplemented type %s", target.Type)
 		}
 	}
-	//TODO (zinger): error here
-	return desc.GetName()
+	return desc.GetName(), errors.Newf("Could not find TargetSpecification for descriptor %v", desc)
 }
 
 // EncodeKey implements the Encoder interface.
 func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]byte, error) {
-	cacheKey := makeTableIDAndVersion(row.tableDesc.GetID(), row.tableDesc.GetVersion())
+	// No familyID in the cache key for keys because it's the same schema for all families
+	cacheKey := tableIDAndVersion{tableID: row.tableDesc.GetID(), version: row.tableDesc.GetVersion()}
 
 	var registered confluentRegisteredKeySchema
 	v, ok := e.keyCache.Get(cacheKey)
@@ -445,7 +496,10 @@ func (e *confluentAvroEncoder) EncodeKey(ctx context.Context, row encodeRow) ([]
 		registered.schema.refreshTypeMetadata(row.tableDesc)
 	} else {
 		var err error
-		tableName := e.rawTableName(row.tableDesc)
+		tableName, err := e.rawTableName(row.tableDesc, row.familyID)
+		if err != nil {
+			return nil, err
+		}
 		registered.schema, err = indexToAvroSchema(row.tableDesc, row.tableDesc.GetPrimaryIndex(), tableName, e.schemaPrefix)
 		if err != nil {
 			return nil, err
@@ -478,9 +532,13 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 
 	var cacheKey tableIDAndVersionPair
 	if e.beforeField && row.prevTableDesc != nil {
-		cacheKey[0] = makeTableIDAndVersion(row.prevTableDesc.GetID(), row.prevTableDesc.GetVersion())
+		cacheKey[0] = tableIDAndVersion{
+			tableID: row.prevTableDesc.GetID(), version: row.prevTableDesc.GetVersion(), familyID: row.prevFamilyID,
+		}
 	}
-	cacheKey[1] = makeTableIDAndVersion(row.tableDesc.GetID(), row.tableDesc.GetVersion())
+	cacheKey[1] = tableIDAndVersion{
+		tableID: row.tableDesc.GetID(), version: row.tableDesc.GetVersion(), familyID: row.familyID,
+	}
 
 	var registered confluentRegisteredEnvelopeSchema
 	v, ok := e.valueCache.Get(cacheKey)
@@ -494,19 +552,23 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 		var beforeDataSchema *avroDataRecord
 		if e.beforeField && row.prevTableDesc != nil {
 			var err error
-			beforeDataSchema, err = tableToAvroSchema(row.prevTableDesc, `before`, e.schemaPrefix, e.virtualColumnVisibility)
+			beforeDataSchema, err = tableToAvroSchema(row.prevTableDesc, row.prevFamilyID, `before`, e.schemaPrefix, e.virtualColumnVisibility)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		afterDataSchema, err := tableToAvroSchema(row.tableDesc, avroSchemaNoSuffix, e.schemaPrefix, e.virtualColumnVisibility)
+		afterDataSchema, err := tableToAvroSchema(row.tableDesc, row.familyID, avroSchemaNoSuffix, e.schemaPrefix, e.virtualColumnVisibility)
 		if err != nil {
 			return nil, err
 		}
 
 		opts := avroEnvelopeOpts{afterField: true, beforeField: e.beforeField, updatedField: e.updatedField}
-		registered.schema, err = envelopeToAvroSchema(e.rawTableName(row.tableDesc), opts, beforeDataSchema, afterDataSchema, e.schemaPrefix)
+		name, err := e.rawTableName(row.tableDesc, row.familyID)
+		if err != nil {
+			return nil, err
+		}
+		registered.schema, err = envelopeToAvroSchema(name, opts, beforeDataSchema, afterDataSchema, e.schemaPrefix)
 
 		if err != nil {
 			return nil, err
@@ -514,7 +576,7 @@ func (e *confluentAvroEncoder) EncodeValue(ctx context.Context, row encodeRow) (
 
 		// NB: This uses the kafka name escaper because it has to match the name
 		// of the kafka topic.
-		subject := SQLNameToKafkaName(e.rawTableName(row.tableDesc)) + confluentSubjectSuffixValue
+		subject := SQLNameToKafkaName(name) + confluentSubjectSuffixValue
 		registered.registryID, err = e.register(ctx, &registered.schema.avroRecord, subject)
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -44,8 +44,9 @@ type rowFetcherCache struct {
 }
 
 type cachedFetcher struct {
-	tableDesc catalog.TableDescriptor
-	fetcher   row.Fetcher
+	tableDesc  catalog.TableDescriptor
+	fetcher    row.Fetcher
+	familyDesc descpb.ColumnFamilyDescriptor
 }
 
 var rfCacheConfig = cache.Config{
@@ -59,6 +60,7 @@ var rfCacheConfig = cache.Config{
 type idVersion struct {
 	id      descpb.ID
 	version descpb.DescriptorVersion
+	family  descpb.FamilyID
 }
 
 func newRowFetcherCache(
@@ -79,16 +81,23 @@ func newRowFetcherCache(
 
 func (c *rowFetcherCache) TableDescForKey(
 	ctx context.Context, key roachpb.Key, ts hlc.Timestamp,
-) (catalog.TableDescriptor, error) {
+) (catalog.TableDescriptor, descpb.FamilyID, error) {
 	var tableDesc catalog.TableDescriptor
 	key, err := c.codec.StripTenantPrefix(key)
 	if err != nil {
-		return nil, err
+		return nil, descpb.FamilyID(0), err
 	}
 	remaining, tableID, _, err := rowenc.DecodePartialTableIDIndexID(key)
 	if err != nil {
-		return nil, err
+		return nil, descpb.FamilyID(0), err
 	}
+
+	familyID, err := keys.DecodeFamilyKey(key)
+	if err != nil {
+		return nil, descpb.FamilyID(0), err
+	}
+
+	family := descpb.FamilyID(familyID)
 
 	// Retrieve the target TableDescriptor from the lease manager. No caching
 	// is attempted because the lease manager does its own caching.
@@ -96,7 +105,7 @@ func (c *rowFetcherCache) TableDescForKey(
 	if err != nil {
 		// Manager can return all kinds of errors during chaos, but based on
 		// its usage, none of them should ever be terminal.
-		return nil, changefeedbase.MarkRetryableError(err)
+		return nil, family, changefeedbase.MarkRetryableError(err)
 	}
 	tableDesc = desc.Underlying().(catalog.TableDescriptor)
 	// Immediately release the lease, since we only need it for the exact
@@ -123,7 +132,7 @@ func (c *rowFetcherCache) TableDescForKey(
 		}); err != nil {
 			// Manager can return all kinds of errors during chaos, but based on
 			// its usage, none of them should ever be terminal.
-			return nil, changefeedbase.MarkRetryableError(err)
+			return nil, family, changefeedbase.MarkRetryableError(err)
 		}
 		// Immediately release the lease, since we only need it for the exact
 		// timestamp requested.
@@ -134,12 +143,12 @@ func (c *rowFetcherCache) TableDescForKey(
 	for skippedCols := 0; skippedCols < tableDesc.GetPrimaryIndex().NumKeyColumns(); skippedCols++ {
 		l, err := encoding.PeekLength(remaining)
 		if err != nil {
-			return nil, err
+			return nil, family, err
 		}
 		remaining = remaining[l:]
 	}
 
-	return tableDesc, nil
+	return tableDesc, family, nil
 }
 
 func (c *rowFetcherCache) RowFetcherForTableDesc(
@@ -165,6 +174,65 @@ func (c *rowFetcherCache) RowFetcherForTableDesc(
 
 	// TODO(dan): Allow for decoding a subset of the columns.
 	var spec descpb.IndexFetchSpec
+	if err := rowenc.InitIndexFetchSpec(
+		&spec, c.codec, tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.PublicColumnIDs(),
+	); err != nil {
+		return nil, err
+	}
+
+	if err := rf.Init(
+		context.TODO(),
+		false, /* reverse */
+		descpb.ScanLockingStrength_FOR_NONE,
+		descpb.ScanLockingWaitPolicy_BLOCK,
+		0, /* lockTimeout */
+		&c.a,
+		nil, /* memMonitor */
+		&spec,
+	); err != nil {
+		return nil, err
+	}
+
+	// Necessary because virtual columns are not populated.
+	// TODO(radu): should we stop requesting those columns from the fetcher?
+	rf.IgnoreUnexpectedNulls = true
+
+	c.fetchers.Add(idVer, f)
+	return rf, nil
+}
+
+func (c *rowFetcherCache) RowFetcherForColumnFamily(
+	tableDesc catalog.TableDescriptor, family descpb.FamilyID,
+) (*row.Fetcher, error) {
+	idVer := idVersion{id: tableDesc.GetID(), version: tableDesc.GetVersion(), family: family}
+	// Ensure that all user defined types are up to date with the cached
+	// version and the desired version to use the cache. It is safe to use
+	// UserDefinedTypeColsHaveSameVersion if we have a hit because we are
+	// guaranteed that the tables have the same version. Additionally, these
+	// fetchers are always initialized with a single tabledesc.Immutable.
+	// TODO (zinger): Only check types used in the relevant family.
+	if v, ok := c.fetchers.Get(idVer); ok {
+		f := v.(*cachedFetcher)
+		if catalog.UserDefinedTypeColsHaveSameVersion(tableDesc, f.tableDesc) {
+			return &f.fetcher, nil
+		}
+	}
+
+	familyDesc, err := tableDesc.FindFamilyByID(family)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &cachedFetcher{
+		tableDesc:  tableDesc,
+		familyDesc: *familyDesc,
+	}
+	rf := &f.fetcher
+
+	var spec descpb.IndexFetchSpec
+
+	// TODO (zinger): Make fetchColumnIDs only the family and the primary key.
+	// This seems to cause an error without further work but would be more efficient.
 	if err := rowenc.InitIndexFetchSpec(
 		&spec, c.codec, tableDesc, tableDesc.GetPrimaryIndex(), tableDesc.PublicColumnIDs(),
 	); err != nil {

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -81,6 +81,7 @@ func New(
 	targets []jobspb.ChangefeedTargetSpecification,
 	initialHighwater hlc.Timestamp,
 	metrics *Metrics,
+	changefeedOpts map[string]string,
 ) SchemaFeed {
 	m := &schemaFeed{
 		filter:            schemaChangeEventFilters[events],
@@ -92,6 +93,7 @@ func New(
 		ie:                cfg.SessionBoundInternalExecutorFactory(ctx, &sessiondata.SessionData{}),
 		collectionFactory: cfg.CollectionFactory,
 		metrics:           metrics,
+		changefeedOpts:    changefeedOpts,
 	}
 	m.mu.previousTableVersion = make(map[descpb.ID]catalog.TableDescriptor)
 	m.mu.highWater = initialHighwater
@@ -110,13 +112,14 @@ func New(
 // invariant (via `validateFn`). An error timestamp is also kept, which is the
 // lowest timestamp where at least one table doesn't meet the invariant.
 type schemaFeed struct {
-	filter   tableEventFilter
-	db       *kv.DB
-	clock    *hlc.Clock
-	settings *cluster.Settings
-	targets  []jobspb.ChangefeedTargetSpecification
-	ie       sqlutil.InternalExecutor
-	metrics  *Metrics
+	filter         tableEventFilter
+	db             *kv.DB
+	clock          *hlc.Clock
+	settings       *cluster.Settings
+	targets        []jobspb.ChangefeedTargetSpecification
+	ie             sqlutil.InternalExecutor
+	metrics        *Metrics
+	changefeedOpts map[string]string
 
 	// TODO(ajwerner): Should this live underneath the FilterFunc?
 	// Should there be another function to decide whether to update the
@@ -525,7 +528,7 @@ func (tf *schemaFeed) validateDescriptor(
 		// manager to acquire the freshest version of the type.
 		return tf.leaseMgr.AcquireFreshestFromStore(ctx, desc.GetID())
 	case catalog.TableDescriptor:
-		if err := changefeedbase.ValidateTable(tf.targets, desc); err != nil {
+		if err := changefeedbase.ValidateTable(tf.targets, desc, tf.changefeedOpts); err != nil {
 			return err
 		}
 		log.VEventf(ctx, 1, "validate %v", formatDesc(desc))


### PR DESCRIPTION
Changes the behavior when starting a changefeed on a table
with multiple column families. Previously, this would error.
Now, we create a feed that will emit individual messages per
column family. Primary key columns will appear in the key
for all column families, but only in the value in the families
they are in. Avro schema names will include the family name.

For UX simplicity, adding a column family to a table that
previously had only one will cause the feed to error out
as before. Since we don't have a good way right now to warn
when making a schema change on a table with a running feed,
the resulting behavior change would potentially be too
surprising, presenting like dropped or incomplete messages.

Release justification: The major changes required for this feature have already been merged in. This change is additive and fairly contained.

Release note (enterprise change): Changefeeds can now be created on tables with more than one column family. Previously, this would error. Now, we create a feed that will emit individual messages per column family. Primary key columns will appear in the key for all column families, but in the value only in the families they are in. For example, if a table foo has families "primary" containing the primary key and a string column, and "secondary" containing a different string column, you'll see two messages for an insert that will look like 0 -> {id: 0, s1: "val1"}, 0 -> {s2: "val2"}. If an update then only affects one family, you'll see only one message (e.g. 0 -> {s2: "newval"}). This behavior reflects CockroachDB's internal treatment of column families: writes are processed and stored separately, with only the ordering and atomicity guarantees that would apply to updates to two different tables within a single transaction. Avro schema names will include the family name concatenated to the table name. Note that if family names are not specified in the CREATE or ALTER TABLE statement, the default family names will either be "primary" or of the form "fam_<zero-indexed family id>_<underscore-delimited list of columns>.

Release note (sql change): Core changefeeds can now be created on tables with more than one column family. Previously, this would error. Now, we create a feed that will emit individual messages per column family. Primary key columns will appear in the key for all column families, but in the value only in the families they are in. For example, if a table foo has families "primary" containing the primary key and a string column, and "secondary" containing a different string column, you'll see two messages for an insert that will look like 0 -> {id: 0, s1: "val1"}, 0 -> {s2: "val2"}. If an update then only affects one family, you'll see only one message (e.g. 0 -> {s2: "newval"}). This behavior reflects CockroachDB's inte
rnal treatment of column families: writes are processed and stored separately, with only the ordering and atomicity guarantees that would apply to
 updates to two different tables within a single transaction.