### PR TITLE
ccl/sqlproxyccl: bump size of `tenant` test

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
 
 go_test(
     name = "tenant_test",
+    size = "large",
     srcs = [
         "directory_test.go",
         "main_test.go",


### PR DESCRIPTION
Release justification: non-production code changes
Release note: None