### PR TITLE
ccl/sqlproxyccl: handle implicit auth in OpenTenantConnWithToken

### DIFF
--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -33,7 +33,7 @@ func TestConnector_OpenTenantConnWithToken(t *testing.T) {
 	const token = "foobarbaz"
 	ctx := context.Background()
 
-	t.Run("error", func(t *testing.T) {
+	t.Run("error during open", func(t *testing.T) {
 		c := &connector{
 			StartupMsg: &pgproto3.StartupMessage{
 				Parameters: make(map[string]string),
@@ -51,6 +51,48 @@ func TestConnector_OpenTenantConnWithToken(t *testing.T) {
 		str, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
 		require.False(t, ok)
 		require.Equal(t, "", str)
+	})
+
+	t.Run("error during auth", func(t *testing.T) {
+		c := &connector{
+			StartupMsg: &pgproto3.StartupMessage{
+				Parameters: make(map[string]string),
+			},
+		}
+		conn, _ := net.Pipe()
+		defer conn.Close()
+
+		var openCalled bool
+		c.testingKnobs.dialTenantCluster = func(ctx context.Context) (net.Conn, error) {
+			openCalled = true
+
+			// Validate that token is set.
+			str, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+			require.True(t, ok)
+			require.Equal(t, token, str)
+
+			return conn, nil
+		}
+
+		defer testutils.TestingHook(
+			&readTokenAuthResult,
+			func(serverConn net.Conn) error {
+				return errors.New("bar")
+			},
+		)()
+
+		crdbConn, err := c.OpenTenantConnWithToken(ctx, token)
+		require.True(t, openCalled)
+		require.EqualError(t, err, "bar")
+		require.Nil(t, crdbConn)
+
+		// Ensure that token is deleted.
+		_, ok := c.StartupMsg.Parameters[sessionRevivalTokenStartupParam]
+		require.False(t, ok)
+
+		// Connection should be closed.
+		_, err = conn.Write([]byte("foo"))
+		require.Regexp(t, "closed pipe", err)
 	})
 
 	t.Run("successful", func(t *testing.T) {
@@ -74,8 +116,19 @@ func TestConnector_OpenTenantConnWithToken(t *testing.T) {
 			return conn, nil
 		}
 
+		var authCalled bool
+		defer testutils.TestingHook(
+			&readTokenAuthResult,
+			func(serverConn net.Conn) error {
+				authCalled = true
+				require.Equal(t, conn, serverConn)
+				return nil
+			},
+		)()
+
 		crdbConn, err := c.OpenTenantConnWithToken(ctx, token)
 		require.True(t, openCalled)
+		require.True(t, authCalled)
 		require.NoError(t, err)
 		require.Equal(t, conn, crdbConn)
 
@@ -111,9 +164,20 @@ func TestConnector_OpenTenantConnWithToken(t *testing.T) {
 			return conn, nil
 		}
 
+		var authCalled bool
+		defer testutils.TestingHook(
+			&readTokenAuthResult,
+			func(serverConn net.Conn) error {
+				authCalled = true
+				require.Equal(t, conn, serverConn)
+				return nil
+			},
+		)()
+
 		crdbConn, err := c.OpenTenantConnWithToken(ctx, token)
 		require.True(t, wrapperCalled)
 		require.True(t, openCalled)
+		require.True(t, authCalled)
 		require.NoError(t, err)
 		require.Equal(t, conn, crdbConn)
 
@@ -641,6 +705,7 @@ func TestRetriableConnectorError(t *testing.T) {
 	require.False(t, isRetriableConnectorError(err))
 	err = markAsRetriableConnectorError(err)
 	require.True(t, isRetriableConnectorError(err))
+	require.True(t, errors.Is(err, errRetryConnectorSentinel))
 }
 
 var _ TenantResolver = &testTenantResolver{}

--- a/pkg/ccl/sqlproxyccl/interceptor/chunkreader.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/chunkreader.go
@@ -34,6 +34,11 @@ func newChunkReader(msg []byte) pgproto3.ChunkReader {
 // returned once the entire message has been read. If the caller tries to read
 // more bytes than it could, an errInvalidRead will be returned.
 func (cr *chunkReader) Next(n int) (buf []byte, err error) {
+	// pgproto3's Receive methods will still invoke Next even if the body size
+	// is 0. We shouldn't return an EOF in that case.
+	if n == 0 {
+		return []byte{}, nil
+	}
 	if cr.pos == len(cr.msg) {
 		return nil, io.EOF
 	}

--- a/pkg/ccl/sqlproxyccl/interceptor/chunkreader_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/chunkreader_test.go
@@ -30,6 +30,11 @@ func TestChunkReader(t *testing.T) {
 	require.EqualError(t, err, errInvalidRead.Error())
 	require.Nil(t, buf)
 
+	// Attempt n = 0 before EOF.
+	buf, err = cr.Next(0)
+	require.NoError(t, err)
+	require.Len(t, buf, 0)
+
 	buf, err = cr.Next(11)
 	require.NoError(t, err)
 	require.Equal(t, "hello world", string(buf))
@@ -37,4 +42,9 @@ func TestChunkReader(t *testing.T) {
 	buf, err = cr.Next(1)
 	require.EqualError(t, err, io.EOF.Error())
 	require.Nil(t, buf)
+
+	// Attempting n = 0 after EOF returns nothing instead of an error.
+	buf, err = cr.Next(0)
+	require.NoError(t, err)
+	require.Len(t, buf, 0)
 }


### PR DESCRIPTION
Informs #76000. Extracted from #76805.

Previously, we assumed that with the token-based authentication, the server is
ready to accept queries the moment we connect to it. This assumption has been
proved wrong during the integration tests with the forwarder, and there's
an implicit AuthenticateOK step that happens after connecting to the server.
During that time, initial connection data such as ParameterStatus and
BackendKeyData messages will be sent to the client as well. For now, we will
ignore those messages. Once we start implementing query cancellation within
the proxy, that has to be updated to cache the new BackendKeyData.

This commit also fixes a buglet to handle pgwire messages with no body.
pgproto3's Receive methods will still call Next if the body size is 0, and
previously, we were returning an io.EOF error. This commit changes that
behavior to return an empty slice.

Release note: None

Release justification: This fixes two buglets: one that was introduced when we
added token-based authentication support to the proxy in #76417, and another
when we added the interceptors. This is low risk as part of the code is
guarded behind the connection migration feature, which is currently not being
used in production. To add on, CockroachCloud is the only user of sqlproxy.