### PR TITLE
server: clean up incorrect use of iterate{Nodes,Pods}

### DIFF
--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -94,7 +93,7 @@ func (s *statusServer) IndexUsageStatistics(
 	// need to aggregate all stats before returning. Returning a partial result
 	// yields an incorrect result.
 	if err := s.iterateNodes(ctx,
-		fmt.Sprintf("requesting index usage stats for node %s", req.NodeID),
+		"requesting index usage stats",
 		dialFn, fetchIndexUsageStats, aggFn, errFn); err != nil {
 		return nil, err
 	}
@@ -177,7 +176,7 @@ func (s *statusServer) ResetIndexUsageStats(
 	}
 
 	if err := s.iterateNodes(ctx,
-		fmt.Sprintf("Resetting index usage stats for node %s", req.NodeID),
+		"Resetting index usage stats",
 		dialFn, resetIndexUsageStats, aggFn, errFn); err != nil {
 		return nil, err
 	}

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -78,7 +77,7 @@ func (s *statusServer) ResetSQLStats(
 
 	var fanoutError error
 
-	if err := s.iterateNodes(ctx, fmt.Sprintf("reset SQL statistics for node %s", req.NodeID),
+	if err := s.iterateNodes(ctx, "reset SQL statistics",
 		dialFn,
 		resetSQLStats,
 		func(nodeID roachpb.NodeID, resp interface{}) {

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -83,7 +82,7 @@ func (s *statusServer) Statements(
 		return status.Statements(ctx, localReq)
 	}
 
-	if err := s.iterateNodes(ctx, fmt.Sprintf("statement statistics for node %s", req.NodeID),
+	if err := s.iterateNodes(ctx, "statement statistics",
 		dialFn,
 		nodeStatement,
 		func(nodeID roachpb.NodeID, resp interface{}) {

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -512,7 +512,7 @@ func (t *tenantStatusServer) ResetSQLStats(
 
 	var fanoutError error
 
-	if err := t.iteratePods(ctx, fmt.Sprintf("reset SQL statistics for instance %s", req.NodeID),
+	if err := t.iteratePods(ctx, "reset SQL statistics",
 		t.dialCallback,
 		nodeResetFn,
 		func(instanceID base.SQLInstanceID, resp interface{}) {
@@ -624,7 +624,7 @@ func (t *tenantStatusServer) Statements(
 		return localResponse, err
 	}
 
-	if err := t.iteratePods(ctx, fmt.Sprintf("statement statistics for node %s", req.NodeID),
+	if err := t.iteratePods(ctx, "statement statistics",
 		t.dialCallback,
 		nodeStatement,
 		func(instanceID base.SQLInstanceID, resp interface{}) {
@@ -917,7 +917,7 @@ func (t *tenantStatusServer) IndexUsageStatistics(
 		combinedError = errors.CombineErrors(combinedError, nodeFnError)
 	}
 
-	if err := t.iteratePods(ctx, fmt.Sprintf("requesting index usage stats for instance %s", req.NodeID),
+	if err := t.iteratePods(ctx, "requesting index usage stats",
 		t.dialCallback,
 		fetchIndexUsageStats,
 		aggFn,
@@ -982,7 +982,7 @@ func (t *tenantStatusServer) ResetIndexUsageStats(
 
 	var combinedError error
 
-	if err := t.iteratePods(ctx, fmt.Sprintf("Resetting index usage stats for instance %s", req.NodeID),
+	if err := t.iteratePods(ctx, "Resetting index usage stats for instance",
 		t.dialCallback,
 		resetIndexUsageStats,
 		func(instanceID base.SQLInstanceID, resp interface{}) {


### PR DESCRIPTION
Previously, the errorCtx argument in iterate{Nodes, Pods} methods was
used incorrectly. The NodeID field in the request payload is often
incorrectly forwarded into the errorCtx.
This commit cleans up the incorrect usage.

Release justification: Bug fixes and low-risk updates to new functionality
Release note: None