### PR TITLE
ccl/sqlproxyccl: skip TestDirectoryConnect under stress

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -609,6 +609,9 @@ func TestDenylistUpdate(t *testing.T) {
 
 func TestDirectoryConnect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	// TODO(jaylim-crl): This is a potential port reuse issue, so skip this
+	// under stress. See linked GitHub issue.
+	skip.UnderStress(t, "https://github.com/cockroachdb/cockroach/issues/76839")
 	skip.UnderDeadlockWithIssue(t, 71365)
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/76839.

TestDirectoryConnect seems to be flaking under stress. After some initial
investigations, it is suspected that this may be due to port reuse issues
within the testing environment. We'll skip this test for now, and a TODO
has been added.

Release note: None

Release justification: Low-risk, test only change.