### PR TITLE
server: Allow bypass of tsdump's strict checks

### DIFF
--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -24,14 +24,33 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	yaml "gopkg.in/yaml.v2"
 )
 
-func maybeImportTS(ctx context.Context, s *Server) error {
+// maxBatchSize governs the maximum size of the kv batch comprising of ts data
+// to be written to the DB.
+const maxBatchSize = 10000
+
+func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
+	var deferError func(error)
+	{
+		var defErr error
+		deferError = func(err error) {
+			log.Infof(ctx, "%v", err)
+			defErr = errors.CombineErrors(defErr, err)
+		}
+		defer func() {
+			if returnErr == nil {
+				returnErr = defErr
+			}
+		}()
+	}
 	knobs, _ := s.cfg.TestingKnobs.Server.(*TestingKnobs)
 	if knobs == nil {
 		return nil
@@ -41,18 +60,6 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 		return nil
 	}
 
-	// In practice we only allow populating time series in `start-single-node` due
-	// to complexities detailed below. Additionally, we allow it only on a fresh
-	// single-node single-store cluster and we also guard against join flags even
-	// though there shouldn't be any.
-	if !s.InitialStart() || len(s.cfg.JoinList) > 0 || len(s.cfg.Stores.Specs) != 1 {
-		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
-	}
-
-	// Also do a best effort at disabling the timeseries of the local node to cause
-	// confusion.
-	ts.TimeseriesStorageEnabled.Override(ctx, &s.ClusterSettings().SV, false)
-
 	// Suppress writing of node statuses for the local node (n1). If it wrote one,
 	// and the imported data also contains n1 but with a different set of stores,
 	// we'd effectively clobber the timeseries display for n1 (which relies on the
@@ -61,27 +68,78 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 	// is not in use in the data set to import.
 	s.node.suppressNodeStatus.Set(true)
 
+	// Disable writing of new timeseries, as well as roll-ups and deletion.
+	for _, stmt := range []string{
+		"SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = 'true';",
+		"SET CLUSTER SETTING timeseries.storage.enabled = 'false';",
+		"SET CLUSTER SETTING timeseries.storage.resolution_10s.ttl = '99999h';",
+		"SET CLUSTER SETTING timeseries.storage.resolution_30m.ttl = '99999h';",
+	} {
+		if _, err := s.sqlServer.internalExecutor.ExecEx(
+			ctx, "tsdump-cfg", nil, /* txn */
+			sessiondata.InternalExecutorOverride{
+				User: security.RootUserName(),
+			},
+			stmt,
+		); err != nil {
+			return errors.Wrapf(err, "%s", stmt)
+		}
+	}
+	if tsImport == "-" {
+		// YOLO mode to look at timeseries after previous import error. This setting is used
+		// to override errors seen during a prior run of tsdump. Since the timeseries data
+		// has already been loaded during the previous tsdump run, we can simply return
+		// here and allow the user to proceed with viewing the loaded timeseries data.
+		return nil
+	}
+	// In practice we only allow populating time series in `start-single-node` due
+	// to complexities detailed below. Additionally, we allow it only on a fresh
+	// single-node single-store cluster and we also guard against join flags even
+	// though there shouldn't be any.
+	if !s.InitialStart() || len(s.cfg.JoinList) > 0 || len(s.cfg.Stores.Specs) != 1 {
+		return errors.New("cannot import timeseries into an existing cluster or a multi-{store,node} cluster")
+	}
+
 	f, err := os.Open(tsImport)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	b := &kv.Batch{}
-	var n int
+	if knobs.ImportTimeseriesMappingFile == "" {
+		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
+			"a YAML file that maps StoreID to NodeID. To generate from the source cluster, run the following command:\n \n" +
+			"cockroach sql --url \"<(unix/sql) url>\" --format tsv -e \\\n  \"select concat(store_id::string, ': ', node_id::string)" +
+			"from crdb_internal.kv_store_status\" | \\\n  grep -E '[0-9]+: [0-9]+' | tee tsdump.gob.yaml\n \n" +
+			"To create from a debug.zip file, run the following command:\n \n" +
+			"tail -n +2 debug/crdb_internal.kv_store_status.txt | awk '{print $2 \": \" $1}' > tsdump.gob.yaml\n \n" +
+			"Then export the created file: export COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE=tsdump.gob.yaml\n \n")
+	}
+	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
+	if err != nil {
+		return err
+	}
+	storeToNode := map[roachpb.StoreID]roachpb.NodeID{}
+	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
+		return err
+	}
+	batch := &kv.Batch{}
+
+	var batchSize int
 	maybeFlush := func(force bool) error {
-		if n == 0 {
+		if batchSize == 0 {
+			// Nothing to write to DB.
 			return nil
 		}
-		if n < 100 && !force {
+		if batchSize < maxBatchSize && !force {
 			return nil
 		}
-		err := s.db.Run(ctx, b)
+		err := s.db.Run(ctx, batch)
 		if err != nil {
 			return err
 		}
-		log.Infof(ctx, "imported %d ts pairs\n", n)
-		*b, n = kv.Batch{}, 0
+		log.Infof(ctx, "imported %d ts pairs\n", batchSize)
+		*batch, batchSize = kv.Batch{}, 0
 		return nil
 	}
 
@@ -103,52 +161,39 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 
 		name, source, _, _, err := ts.DecodeDataKey(v.Key)
 		if err != nil {
-			return err
+			deferError(err)
+			continue
 		}
 		if strings.HasPrefix(name, "cr.node.") {
 			nodeIDs[source] = struct{}{}
 		} else if strings.HasPrefix(name, "cr.store.") {
 			storeIDs[source] = struct{}{}
 		} else {
-			return errors.Errorf("unknown metric %s", name)
+			deferError(errors.Errorf("unknown metric %s", name))
+			continue
 		}
 
 		p := roachpb.NewPut(v.Key, v.Value)
 		p.(*roachpb.PutRequest).Inline = true
-		b.AddRawRequest(p)
-		n++
+		batch.AddRawRequest(p)
+		batchSize++
 		if err := maybeFlush(false /* force */); err != nil {
 			return err
 		}
 	}
 
-	if knobs.ImportTimeseriesMappingFile == "" {
-		return errors.Errorf("need to specify COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE; it should point at " +
-			"a YAML file that maps StoreID to NodeID. To generate from the source cluster, run the following command:\n \n" +
-			"cockroach sql --url \"<(unix/sql) url>\" --format tsv -e \\\n  \"select concat(store_id::string, ': ', node_id::string)" +
-			"from crdb_internal.kv_store_status\" | \\\n  grep -E '[0-9]+: [0-9]+' | tee tsdump.gob.yaml\n \n" +
-			"To create from a debug.zip file, run the following command:\n \n" +
-			"tail -n +2 debug/crdb_internal.kv_store_status.txt | awk '{print $2 \": \" $1}' > tsdump.gob.yaml\n \n" +
-			"Then export the created file: export COCKROACH_DEBUG_TS_IMPORT_MAPPING_FILE=tsdump.gob.yaml\n \n")
-	}
-	mapBytes, err := ioutil.ReadFile(knobs.ImportTimeseriesMappingFile)
-	if err != nil {
-		return err
-	}
-	storeToNode := map[roachpb.StoreID]roachpb.NodeID{}
-	if err := yaml.NewDecoder(bytes.NewReader(mapBytes)).Decode(&storeToNode); err != nil {
-		return err
-	}
-
-	fakeStatuses, err := makeFakeNodeStatuses(storeToNode)
-	if err != nil {
-		return err
-	}
+	fakeStatuses := makeFakeNodeStatuses(storeToNode)
 	if err := checkFakeStatuses(fakeStatuses, storeIDs); err != nil {
-		return errors.Wrapf(err, "please provide an updated mapping file %s", knobs.ImportTimeseriesMappingFile)
+		// The checks are pretty strict and in particular make sure that there is at
+		// least one data point for each store. Sometimes stores are down for the
+		// time periods passed to tsdump or decommissioned nodes show up, etc; these
+		// are important to point out but often the data set is actually OK and we
+		// want to be able to view it.
+		deferError(errors.Wrapf(err, "consider updating the mapping file %s or restarting the server with "+
+			"COCKROACH_DEBUG_TS_IMPORT_FILE=- to ignore the error", knobs.ImportTimeseriesMappingFile))
 	}
 
-	// All checks passed, write the statuses.
+	// Write the statuses.
 	for _, status := range fakeStatuses {
 		key := keys.NodeStatusKey(status.Desc.NodeID)
 		if err := s.db.PutInline(ctx, key, &status); err != nil {
@@ -159,9 +204,7 @@ func maybeImportTS(ctx context.Context, s *Server) error {
 	return nil
 }
 
-func makeFakeNodeStatuses(
-	storeToNode map[roachpb.StoreID]roachpb.NodeID,
-) ([]statuspb.NodeStatus, error) {
+func makeFakeNodeStatuses(storeToNode map[roachpb.StoreID]roachpb.NodeID) []statuspb.NodeStatus {
 	var sl []statuspb.NodeStatus
 	nodeToStore := map[roachpb.NodeID][]roachpb.StoreID{}
 	for sid, nid := range storeToNode {
@@ -189,7 +232,7 @@ func makeFakeNodeStatuses(
 	sort.Slice(sl, func(i, j int) bool {
 		return sl[i].Desc.NodeID < sl[j].Desc.NodeID
 	})
-	return sl, nil
+	return sl
 }
 
 func checkFakeStatuses(fakeStatuses []statuspb.NodeStatus, storeIDs map[string]struct{}) error {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1155,11 +1155,9 @@ func Test_makeFakeNodeStatuses(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := makeFakeNodeStatuses(tt.mapping)
-			if err == nil {
-				err = checkFakeStatuses(result, tt.storesSeen)
-			}
-			if err != nil {
+			result := makeFakeNodeStatuses(tt.mapping)
+			var err error
+			if err = checkFakeStatuses(result, tt.storesSeen); err != nil {
 				result = nil
 			}
 			require.Equal(t, tt.exp, result)


### PR DESCRIPTION
tsdump performs strict checks that verify that it
has data for exactly the stores it expects to see
according to the node->store mapping. It can happen
that there legitimately isn't data there, for example
when nodes are down during the tsdump window. We still
want the strict checks, but now tsdump will defer
returning an error and allow restarting with a "-"
in lieu of the tsimport file name  to display the data
anyway.

Additionally, cluster settings are set via SET CLUSTER SETTING
as opposed to overriding settings directly.

Release note (cli change): debug tsdump command allows
viewing timeseries data even in case of node failures
by rerunning the command with the import filename set
to "-".

Addresses #75993

Release justification: low risk, high benefit changes to existing functionality
