### PR TITLE
cli: remove debug backup from help output

### DIFF
--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -182,6 +182,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cli.UsageAndErr(cmd, args)
 		},
+		// The debug backups command is hidden from the help
+		// to signal that it isn't yet a stable interface.
+		Hidden: true,
 	}
 
 	backupFlags := backupCmds.Flags()


### PR DESCRIPTION
The Bulk IO team doesn't feel the interface here is ready for prime
time and the current interface is likely to cause confusion for anyone
who stumbles upon it. While it is a useful set of commands we want
available to us, we don't yet want to indicate that it is
stable. Thus, we are removing it from the default help output.

Release justification: Low risk change to ensure we do not
inadvertantly end up supporting an interface we aren't ready to
support.

Release note: None