### PR TITLE
sql: new built-in function `crdb_internal.active_version()`

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2910,6 +2910,8 @@ a CockroachDB HLC in decimal form.</p>
 <p>Note that uses of this function disable server-side optimizations and
 may increase either contention or retry errors, or both.</p>
 </span></td></tr>
+<tr><td><a name="crdb_internal.active_version"></a><code>crdb_internal.active_version() &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the current active cluster version.</p>
+</span></td></tr>
 <tr><td><a name="crdb_internal.approximate_timestamp"></a><code>crdb_internal.approximate_timestamp(timestamp: <a href="decimal.html">decimal</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Converts the crdb_internal_mvcc_timestamp column into an approximate timestamp.</p>
 </span></td></tr>
 <tr><td><a name="crdb_internal.assignment_cast"></a><code>crdb_internal.assignment_cast(val: anyelement, type: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used internally to perform assignment casts during mutations.</p>

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1580,12 +1580,12 @@
           "format": "int32",
           "x-go-name": "Internal"
         },
-        "major_val": {
+        "major": {
           "type": "integer",
           "format": "int32",
           "x-go-name": "Major"
         },
-        "minor_val": {
+        "minor": {
           "type": "integer",
           "format": "int32",
           "x-go-name": "Minor"

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -448,8 +448,8 @@ message Version {
   // The names "major" and "minor" are reserved in C in
   // some platforms (e.g. FreeBSD).
 
-  optional int32 major_val = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "Major"];
-  optional int32 minor_val = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "Minor"];
+  optional int32 major_val = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "Major", (gogoproto.jsontag) = "major"];
+  optional int32 minor_val = 2 [(gogoproto.nullable) = false, (gogoproto.customname) = "Minor", (gogoproto.jsontag) = "minor"];
   // Note that patch is a placeholder and will always be zero.
   optional int32 patch = 3 [(gogoproto.nullable) = false];
   // The internal version is used to introduce migrations during the development

--- a/pkg/sql/logictest/testdata/logic_test/active_version
+++ b/pkg/sql/logictest/testdata/logic_test/active_version
@@ -1,0 +1,14 @@
+# LogicTest: local-v1.1@v1.0-noupgrade
+
+query T
+SELECT crdb_internal.active_version()
+----
+{"internal": 0, "major": 1, "minor": 0, "patch": 0}
+
+statement ok
+SET CLUSTER SETTING version = '1.1'
+
+query T
+SELECT crdb_internal.active_version()
+----
+{"internal": 0, "major": 1, "minor": 1, "patch": 0}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4558,6 +4558,28 @@ value if you rely on the HLC for accuracy.`,
 		},
 	),
 
+	"crdb_internal.active_version": makeBuiltin(
+		tree.FunctionProperties{Category: categorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn: func(ctx *tree.EvalContext, _ tree.Datums) (tree.Datum, error) {
+				activeVersion := ctx.Settings.Version.ActiveVersionOrEmpty(ctx.Context)
+				jsonStr, err := gojson.Marshal(&activeVersion.Version)
+				if err != nil {
+					return nil, err
+				}
+				jsonDatum, err := tree.ParseDJSON(string(jsonStr))
+				if err != nil {
+					return nil, err
+				}
+				return jsonDatum, nil
+			},
+			Info:       "Returns the current active cluster version.",
+			Volatility: tree.VolatilityVolatile,
+		},
+	),
+
 	"crdb_internal.is_at_least_version": makeBuiltin(
 		tree.FunctionProperties{Category: categorySystemInfo},
 		tree.Overload{


### PR DESCRIPTION
Release justification: low risk, high benefit changes to existing functionality

Release note (sql change): The new built-in scalar function
`crdb_internal.active_version()` can now be used alongside
`crdb_internal.is_at_least_version()` to determine which cluster
version is currently active and choose client-side feature levels
accordingly.