### PR TITLE
changefeedccl: Make alter sink type error more prescriptive

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -192,7 +192,7 @@ func alterChangefeedPlanHook(
 						if newSinkURI.Scheme != prevSinkURI.Scheme {
 							return pgerror.Newf(
 								pgcode.InvalidParameterValue,
-								`new sink type %q does not match original sink type %q, sink type cannot be altered`,
+								`New sink type %q does not match original sink type %q. Altering the sink type of a changefeed is disallowed, consider creating a new changefeed instead.`,
 								newSinkURI.Scheme,
 								prevSinkURI.Scheme,
 							)

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -328,7 +328,7 @@ func TestAlterChangefeedChangeSinkTypeError(t *testing.T) {
 		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
 
 		sqlDB.ExpectErr(t,
-			`pq: new sink type "s3" does not match original sink type "kafka", sink type cannot be altered`,
+			`pq: New sink type "s3" does not match original sink type "kafka". Altering the sink type of a changefeed is disallowed, consider creating a new changefeed instead.`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d SET sink = 's3://fake-bucket-name/fake/path?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456'`, feed.JobID()),
 		)
 	}


### PR DESCRIPTION
Altering the sink type of a changefeed is disallowed.
In this PR we offer alternatives in the error message
for users who would like to use a new sink type.

Release note (enterprise change): Altering the sink type
of a changefeed is disallowed. In this PR we offer solutions
for those who would like to use a new sink type in the
error message.

Release justification: This is a safe, low-risk code change
as we are only changing the content of the error message
to make it more prescriptive for users.