### PR TITLE
catalog: use correct ctx when releasing lease

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -507,7 +507,7 @@ func acquireNodeLease(ctx context.Context, m *Manager, id descpb.ID) (bool, erro
 			m.names.insert(newDescVersionState)
 		}
 		if toRelease != nil {
-			releaseLease(ctx, toRelease, m)
+			releaseLease(newCtx, toRelease, m)
 		}
 		return true, nil
 	})

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2132,7 +2132,14 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`In file included from.*(start|runtime)_jemalloc\.go`),
 			stream.GrepNot(`include/jemalloc/jemalloc\.h`),
 
+			// Allow shadowing for variables named err, pErr (proto-errors in kv) and
+			// ctx. For these variables, these names are very common and having too
+			// look for new names to avoid shadowing is too onerous or even
+			// counter-productive if it makes people use the wrong variable by
+			// mistake.
 			stream.GrepNot(`declaration of "?(pE|e)rr"? shadows`),
+			stream.GrepNot(`declaration of "ctx" shadows`),
+
 			// This exception is for hash.go, which re-implements runtime.noescape
 			// for efficient hashing.
 			stream.GrepNot(`pkg/sql/colexec/colexechash/hash.go:[0-9:]+: possible misuse of unsafe.Pointer`),


### PR DESCRIPTION
A recent refactoring used the wrong ctx when calling releaseLease(). A
different ctx needs to be used in that singleflight async code region,
as a comment explains, in order to not inherit the caller's
cancellation. Additionally, using the wrong ctx can also result in a
span use-after-Finish as the caller doesn't always wait for the
singleflight.

Fixes https://github.com/cockroachdb/cockroach/issues/76926
Fixes https://github.com/cockroachdb/cockroach/issues/77031
Fixes https://github.com/cockroachdb/cockroach/issues/76650

Release note: None
Release justification: bug fix