### PR TITLE
release-21.2: sql: dropping user with default privilege's error message is more clear

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges
@@ -1,85 +1,103 @@
 statement ok
-CREATE USER test1;
-CREATE USER test2;
-GRANT test1 TO ROOT;
+CREATE USER testuser1;
+CREATE USER testuser2;
+GRANT testuser1 TO ROOT;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT SELECT ON TABLES TO test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 GRANT SELECT ON TABLES TO testuser2;
 
-statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new relations belonging to role test1
-DROP ROLE test1
+statement error pq: role testuser1 cannot be dropped because some objects depend on it\nowner of default privileges on new relations belonging to role testuser1 in database test
+DROP ROLE testuser1
 
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations belonging to role test1
-DROP ROLE test2;
-
-statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON TABLES FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT USAGE ON SCHEMAS TO test2;
-
-statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new schemas belonging to role test1
-DROP ROLE test1
-
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new schemas belonging to role test1
-DROP ROLE test2;
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations belonging to role testuser1 in database test
+DROP ROLE testuser2;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON SCHEMAS FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT USAGE ON TYPES TO test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE SELECT ON TABLES FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 GRANT USAGE ON SCHEMAS TO testuser2;
 
-statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new types belonging to role test1
-DROP ROLE test1
+statement error pq: role testuser1 cannot be dropped because some objects depend on it\nowner of default privileges on new schemas belonging to role testuser1 in database test
+DROP ROLE testuser1
 
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new types belonging to role test1
-DROP ROLE test2;
-
-statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON TYPES FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT SELECT ON SEQUENCES TO test2;
-
-statement error pq: role test1 cannot be dropped because some objects depend on it\nowner of default privileges on new sequences belonging to role test1
-DROP ROLE test1
-
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new sequences belonging to role test1
-DROP ROLE test2;
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new schemas belonging to role testuser1 in database test
+DROP ROLE testuser2;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON TABLES FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON SCHEMAS FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE USAGE ON TYPES FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON SEQUENCES FROM test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE USAGE ON SCHEMAS FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 GRANT USAGE ON TYPES TO testuser2;
+
+statement error pq: role testuser1 cannot be dropped because some objects depend on it\nowner of default privileges on new types belonging to role testuser1 in database test
+DROP ROLE testuser1
+
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new types belonging to role testuser1 in database test
+DROP ROLE testuser2;
 
 statement ok
-DROP ROLE test1;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE USAGE ON TYPES FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 GRANT SELECT ON SEQUENCES TO testuser2;
+
+statement error pq: role testuser1 cannot be dropped because some objects depend on it\nowner of default privileges on new sequences belonging to role testuser1 in database test
+DROP ROLE testuser1
+
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new sequences belonging to role testuser1 in database test
+DROP ROLE testuser2;
 
 statement ok
-DROP ROLE test2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE SELECT ON TABLES FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE USAGE ON SCHEMAS FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE USAGE ON TYPES FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser1 REVOKE SELECT ON SEQUENCES FROM testuser2;
 
 statement ok
-CREATE USER test2
+DROP ROLE testuser1;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO test2
-
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations for all roles
-DROP ROLE test2;
+DROP ROLE testuser2;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE SELECT ON TABLES FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON SCHEMAS TO test2;
-
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new schemas for all roles
-DROP ROLE test2;
+CREATE USER testuser2
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE USAGE ON SCHEMAS FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON TYPES TO test2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO testuser2
 
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new types for all roles
-DROP ROLE test2
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations for all roles in database test
+DROP ROLE testuser2;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE USAGE ON TYPES FROM test2;
-ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON SEQUENCES TO test2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE SELECT ON TABLES FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON SCHEMAS TO testuser2;
 
-statement error pq: role test2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new sequences for all roles
-DROP ROLE test2
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new schemas for all roles in database test
+DROP ROLE testuser2;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE USAGE ON SCHEMAS FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT USAGE ON TYPES TO testuser2;
+
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new types for all roles in database test
+DROP ROLE testuser2
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE USAGE ON TYPES FROM testuser2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON SEQUENCES TO testuser2;
+
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nprivileges for default privileges on new sequences for all roles in database test
+DROP ROLE testuser2
+
+# Grant default privileges to testuser2 in a second database.
+statement ok
+CREATE ROLE testuser3;
+GRANT testuser2 TO root;
+GRANT testuser3 TO root;
+CREATE DATABASE testdb2;
+USE testdb2;
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON SEQUENCES TO testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser3 GRANT SELECT ON SEQUENCES TO testuser2;
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser2 GRANT SELECT ON SEQUENCES TO testuser3;
+
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nowner of default privileges on new sequences belonging to role testuser2 in database testdb2\nprivileges for default privileges on new sequences belonging to role testuser3 in database testdb2\nprivileges for default privileges on new sequences for all roles in database test\nprivileges for default privileges on new sequences for all roles in database testdb2
+DROP ROLE testuser2
+
+# Check the hint output.
+statement error pq: role testuser2 cannot be dropped because some objects depend on it\nowner of default privileges on new sequences belonging to role testuser2 in database testdb2\nprivileges for default privileges on new sequences belonging to role testuser3 in database testdb2\nprivileges for default privileges on new sequences for all roles in database test\nprivileges for default privileges on new sequences for all roles in database testdb2\nHINT: USE testdb2; ALTER DEFAULT PRIVILEGES FOR ROLE testuser2 REVOKE ALL ON SEQUENCES FROM testuser3;\nUSE testdb2; ALTER DEFAULT PRIVILEGES FOR ROLE testuser3 REVOKE ALL ON SEQUENCES FROM testuser2;\nUSE test; ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON SEQUENCES FROM testuser2;\nUSE testdb2; ALTER DEFAULT PRIVILEGES FOR ALL ROLES REVOKE ALL ON SEQUENCES FROM testuser2;
+DROP ROLE testuser2

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -202,7 +202,7 @@ statement ok
 REVOKE ALL ON DATABASE test FROM testuser;
 REVOKE ALL ON TABLE d.t FROM testuser;
 
-statement error pq: role testuser cannot be dropped because some objects depend on it.*\n.*owner of database d.*\n.*owner of table test.public.t.*\n.*owner of table d.public.t
+statement error pq: role testuser cannot be dropped because some objects depend on it\nowner of database d\nowner of table d.public.t\nowner of table test.public.t
 DROP ROLE testuser
 
 # Cannot drop object due to owned objects message should only show the owned
@@ -246,5 +246,5 @@ REVOKE ALL ON TABLE d.s.t FROM testuser;
 
 user testuser
 
-statement error pq: role testuser cannot be dropped because some objects depend on it.*\n.*owner of database d.*\n.*owner of table test.public.t.*\n.*owner of table d.public.t.*\n.*owner of table d.s.t.*\n.*owner of schema s.*\n.*owner of type d.public._?typ.*\n.*owner of type d.public._?typ
+statement error pq: role testuser cannot be dropped because some objects depend on it\nowner of database d\nowner of schema s
 DROP ROLE testuser


### PR DESCRIPTION
Backport 1/1 commits from #77016.

/cc @cockroachdb/release

---

Release note (sql change): When dropping a user that has default privileges,
the error message now includes which database and schema the default privileges
are defined in.

Error message now includes the database name and schema name for which the default privileges are defined.

The UX is still not ideal here but this is a good first step.

```
Example:
role testuser2 cannot be dropped because some objects depend on it
owner of default privileges on new sequences belonging to role testuser2 in database testdb2
privileges for default privileges on new sequences belonging to role testuser3 in database testdb2
privileges for default privileges on new sequences for all roles in database test
privileges for default privileges on new sequences for all roles in database testdb2

```
