### PR TITLE
release: fetch release blockers

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -811,6 +811,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_bradleyfalzon_ghinstallation_v2",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/bradleyfalzon/ghinstallation/v2",
+        sha256 = "cb473a9105ac77549a8e04a989cc95e72dc615b3993b9ee16d75da8c6ef23bd4",
+        strip_prefix = "github.com/bradleyfalzon/ghinstallation/v2@v2.0.3",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/bradleyfalzon/ghinstallation/v2/com_github_bradleyfalzon_ghinstallation_v2-v2.0.3.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_broady_gogeohash",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/broady/gogeohash",
@@ -3433,13 +3443,33 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_google_go_github_v39",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/google/go-github/v39",
+        sha256 = "e8c6bb1c02f57d533559b4125a7f931c55901c9e2560bd688770314c27bcef4f",
+        strip_prefix = "github.com/google/go-github/v39@v39.0.0",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/google/go-github/v39/com_github_google_go_github_v39-v39.0.0.zip",
+        ],
+    )
+    go_repository(
+        name = "com_github_google_go_github_v42",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/google/go-github/v42",
+        sha256 = "250d7e937ea6b1d06a95168dba8708db6cc1f447ffe94712d0e2a82540ea01c9",
+        strip_prefix = "github.com/google/go-github/v42@v42.0.0",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/google/go-github/v42/com_github_google_go_github_v42-v42.0.0.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_google_go_querystring",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/google/go-querystring",
-        sha256 = "1c0a0b81b921ee270e47e05cf0bf8df4475de850671e553c07740849068d4f9f",
-        strip_prefix = "github.com/google/go-querystring@v1.0.0",
+        sha256 = "a6aafc01f5602e6177928751074e325792a654e1d92f0e238b8e8739656dd72b",
+        strip_prefix = "github.com/google/go-querystring@v1.1.0",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/google/go-querystring/com_github_google_go_querystring-v1.0.0.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/google/go-querystring/com_github_google_go_querystring-v1.1.0.zip",
         ],
     )
     go_repository(
@@ -9015,10 +9045,10 @@ def go_deps():
         name = "org_golang_x_crypto",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/crypto",
-        sha256 = "c8c5cf6be93366723efffb4d1a71dde0da4a77886186c890de1b6821ee30cb3d",
-        strip_prefix = "golang.org/x/crypto@v0.0.0-20220112180741-5e0467b6c7ce",
+        sha256 = "882c2c5b949711073e3cc937d7e0bac965aae7ffefcc556b8fd7966f2349127a",
+        strip_prefix = "golang.org/x/crypto@v0.0.0-20220307211146-efcb8507fb70",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/golang.org/x/crypto/org_golang_x_crypto-v0.0.0-20220112180741-5e0467b6c7ce.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/golang.org/x/crypto/org_golang_x_crypto-v0.0.0-20220307211146-efcb8507fb70.zip",
         ],
     )
     go_repository(
@@ -9075,20 +9105,20 @@ def go_deps():
         name = "org_golang_x_net",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/net",
-        sha256 = "75a58bccc53fccc844e501fa7a21daf3230f55dba680df730099918a6e90aa79",
-        strip_prefix = "golang.org/x/net@v0.0.0-20220121210141-e204ce36a2ba",
+        sha256 = "fb6a68784dabf543c3d90fc35598bdd9c356f22bddc59c8f820de6db7ea6a039",
+        strip_prefix = "golang.org/x/net@v0.0.0-20220225172249-27dd8689420f",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/golang.org/x/net/org_golang_x_net-v0.0.0-20220121210141-e204ce36a2ba.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/golang.org/x/net/org_golang_x_net-v0.0.0-20220225172249-27dd8689420f.zip",
         ],
     )
     go_repository(
         name = "org_golang_x_oauth2",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/oauth2",
-        sha256 = "7317b4f8c045bf2840b67cf2981cee14facc6d38a86b2781b62b32c0600f607c",
-        strip_prefix = "golang.org/x/oauth2@v0.0.0-20211104180415-d3ed0bb246c8",
+        sha256 = "f67c8da0113402471bd476d772e1f4e20907cb3d12c413c0c445e0f4c906b002",
+        strip_prefix = "golang.org/x/oauth2@v0.0.0-20220309155454-6242fa91716a",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/golang.org/x/oauth2/org_golang_x_oauth2-v0.0.0-20211104180415-d3ed0bb246c8.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/golang.org/x/oauth2/org_golang_x_oauth2-v0.0.0-20220309155454-6242fa91716a.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	github.com/google/flatbuffers v2.0.0+incompatible
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v42 v42.0.0
 	github.com/google/pprof v0.0.0-20210827144239-02619b876842
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/skylark v0.0.0-20181101142754-a5f7082aabed
@@ -146,11 +147,11 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.0.0-RC3
 	go.opentelemetry.io/otel/sdk v1.0.0-RC3
 	go.opentelemetry.io/otel/trace v1.0.0-RC3
-	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce
+	golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70
 	golang.org/x/exp v0.0.0-20220104160115-025e73f80486
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
-	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba
-	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
+	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
 	golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
@@ -233,7 +234,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,7 @@ github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+Wji
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bonitoo-io/go-sql-bigquery v0.3.4-1.4.0/go.mod h1:J4Y6YJm0qTWB9aFziB7cPeSyc6dOZFyJdteSeybVpXQ=
+github.com/bradleyfalzon/ghinstallation/v2 v2.0.3/go.mod h1:tlgi+JWCXnKFx/Y4WtnDbZEINo31N5bcvnCoqieefmk=
 github.com/broady/gogeohash v0.0.0-20120525094510-7b2c40d64042 h1:iEdmkrNMLXbM7ecffOAtZJQOQUTE4iMonxrb5opUgE4=
 github.com/broady/gogeohash v0.0.0-20120525094510-7b2c40d64042/go.mod h1:f1L9YvXvlt9JTa+A17trQjSMM6bV40f+tHjB+Pi+Fqk=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
@@ -1050,9 +1051,13 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
+github.com/google/go-github/v39 v39.0.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
+github.com/google/go-github/v42 v42.0.0 h1:YNT0FwjPrEysRkLIiKuEfSvBPCGKphW5aS5PxwaoLec=
+github.com/google/go-github/v42 v42.0.0/go.mod h1:jgg/jvyI0YlDOM1/ps6XYh04HNQ3vKf0CVko62/EhRg=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -2283,8 +2288,8 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70 h1:syTAU9FwmvzEoIYMqcPHOcVm4H3U5u90WsvuYgwpETU=
+golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -2414,8 +2419,9 @@ golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba h1:6u6sik+bn/y7vILcYkK3iwTBWN7WtBvB0+SZswQnbf8=
-golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -2433,8 +2439,9 @@ golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a h1:qfl7ob3DIEs3Ml9oLuPwY2N04gymzAW04WsUQHIClgM=
+golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852 h1:xYq6+9AtI+xP3M4r0N1hCkHrInHDBohhquRgx9Kk6gI=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "blockers.go",
         "git.go",
+        "github.go",
         "jira.go",
         "main.go",
         "metadata.go",
@@ -17,10 +18,12 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_andygrunwald_go_jira//:go-jira",
+        "@com_github_google_go_github_v42//github",
         "@com_github_jordan_wright_email//:email",
         "@com_github_masterminds_semver_v3//:semver",
         "@com_github_spf13_cobra//:cobra",
         "@com_google_cloud_go_storage//:storage",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -32,7 +35,10 @@ go_binary(
 
 go_test(
     name = "release_test",
-    srcs = ["sender_test.go"],
+    srcs = [
+        "blockers_test.go",
+        "sender_test.go",
+    ],
     data = glob([
         "templates/**",
         "testdata/**",

--- a/pkg/cmd/release/blockers.go
+++ b/pkg/cmd/release/blockers.go
@@ -11,16 +11,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 )
 
 const (
-	// dateLayout is the expected date format for prepDate and publishDate input values.
-	dateLayout = "2006-01-02"
+	// dateFormatCommandLine is the expected date format for prepDate and publishDate input values.
+	dateFormatCommandLine = "2006-01-02"
+	// dateFormatEmail is the expected date format for prepDate and publishDate input values.
+	dateFormatEmail = "Monday, January 2"
 
 	// prepDate is the date when we expect to select the release candidate.
 	prepDate = "prep-date"
@@ -29,6 +34,12 @@ const (
 
 	// nextVersion can be left out for stable/patch releases, but needs to be passed in for pre-releases (alpha/beta/rc).
 	nextVersion = "next-version"
+
+	// NoProjectName is the project value for issues without a project.
+	NoProjectName = "No Project"
+
+	eventRemovedProject = "removed_from_project"
+	eventAddedProject   = "added_to_project"
 )
 
 var blockersFlags = struct {
@@ -82,13 +93,13 @@ func fetchReleaseSeriesBlockers(_ *cobra.Command, _ []string) error {
 	if blockersFlags.smtpUser == "" {
 		return fmt.Errorf("either %s environment variable or %s flag should be set", envSMTPUser, smtpUser)
 	}
-	releasePrepDate, err := time.Parse(dateLayout, blockersFlags.prepDate)
+	releasePrepDate, err := time.Parse(dateFormatCommandLine, blockersFlags.prepDate)
 	if err != nil {
-		return fmt.Errorf("%s is not parseable into %s date layout", blockersFlags.prepDate, dateLayout)
+		return fmt.Errorf("%s is not parseable into %s date layout", blockersFlags.prepDate, dateFormatCommandLine)
 	}
-	releasePublishDate, err := time.Parse(dateLayout, blockersFlags.publishDate)
+	releasePublishDate, err := time.Parse(dateFormatCommandLine, blockersFlags.publishDate)
 	if err != nil {
-		return fmt.Errorf("%s is not parseable into %s date layout", blockersFlags.publishDate, dateLayout)
+		return fmt.Errorf("%s is not parseable into %s date layout", blockersFlags.publishDate, dateFormatCommandLine)
 	}
 	if blockersFlags.nextVersion == "" {
 		var err error
@@ -98,37 +109,39 @@ func fetchReleaseSeriesBlockers(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// TODO(celia): (future PR) fetch blockers and use real data instead of `temp*` values.
-	fmt.Println("TODO(celia): fetch blockers")
-	tempTotalBlockers := 23
-	tempBlockerList := []ProjectBlocker{
-		{
-			ProjectName: "Project ABC",
-			NumBlockers: 11,
-		},
-		{
-			ProjectName: "Project XYZ",
-			NumBlockers: 12,
-		},
+	// simple check to ensure that .releaseSeries matches .nextVersion
+	if !strings.HasPrefix(blockersFlags.nextVersion, fmt.Sprintf("v%s.", blockersFlags.releaseSeries)) {
+		return fmt.Errorf("version %s does not match release series %s", blockersFlags.nextVersion, blockersFlags.releaseSeries)
 	}
 
 	blockersURL := "go.crdb.dev/blockers/" + blockersFlags.releaseSeries
 	releaseBranch := "release-" + blockersFlags.releaseSeries
+	releaseBranchLabel := fmt.Sprintf("branch-release-%s", blockersFlags.releaseSeries)
 
-	// TODO(celia): (future PR) dynamically set branchExists, based on whether `releaseBranch` branch exists in crdb repo
-	branchExists := true
+	client := newGithubClient(context.Background(), githubToken)
+	branchExists, err := client.branchExists(releaseBranch)
+	if err != nil {
+		return fmt.Errorf("cannot fetch branches: %w", err)
+	}
 	if !branchExists {
 		blockersURL = "go.crdb.dev/blockers"
 		releaseBranch = "master"
+		releaseBranchLabel = "branch-master"
 	}
+
+	blockers, err := fetchOpenBlockers(client, releaseBranchLabel)
+	if err != nil {
+		return fmt.Errorf("cannot fetch blockers: %w", err)
+	}
+
 	args := messageDataPostBlockers{
 		Version:       blockersFlags.nextVersion,
-		PrepDate:      releasePrepDate.Format("Monday, January 2"),
-		ReleaseDate:   releasePublishDate.Format("Monday, January 2"),
-		TotalBlockers: tempTotalBlockers,
+		PrepDate:      releasePrepDate.Format(dateFormatEmail),
+		ReleaseDate:   releasePublishDate.Format(dateFormatEmail),
+		TotalBlockers: blockers.TotalBlockers,
 		BlockersURL:   blockersURL,
 		ReleaseBranch: releaseBranch,
-		BlockerList:   tempBlockerList,
+		BlockerList:   blockers.BlockerList,
 	}
 	opts := sendOpts{
 		templatesDir: blockersFlags.templatesDir,
@@ -145,4 +158,128 @@ func fetchReleaseSeriesBlockers(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("cannot send email: %w", err)
 	}
 	return nil
+}
+
+type openBlockers struct {
+	TotalBlockers int
+	BlockerList   []ProjectBlocker
+}
+
+func fetchOpenBlockers(client githubClient, releaseBranchLabel string) (*openBlockers, error) {
+	issues, err := client.openIssues([]string{
+		"release-blocker",
+		releaseBranchLabel,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(issues) == 0 {
+		return &openBlockers{}, nil
+	}
+	numBlockersByProject := make(map[string]int)
+	for _, issue := range issues {
+		if len(issue.ProjectName) == 0 {
+			issue.ProjectName = NoProjectName
+		}
+		total := numBlockersByProject[issue.ProjectName]
+		numBlockersByProject[issue.ProjectName] = total + 1
+	}
+	var blockers projectBlockers
+	for projectName, numBlockers := range numBlockersByProject {
+		blockers = append(blockers, ProjectBlocker{
+			ProjectName: projectName,
+			NumBlockers: numBlockers,
+		})
+	}
+	// sorting blockers Projects alphabetically, except for "No Project", which always goes last.
+	sort.Sort(blockers)
+	return &openBlockers{
+		TotalBlockers: len(issues),
+		BlockerList:   blockers,
+	}, nil
+}
+
+// mostRecentProjectName returns the most recently added project name, by iterating
+// through issue.Project.Name values found in the issues' timeline.
+// Returns nil if no project name found.
+func mostRecentProjectName(client githubClient, issueNum int) (string, error) {
+	removedProjects := make(map[string]bool)
+	events, err := client.issueEvents(issueNum)
+	if err != nil {
+		return "", err
+	}
+
+	// Ensure that events are sorted in chronological order.
+	sort.Sort(githubEvents(events))
+
+	// Iterate backwards through the events, to find the most recently added project.
+	for i := len(events) - 1; i >= 0; i-- {
+		projectName := events[i].ProjectName
+		if len(projectName) == 0 {
+			continue
+		}
+
+		// A "removed" project event means that this ProjectCard was added
+		// at some earlier point in time, but was subsequently removed.
+		if events[i].Event == eventRemovedProject {
+			// Add ProjectName to a removedProjects "stack", so
+			// that we don't return this Project when we eventually
+			// get to the earlier "added" project event.
+			removedProjects[projectName] = true
+		} else if events[i].Event == eventAddedProject {
+
+			if _, exists := removedProjects[projectName]; exists {
+				// This "added" project was subsequently removed from the issue,
+				// so we shouldn't return this Project. Now that we got to the
+				// "added" event, we can pop it from the "stack".
+				delete(removedProjects, projectName)
+			} else {
+				// This is the most recent project that was added; return this.
+				return projectName, err
+			}
+		}
+
+	}
+
+	return "", nil
+}
+
+// githubEvents implements the sort.Sort interface, so that we can
+// sort events chronologically by CreatedAt.
+type githubEvents []githubEvent
+
+func (e githubEvents) Len() int {
+	return len(e)
+}
+
+func (e githubEvents) Less(i, j int) bool {
+	return e[i].CreatedAt.Before(e[j].CreatedAt)
+}
+
+func (e githubEvents) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+// projectBlockers implements the sort.Sort interface, so that we can
+// sort blockers alphabetically by Project Name,
+// except for "No Project" (blockers without a project), which should always
+// be listed last.
+type projectBlockers []ProjectBlocker
+
+func (p projectBlockers) Len() int {
+	return len(p)
+}
+
+func (p projectBlockers) Less(i, j int) bool {
+	if p[i].ProjectName == NoProjectName {
+		return false
+	}
+	if p[j].ProjectName == NoProjectName {
+		return true
+	}
+	return p[i].ProjectName < p[j].ProjectName
+}
+
+func (p projectBlockers) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
 }

--- a/pkg/cmd/release/blockers_test.go
+++ b/pkg/cmd/release/blockers_test.go
@@ -1,0 +1,263 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type githubTestClient struct {
+	issues []githubIssue
+	events []githubEvent
+}
+
+var _ githubClient = &githubTestClient{}
+
+func newTestClient(issues []githubIssue) *githubTestClient {
+	return &githubTestClient{
+		issues: issues,
+	}
+}
+
+func (c *githubTestClient) openIssues(_ []string) ([]githubIssue, error) {
+	return c.issues, nil
+}
+
+func (c *githubTestClient) issueEvents(_ int) ([]githubEvent, error) {
+	return c.events, nil
+}
+
+func (c *githubTestClient) addEvents(t *testing.T, events ...githubEvent) {
+	length := len(c.events)
+	for i, e := range events {
+		// first event will be 2006-01-01, second event 2006-01-02, etc
+		e.CreatedAt = testCreatedAtDay(t, length+i+1)
+		c.events = append(c.events, e)
+	}
+}
+
+// testCreatedAtDay returns time.Time object for Jan {day}, 2006.
+func testCreatedAtDay(t *testing.T, day int) time.Time {
+	date, err := time.Parse(time.RFC3339, fmt.Sprintf("2006-01-%02dT00:00:00Z", day))
+	require.NoError(t, err)
+	return date
+}
+
+func TestFetchOpenBlockers(t *testing.T) {
+	tests := []struct {
+		descr            string
+		openIssues       []githubIssue
+		expectedBlockers *openBlockers
+	}{
+		{
+			descr:            "no open issues",
+			openIssues:       []githubIssue{},
+			expectedBlockers: &openBlockers{},
+		},
+		{
+			descr: "one issue, has project",
+			openIssues: []githubIssue{
+				{1, "AAAA"},
+			},
+			expectedBlockers: &openBlockers{
+				TotalBlockers: 1,
+				BlockerList: []ProjectBlocker{
+					{ProjectName: "AAAA", NumBlockers: 1},
+				},
+			},
+		},
+		{
+			descr: "two issues, no project",
+			openIssues: []githubIssue{
+				{1, ""},
+				{2, ""},
+			},
+			expectedBlockers: &openBlockers{
+				TotalBlockers: 2,
+				BlockerList: []ProjectBlocker{
+					{ProjectName: NoProjectName, NumBlockers: 2},
+				},
+			},
+		},
+		{
+			descr: "multiple issues, with/without projects, 'no project' should still be last",
+			openIssues: []githubIssue{
+				{1, "BBBB"},
+				{2, "AAAA"},
+				{3, ""},
+				{4, "CCCC"},
+				{5, ""},
+				{6, "AAAA"},
+				{7, "AAAA"},
+			},
+			expectedBlockers: &openBlockers{
+				TotalBlockers: 7,
+				BlockerList: []ProjectBlocker{
+					{ProjectName: "AAAA", NumBlockers: 3},
+					{ProjectName: "BBBB", NumBlockers: 1},
+					{ProjectName: "CCCC", NumBlockers: 1},
+					{ProjectName: NoProjectName, NumBlockers: 2},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.descr, func(t *testing.T) {
+			testClient := newTestClient(test.openIssues)
+			blockers, err := fetchOpenBlockers(testClient, "21.2")
+			require.NoError(t, err)
+			require.EqualValues(t, test.expectedBlockers, blockers)
+		})
+	}
+}
+
+func TestMostRecentProjectName(t *testing.T) {
+	testIssueNum := 12345
+	testClient := newTestClient(nil /* issues */)
+
+	// these steps build upon each other, i.e. the events from the previous steps
+	// stay in the client's list of events.
+	steps := []struct {
+		eventsToAdd         []githubEvent
+		expectedProjectName string
+	}{
+		{
+			eventsToAdd:         []githubEvent{},
+			expectedProjectName: "",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventAddedProject, ProjectName: "AAA"},
+			},
+			expectedProjectName: "AAA",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventRemovedProject, ProjectName: "AAA"},
+			},
+			expectedProjectName: "",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventAddedProject, ProjectName: "AAA"},
+				{Event: eventRemovedProject, ProjectName: "AAA"},
+			},
+			expectedProjectName: "",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventAddedProject, ProjectName: "AAA"},
+			},
+			expectedProjectName: "AAA",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventAddedProject, ProjectName: "BBB"},
+				{Event: eventAddedProject, ProjectName: "CCC"},
+				{Event: eventAddedProject, ProjectName: "DDD"},
+			},
+			expectedProjectName: "DDD",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventRemovedProject, ProjectName: "CCC"},
+			},
+			expectedProjectName: "DDD",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventRemovedProject, ProjectName: "DDD"},
+			},
+			expectedProjectName: "BBB",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventRemovedProject, ProjectName: "AAA"},
+			},
+			expectedProjectName: "BBB",
+		},
+		{
+			eventsToAdd: []githubEvent{
+				{Event: eventRemovedProject, ProjectName: "BBB"},
+			},
+			expectedProjectName: "",
+		},
+	}
+	for _, step := range steps {
+		testClient.addEvents(t, step.eventsToAdd...)
+		projectName, err := mostRecentProjectName(testClient, testIssueNum)
+		require.NoError(t, err)
+		require.Equal(t, step.expectedProjectName, projectName)
+	}
+}
+
+func TestSortGithubEvents(t *testing.T) {
+	events := githubEvents{
+		{CreatedAt: testCreatedAtDay(t, 3), Event: eventAddedProject, ProjectName: "333"},
+		{CreatedAt: testCreatedAtDay(t, 6), Event: eventAddedProject, ProjectName: "666"},
+		{CreatedAt: testCreatedAtDay(t, 4), Event: eventAddedProject, ProjectName: "444"},
+		{CreatedAt: testCreatedAtDay(t, 5), Event: eventAddedProject, ProjectName: "555"},
+		{CreatedAt: testCreatedAtDay(t, 1), Event: eventAddedProject, ProjectName: "111"},
+		{CreatedAt: testCreatedAtDay(t, 2), Event: eventAddedProject, ProjectName: "222"},
+	}
+	sort.Sort(events)
+	require.EqualValues(t, githubEvents{
+		{CreatedAt: testCreatedAtDay(t, 1), Event: eventAddedProject, ProjectName: "111"},
+		{CreatedAt: testCreatedAtDay(t, 2), Event: eventAddedProject, ProjectName: "222"},
+		{CreatedAt: testCreatedAtDay(t, 3), Event: eventAddedProject, ProjectName: "333"},
+		{CreatedAt: testCreatedAtDay(t, 4), Event: eventAddedProject, ProjectName: "444"},
+		{CreatedAt: testCreatedAtDay(t, 5), Event: eventAddedProject, ProjectName: "555"},
+		{CreatedAt: testCreatedAtDay(t, 6), Event: eventAddedProject, ProjectName: "666"},
+	}, events)
+}
+
+func TestSortProjectBlockers(t *testing.T) {
+	// list1: all have non-project project name; not alphabetized
+	list1 := projectBlockers{
+		{"BBBB", 1111},
+		{"CCCC", 1111},
+		{"AAAA", 1111},
+	}
+	var listCopy projectBlockers
+	copy(listCopy, list1)
+
+	sort.Sort(list1)
+	// list1: verify that list is alphabetized by project name
+	require.NotEqualValues(t, listCopy, list1)
+	require.EqualValues(t, projectBlockers{
+		{"AAAA", 1111},
+		{"BBBB", 1111},
+		{"CCCC", 1111},
+	}, list1)
+
+	// list2: some project names, one with "No Project"; not alphabetized
+	list2 := projectBlockers{
+		{NoProjectName, 1111},
+		{"CCCC", 1111},
+		{"AAAA", 1111},
+	}
+	copy(listCopy, list2)
+
+	// list2: verify that list is alphabetized by project name, except for
+	// "No Project", which should be last
+	sort.Sort(list2)
+	require.NotEqualValues(t, listCopy, list2)
+	require.EqualValues(t, projectBlockers{
+		{"AAAA", 1111},
+		{"CCCC", 1111},
+		{NoProjectName, 1111},
+	}, list2)
+}

--- a/pkg/cmd/release/github.go
+++ b/pkg/cmd/release/github.go
@@ -1,0 +1,174 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v42/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	githubPageSize = 100 // max is 100
+
+	// openIssueMaxPages is the max number of pages we try to fetch for openIssues.
+	// Setting to 3: if for some reason we had 300+ open blockers, what the team
+	// really gets from that email is "there's a LOT of blockers to resolve".
+	openIssueMaxPages = 3
+
+	timelineEventMaxPages = 3
+)
+
+type githubClient interface {
+	openIssues(labels []string) ([]githubIssue, error)
+	issueEvents(issueNum int) ([]githubEvent, error)
+}
+
+// githubClientImpl implements the githubClient interface.
+type githubClientImpl struct {
+	client *github.Client
+	ctx    context.Context
+	owner  string
+	repo   string
+}
+
+var _ githubClient = &githubClientImpl{}
+
+type githubIssue struct {
+	Number      int
+	ProjectName string
+}
+
+type githubEvent struct {
+	// The timestamp indicating when the event occurred.
+	CreatedAt time.Time
+
+	Event       string
+	ProjectName string
+}
+
+// newGithubClient returns a githubClient, which is wrapper for a *github.Client
+// for a specific repository.
+// To generate personal access token, go to https://github.com/settings/tokens.
+func newGithubClient(ctx context.Context, accessToken string) *githubClientImpl {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: accessToken},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	return &githubClientImpl{
+		client: github.NewClient(tc),
+		ctx:    ctx,
+		owner:  "cockroachdb",
+		repo:   "cockroach",
+	}
+}
+
+func (c *githubClientImpl) openIssues(labels []string) ([]githubIssue, error) {
+	var details []githubIssue
+	for pageNum := 1; pageNum <= openIssueMaxPages; pageNum++ {
+		// TODO: This pagination pattern is a potential race condition: we may want to move to graphql api,
+		// which has cursor-based pagination. But for now, this is probably good enough, as issues don't
+		// change _that_ frequently.
+		issues, _, err := c.client.Issues.List(
+			c.ctx,
+			true, /* all: true searches `/issues/`, false searches `/user/issues/` */
+			&github.IssueListOptions{
+				Filter: "all",
+				State:  "open",
+				Labels: labels,
+				ListOptions: github.ListOptions{
+					PerPage: githubPageSize,
+					Page:    pageNum,
+				},
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error calling Issues.List: %w", err)
+		}
+		for _, i := range issues {
+			issueNum := *i.Number
+			projectName, err := mostRecentProjectName(c, issueNum)
+			if err != nil {
+				return nil, fmt.Errorf("error calling mostRecentProjectName: %w", err)
+			}
+
+			details = append(details, githubIssue{
+				Number:      issueNum,
+				ProjectName: projectName,
+			})
+		}
+
+		if len(issues) < githubPageSize {
+			break
+		}
+	}
+
+	return details, nil
+}
+
+func (c *githubClientImpl) branchExists(branchName string) (bool, error) {
+	protected := true
+	branches, _, err := c.client.Repositories.ListBranches(
+		c.ctx, c.owner, c.repo,
+		&github.BranchListOptions{Protected: &protected},
+	)
+	if err != nil {
+		return false, fmt.Errorf("error calling Repositories.ListBranches: %w", err)
+	}
+	for _, b := range branches {
+		if *b.Name == branchName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// issueEvents returns events in chronological order, e.g.
+//   https://api.github.com/repos/cockroachdb/cockroach/issues/77157/timeline
+func (c *githubClientImpl) issueEvents(issueNum int) ([]githubEvent, error) {
+	var details []githubEvent
+	// TODO: This pagination pattern is a potential race condition: we may want to move to graphql api,
+	// which has cursor-based pagination. But for now, this is probably fine, as timeline events are
+	// returned sequentially, so we don't expect past events (previous page values) to change.
+	for pageNum := 1; pageNum <= timelineEventMaxPages; pageNum++ {
+		events, _, err := c.client.Issues.ListIssueTimeline(
+			c.ctx, c.owner, c.repo, issueNum, &github.ListOptions{
+				PerPage: githubPageSize,
+				Page:    pageNum,
+			})
+		if err != nil {
+			return nil, fmt.Errorf("error calling Issues.ListIssueTimeline: %w", err)
+		}
+		for _, event := range events {
+			detail := githubEvent{
+				CreatedAt: *event.CreatedAt,
+				Event:     *event.Event,
+			}
+			if event.ProjectCard != nil && event.ProjectCard.ProjectID != nil {
+				project, _, err := c.client.Projects.GetProject(c.ctx, *event.ProjectCard.ProjectID)
+				if err != nil {
+					return nil, fmt.Errorf("error calling Projects.GetProject: %w", err)
+				}
+				if project.Name != nil {
+					detail.ProjectName = *project.Name
+				}
+			}
+			details = append(details, detail)
+		}
+		if len(events) < githubPageSize {
+			break
+		}
+	}
+	return details, nil
+}


### PR DESCRIPTION
This commit implements the Week -1 task of fetching the list of open release blockers for the specified releaseSeries,
and summarizing and sorting the blocker list by project name (if any).

#### Implementation Notes

This PR associates a release blocker with the most recently-added project, so that we report the correct number of open blockers.

If you're using roashdash to verify open blocker data, note that https://roachdash.crdb.dev/  groups things by project, which means that if an issue belongs to multiple projects, that issue will appear under both projects. (I.e. the old release process was sometimes double-counting and over reporting the number of open blockers, if an issue was assigned to multiple project).

### Manual Testing

Confirmed blockers for older production release branch (21.2) and upcoming 22.1 release (which as on March 9 is still `master`, since the 22.1 branch hasn't been cut yet).

```
# Test 1: generates alpha email
# --next-version v22.1.0-alpha.3
# --release-series 22.1
#
SMTP_PASSWORD=$MY_SMTP_PWD SMTP_USER=$MY_SMTP_USER GITHUB_TOKEN=$MY_GITHUB_TOKEN \
$(bazel info bazel-bin)/pkg/cmd/release/release_/release post-blockers \
  --release-series 22.1 \
  --smtp-user $MY_SMTP_USER --smtp-host smtp.gmail.com --smtp-port 587 \
  --to $MY_TO_EMAIL \
  --template-dir ./pkg/cmd/release/templates \
  --prep-date 2022-04-01 --publish-date 2022-05-01 \
  --next-version v22.1.0-alpha.3
```

<img width="500" src="https://user-images.githubusercontent.com/3051672/157559211-1a2985bd-a8fc-4f5c-8ae9-575101351412.png">

```
# Test 2: generates email for stable release, no need to set `next-version` parameter
# --release-series 21.1
SMTP_PASSWORD=$MY_SMTP_PWD SMTP_USER=$MY_SMTP_USER GITHUB_TOKEN=$MY_GITHUB_TOKEN \
$(bazel info bazel-bin)/pkg/cmd/release/release_/release post-blockers \
  --release-series 21.1 \
  --smtp-user $MY_SMTP_USER --smtp-host smtp.gmail.com --smtp-port 587 \
  --to $MY_TO_EMAIL \
  --template-dir ./pkg/cmd/release/templates \
  --prep-date 2022-04-01 --publish-date 2022-05-01
```

<img width="500" src="https://user-images.githubusercontent.com/3051672/157559564-e6b7af11-3b30-4064-a5ff-17443e4ce341.png">

Release note: None
Release justification: non-production code change.
