### PR TITLE
ccl/sqlproxyccl: add helpers related to connection migration

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "authentication.go",
         "backend_dialer.go",
+        "conn_migration.go",
         "connector.go",
         "error.go",
         "forwarder.go",
@@ -28,6 +29,7 @@ go_library(
         "//pkg/security/certmgr",
         "//pkg/sql/pgwire",
         "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgwirebase",
         "//pkg/util/contextutil",
         "//pkg/util/grpcutil",
         "//pkg/util/httputil",
@@ -52,6 +54,7 @@ go_test(
     size = "small",
     srcs = [
         "authentication_test.go",
+        "conn_migration_test.go",
         "connector_test.go",
         "forwarder_test.go",
         "frontend_admitter_test.go",
@@ -65,6 +68,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/sqlproxyccl/denylist",
+        "//pkg/ccl/sqlproxyccl/interceptor",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/sqlproxyccl/throttler",
         "//pkg/ccl/utilccl",

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -1,0 +1,375 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
+	"github.com/cockroachdb/errors"
+	pgproto3 "github.com/jackc/pgproto3/v2"
+)
+
+// runShowTransferState sends a SHOW TRANSFER STATE query with the input
+// transferKey to the given writer. The transferKey will be used to uniquely
+// identify the request when parsing the response messages in
+// waitForShowTransferState.
+//
+// Unlike runAndWaitForDeserializeSession, we split the SHOW TRANSFER STATE
+// operation into `run` and `wait` since they both will be invoked in different
+// goroutines. If we combined them, we'll have to wait for at least one of the
+// goroutines to pause, which can introduce a latency of about 1-2s per transfer
+// while waiting for Read in readTimeoutConn to be unblocked.
+func runShowTransferState(w io.Writer, transferKey string) error {
+	return writeQuery(w, "SHOW TRANSFER STATE WITH '%s'", transferKey)
+}
+
+// waitForShowTransferState retrieves the transfer state from the SQL pod
+// through SHOW TRANSFER STATE WITH 'key'. It is assumed that the last message
+// from the server was ReadyForQuery, so the server is ready to accept a query.
+// Since ReadyForQuery may be for a previous pipelined query, this handles the
+// forwarding of messages back to the client in case we don't see our state yet.
+//
+// WARNING: When using this, we assume that no other goroutines are using both
+// serverConn and clientConn, as well as their respective interceptors. In the
+// context of a transfer, the client-to-server processor must be blocked.
+var waitForShowTransferState = func(
+	ctx context.Context,
+	serverInterceptor *interceptor.FrontendInterceptor,
+	clientConn io.Writer,
+	transferKey string,
+) (transferErr string, state string, revivalToken string, retErr error) {
+	// Wait for a response that looks like the following:
+	//
+	//   error | session_state_base64 | session_revival_token_base64 | transfer_key
+	// --------+----------------------+------------------------------+---------------
+	//   NULL  | .................... | ............................ | <transferKey>
+	// (1 row)
+	//
+	// Postgres messages always come in the following order for the
+	// SHOW TRANSFER STATE WITH '<transferKey>' query:
+	//   1. RowDescription
+	//   2. DataRow
+	//   3. CommandComplete
+	//   4. ReadyForQuery
+
+	// 1. Wait for the relevant RowDescription.
+	if err := waitForSmallRowDescription(
+		ctx,
+		serverInterceptor,
+		clientConn,
+		func(msg *pgproto3.RowDescription) bool {
+			// Do we have the right number of columns?
+			if len(msg.Fields) != 4 {
+				return false
+			}
+			// Do the names of the columns match?
+			var transferStateCols = []string{
+				"error",
+				"session_state_base64",
+				"session_revival_token_base64",
+				"transfer_key",
+			}
+			for i, col := range transferStateCols {
+				if string(msg.Fields[i].Name) != col {
+					return false
+				}
+			}
+			return true
+		},
+	); err != nil {
+		return "", "", "", errors.Wrap(err, "waiting for RowDescription")
+	}
+
+	// 2. Read DataRow.
+	if err := expectDataRow(ctx, serverInterceptor, func(msg *pgproto3.DataRow) bool {
+		// This has to be 4 since we validated RowDescription earlier.
+		if len(msg.Values) != 4 {
+			return false
+		}
+
+		// Validate transfer key. It is possible that the end-user uses the SHOW
+		// TRANSFER STATE WITH 'transfer_key' statement, but that isn't designed
+		// for external usage, so it is fine to just terminate here if the
+		// transfer key does not match.
+		if string(msg.Values[3]) != transferKey {
+			return false
+		}
+
+		// NOTE: We have to cast to string and copy here since the slice
+		// referenced in msg will no longer be valid once we read the next pgwire
+		// message.
+		transferErr, state, revivalToken = string(msg.Values[0]), string(msg.Values[1]), string(msg.Values[2])
+		return true
+	}); err != nil {
+		return "", "", "", errors.Wrap(err, "expecting DataRow")
+	}
+
+	// 3. Read CommandComplete.
+	if err := expectCommandComplete(ctx, serverInterceptor, "SHOW TRANSFER STATE 1"); err != nil {
+		return "", "", "", errors.Wrap(err, "expecting CommandComplete")
+	}
+
+	// 4. Read ReadyForQuery.
+	if err := expectReadyForQuery(ctx, serverInterceptor); err != nil {
+		return "", "", "", errors.Wrap(err, "expecting ReadyForQuery")
+	}
+
+	return transferErr, state, revivalToken, nil
+}
+
+// runAndWaitForDeserializeSession deserializes state into the SQL pod through
+// crdb_internal.deserialize_session. It is assumed that the last message from
+// the server was ReadyForQuery, so the server is ready to accept a query.
+//
+// This is meant to be used with a new connection, and nothing needs to be
+// forwarded back to the client.
+//
+// WARNING: When using this, we assume that no other goroutines are using both
+// serverConn and clientConn, and their respective interceptors.
+var runAndWaitForDeserializeSession = func(
+	ctx context.Context,
+	serverConn io.Writer,
+	serverInterceptor *interceptor.FrontendInterceptor,
+	state string,
+) error {
+	// Send deserialization query.
+	if err := writeQuery(serverConn,
+		"SELECT crdb_internal.deserialize_session(decode('%s', 'base64'))", state); err != nil {
+		return err
+	}
+
+	// Wait for a response that looks like the following:
+	//
+	//   crdb_internal.deserialize_session
+	// -------------------------------------
+	//                 true
+	// (1 row)
+	//
+	// Postgres messages always come in the following order for the
+	// deserialize_session query:
+	//   1. RowDescription
+	//   2. DataRow
+	//   3. CommandComplete
+	//   4. ReadyForQuery
+
+	// 1. Read RowDescription. We reuse waitFor here for convenience when we are
+	//    really expecting instead. This is fine because we only deserialize a
+	//    session for a new connection which hasn't been handed off to the user,
+	//    so we can guarantee that there won't be pipelined queries.
+	if err := waitForSmallRowDescription(
+		ctx,
+		serverInterceptor,
+		&errWriter{},
+		func(msg *pgproto3.RowDescription) bool {
+			return len(msg.Fields) == 1 &&
+				string(msg.Fields[0].Name) == "crdb_internal.deserialize_session"
+		},
+	); err != nil {
+		return errors.Wrap(err, "expecting RowDescription")
+	}
+
+	// 2. Read DataRow.
+	if err := expectDataRow(ctx, serverInterceptor, func(msg *pgproto3.DataRow) bool {
+		return len(msg.Values) == 1 && string(msg.Values[0]) == "t"
+	}); err != nil {
+		return errors.Wrap(err, "expecting DataRow")
+	}
+
+	// 3. Read CommandComplete.
+	if err := expectCommandComplete(ctx, serverInterceptor, "SELECT 1"); err != nil {
+		return errors.Wrap(err, "expecting CommandComplete")
+	}
+
+	// 4. Read ReadyForQuery.
+	if err := expectReadyForQuery(ctx, serverInterceptor); err != nil {
+		return errors.Wrap(err, "expecting ReadyForQuery")
+	}
+
+	return nil
+}
+
+// writeQuery writes a SimpleQuery to the given writer w.
+func writeQuery(w io.Writer, format string, a ...interface{}) error {
+	query := &pgproto3.Query{String: fmt.Sprintf(format, a...)}
+	_, err := w.Write(query.Encode(nil))
+	return err
+}
+
+// waitForSmallRowDescription waits until the next message from the interceptor
+// is a *small* RowDescription message (i.e. within 4K bytes), and one that
+// passes matchFn. When that happens, this returns nil.
+//
+// For all other messages (i.e. non RowDescription or large messages), they will
+// be forwarded to conn. One exception to this would be the ErrorResponse
+// message, which will result in an error since we're in an ambiguous state.
+// The ErrorResponse message may be for a pipelined query, or the RowDescription
+// message that we're waiting.
+func waitForSmallRowDescription(
+	ctx context.Context,
+	interceptor *interceptor.FrontendInterceptor,
+	conn io.Writer,
+	matchFn func(*pgproto3.RowDescription) bool,
+) error {
+	// Since we're waiting for the first message that matches the given
+	// condition, we're going to loop here until we find one.
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		typ, size, err := interceptor.PeekMsg()
+		if err != nil {
+			return errors.Wrap(err, "peeking message")
+		}
+
+		// We don't know if the ErrorResponse is for the expected RowDescription
+		// or a previous pipelined query, so return an error.
+		if typ == pgwirebase.ServerMsgErrorResponse {
+			// Error messages are small, so read for debugging purposes.
+			msg, err := interceptor.ReadMsg()
+			if err != nil {
+				return errors.Wrap(err, "ambiguous ErrorResponse")
+			}
+			return errors.Newf("ambiguous ErrorResponse: %v", jsonOrRaw(msg))
+		}
+
+		// Messages are intended for the client in two cases:
+		//   1. We have not seen a RowDescription message yet
+		//   2. Message was too large. This function only expects a few columns.
+		//
+		// This is mostly an optimization, and there's no point reading such
+		// messages into memory, so we'll just forward them back to the client
+		// right away.
+		const maxSmallMsgSize = 1 << 12 // 4KB
+		if typ != pgwirebase.ServerMsgRowDescription || size > maxSmallMsgSize {
+			if _, err := interceptor.ForwardMsg(conn); err != nil {
+				return errors.Wrap(err, "forwarding message")
+			}
+			continue
+		}
+
+		msg, err := interceptor.ReadMsg()
+		if err != nil {
+			return errors.Wrap(err, "reading RowDescription")
+		}
+
+		pgMsg, ok := msg.(*pgproto3.RowDescription)
+		if !ok {
+			// This case will not occur since have validated the type earlier.
+			return errors.Newf("unexpected message: %v", jsonOrRaw(msg))
+		}
+
+		// We have found our desired RowDescription.
+		if matchFn(pgMsg) {
+			return nil
+		}
+
+		// Matching fails, so forward the message back to the client, and
+		// continue searching.
+		if _, err := conn.Write(msg.Encode(nil)); err != nil {
+			return errors.Wrap(err, "writing message")
+		}
+	}
+}
+
+// expectDataRow expects that the next message from the interceptor is a DataRow
+// message. If the next message is a DataRow message, validateFn will be called
+// to validate the contents. This function will return an error if we don't see
+// a DataRow message or the validation failed.
+//
+// WARNING: Use this with care since this reads the entire message into memory.
+// Unlike the other expectX methods, DataRow messages may be large, and this
+// does not check for that. We are currently only using this for the SHOW
+// TRANSFER and crdb_internal.deserialize_session() statements, and they both
+// have been vetted. The former's size will be guarded behind a cluster setting,
+// whereas for the latter, the response is expected to be small.
+func expectDataRow(
+	ctx context.Context,
+	interceptor *interceptor.FrontendInterceptor,
+	validateFn func(*pgproto3.DataRow) bool,
+) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	msg, err := interceptor.ReadMsg()
+	if err != nil {
+		return errors.Wrap(err, "reading message")
+	}
+	pgMsg, ok := msg.(*pgproto3.DataRow)
+	if !ok {
+		return errors.Newf("unexpected message: %v", jsonOrRaw(msg))
+	}
+	if !validateFn(pgMsg) {
+		return errors.Newf("validation failed for message: %v", jsonOrRaw(msg))
+	}
+	return nil
+}
+
+// expectCommandComplete expects that the next message from the interceptor is
+// a CommandComplete message with the input tag, and returns an error if it
+// isn't.
+func expectCommandComplete(
+	ctx context.Context, interceptor *interceptor.FrontendInterceptor, tag string,
+) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	msg, err := interceptor.ReadMsg()
+	if err != nil {
+		return errors.Wrap(err, "reading message")
+	}
+	pgMsg, ok := msg.(*pgproto3.CommandComplete)
+	if !ok || string(pgMsg.CommandTag) != tag {
+		return errors.Newf("unexpected message: %v", jsonOrRaw(msg))
+	}
+	return nil
+}
+
+// expectReadyForQuery expects that the next message from the interceptor is a
+// ReadyForQuery message, and returns an error if it isn't.
+func expectReadyForQuery(ctx context.Context, interceptor *interceptor.FrontendInterceptor) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	msg, err := interceptor.ReadMsg()
+	if err != nil {
+		return errors.Wrap(err, "reading message")
+	}
+	_, ok := msg.(*pgproto3.ReadyForQuery)
+	if !ok {
+		return errors.Newf("unexpected message: %v", jsonOrRaw(msg))
+	}
+	return nil
+}
+
+// jsonOrRaw returns msg in a json string representation if it can be marshaled
+// into one, or in a raw struct string representation otherwise. Only used for
+// displaying better error messages.
+func jsonOrRaw(msg pgproto3.BackendMessage) string {
+	m, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Sprintf("%v", msg)
+	}
+	return string(m)
+}
+
+var _ io.Writer = &errWriter{}
+
+// errWriter is an io.Writer that fails whenever a Write call is made.
+type errWriter struct{}
+
+// Write implements the io.Writer interface.
+func (w *errWriter) Write(p []byte) (int, error) {
+	return 0, errors.AssertionFailedf("unexpected Write call")
+}

--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -1,0 +1,773 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlproxyccl
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunShowTransferState(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("successful", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		err := runShowTransferState(buf, "foo-bar-baz")
+		require.NoError(t, err)
+
+		backend := pgproto3.NewBackend(pgproto3.NewChunkReader(buf), buf)
+		msg, err := backend.Receive()
+		require.NoError(t, err)
+		m, ok := msg.(*pgproto3.Query)
+		require.True(t, ok)
+		require.Equal(t, "SHOW TRANSFER STATE WITH 'foo-bar-baz'", m.String)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		err := runShowTransferState(&errWriter{}, "foo")
+		require.Regexp(t, "unexpected Write call", err)
+	})
+}
+
+func TestWaitForShowTransferState(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		tCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		transferErr, state, token, err := waitForShowTransferState(tCtx, nil, nil, "")
+		require.True(t, errors.Is(err, context.Canceled))
+		require.Equal(t, "", transferErr)
+		require.Equal(t, "", state)
+		require.Equal(t, "", token)
+	})
+
+	transferStateDataRow := &pgproto3.DataRow{
+		Values: [][]byte{
+			{},
+			[]byte("foo-state"),
+			[]byte("foo-token"),
+			[]byte("foo-transfer-key"),
+		},
+	}
+
+	for _, tc := range []struct {
+		name         string
+		sendSequence []pgproto3.BackendMessage
+		postValidate func(*testing.T, *interceptor.FrontendInterceptor)
+		err          string
+		transferErr  string
+	}{
+		{
+			// All irrelevant messages are forwarded to the client. This returns
+			// an error when we see ErrorResponse.
+			name: "RowDescription/candidate_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				// not RowDescription.
+				&pgproto3.BackendKeyData{},
+				// Too large (> 4k).
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("foo1")},
+						{Name: make([]byte, 1<<13 /* 8K */)},
+					},
+				},
+				// Invalid number of columns.
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("foo2")},
+					},
+				},
+				// Invalid column names.
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_foo")},
+						{Name: []byte("session_revival_token_bar")},
+						{Name: []byte("apple")},
+					},
+				},
+				&pgproto3.ErrorResponse{},
+			},
+			err: "ambiguous ErrorResponse",
+			postValidate: func(t *testing.T, fi *interceptor.FrontendInterceptor) {
+				t.Helper()
+				expectMsg(t, fi, `"Type":"BackendKeyData"`)
+				expectMsg(t, fi, `"Type":"RowDescription".*"Name":"foo1"`)
+				expectMsg(t, fi, `"Type":"RowDescription".*"Name":"foo2"`)
+				expectMsg(t, fi, `"Type":"RowDescription".*session_state_foo.*session_revival_token_bar`)
+			},
+		},
+		{
+			name: "DataRow/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.ReadyForQuery{},
+			},
+			err: `DataRow: unexpected message:.*"Type":"ReadyForQuery"`,
+		},
+		{
+			name: "DataRow/invalid_response",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.DataRow{
+					// 3 columns instead of 4.
+					Values: [][]byte{
+						{},
+						{},
+						[]byte("bar"),
+					},
+				},
+			},
+			err: "DataRow: validation failed for message",
+		},
+		{
+			name: "DataRow/invalid_transfer_key",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.DataRow{
+					Values: [][]byte{
+						{},
+						{},
+						{},
+						[]byte("bar"),
+					},
+				},
+			},
+			err: "DataRow: validation failed for message",
+		},
+		{
+			name: "CommandComplete/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.DataRow{
+					Values: [][]byte{
+						{},
+						{},
+						{},
+						[]byte("foo-transfer-key"),
+					},
+				},
+				&pgproto3.ReadyForQuery{},
+			},
+			err: `CommandComplete: unexpected message:.*"Type":"ReadyForQuery"`,
+		},
+		{
+			name: "CommandComplete/value_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.DataRow{
+					Values: [][]byte{
+						{},
+						{},
+						{},
+						[]byte("foo-transfer-key"),
+					},
+				},
+				&pgproto3.CommandComplete{CommandTag: []byte("SHOW TRANSFER STATE 2")},
+			},
+			err: `CommandComplete: unexpected message:.*"Type":"CommandComplete".*"CommandTag":"SHOW TRANSFER STATE 2"`,
+		},
+		{
+			name: "ReadyForQuery/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.DataRow{
+					Values: [][]byte{
+						{},
+						{},
+						{},
+						[]byte("foo-transfer-key"),
+					},
+				},
+				&pgproto3.CommandComplete{CommandTag: []byte("SHOW TRANSFER STATE 1")},
+				&pgproto3.CommandComplete{},
+			},
+			err: `ReadyForQuery: unexpected message:.*"Type":"CommandComplete"`,
+		},
+		{
+			// This should be a common case with open transactions.
+			name: "transfer_state_error",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				&pgproto3.DataRow{
+					Values: [][]byte{
+						[]byte("serialization error"),
+						{},
+						{},
+						[]byte("foo-transfer-key"),
+					},
+				},
+				&pgproto3.CommandComplete{CommandTag: []byte("SHOW TRANSFER STATE 1")},
+				&pgproto3.ReadyForQuery{},
+			},
+			transferErr: "serialization error",
+		},
+		{
+			name: "successful",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.BackendKeyData{},
+				&pgproto3.RowDescription{},
+				&pgproto3.CommandComplete{},
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("error")},
+						{Name: []byte("session_state_base64")},
+						{Name: []byte("session_revival_token_base64")},
+						{Name: []byte("transfer_key")},
+					},
+				},
+				transferStateDataRow,
+				&pgproto3.CommandComplete{CommandTag: []byte("SHOW TRANSFER STATE 1")},
+				&pgproto3.ReadyForQuery{},
+			},
+			postValidate: func(t *testing.T, fi *interceptor.FrontendInterceptor) {
+				t.Helper()
+				expectMsg(t, fi, `"Type":"BackendKeyData"`)
+				expectMsg(t, fi, `"Type":"RowDescription"`)
+				expectMsg(t, fi, `"Type":"CommandComplete"`)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			for _, m := range tc.sendSequence {
+				writeServerMsg(buf, m)
+			}
+			toClient := new(bytes.Buffer)
+
+			transferErr, state, token, err := waitForShowTransferState(
+				ctx,
+				interceptor.NewFrontendInterceptor(buf),
+				toClient,
+				"foo-transfer-key",
+			)
+			if tc.err == "" {
+				require.NoError(t, err)
+				if tc.transferErr != "" {
+					require.Equal(t, tc.transferErr, transferErr)
+				} else {
+					require.Equal(t, "", transferErr)
+					require.Equal(t, "foo-state", state)
+					require.Equal(t, "foo-token", token)
+
+					// Ensure that returned strings are copied. Alternatively,
+					// we could also check pointers using encoding.UnsafeConvertStringToBytes.
+					transferStateDataRow.Values[0] = []byte("x")
+					transferStateDataRow.Values[1][1] = '-'
+					transferStateDataRow.Values[2][1] = '-'
+					require.Equal(t, "", transferErr)
+					require.Equal(t, "foo-state", state)
+					require.Equal(t, "foo-token", token)
+				}
+				require.Equal(t, 0, buf.Len())
+			} else {
+				require.Regexp(t, tc.err, err)
+			}
+
+			// Verify that forwarding was correct.
+			if tc.postValidate != nil {
+				frontend := interceptor.NewFrontendInterceptor(toClient)
+				tc.postValidate(t, frontend)
+				_, _, err := frontend.PeekMsg()
+				require.Regexp(t, "EOF", err)
+			}
+			require.Equal(t, 0, toClient.Len())
+		})
+	}
+}
+
+func TestRunAndWaitForDeserializeSession(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("write_failed", func(t *testing.T) {
+		err := runAndWaitForDeserializeSession(ctx, &errWriter{}, nil, "foo")
+		require.Regexp(t, "unexpected Write call", err)
+	})
+
+	for _, tc := range []struct {
+		name         string
+		sendSequence []pgproto3.BackendMessage
+		err          string
+	}{
+		{
+			name: "RowDescription/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.BackendKeyData{},
+			},
+			err: "RowDescription: forwarding message: unexpected Write call",
+		},
+		{
+			name: "RowDescription/column_mismatch/length",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{},
+			},
+			err: "RowDescription: writing message: unexpected Write call",
+		},
+		{
+			name: "RowDescription/column_mismatch/name",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{{Name: []byte("bar")}}},
+			},
+			err: "RowDescription: writing message: unexpected Write call",
+		},
+		{
+			name: "DataRow/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.ReadyForQuery{},
+			},
+			err: `DataRow: unexpected message:.*"Type":"ReadyForQuery"`,
+		},
+		{
+			name: "DataRow/column_mismatch/length",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.DataRow{},
+			},
+			err: `DataRow: validation failed for message`,
+		},
+		{
+			name: "DataRow/column_mismatch/value",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.DataRow{Values: [][]byte{[]byte("temp")}},
+			},
+			err: "DataRow: validation failed for message",
+		},
+		{
+			name: "CommandComplete/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.DataRow{Values: [][]byte{[]byte("t")}},
+				&pgproto3.ReadyForQuery{},
+			},
+			err: `CommandComplete: unexpected message:.*"Type":"ReadyForQuery"`,
+		},
+		{
+			name: "CommandComplete/value_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.DataRow{Values: [][]byte{[]byte("t")}},
+				&pgproto3.CommandComplete{CommandTag: []byte("SELECT 2")},
+			},
+			err: `CommandComplete: unexpected message:.*"Type":"CommandComplete".*"CommandTag":"SELECT 2"`,
+		},
+		{
+			name: "ReadyForQuery/type_mismatch",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.DataRow{Values: [][]byte{[]byte("t")}},
+				&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+				&pgproto3.CommandComplete{},
+			},
+			err: `ReadyForQuery: unexpected message:.*"Type":"CommandComplete"`,
+		},
+		{
+			name: "successful",
+			sendSequence: []pgproto3.BackendMessage{
+				&pgproto3.RowDescription{
+					Fields: []pgproto3.FieldDescription{
+						{Name: []byte("crdb_internal.deserialize_session")},
+					},
+				},
+				&pgproto3.DataRow{Values: [][]byte{[]byte("t")}},
+				&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+				&pgproto3.ReadyForQuery{},
+			},
+			err: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			readBuf := new(bytes.Buffer)
+			for _, m := range tc.sendSequence {
+				writeServerMsg(readBuf, m)
+			}
+			writeBuf := new(bytes.Buffer)
+
+			err := runAndWaitForDeserializeSession(ctx, writeBuf,
+				interceptor.NewFrontendInterceptor(readBuf), "foo-transfer-key")
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.Regexp(t, tc.err, err)
+			}
+
+			backend := interceptor.NewBackendInterceptor(writeBuf)
+			msg, err := backend.ReadMsg()
+			require.NoError(t, err)
+			m, ok := msg.(*pgproto3.Query)
+			require.True(t, ok)
+			const queryStr = "SELECT crdb_internal.deserialize_session(decode('foo-transfer-key', 'base64'))"
+			require.Equal(t, queryStr, m.String)
+		})
+	}
+}
+
+func TestWaitForSmallRowDescription(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		tCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		err := waitForSmallRowDescription(tCtx, nil, nil, nil)
+		require.EqualError(t, err, context.Canceled.Error())
+	})
+
+	t.Run("peek_error", func(t *testing.T) {
+		r, w := net.Pipe()
+		r.Close()
+		w.Close()
+
+		err := waitForSmallRowDescription(ctx, interceptor.NewFrontendInterceptor(r), nil, nil)
+		require.Regexp(t, "peeking message", err)
+	})
+
+	t.Run("ambiguous_error", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.ErrorResponse{})
+		}()
+
+		err := waitForSmallRowDescription(ctx, interceptor.NewFrontendInterceptor(r), nil, nil)
+		require.Regexp(t, "ambiguous ErrorResponse.*ErrorResponse", err)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		toClient := new(bytes.Buffer)
+
+		go func() {
+			// Not RowDescription.
+			writeServerMsg(w, &pgproto3.BackendKeyData{ProcessID: 42})
+			// Too large (> 4k bytes).
+			writeServerMsg(w, &pgproto3.RowDescription{
+				Fields: []pgproto3.FieldDescription{
+					{Name: []byte("foo1")},
+					{Name: make([]byte, 1<<13 /* 8K */)},
+				},
+			})
+			// Mismatch.
+			writeServerMsg(w, &pgproto3.RowDescription{
+				Fields: []pgproto3.FieldDescription{
+					{Name: []byte("foo2")},
+					{Name: []byte("foo3")},
+				},
+			})
+			// Match.
+			writeServerMsg(w, &pgproto3.RowDescription{
+				Fields: []pgproto3.FieldDescription{
+					{Name: []byte("foo1")},
+				},
+			})
+		}()
+
+		err := waitForSmallRowDescription(
+			ctx,
+			interceptor.NewFrontendInterceptor(r),
+			toClient,
+			func(m *pgproto3.RowDescription) bool {
+				return len(m.Fields) == 1 && string(m.Fields[0].Name) == "foo1"
+			},
+		)
+		require.Nil(t, err)
+
+		// Verify that forwarding was correct.
+		fi := interceptor.NewFrontendInterceptor(toClient)
+		expectMsg(t, fi, `"Type":"BackendKeyData".*"ProcessID":42`)
+		expectMsg(t, fi, `"Type":"RowDescription".*"Name":"foo1"`)
+		expectMsg(t, fi, `"Type":"RowDescription".*"Name":"foo2".*"Name":"foo3"`)
+		_, _, err = fi.PeekMsg()
+		require.Regexp(t, "EOF", err)
+		require.Equal(t, 0, toClient.Len())
+	})
+}
+
+func TestExpectDataRow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	falseValidateFn := func(m *pgproto3.DataRow) bool { return false }
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		tCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		err := expectDataRow(tCtx, nil, falseValidateFn)
+		require.EqualError(t, err, context.Canceled.Error())
+	})
+
+	t.Run("read_error", func(t *testing.T) {
+		r, w := net.Pipe()
+		r.Close()
+		w.Close()
+
+		err := expectDataRow(ctx, interceptor.NewFrontendInterceptor(r), falseValidateFn)
+		require.Regexp(t, "reading message", err)
+	})
+
+	t.Run("type_mismatch", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.ReadyForQuery{})
+		}()
+
+		err := expectDataRow(ctx, interceptor.NewFrontendInterceptor(r), falseValidateFn)
+		require.Regexp(t, "unexpected message.*ReadyForQuery", err)
+	})
+
+	t.Run("validation_failed", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.DataRow{})
+		}()
+
+		err := expectDataRow(ctx, interceptor.NewFrontendInterceptor(r), falseValidateFn)
+		require.Regexp(t, "validation failed for message.*DataRow", err)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.DataRow{Values: [][]byte{[]byte("foo")}})
+		}()
+
+		err := expectDataRow(
+			ctx,
+			interceptor.NewFrontendInterceptor(r),
+			func(m *pgproto3.DataRow) bool {
+				return len(m.Values) == 1 && string(m.Values[0]) == "foo"
+			},
+		)
+		require.Nil(t, err)
+	})
+}
+
+func TestExpectCommandComplete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		tCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		err := expectCommandComplete(tCtx, nil, "")
+		require.EqualError(t, err, context.Canceled.Error())
+	})
+
+	t.Run("read_error", func(t *testing.T) {
+		r, w := net.Pipe()
+		r.Close()
+		w.Close()
+
+		err := expectCommandComplete(ctx, interceptor.NewFrontendInterceptor(r), "")
+		require.Regexp(t, "reading message", err)
+	})
+
+	t.Run("type_mismatch", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.ReadyForQuery{})
+		}()
+
+		err := expectCommandComplete(ctx, interceptor.NewFrontendInterceptor(r), "")
+		require.Regexp(t, "unexpected message.*ReadyForQuery", err)
+	})
+
+	t.Run("tag_mismatch", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.CommandComplete{CommandTag: []byte("foo")})
+		}()
+
+		err := expectCommandComplete(ctx, interceptor.NewFrontendInterceptor(r), "bar")
+		require.Regexp(t, "unexpected message.*CommandComplete.*CommandTag.*foo", err)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")})
+		}()
+
+		err := expectCommandComplete(ctx, interceptor.NewFrontendInterceptor(r), "SELECT 1")
+		require.Nil(t, err)
+	})
+}
+
+func TestExpectReadyForQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		tCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		err := expectReadyForQuery(tCtx, nil)
+		require.EqualError(t, err, context.Canceled.Error())
+	})
+
+	t.Run("read_error", func(t *testing.T) {
+		r, w := net.Pipe()
+		r.Close()
+		w.Close()
+
+		err := expectReadyForQuery(ctx, interceptor.NewFrontendInterceptor(r))
+		require.Regexp(t, "reading message", err)
+	})
+
+	t.Run("type_mismatch", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.ErrorResponse{})
+		}()
+
+		err := expectReadyForQuery(ctx, interceptor.NewFrontendInterceptor(r))
+		require.Regexp(t, "unexpected message.*ErrorResponse", err)
+	})
+
+	t.Run("successful", func(t *testing.T) {
+		r, w := net.Pipe()
+		defer r.Close()
+		defer w.Close()
+
+		go func() {
+			writeServerMsg(w, &pgproto3.ReadyForQuery{TxStatus: 'I'})
+		}()
+
+		err := expectReadyForQuery(ctx, interceptor.NewFrontendInterceptor(r))
+		require.Nil(t, err)
+	})
+}
+
+func writeServerMsg(w io.Writer, msg pgproto3.BackendMessage) {
+	_, _ = w.Write(msg.Encode(nil))
+}
+
+func expectMsg(t *testing.T, fi *interceptor.FrontendInterceptor, match string) {
+	t.Helper()
+	msg, err := fi.ReadMsg()
+	require.NoError(t, err)
+	require.Regexp(t, match, jsonOrRaw(msg))
+}

--- a/pkg/ccl/sqlproxyccl/interceptor/base.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/base.go
@@ -26,7 +26,7 @@ const pgHeaderSizeBytes = 5
 // chosen to match Postgres' send and receive buffer sizes.
 //
 // See: https://github.com/postgres/postgres/blob/249d64999615802752940e017ee5166e726bc7cd/src/backend/libpq/pqcomm.c#L134-L135.
-const defaultBufferSize = 2 << 13 // 8K
+const defaultBufferSize = 1 << 13 // 8K
 
 // ErrProtocolError indicates that the packets are malformed, and are not as
 // expected.

--- a/pkg/ccl/sqlproxyccl/interceptor/base_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/base_test.go
@@ -33,8 +33,8 @@ func TestNewPgInterceptor(t *testing.T) {
 		bufSize           int
 		normalizedBufSize int
 	}{
-		{-1, defaultBufferSize},
-		{pgHeaderSizeBytes - 1, defaultBufferSize},
+		{-1, 8192},
+		{pgHeaderSizeBytes - 1, 8192},
 		{pgHeaderSizeBytes, pgHeaderSizeBytes},
 		{1024, 1024},
 	} {


### PR DESCRIPTION
#### ccl/sqlproxyccl: add helpers related to connection migration 

Informs #76000. Extracted from #76805.

This commit adds helpers related to connection migration. This includes support
for retrieving the transfer state through SHOW TRANSFER STATE, as well as
deserializing the session through crdb_internal.deserialize_session.

Release note: None

Release justification: Helpers added in this commit are needed for the
connection migration work. Connection migration is currently not being used
in production, and CockroachCloud is the only user of sqlproxy.
  
#### ccl/sqlproxyccl: fix math for defaultBufferSize in interceptors 

Previously, we incorrectly defined defaultBufferSize as 16K bytes. Note that
2 << 13 is 16K bytes. This commit fixes that behavior to match the original
intention of 8K bytes.

Release note: None

Release justification: This fixes an unintentional buglet within the sqlproxy
code that was introduced with the interceptors back then. Not having this in
means we're using double the memory for each connection within the sqlproxy.

