### PR TITLE
server: remove nullable false creating warnings

### DIFF
--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1329,7 +1329,7 @@ message StatementDetailsRequest {
   // query, failed, implicitTxn and database. So we don't need to add them
   // to the request.
   string fingerprint_id = 1;
-  repeated string app_names = 2 [(gogoproto.nullable) = false];
+  repeated string app_names = 2;
   // Unix time range for aggregated statements.
   int64 start = 3 [(gogoproto.nullable) = true];
   int64 end = 4 [(gogoproto.nullable) = true];
@@ -1342,7 +1342,7 @@ message StatementDetailsResponse {
     // The value from the key_data cannot be replaced by the formatted value, because is used as is for
     // diagnostic bundle.
     string formatted_query = 2;
-    repeated string app_names = 3 [(gogoproto.nullable) = false];
+    repeated string app_names = 3;
     cockroach.sql.StatementStatistics stats = 4 [(gogoproto.nullable) = false];
     google.protobuf.Duration aggregation_interval = 5 [(gogoproto.nullable) = false,
       (gogoproto.stdduration) = true];


### PR DESCRIPTION
Repeatable app_names on the new StatementDetails endpoint
had the nullable=false, creating a warning to it:
```
WARNING: field StatementDetailsRequest.AppNames is a repeated
non-nullable native type, nullable=false has no effect
WARNING: field CollectedStatementSummary.AppNames is a repeated
non-nullable native type, nullable=false has no effect
```

This commit removes the unnecessary nullable flag.

Release justification: Category 1
Release note: None