### PR TITLE
sql: fix sql.txns.open leaking empty transactions

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2172,13 +2172,6 @@ func (ex *connExecutor) recordTransactionFinish(
 	implicit bool,
 	txnStart time.Time,
 ) error {
-	if len(ex.extraTxnState.transactionStatementFingerprintIDs) == 0 {
-		// If the slice of transaction statement fingerprint IDs is empty, this
-		// means there is no statements that's being executed within this
-		// transaction. Hence, recording stats for this transaction is not
-		// meaningful.
-		return nil
-	}
 	recordingStart := timeutil.Now()
 	defer func() {
 		recordingOverhead := timeutil.Since(recordingStart)
@@ -2199,6 +2192,14 @@ func (ex *connExecutor) recordTransactionFinish(
 		TxnID:            ev.txnID,
 		TxnFingerprintID: transactionFingerprintID,
 	})
+
+	if len(ex.extraTxnState.transactionStatementFingerprintIDs) == 0 {
+		// If the slice of transaction statement fingerprint IDs is empty, this
+		// means there is no statements that's being executed within this
+		// transaction. Hence, recording stats for this transaction is not
+		// meaningful.
+		return nil
+	}
 
 	txnServiceLat := ex.phaseTimes.GetTransactionServiceLatency()
 	txnRetryLat := ex.phaseTimes.GetTransactionRetryLatency()

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1554,6 +1554,37 @@ func TestTrackOnlyUserOpenTransactionsAndActiveStatements(t *testing.T) {
 	<-waitChannel
 }
 
+// TestEmptyTxnIsBeingCorrectlyCounted tests that SQL Active Transaction
+// metric correctly handles empty transactions.
+func TestEmptyTxnIsBeingCorrectlyCounted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params := base.TestServerArgs{}
+	s, conn, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	sqlConn := sqlutils.MakeSQLRunner(conn)
+	openSQLTxnCountPreEmptyTxns := s.SQLServer().(*sql.Server).Metrics.EngineMetrics.SQLTxnsOpen.Value()
+	numOfEmptyTxns := int64(100)
+
+	// Since we constantly have background transactions running, it introduces
+	// some uncertainties and makes it difficult to compare the exact value of
+	// sql.txns.open metrics. To account for the uncertainties, we execute a
+	// large number of empty transactions. Then we compare the sql.txns.open
+	// metrics before and after executing the batch empty transactions. We assert
+	// that the delta between two observations is less than the size of the batch.
+	for i := int64(0); i < numOfEmptyTxns; i++ {
+		sqlConn.Exec(t, "BEGIN;COMMIT;")
+	}
+
+	openSQLTxnCountPostEmptyTxns := s.SQLServer().(*sql.Server).Metrics.EngineMetrics.SQLTxnsOpen.Value()
+	require.Less(t, openSQLTxnCountPostEmptyTxns-openSQLTxnCountPreEmptyTxns, numOfEmptyTxns,
+		"expected the sql.txns.open counter to be properly decremented "+
+			"after executing empty transactions, but it was not")
+}
+
 // dynamicRequestFilter exposes a filter method which is a
 // kvserverbase.ReplicaRequestFilter but can be set dynamically.
 type dynamicRequestFilter struct {


### PR DESCRIPTION
Resolves #76404

Previously, when empty txns were being executed, the sql.txns.open
gauage would increment the count. However, when the empty txns finished
execution, the gauge would not decrement. This caused the Open
Transaction graph in DB Console to show incorrect active transaction
count.
This commit fixes this issue.

Release justification: bug fix to existing functionality
Release note (bug fix): Previously, a bug in CRDB caused the Open
Transaction chart in Metrics Page to constantly increase for empty
transactions. This issue has now been fixed.