### PR TITLE
spanconfigreconcilerccl: fix flakey protectedts test

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
@@ -50,6 +50,13 @@ protect record-id=4 ts=4
 descs 104
 ----
 
+mutations
+----
+delete /Table/10{6-7}
+upsert /Table/10{6-7}                      protection_policies=[{ts: 3} {ts: 4}]
+delete /Table/10{7-8}
+upsert /Table/10{7-8}                      protection_policies=[{ts: 3} {ts: 4}]
+
 # Write a protected timestamp record on the entire keyspace.
 protect record-id=5 ts=5
 cluster
@@ -59,10 +66,6 @@ mutations
 ----
 delete {entire-keyspace}
 upsert {entire-keyspace}                   protection_policies=[{ts: 1} {ts: 5}]
-delete /Table/10{6-7}
-upsert /Table/10{6-7}                      protection_policies=[{ts: 3} {ts: 4}]
-delete /Table/10{7-8}
-upsert /Table/10{7-8}                      protection_policies=[{ts: 3} {ts: 4}]
 
 state limit=3
 ----


### PR DESCRIPTION
We increment the batchIdx on every call to UpdateSpanConfigRecords
in the KVAccessorRecorder. If you run two protects, one on table
target and one on cluster, and they get picked in two calls to
reconcile (which in turn calls UpdateSpanConfigRecords )
then I believe they can Apply the deletes and upserts in two batches
and then that would cause them to sort:

SpanConfig mutations
SystemSpanConfig mutations

If instead they get picked up in a single reconciliation they would sort:

SystemSpanConfig
SpanConfig

Under --stress this test flakes almost immediately. To remedy, we
split up the mutations that we print out for the two calls to Protect.
This way there is no scope for the indeterminism.

Fixes: #77076
Fixes: #77071

Release note: None

Release justification: non-production code changes, test flake fix.