### PR TITLE
rangefeed: use system mem budget for reserved tenant tables

### DIFF
--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -293,9 +293,11 @@ func (f *BudgetFactory) CreateBudget(key roachpb.RKey) *FeedBudget {
 		return nil
 	}
 	// We use any table with reserved ID in system tenant as system case.
-	if key.Less(roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID + 1))) {
-		acc := f.systemFeedBytesMon.MakeBoundAccount()
-		return NewFeedBudget(&acc, 0)
+	if _, id, err := keys.DecodeTenantPrefix(key.AsRawKey()); err == nil && id.IsSystem() {
+		if key.Less(roachpb.RKey(keys.SystemSQLCodec.TablePrefix(keys.MaxReservedDescID + 1))) {
+			acc := f.systemFeedBytesMon.MakeBoundAccount()
+			return NewFeedBudget(&acc, 0)
+		}
 	}
 	acc := f.feedBytesMon.MakeBoundAccount()
 	return NewFeedBudget(&acc, f.limit)


### PR DESCRIPTION
Previously all tenant keyspace rangefeeds were classified as user
even for reserved table ids containing configuration info.
Those feeds should use system budget as they shouldn't compete for
memory with tenant user tables.
This patch adds check for keys in the tenant keyspace when creating
budgets.

Release justification: This change is needed for stability of
rangefeeds on tenants to prevent info like zone configs being
delayed by other rangefeed data.
Release note: None