### PR TITLE
sql: replace sampledPlanKey with statement fingerprint ID in ssmemstorage

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -63,7 +63,7 @@ func (s *StmtStatsIterator) Next() bool {
 
 	stmtKey := s.stmtKeys[s.idx]
 
-	stmtFingerprintID := constructStatementFingerprintIDFromStmtKey(stmtKey)
+	stmtFingerprintID := stmtKey.statementFingerprintID
 	statementStats, _, _ :=
 		s.container.getStatsForStmtWithKey(stmtKey, invalidStmtFingerprintID, false /* createIfNonexistent */)
 
@@ -81,17 +81,20 @@ func (s *StmtStatsIterator) Next() bool {
 	fullScan := statementStats.mu.fullScan
 	database := statementStats.mu.database
 	querySummary := statementStats.mu.querySummary
+	anonymizedStmt := statementStats.mu.anonymizedStmt
+	failed := statementStats.mu.failed
+	implicitTxn := statementStats.mu.implicitTxn
 	statementStats.mu.Unlock()
 
 	s.currentValue = &roachpb.CollectedStatementStatistics{
 		Key: roachpb.StatementStatisticsKey{
-			Query:                    stmtKey.anonymizedStmt,
+			Query:                    anonymizedStmt,
 			QuerySummary:             querySummary,
 			DistSQL:                  distSQLUsed,
 			Vec:                      vectorized,
-			ImplicitTxn:              stmtKey.implicitTxn,
+			ImplicitTxn:              implicitTxn,
 			FullScan:                 fullScan,
-			Failed:                   stmtKey.failed,
+			Failed:                   failed,
 			App:                      s.container.appName,
 			Database:                 database,
 			PlanHash:                 stmtKey.planHash,

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -105,7 +105,7 @@ func (s *Container) RecordStatement(
 	if value.Plan != nil {
 		stats.mu.data.SensitiveInfo.MostRecentPlanDescription = *value.Plan
 		stats.mu.data.SensitiveInfo.MostRecentPlanTimestamp = s.getTimeNow()
-		s.setLogicalPlanLastSampled(statementKey.sampledPlanKey, stats.mu.data.SensitiveInfo.MostRecentPlanTimestamp)
+		s.setLogicalPlanLastSampled(stmtFingerprintID, stats.mu.data.SensitiveInfo.MostRecentPlanTimestamp)
 	}
 	if value.AutoRetryCount == 0 {
 		stats.mu.data.FirstAttemptCount++
@@ -141,8 +141,8 @@ func (s *Container) RecordStatement(
 		estimatedMemoryAllocBytes := stats.sizeUnsafe() + statementKey.size() + 8
 
 		// We also accounts for the memory used for s.sampledPlanMetadataCache.
-		// timestamp size + key size + hash.
-		estimatedMemoryAllocBytes += timestampSize + statementKey.sampledPlanKey.size() + 8
+		// timestamp size + hash.
+		estimatedMemoryAllocBytes += timestampSize + 8
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
@@ -187,11 +187,9 @@ func (s *Container) RecordStatementExecStats(
 func (s *Container) ShouldSaveLogicalPlanDesc(
 	fingerprint string, implicitTxn bool, database string,
 ) bool {
-	lastSampled := s.getLogicalPlanLastSampled(sampledPlanKey{
-		anonymizedStmt: fingerprint,
-		implicitTxn:    implicitTxn,
-		database:       database,
-	})
+	lastSampled := s.getLogicalPlanLastSampled(
+		constructStatementFingerprintIDFromStmtKey(fingerprint, false /* failed */, implicitTxn, database),
+	)
 	return s.shouldSaveLogicalPlanDescription(lastSampled)
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/utils.go
+++ b/pkg/sql/sqlstats/ssmemstorage/utils.go
@@ -11,8 +11,6 @@
 package ssmemstorage
 
 import (
-	"strings"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
@@ -25,15 +23,10 @@ func (s stmtList) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 func (s stmtList) Less(i, j int) bool {
-	cmp := strings.Compare(s[i].anonymizedStmt, s[j].anonymizedStmt)
-	if cmp == -1 {
-		return true
+	if s[i].statementFingerprintID == s[j].statementFingerprintID {
+		return s[i].transactionFingerprintID < s[j].transactionFingerprintID
 	}
-
-	if cmp == 1 {
-		return false
-	}
-	return s[i].transactionFingerprintID < s[j].transactionFingerprintID
+	return s[i].statementFingerprintID < s[j].statementFingerprintID
 }
 
 type txnList []roachpb.TransactionFingerprintID


### PR DESCRIPTION
Closes [#69036](https://github.com/cockroachdb/cockroach/issues/69036).

Previously, the `stmtKey` struct contained the `sampledPlanKey` struct
which was redundant because a statement fingerprint ID has a one-to-one
mapping to a `sampledPlanKey`. This change replaces the `sampledPlanKey`
struct with a statement fingerprint ID and refactors the code in
`ssmemstorage` accordingly.