### PR TITLE
release-21.2: sql: fix sql.txns.open leaking empty transactions

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1946,6 +1946,12 @@ func (ex *connExecutor) recordTransaction(
 	implicit bool,
 	txnStart time.Time,
 ) error {
+
+	txnEnd := timeutil.Now()
+	txnTime := txnEnd.Sub(txnStart)
+	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1)
+	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(txnTime.Nanoseconds())
+
 	if len(ex.extraTxnState.transactionStatementFingerprintIDs) == 0 {
 		// If the slice of transaction statement fingerprint IDs is empty, this
 		// means there is no statements that's being executed within this
@@ -1953,11 +1959,6 @@ func (ex *connExecutor) recordTransaction(
 		// meaningful.
 		return nil
 	}
-
-	txnEnd := timeutil.Now()
-	txnTime := txnEnd.Sub(txnStart)
-	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1)
-	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(txnTime.Nanoseconds())
 
 	txnServiceLat := ex.phaseTimes.GetTransactionServiceLatency()
 	txnRetryLat := ex.phaseTimes.GetTransactionRetryLatency()


### PR DESCRIPTION
Resolves #76404

Previously, when empty txns were being executed, the sql.txns.open
gauage would increment the count. However, when the empty txns finished
execution, the gauge would not decrement. This caused the Open
Transaction graph in DB Console to show incorrect active transaction
count.
This commit fixes this issue.

Release justification: bug fix to existing functionality
Release note (bug fix): Previously, a bug in CRDB caused the Open
Transaction chart in Metrics Page to constantly increase for empty
transactions. This issue has now been fixed.