### PR TITLE
sql/importer: use desc's PK ID to sort KVs by index

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
         "//pkg/sql/sem/builtins",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqltelemetry",


### PR DESCRIPTION
Release note: none.

Fixes: #76196.

Release justification: low-risk bug fix.