### PR TITLE
vendor: bump Pebble to 69a82fe41c31

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1287,10 +1287,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "71da6a69951ab9767aa51efd34b2a4040ab655f67a5b0be87578af5a85132d26",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220227235451-40d39da505a5",
+        sha256 = "5b306806fca1c0defafe031c4cd842934aec44394bc44dc24bc805bc3fd609b8",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220301234049-69a82fe41c31",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220227235451-40d39da505a5.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220301234049-69a82fe41c31.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220227235451-40d39da505a5
+	github.com/cockroachdb/pebble v0.0.0-20220301234049-69a82fe41c31
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220217190341-94cf65c2a29f

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220227235451-40d39da505a5 h1:6ZsiW1sWGEsx2kDq98bdoDfdDeO2IgfI4e2FxUQwkdk=
-github.com/cockroachdb/pebble v0.0.0-20220227235451-40d39da505a5/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220301234049-69a82fe41c31 h1:hkBQIZdAeGQzF3pVbL1lrPJNx/Hvwiy5HHpRf0Nz6y8=
+github.com/cockroachdb/pebble v0.0.0-20220301234049-69a82fe41c31/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -870,6 +870,8 @@ func TestEngineScan1(t *testing.T) {
 				iter.Next()
 			}
 			stats := iter.Stats().Stats
+			// Setting non-deterministic InternalStats to empty.
+			stats.InternalStats = pebble.InternalIteratorStats{}
 			require.Equal(t, "(interface (dir, seek, step): (fwd, 1, 5), (rev, 0, 0)), "+
 				"(internal (dir, seek, step): (fwd, 1, 5), (rev, 0, 0))", stats.String())
 			iter.Close()
@@ -877,11 +879,15 @@ func TestEngineScan1(t *testing.T) {
 				IterOptions{LowerBound: roachpb.Key("cat"), UpperBound: roachpb.Key("server")})
 			// pebble.Iterator is reused, but stats are reset.
 			stats = iter.Stats().Stats
+			// Setting non-deterministic InternalStats to empty.
+			stats.InternalStats = pebble.InternalIteratorStats{}
 			require.Equal(t, "(interface (dir, seek, step): (fwd, 0, 0), (rev, 0, 0)), "+
 				"(internal (dir, seek, step): (fwd, 0, 0), (rev, 0, 0))", stats.String())
 			iter.SeekGE(MVCCKey{Key: roachpb.Key("french")})
 			iter.SeekLT(MVCCKey{Key: roachpb.Key("server")})
 			stats = iter.Stats().Stats
+			// Setting non-deterministic InternalStats to empty.
+			stats.InternalStats = pebble.InternalIteratorStats{}
 			require.Equal(t, "(interface (dir, seek, step): (fwd, 1, 0), (rev, 1, 0)), "+
 				"(internal (dir, seek, step): (fwd, 1, 0), (rev, 1, 1))", stats.String())
 			iter.Close()

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
 )
 
@@ -367,6 +368,8 @@ func TestIntentInterleavingIter(t *testing.T) {
 						fmt.Fprintf(&b, "set-upper %s\n", string(makePrintableKey(MVCCKey{Key: k}).Key))
 					case "stats":
 						stats := iter.Stats()
+						// Setting non-deterministic InternalStats to empty.
+						stats.Stats.InternalStats = pebble.InternalIteratorStats{}
 						fmt.Fprintf(&b, "stats: %s\n", stats.Stats.String())
 					default:
 						fmt.Fprintf(&b, "unknown command: %s\n", d.Cmd)


### PR DESCRIPTION
Changes:

```
69a82fe4 sstable: circumvent a dataBlockBuf race in the sstable Writer
d11e5f36 compaction: change `conflictsWithInProgress` to check keyranges
3f8713d3 tool/logs: various improvements to compaction event parser
bdf07cc3 db: add iterator stats for iterators below the top-level
db4b6dca sstable: fix race in sstable when parallelism is enabled
```

Release note: None.

Release justification: Pulls in fixes for various test flakes.