### PR TITLE
jobs: fix startable job num-runs overcount

### DIFF
--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -934,10 +934,6 @@ func (sj *StartableJob) Start(ctx context.Context) (err error) {
 		return fmt.Errorf("cannot resume %T job which is not committed", sj.resumer)
 	}
 
-	if err := sj.started(ctx, nil /* txn */); err != nil {
-		return err
-	}
-
 	if err := sj.registry.stopper.RunAsyncTask(ctx, sj.taskName(), func(ctx context.Context) {
 		sj.execErr = sj.registry.runJob(sj.resumerCtx, sj.resumer, sj.Job, StatusRunning, sj.taskName())
 		close(sj.execDone)


### PR DESCRIPTION
Release justification: low risk bug fix

Removes extra call to started() in StartableJob's Start since its
already called in stepThroughStateMachine later on

Release note (bug fix): fix num_runs being incremented twice for certain
jobs upon being started