### PR TITLE
kvserver: executeAdminCommandWithDescriptor should retry on ExpectedR…

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -557,7 +557,8 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 		// On seeing a ConditionFailedError or an AmbiguousResultError, retry the
 		// command with the updated descriptor.
 		if !errors.HasType(lastErr, (*roachpb.ConditionFailedError)(nil)) &&
-			!errors.HasType(lastErr, (*roachpb.AmbiguousResultError)(nil)) {
+			!errors.HasType(lastErr, (*roachpb.AmbiguousResultError)(nil)) &&
+			!kv.IsExpectedRelocateError(lastErr) {
 			break
 		}
 	}


### PR DESCRIPTION
…elocateError

Previously, AdminSplit could fail without retrying, e.g.,
https://github.com/cockroachdb/cockroach/issues/76922

This likely fixes the issue above (more than 200 successful runs).

Release note: None