### PR TITLE
vendor: bump Pebble to 40d39da505a5

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1287,10 +1287,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "1d4eff199bd4952fad40c7c1c64e167ef8600f222f57058ae7a050979c7650d8",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220217165617-821db50635d6",
+        sha256 = "71da6a69951ab9767aa51efd34b2a4040ab655f67a5b0be87578af5a85132d26",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220227235451-40d39da505a5",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220217165617-821db50635d6.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220227235451-40d39da505a5.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220217165617-821db50635d6
+	github.com/cockroachdb/pebble v0.0.0-20220227235451-40d39da505a5
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220217190341-94cf65c2a29f

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220217165617-821db50635d6 h1:h0QXUCqMzrxfdxAh+WTYZZOqilZBc7sOpDTMFZHzhy4=
-github.com/cockroachdb/pebble v0.0.0-20220217165617-821db50635d6/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220227235451-40d39da505a5 h1:6ZsiW1sWGEsx2kDq98bdoDfdDeO2IgfI4e2FxUQwkdk=
+github.com/cockroachdb/pebble v0.0.0-20220227235451-40d39da505a5/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -162,7 +162,7 @@ func (is Server) CompactEngineSpan(
 	resp := &CompactEngineSpanResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			return s.Engine().CompactRange(req.Span.Key, req.Span.EndKey, true /* forceBottommost */)
+			return s.Engine().CompactRange(req.Span.Key, req.Span.EndKey)
 		})
 	return resp, err
 }

--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -238,7 +238,7 @@ func TestPebbleMapClose(t *testing.T) {
 	startKey := diskMap.makeKey([]byte{'a'})
 	startKeyCopy := make([]byte, len(startKey))
 	copy(startKeyCopy, startKey)
-	if err := e.db.Compact(startKeyCopy, diskMap.makeKey([]byte{'z'})); err != nil {
+	if err := e.db.Compact(startKeyCopy, diskMap.makeKey([]byte{'z'}), false /* parallel */); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -746,10 +746,8 @@ type Engine interface {
 	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 	// CompactRange ensures that the specified range of key value pairs is
-	// optimized for space efficiency. The forceBottommost parameter ensures
-	// that the key range is compacted all the way to the bottommost level of
-	// SSTables, which is necessary to pick up changes to bloom filters.
-	CompactRange(start, end roachpb.Key, forceBottommost bool) error
+	// optimized for space efficiency.
+	CompactRange(start, end roachpb.Key) error
 	// InMem returns true if the receiver is an in-memory engine and false
 	// otherwise.
 	//

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -702,7 +702,7 @@ type compactOp struct {
 }
 
 func (c compactOp) run(ctx context.Context) string {
-	err := c.m.engine.CompactRange(c.key, c.endKey, false)
+	err := c.m.engine.CompactRange(c.key, c.endKey)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err.Error())
 	}

--- a/pkg/storage/metamorphic/options.go
+++ b/pkg/storage/metamorphic/options.go
@@ -49,7 +49,7 @@ func standardOptions(i int) *pebble.Options {
 `,
 		7: `
 [Options]
-  mem_table_size=1000
+  mem_table_size=2000
 `,
 		8: `
 [Options]
@@ -129,7 +129,7 @@ func randomOptions() *pebble.Options {
 	}
 	opts.MaxManifestFileSize = 1 << rngIntRange(rng, 1, 28)
 	opts.MaxOpenFiles = int(rngIntRange(rng, 20, 2000))
-	opts.MemTableSize = 1 << rngIntRange(rng, 10, 28)
+	opts.MemTableSize = 1 << rngIntRange(rng, 11, 28)
 	opts.MemTableStopWritesThreshold = int(rngIntRange(rng, 2, 7))
 	opts.MaxConcurrentCompactions = int(rngIntRange(rng, 1, 4))
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1482,14 +1482,14 @@ func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
 
 // Compact implements the Engine interface.
 func (p *Pebble) Compact() error {
-	return p.db.Compact(nil, EncodeMVCCKey(MVCCKeyMax))
+	return p.db.Compact(nil, EncodeMVCCKey(MVCCKeyMax), false /* parallel */)
 }
 
 // CompactRange implements the Engine interface.
-func (p *Pebble) CompactRange(start, end roachpb.Key, forceBottommost bool) error {
+func (p *Pebble) CompactRange(start, end roachpb.Key) error {
 	bufStart := EncodeMVCCKey(MVCCKey{start, hlc.Timestamp{}})
 	bufEnd := EncodeMVCCKey(MVCCKey{end, hlc.Timestamp{}})
-	return p.db.Compact(bufStart, bufEnd)
+	return p.db.Compact(bufStart, bufEnd, false /* parallel */)
 }
 
 // InMem returns true if the receiver is an in-memory engine and false

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -172,7 +172,7 @@ func (p *pebbleIterator) init(
 		// We are given an inclusive [MinTimestampHint, MaxTimestampHint]. The
 		// MVCCWAllTimeIntervalCollector has collected the WallTimes and we need
 		// [min, max), i.e., exclusive on the upper bound.
-		p.options.BlockPropertyFilters = []pebble.BlockPropertyFilter{
+		p.options.PointKeyFilters = []pebble.BlockPropertyFilter{
 			sstable.NewBlockIntervalFilter(mvccWallTimeIntervalCollector,
 				uint64(opts.MinTimestampHint.WallTime),
 				uint64(opts.MaxTimestampHint.WallTime)+1),


### PR DESCRIPTION
```
40d39da5 db: produce the FlushEnd event after installing readState
cef3f146 compaction: add support for concurrent manual compactions
cb848478 manifest: add methods for extending table bounds
7e5c8ee1 sstable: move block property collector calls to the Writer client goroutine
0e0d279a  internal/keyspan: move MergingIter from internal/rangekey
09203fd9 *: Expose range key iterators through table cache
894b57aa db: correctly set point key bounds in `TestIngest_UpdateSequenceNumber`
6c7f6ed4 base: update IsExclusiveSentinel to account for multiple range key kinds
e0589417 db: add external sstable merging iterator
85162b61 sstable: unify sstable size estimation by using a single abstraction
bac6da8f internal/rangekey: adjust MergingIter interface, return fragment sets
7eb64ae7 Revert "db: add experimental DB.RegisterFlushCompletedCallback"
2c522458 db: remove unnecessary key clones during ingest load
998400e7 db: fix skipped key during Prev at synthetic range key marker
13f8f7ce *: separately track smallest/largest point/range keys in FileMetadata
7449c652 sstable: change index block size estimation to use inflight size
31899eb1 sstable: flush index blocks only from the Writer client goroutine
129bc0d4 internal/rangekey: fix invariant violation during SeekGE(upper-bound)
87ab6c71 db: write range keys to memtables
```

Release note: None

Release justification: commits merged in Pebble before stability period