### PR TITLE
*: fix up panic recovery as errors

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -172,6 +172,7 @@ go_library(
         "//pkg/util/contextutil",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil",
         "//pkg/util/flagutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",

--- a/pkg/cli/debug_merge_logs.go
+++ b/pkg/cli/debug_merge_logs.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/errors"
@@ -570,7 +571,12 @@ func seekToFirstAfterFrom(
 	size := fi.Size()
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
+			ok, e := errorutil.ShouldCatch(r)
+			if !ok {
+				// Not an error, nothing we can do.
+				panic(r)
+			}
+			err = e
 		}
 	}()
 	offset := sort.Search(int(size), func(i int) bool {

--- a/pkg/internal/rsg/yacc/BUILD.bazel
+++ b/pkg/internal/rsg/yacc/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/internal/rsg/yacc",
     visibility = ["//pkg:__subpackages__"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
+    deps = [
+        "//pkg/util/errorutil",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
 )
 
 go_test(

--- a/pkg/internal/rsg/yacc/parse.go
+++ b/pkg/internal/rsg/yacc/parse.go
@@ -22,8 +22,8 @@ package yacc
 
 import (
 	"fmt"
-	"runtime"
 
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -103,14 +103,15 @@ func (t *Tree) unexpected(token item, context string) {
 
 // recover is the handler that turns panics into returns from the top level of Parse.
 func (t *Tree) recover(errp *error) {
-	if e := recover(); e != nil {
-		if _, ok := e.(runtime.Error); ok {
-			panic(e)
+	if r := recover(); r != nil {
+		ok, e := errorutil.ShouldCatch(r)
+		if !ok {
+			panic(r)
 		}
 		if t != nil {
 			t.stopParse()
 		}
-		*errp = e.(error)
+		*errp = e
 	}
 }
 

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/json",
         "//pkg/util/log",

--- a/pkg/sql/catalog/nstree/BUILD.bazel
+++ b/pkg/sql/catalog/nstree/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/internal/validate",
+        "//pkg/util/errorutil",
         "//pkg/util/iterutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_btree//:btree",

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util/contextutil",
         "//pkg/util/duration",
         "//pkg/util/envutil",
+        "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/humanizeutil",
         "//pkg/util/ipaddr",

--- a/pkg/sql/schemachanger/rel/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util",
+        "//pkg/util/errorutil",
         "//pkg/util/iterutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/rel/query_build.go
+++ b/pkg/sql/schemachanger/rel/query_build.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -88,9 +89,9 @@ func newQuery(sc *Schema, clauses Clauses) *Query {
 func (p *queryBuilder) processClause(t Clause) {
 	defer func() {
 		if r := recover(); r != nil {
-			rErr, ok := r.(error)
+			ok, rErr := errorutil.ShouldCatch(r)
 			if !ok {
-				rErr = errors.AssertionFailedf("processClause: panic: %v", r)
+				panic(r)
 			}
 			encoded, err := yaml.Marshal(t)
 			if err != nil {

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -39,10 +39,12 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/util/errorutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
+        "@com_github_pkg_errors//:errors",
     ],
 )
 

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sessiondata",
         "//pkg/util/ctxgroup",
+        "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/scplan/internal/scgraphviz",
         "//pkg/sql/schemachanger/scplan/internal/scstage",
+        "//pkg/util/errorutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/screl/BUILD.bazel
+++ b/pkg/sql/schemachanger/screl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/errorutil",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -654,13 +654,11 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 				if err := func() (err error) {
 					defer func() {
 						if p := recover(); p != nil {
-							if errP, ok := p.(error); ok {
-								// Catch and return the error.
-								err = errP
-							} else {
-								// Nothing we know about, let it continue as a panic.
+							ok, errP := errorutil.ShouldCatch(p)
+							if !ok {
 								panic(p)
 							}
+							err = errP
 						}
 					}()
 

--- a/pkg/util/keysutil/BUILD.bazel
+++ b/pkg/util/keysutil/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/util/errorutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/util/keysutil/keys.go
+++ b/pkg/util/keysutil/keys.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -92,11 +93,11 @@ func customizeKeyComprehension(
 func (s PrettyScanner) Scan(input string) (_ roachpb.Key, rErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			if err, ok := r.(error); ok {
-				rErr = err
-				return
+			ok, e := errorutil.ShouldCatch(r)
+			if !ok {
+				panic(r)
 			}
-			rErr = errors.Errorf("%v", r)
+			rErr = e
 		}
 	}()
 


### PR DESCRIPTION
This commit changes uses of an `.(error)` cast after `recover()` to
use `errorutil.ShouldCatch` instead.

This is to avoid two separate types of problem:

- non-`error` panics should always be propagated, as these correspond
  to unrecoverable go runtime failures (internal data structure
  corruption, etc).
  This corresponds to a `!ok` boolean return on `ShouldCatch()`.

- when an `error` panic originates inside a go runtime library
  (`runtime.Error`), we want that to trigger a Sentry report
  when that error reaches a network edge. `ShouldCatch` achieves this
  by ensuring all such errors are marked as assertion failures.

Release justification: bug fix

Release note: None