### PR TITLE
changefeedccl: allow users to perform initial scans on newly added targets

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2542,7 +2542,7 @@ alter_default_privileges_target_object ::=
 	| 'SCHEMAS'
 
 alter_changefeed_cmd ::=
-	'ADD' changefeed_targets
+	'ADD' changefeed_targets opt_with_options
 	| 'DROP' changefeed_targets
 	| 'SET' kv_option_list
 	| 'UNSET' name_list

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -17,7 +17,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -74,194 +76,40 @@ func alterChangefeedPlanHook(
 			return errors.Errorf(`job %d is not paused`, jobID)
 		}
 
-		// this CREATE CHANGEFEED node will be used to update the existing changefeed
-		newChangefeedStmt := &tree.CreateChangefeed{
-			SinkURI: tree.NewDString(prevDetails.SinkURI),
+		newChangefeedStmt := &tree.CreateChangefeed{}
+
+		newOptions, newSinkURI, err := generateNewOpts(ctx, p, alterChangefeedStmt.Cmds, prevDetails)
+		if err != nil {
+			return err
 		}
 
-		optionsMap := make(map[string]tree.KVOption, len(prevDetails.Opts))
+		newTargets, newProgress, newStatementTime, err := generateNewTargets(ctx,
+			p,
+			alterChangefeedStmt.Cmds,
+			newOptions,
+			prevDetails,
+			job.Progress(),
+		)
+		if err != nil {
+			return err
+		}
+		newChangefeedStmt.Targets = *newTargets
 
-		// pull the options that are set for the existing changefeed
-		for key, value := range prevDetails.Opts {
-			// There are some options (e.g. topics) that we set during the creation of
-			// a changefeed, but we do not allow these options to be set by the user.
-			// Hence, we can not include these options in our new CREATE CHANGEFEED
-			// statement.
-			if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
-				continue
-			}
-			existingOpt := tree.KVOption{Key: tree.Name(key)}
+		for key, value := range newOptions {
+			opt := tree.KVOption{Key: tree.Name(key)}
 			if len(value) > 0 {
-				existingOpt.Value = tree.NewDString(value)
+				opt.Value = tree.NewDString(value)
 			}
-			optionsMap[key] = existingOpt
+			newChangefeedStmt.Options = append(newChangefeedStmt.Options, opt)
 		}
-
-		statementTime := hlc.Timestamp{
-			WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
-		}
-
-		allDescs, err := backupresolver.LoadAllDescs(ctx, p.ExecCfg(), statementTime)
-		if err != nil {
-			return err
-		}
-		descResolver, err := backupresolver.NewDescriptorResolver(allDescs)
-		if err != nil {
-			return err
-		}
-
-		newDescs := make(map[descpb.ID]*tree.UnresolvedName)
-
-		for _, target := range AllTargets(prevDetails) {
-			desc := descResolver.DescByID[target.TableID]
-			newDescs[target.TableID] = tree.NewUnresolvedName(desc.GetName())
-		}
-
-		for _, cmd := range alterChangefeedStmt.Cmds {
-			switch v := cmd.(type) {
-			case *tree.AlterChangefeedAddTarget:
-				for _, targetPattern := range v.Targets.Tables {
-					targetName, err := getTargetName(targetPattern)
-					if err != nil {
-						return err
-					}
-					found, _, desc, err := resolver.ResolveExisting(
-						ctx,
-						targetName.ToUnresolvedObjectName(),
-						descResolver,
-						tree.ObjectLookupFlags{},
-						p.CurrentDatabase(),
-						p.CurrentSearchPath(),
-					)
-					if err != nil {
-						return err
-					}
-					if !found {
-						return pgerror.Newf(pgcode.InvalidParameterValue, `target %q does not exist`, tree.ErrString(targetPattern))
-					}
-					newDescs[desc.GetID()] = tree.NewUnresolvedName(desc.GetName())
-				}
-			case *tree.AlterChangefeedDropTarget:
-				for _, targetPattern := range v.Targets.Tables {
-					targetName, err := getTargetName(targetPattern)
-					if err != nil {
-						return err
-					}
-					found, _, desc, err := resolver.ResolveExisting(
-						ctx,
-						targetName.ToUnresolvedObjectName(),
-						descResolver,
-						tree.ObjectLookupFlags{},
-						p.CurrentDatabase(),
-						p.CurrentSearchPath(),
-					)
-					if err != nil {
-						return err
-					}
-					if !found {
-						return pgerror.Newf(pgcode.InvalidParameterValue, `target %q does not exist`, tree.ErrString(targetPattern))
-					}
-					delete(newDescs, desc.GetID())
-				}
-			case *tree.AlterChangefeedSetOptions:
-				optsFn, err := p.TypeAsStringOpts(ctx, v.Options, changefeedbase.AlterChangefeedOptionExpectValues)
-				if err != nil {
-					return err
-				}
-
-				opts, err := optsFn()
-				if err != nil {
-					return err
-				}
-
-				for key, value := range opts {
-					if _, ok := changefeedbase.AlterChangefeedUnsupportedOptions[key]; ok {
-						return pgerror.Newf(pgcode.InvalidParameterValue, `cannot alter option %q`, key)
-					}
-					if key == changefeedbase.OptSink {
-						newSinkURI, err := url.Parse(value)
-						if err != nil {
-							return err
-						}
-
-						prevSinkURI, err := url.Parse(prevDetails.SinkURI)
-						if err != nil {
-							return err
-						}
-
-						if newSinkURI.Scheme != prevSinkURI.Scheme {
-							return pgerror.Newf(
-								pgcode.InvalidParameterValue,
-								`New sink type %q does not match original sink type %q. Altering the sink type of a changefeed is disallowed, consider creating a new changefeed instead.`,
-								newSinkURI.Scheme,
-								prevSinkURI.Scheme,
-							)
-						}
-
-						newChangefeedStmt.SinkURI = tree.NewDString(value)
-					} else {
-						opt := tree.KVOption{Key: tree.Name(key)}
-						if len(value) > 0 {
-							opt.Value = tree.NewDString(value)
-						}
-						optionsMap[key] = opt
-					}
-				}
-			case *tree.AlterChangefeedUnsetOptions:
-				optKeys := v.Options.ToStrings()
-				for _, key := range optKeys {
-					if key == changefeedbase.OptSink {
-						return pgerror.Newf(pgcode.InvalidParameterValue, `cannot unset option %q`, key)
-					}
-					if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
-						return pgerror.Newf(pgcode.InvalidParameterValue, `invalid option %q`, key)
-					}
-					if _, ok := changefeedbase.AlterChangefeedUnsupportedOptions[key]; ok {
-						return pgerror.Newf(pgcode.InvalidParameterValue, `cannot alter option %q`, key)
-					}
-					delete(optionsMap, key)
-				}
-			}
-		}
-
-		if len(newDescs) == 0 {
-			return pgerror.Newf(pgcode.InvalidParameterValue, "cannot drop all targets for changefeed job %d", jobID)
-		}
-
-		for _, targetName := range newDescs {
-			newChangefeedStmt.Targets.Tables = append(newChangefeedStmt.Targets.Tables, targetName)
-		}
-
-		for _, val := range optionsMap {
-			newChangefeedStmt.Options = append(newChangefeedStmt.Options, val)
-		}
-
-		sinkURIFn, err := p.TypeAsString(ctx, newChangefeedStmt.SinkURI, `ALTER CHANGEFEED`)
-		if err != nil {
-			return err
-		}
-
-		optsFn, err := p.TypeAsStringOpts(ctx, newChangefeedStmt.Options, changefeedbase.ChangefeedOptionExpectValues)
-		if err != nil {
-			return err
-		}
-
-		sinkURI, err := sinkURIFn()
-		if err != nil {
-			return err
-		}
-
-		opts, err := optsFn()
-		if err != nil {
-			return err
-		}
+		newChangefeedStmt.SinkURI = tree.NewDString(newSinkURI)
 
 		jobRecord, err := createChangefeedJobRecord(
 			ctx,
 			p,
 			newChangefeedStmt,
-			sinkURI,
-			opts,
+			newSinkURI,
+			newOptions,
 			jobID,
 			``,
 		)
@@ -270,10 +118,11 @@ func alterChangefeedPlanHook(
 		}
 
 		newDetails := jobRecord.Details.(jobspb.ChangefeedDetails)
+		newDetails.Opts[changefeedbase.OptInitialScan] = ``
 
-		// We need to persist the statement time that was generated during the
-		// creation of the changefeed
-		newDetails.StatementTime = prevDetails.StatementTime
+		// newStatementTime will either be the StatementTime of the job prior to the
+		// alteration, or it will be the high watermark of the job.
+		newDetails.StatementTime = newStatementTime
 
 		newPayload := job.Payload()
 		newPayload.Details = jobspb.WrapPayloadDetails(newDetails)
@@ -284,6 +133,9 @@ func alterChangefeedPlanHook(
 			txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
 		) error {
 			ju.UpdatePayload(&newPayload)
+			if newProgress != nil {
+				ju.UpdateProgress(newProgress)
+			}
 			return nil
 		})
 
@@ -305,15 +157,454 @@ func alterChangefeedPlanHook(
 	return fn, header, nil, false, nil
 }
 
-func getTargetName(targetPattern tree.TablePattern) (*tree.TableName, error) {
+func getTargetDesc(
+	ctx context.Context,
+	p sql.PlanHookState,
+	descResolver *backupresolver.DescriptorResolver,
+	targetPattern tree.TablePattern,
+) (catalog.Descriptor, bool, error) {
 	pattern, err := targetPattern.NormalizeTablePattern()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	targetName, ok := pattern.(*tree.TableName)
 	if !ok {
-		return nil, errors.Errorf(`CHANGEFEED cannot target %q`, tree.AsString(targetPattern))
+		return nil, false, errors.Errorf(`CHANGEFEED cannot target %q`, tree.AsString(targetPattern))
 	}
 
-	return targetName, nil
+	found, _, desc, err := resolver.ResolveExisting(
+		ctx,
+		targetName.ToUnresolvedObjectName(),
+		descResolver,
+		tree.ObjectLookupFlags{},
+		p.CurrentDatabase(),
+		p.CurrentSearchPath(),
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return desc, found, nil
+}
+
+func generateNewOpts(
+	ctx context.Context,
+	p sql.PlanHookState,
+	alterCmds tree.AlterChangefeedCmds,
+	details jobspb.ChangefeedDetails,
+) (map[string]string, string, error) {
+	sinkURI := details.SinkURI
+	newOptions := make(map[string]string, len(details.Opts))
+
+	// pull the options that are set for the existing changefeed.
+	for key, value := range details.Opts {
+		// There are some options (e.g. topics) that we set during the creation of
+		// a changefeed, but we do not allow these options to be set by the user.
+		// Hence, we can not include these options in our new CREATE CHANGEFEED
+		// statement.
+		if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
+			continue
+		}
+		newOptions[key] = value
+	}
+
+	for _, cmd := range alterCmds {
+		switch v := cmd.(type) {
+		case *tree.AlterChangefeedSetOptions:
+			optsFn, err := p.TypeAsStringOpts(ctx, v.Options, changefeedbase.AlterChangefeedOptionExpectValues)
+			if err != nil {
+				return nil, ``, err
+			}
+
+			opts, err := optsFn()
+			if err != nil {
+				return nil, ``, err
+			}
+
+			for key, value := range opts {
+				if _, ok := changefeedbase.AlterChangefeedUnsupportedOptions[key]; ok {
+					return nil, ``, pgerror.Newf(pgcode.InvalidParameterValue, `cannot alter option %q`, key)
+				}
+				if key == changefeedbase.OptSink {
+					newSinkURI, err := url.Parse(value)
+					if err != nil {
+						return nil, ``, err
+					}
+
+					prevSinkURI, err := url.Parse(details.SinkURI)
+					if err != nil {
+						return nil, ``, err
+					}
+
+					if newSinkURI.Scheme != prevSinkURI.Scheme {
+						return nil, ``, pgerror.Newf(
+							pgcode.InvalidParameterValue,
+							`New sink type %q does not match original sink type %q. `+
+								`Altering the sink type of a changefeed is disallowed, consider creating a new changefeed instead.`,
+							newSinkURI.Scheme,
+							prevSinkURI.Scheme,
+						)
+					}
+
+					sinkURI = value
+				} else {
+					newOptions[key] = value
+				}
+			}
+		case *tree.AlterChangefeedUnsetOptions:
+			optKeys := v.Options.ToStrings()
+			for _, key := range optKeys {
+				if key == changefeedbase.OptSink {
+					return nil, ``, pgerror.Newf(pgcode.InvalidParameterValue, `cannot unset option %q`, key)
+				}
+				if _, ok := changefeedbase.ChangefeedOptionExpectValues[key]; !ok {
+					return nil, ``, pgerror.Newf(pgcode.InvalidParameterValue, `invalid option %q`, key)
+				}
+				if _, ok := changefeedbase.AlterChangefeedUnsupportedOptions[key]; ok {
+					return nil, ``, pgerror.Newf(pgcode.InvalidParameterValue, `cannot alter option %q`, key)
+				}
+				delete(newOptions, key)
+			}
+		}
+	}
+
+	return newOptions, sinkURI, nil
+}
+
+func generateNewTargets(
+	ctx context.Context,
+	p sql.PlanHookState,
+	alterCmds tree.AlterChangefeedCmds,
+	opts map[string]string,
+	prevDetails jobspb.ChangefeedDetails,
+	prevProgress jobspb.Progress,
+) (*tree.TargetList, *jobspb.Progress, hlc.Timestamp, error) {
+	newTargetList := &tree.TargetList{}
+
+	// When we add new targets with or without initial scans, indicating
+	// initial_scan or no_initial_scan in the job description would lose its
+	// meaning. Hence, we will omit these details from the changefeed
+	// description. However, to ensure that we do perform the initial scan on
+	// newly added targets, we will introduce the initial_scan opt after the
+	// job record is created.
+	delete(opts, changefeedbase.OptNoInitialScan)
+	delete(opts, changefeedbase.OptInitialScan)
+
+	// the new progress and statement time will start from the progress and
+	// statement time of the job prior to the alteration of the changefeed. Each
+	// time we add a new set of targets we update the newJobProgress and
+	// newJobStatementTime accordingly.
+	newJobProgress := prevProgress
+	newJobStatementTime := prevDetails.StatementTime
+
+	statementTime := hlc.Timestamp{
+		WallTime: p.ExtendedEvalContext().GetStmtTimestamp().UnixNano(),
+	}
+
+	// we attempt to resolve the changefeed targets as of the current time to
+	// ensure that all targets exist. However, we also need to make sure that all
+	// targets can be resolved at the time in which the changefeed is resumed. We
+	// perform these validations in the validateNewTargets function.
+	allDescs, err := backupresolver.LoadAllDescs(ctx, p.ExecCfg(), statementTime)
+	if err != nil {
+		return nil, nil, hlc.Timestamp{}, err
+	}
+	descResolver, err := backupresolver.NewDescriptorResolver(allDescs)
+	if err != nil {
+		return nil, nil, hlc.Timestamp{}, err
+	}
+
+	newTargets := make(map[descpb.ID]catalog.Descriptor)
+
+	for _, target := range AllTargets(prevDetails) {
+		desc := descResolver.DescByID[target.TableID]
+		newTargets[target.TableID] = desc
+	}
+
+	for _, cmd := range alterCmds {
+		switch v := cmd.(type) {
+		case *tree.AlterChangefeedAddTarget:
+			targetOptsFn, err := p.TypeAsStringOpts(ctx, v.Options, changefeedbase.AlterChangefeedTargetOptions)
+			if err != nil {
+				return nil, nil, hlc.Timestamp{}, err
+			}
+			targetOpts, err := targetOptsFn()
+			if err != nil {
+				return nil, nil, hlc.Timestamp{}, err
+			}
+
+			_, withInitialScan := targetOpts[changefeedbase.OptInitialScan]
+			_, noInitialScan := targetOpts[changefeedbase.OptNoInitialScan]
+			if withInitialScan && noInitialScan {
+				return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+					pgcode.InvalidParameterValue,
+					`cannot specify both %q and %q`, changefeedbase.OptInitialScan,
+					changefeedbase.OptNoInitialScan,
+				)
+			}
+
+			var existingTargetDescs []catalog.Descriptor
+			for _, targetDesc := range newTargets {
+				existingTargetDescs = append(existingTargetDescs, targetDesc)
+			}
+			existingTargetSpans, err := fetchSpansForDescs(ctx, p, opts, statementTime, existingTargetDescs)
+			if err != nil {
+				return nil, nil, hlc.Timestamp{}, err
+			}
+
+			var newTargetDescs []catalog.Descriptor
+			for _, targetPattern := range v.Targets.Tables {
+				desc, found, err := getTargetDesc(ctx, p, descResolver, targetPattern)
+				if err != nil {
+					return nil, nil, hlc.Timestamp{}, err
+				}
+				if !found {
+					return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+						pgcode.InvalidParameterValue,
+						`target %q does not exist`,
+						tree.ErrString(targetPattern),
+					)
+				}
+				newTargets[desc.GetID()] = desc
+				newTargetDescs = append(newTargetDescs, desc)
+			}
+
+			addedTargetSpans, err := fetchSpansForDescs(ctx, p, opts, statementTime, newTargetDescs)
+			if err != nil {
+				return nil, nil, hlc.Timestamp{}, err
+			}
+
+			// By default, we will not perform an initial scan on newly added
+			// targets. Hence, the user must explicitly state that they want an
+			// initial scan performed on the new targets.
+			newJobProgress, newJobStatementTime, err = generateNewProgress(
+				newJobProgress,
+				newJobStatementTime,
+				existingTargetSpans,
+				addedTargetSpans,
+				withInitialScan,
+			)
+			if err != nil {
+				return nil, nil, hlc.Timestamp{}, err
+			}
+		case *tree.AlterChangefeedDropTarget:
+			var droppedTargetDescs []catalog.Descriptor
+			for _, targetPattern := range v.Targets.Tables {
+				desc, found, err := getTargetDesc(ctx, p, descResolver, targetPattern)
+				if err != nil {
+					return nil, nil, hlc.Timestamp{}, err
+				}
+				if !found {
+					return nil, nil, hlc.Timestamp{}, pgerror.Newf(
+						pgcode.InvalidParameterValue,
+						`target %q does not exist`,
+						tree.ErrString(targetPattern),
+					)
+				}
+				delete(newTargets, desc.GetID())
+				droppedTargetDescs = append(droppedTargetDescs, desc)
+			}
+			droppedTargetSpans, err := fetchSpansForDescs(ctx, p, opts, statementTime, droppedTargetDescs)
+			if err != nil {
+				return nil, nil, hlc.Timestamp{}, err
+			}
+			removeSpansFromProgress(newJobProgress, droppedTargetSpans)
+		}
+	}
+
+	for _, targetDesc := range newTargets {
+		targetName := tree.NewUnresolvedName(targetDesc.GetName())
+		newTargetList.Tables = append(newTargetList.Tables, targetName)
+	}
+
+	if err := validateNewTargets(ctx, p, newTargetList, newJobProgress, newJobStatementTime); err != nil {
+		return nil, nil, hlc.Timestamp{}, err
+	}
+
+	return newTargetList, &newJobProgress, newJobStatementTime, nil
+}
+
+func validateNewTargets(
+	ctx context.Context,
+	p sql.PlanHookState,
+	newTargets *tree.TargetList,
+	jobProgress jobspb.Progress,
+	jobStatementTime hlc.Timestamp,
+) error {
+	if len(newTargets.Tables) == 0 {
+		return pgerror.New(pgcode.InvalidParameterValue, "cannot drop all targets")
+	}
+
+	// when we resume the changefeed, we need to ensure that the newly added
+	// targets can be resolved at the time of the high watermark. If the high
+	// watermark is empty, then we need to ensure that the newly added targets can
+	// be resolved at the StatementTime of the changefeed job.
+	var resolveTime hlc.Timestamp
+	highWater := jobProgress.GetHighWater()
+	if highWater != nil && !highWater.IsEmpty() {
+		resolveTime = *highWater
+	} else {
+		resolveTime = jobStatementTime
+	}
+
+	allDescs, err := backupresolver.LoadAllDescs(ctx, p.ExecCfg(), resolveTime)
+	if err != nil {
+		return errors.Wrap(err, `error while validating new targets`)
+	}
+	descResolver, err := backupresolver.NewDescriptorResolver(allDescs)
+	if err != nil {
+		return errors.Wrap(err, `error while validating new targets`)
+	}
+
+	for _, targetName := range newTargets.Tables {
+		_, found, err := getTargetDesc(ctx, p, descResolver, targetName)
+		if err != nil {
+			return errors.Wrap(err, `error while validating new targets`)
+		}
+		if !found {
+			if highWater != nil && !highWater.IsEmpty() {
+				return errors.Errorf(`target %q cannot be resolved as of the high water mark. `+
+					`Please wait until the high water mark progresses past the creation time of this target in order to add it to the changefeed.`,
+					tree.ErrString(targetName),
+				)
+			}
+			return errors.Errorf(`target %q cannot be resolved as of the creation time of the changefeed. `+
+				`Please wait until the high water mark progresses past the creation time of this target in order to add it to the changefeed.`,
+				tree.ErrString(targetName),
+			)
+		}
+	}
+
+	return nil
+}
+
+// generateNewProgress determines if the progress of a changefeed job needs to
+// be updated based on the targets that have been added, the options associated
+// with each target we are adding/removing (i.e. with initial_scan or
+// no_initial_scan), and the current status of the job. If the progress does not
+// need to be updated, we will simply return the previous progress and statement
+// time that is passed into the function.
+func generateNewProgress(
+	prevProgress jobspb.Progress,
+	prevStatementTime hlc.Timestamp,
+	existingTargetSpans []roachpb.Span,
+	newSpans []roachpb.Span,
+	withInitialScan bool,
+) (jobspb.Progress, hlc.Timestamp, error) {
+	prevHighWater := prevProgress.GetHighWater()
+	changefeedProgress := prevProgress.GetChangefeed()
+
+	haveHighwater := !(prevHighWater == nil || prevHighWater.IsEmpty())
+	haveCheckpoint := changefeedProgress != nil && changefeedProgress.Checkpoint != nil &&
+		len(changefeedProgress.Checkpoint.Spans) != 0
+
+	// Check if the progress does not need to be updated. The progress does not
+	// need to be updated if:
+	// * the high watermark is empty, and we would like to perform an initial scan.
+	// * the high watermark is non-empty, the checkpoint is empty, and we do not want to
+	//   perform an initial scan.
+	if (!haveHighwater && withInitialScan) || (haveHighwater && !haveCheckpoint && !withInitialScan) {
+		return prevProgress, prevStatementTime, nil
+	}
+
+	// Check if the user is trying to perform an initial scan during a
+	// non-initial backfill.
+	if haveHighwater && haveCheckpoint && withInitialScan {
+		return prevProgress, prevStatementTime, errors.Errorf(
+			`cannot perform initial scan on newly added targets while the checkpoint is non-empty, `+
+				`please unpause the changefeed and wait until the high watermark progresses past the current value %s to add these targets.`,
+			tree.TimestampToDecimalDatum(*prevHighWater).Decimal.String(),
+		)
+	}
+
+	// Check if the user is trying to perform an initial scan while the high
+	// watermark is non-empty but the checkpoint is empty.
+	if haveHighwater && !haveCheckpoint && withInitialScan {
+		// If we would like to perform an initial scan on the new targets,
+		// we need to reset the high watermark. However, by resetting the high
+		// watermark, the initial scan will be performed on existing targets as well.
+		// To avoid this, we update the statement time of the job to the previous high
+		// watermark, and add all the existing targets to the checkpoint to skip the
+		// initial scan on these targets.
+		newStatementTime := *prevHighWater
+
+		newProgress := jobspb.Progress{
+			Progress: &jobspb.Progress_HighWater{},
+			Details: &jobspb.Progress_Changefeed{
+				Changefeed: &jobspb.ChangefeedProgress{
+					Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
+						Spans: existingTargetSpans,
+					},
+				},
+			},
+		}
+
+		return newProgress, newStatementTime, nil
+	}
+
+	// At this point, we are left with one of two cases:
+	// * the high watermark is empty, and we do not want to perform
+	//   an initial scan on the new targets.
+	// * the high watermark is non-empty, the checkpoint is non-empty,
+	//   and we do not want to perform an initial scan on the new targets.
+	// In either case, we need to update the checkpoint to include the spans
+	// of the newly added targets so that the changefeed will skip performing
+	// a backfill on these targets.
+
+	var mergedSpanGroup roachpb.SpanGroup
+	if haveCheckpoint {
+		mergedSpanGroup.Add(changefeedProgress.Checkpoint.Spans...)
+	}
+	mergedSpanGroup.Add(newSpans...)
+
+	newProgress := jobspb.Progress{
+		Progress: &jobspb.Progress_HighWater{},
+		Details: &jobspb.Progress_Changefeed{
+			Changefeed: &jobspb.ChangefeedProgress{
+				Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
+					Spans: mergedSpanGroup.Slice(),
+				},
+			},
+		},
+	}
+	return newProgress, prevStatementTime, nil
+}
+
+func removeSpansFromProgress(prevProgress jobspb.Progress, spansToRemove []roachpb.Span) {
+	changefeedProgress := prevProgress.GetChangefeed()
+	if changefeedProgress == nil {
+		return
+	}
+	changefeedCheckpoint := changefeedProgress.Checkpoint
+	if changefeedCheckpoint == nil {
+		return
+	}
+	prevSpans := changefeedCheckpoint.Spans
+
+	var spanGroup roachpb.SpanGroup
+	spanGroup.Add(prevSpans...)
+	spanGroup.Sub(spansToRemove...)
+	changefeedProgress.Checkpoint.Spans = spanGroup.Slice()
+}
+
+func fetchSpansForDescs(
+	ctx context.Context,
+	p sql.PlanHookState,
+	opts map[string]string,
+	statementTime hlc.Timestamp,
+	descs []catalog.Descriptor,
+) ([]roachpb.Span, error) {
+	targets, tables, err := getTargetsAndTables(ctx, p, descs, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	details := jobspb.ChangefeedDetails{
+		TargetSpecifications: targets,
+		Tables:               tables,
+	}
+
+	spans, err := fetchSpansForTargets(ctx, p.ExecCfg(), AllTargets(details), statementTime)
+
+	return spans, err
 }

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -12,16 +12,31 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -223,6 +238,16 @@ func TestAlterChangefeedErrors(t *testing.T) {
 			`cannot unset option "sink"`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d UNSET sink`, feed.JobID()),
 		)
+
+		sqlDB.ExpectErr(t,
+			`pq: invalid option "diff"`,
+			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH diff`, feed.JobID()),
+		)
+
+		sqlDB.ExpectErr(t,
+			`pq: cannot specify both "initial_scan" and "no_initial_scan"`,
+			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan, no_initial_scan`, feed.JobID()),
+		)
 	}
 
 	t.Run(`kafka`, kafkaTest(testFn))
@@ -247,7 +272,7 @@ func TestAlterChangefeedDropAllTargetsError(t *testing.T) {
 		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
 
 		sqlDB.ExpectErr(t,
-			fmt.Sprintf(`cannot drop all targets for changefeed job %d`, feed.JobID()),
+			`cannot drop all targets`,
 			fmt.Sprintf(`ALTER CHANGEFEED %d DROP foo, bar`, feed.JobID()),
 		)
 	}
@@ -372,4 +397,475 @@ func TestAlterChangefeedChangeSinkURI(t *testing.T) {
 	}
 
 	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedAddTargetErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo (a) SELECT * FROM generate_series(1, 1000)`)
+
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		//Ensure Scan Requests are always small enough that we receive multiple
+		//resolved events during a backfill
+		knobs.FeedKnobs.BeforeScanRequest = func(b *kv.Batch) error {
+			b.Header.MaxSpanRequestKeys = 10
+			return nil
+		}
+
+		// ensure that we do not emit a resolved timestamp
+		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+			return true
+		}
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '100ms'`)
+
+		// Kafka feeds are not buffered, so we have to consume messages.
+		g := ctxgroup.WithContext(context.Background())
+		g.Go(func() error {
+			for {
+				_, err := testFeed.Next()
+				if err != nil {
+					return err
+				}
+			}
+		})
+		defer func() {
+			closeFeed(t, testFeed)
+			_ = g.Wait()
+		}()
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		require.NoError(t, feed.Pause())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (1), (2), (3)`)
+		sqlDB.ExpectErr(t,
+			`pq: target "bar" cannot be resolved as of the creation time of the changefeed. Please wait until the high water mark progresses past the creation time of this target in order to add it to the changefeed.`,
+			fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar`, feed.JobID()),
+		)
+
+		// allow the changefeed to emit resolved events now
+		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+			return false
+		}
+
+		require.NoError(t, feed.Resume())
+
+		// Wait for the high water mark to be non-zero.
+		testutils.SucceedsSoon(t, func() error {
+			registry := f.Server().JobRegistry().(*jobs.Registry)
+			job, err := registry.LoadJob(context.Background(), feed.JobID())
+			require.NoError(t, err)
+			prog := job.Progress()
+			if p := prog.GetHighWater(); p != nil && !p.IsEmpty() {
+				return nil
+			}
+			return errors.New("waiting for highwater")
+		})
+
+		require.NoError(t, feed.Pause())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, `CREATE TABLE baz (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO baz VALUES (1), (2), (3)`)
+
+		sqlDB.ExpectErr(t,
+			`pq: target "baz" cannot be resolved as of the high water mark. Please wait until the high water mark progresses past the creation time of this target in order to add it to the changefeed.`,
+			fmt.Sprintf(`ALTER CHANGEFEED %d ADD baz`, feed.JobID()),
+		)
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn, feedTestNoTenants))
+}
+
+func TestAlterChangefeedInitialScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (1), (2), (3)`)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s', no_initial_scan`)
+		defer closeFeed(t, testFeed)
+
+		expectResolvedTimestamp(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan`, feed.JobID()))
+
+		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
+		waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
+
+		assertPayloads(t, testFeed, []string{
+			`bar: [1]->{"after": {"a": 1}}`,
+			`bar: [2]->{"after": {"a": 2}}`,
+			`bar: [3]->{"after": {"a": 3}}`,
+		})
+
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (4)`)
+		assertPayloads(t, testFeed, []string{
+			`bar: [4]->{"after": {"a": 4}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedNoInitialScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (1), (2), (3)`)
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s'`)
+		defer closeFeed(t, testFeed)
+
+		assertPayloads(t, testFeed, []string{
+			`foo: [1]->{"after": {"a": 1}}`,
+			`foo: [2]->{"after": {"a": 2}}`,
+			`foo: [3]->{"after": {"a": 3}}`,
+		})
+		expectResolvedTimestamp(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH no_initial_scan`, feed.JobID()))
+
+		sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
+		waitForJobStatus(sqlDB, t, feed.JobID(), `running`)
+
+		expectResolvedTimestamp(t, testFeed)
+
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (4)`)
+		assertPayloads(t, testFeed, []string{
+			`bar: [4]->{"after": {"a": 4}}`,
+		})
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn))
+}
+
+func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rnd, _ := randutil.NewPseudoRand()
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		sqlDB.Exec(t, `CREATE TABLE foo(val INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo (val) SELECT * FROM generate_series(0, 999)`)
+
+		sqlDB.Exec(t, `CREATE TABLE bar(val INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO bar (val) SELECT * FROM generate_series(0, 999)`)
+
+		// Ensure Scan Requests are always small enough that we receive multiple
+		// resolved events during a backfill
+		knobs.FeedKnobs.BeforeScanRequest = func(b *kv.Batch) error {
+			b.Header.MaxSpanRequestKeys = 10
+			return nil
+		}
+
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '1s', no_initial_scan`)
+		jobFeed := testFeed.(cdctest.EnterpriseTestFeed)
+		jobRegistry := f.Server().JobRegistry().(*jobs.Registry)
+
+		// Kafka feeds are not buffered, so we have to consume messages.
+		g := ctxgroup.WithContext(context.Background())
+		g.Go(func() error {
+			for {
+				_, err := testFeed.Next()
+				if err != nil {
+					return err
+				}
+			}
+		})
+		defer func() {
+			closeFeed(t, testFeed)
+			_ = g.Wait()
+		}()
+
+		// Helper to read job progress
+		loadProgress := func() jobspb.Progress {
+			jobID := jobFeed.JobID()
+			job, err := jobRegistry.LoadJob(context.Background(), jobID)
+			require.NoError(t, err)
+			return job.Progress()
+		}
+
+		// Ensure initial backfill completes
+		testutils.SucceedsSoon(t, func() error {
+			prog := loadProgress()
+			if p := prog.GetHighWater(); p != nil && !p.IsEmpty() {
+				return nil
+			}
+			return errors.New("waiting for highwater")
+		})
+
+		// Pause job and setup overrides to force a checkpoint
+		require.NoError(t, jobFeed.Pause())
+
+		var maxCheckpointSize int64 = 100 << 20
+		// Checkpoint progress frequently, and set the checkpoint size limit.
+		changefeedbase.FrontierCheckpointFrequency.Override(
+			context.Background(), &f.Server().ClusterSettings().SV, 10*time.Millisecond)
+		changefeedbase.FrontierCheckpointMaxBytes.Override(
+			context.Background(), &f.Server().ClusterSettings().SV, maxCheckpointSize)
+
+		// Note the tableSpan to avoid resolved events that leave no gaps
+		fooDesc := desctestutils.TestingGetPublicTableDescriptor(
+			f.Server().DB(), keys.SystemSQLCodec, "d", "foo")
+		tableSpan := fooDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
+
+		// ShouldSkipResolved should ensure that once the backfill begins, the following resolved events
+		// that are for that backfill (are of the timestamp right after the backfill timestamp) resolve some
+		// but not all of the time, which results in a checkpoint eventually being created
+		haveGaps := false
+		var backfillTimestamp hlc.Timestamp
+		var initialCheckpoint roachpb.SpanGroup
+		var foundCheckpoint int32
+		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+			// Stop resolving anything after checkpoint set to avoid eventually resolving the full span
+			if initialCheckpoint.Len() > 0 {
+				return true
+			}
+
+			// A backfill begins when the backfill resolved event arrives, which has a
+			// timestamp such that all backfill spans have a timestamp of
+			// timestamp.Next()
+			if r.BoundaryType == jobspb.ResolvedSpan_BACKFILL {
+				backfillTimestamp = r.Timestamp
+				return false
+			}
+
+			// Check if we've set a checkpoint yet
+			progress := loadProgress()
+			if p := progress.GetChangefeed(); p != nil && p.Checkpoint != nil && len(p.Checkpoint.Spans) > 0 {
+				initialCheckpoint.Add(p.Checkpoint.Spans...)
+				atomic.StoreInt32(&foundCheckpoint, 1)
+			}
+
+			// Filter non-backfill-related spans
+			if !r.Timestamp.Equal(backfillTimestamp.Next()) {
+				// Only allow spans prior to a valid backfillTimestamp to avoid moving past the backfill
+				return !(backfillTimestamp.IsEmpty() || r.Timestamp.LessEq(backfillTimestamp.Next()))
+			}
+
+			// Only allow resolving if we definitely won't have a completely resolved table
+			if !r.Span.Equal(tableSpan) && haveGaps {
+				return rnd.Intn(10) > 7
+			}
+			haveGaps = true
+			return true
+		}
+
+		require.NoError(t, jobFeed.Resume())
+		sqlDB.Exec(t, `ALTER TABLE foo ADD COLUMN b STRING DEFAULT 'd'`)
+
+		// Wait for a checkpoint to have been set
+		testutils.SucceedsSoon(t, func() error {
+			if atomic.LoadInt32(&foundCheckpoint) != 0 {
+				return nil
+			}
+			return errors.New("waiting for checkpoint")
+		})
+
+		require.NoError(t, jobFeed.Pause())
+		waitForJobStatus(sqlDB, t, jobFeed.JobID(), `paused`)
+
+		errMsg := fmt.Sprintf(
+			`pq: cannot perform initial scan on newly added targets while the checkpoint is non-empty, please unpause the changefeed and wait until the high watermark progresses past the current value %s to add these targets.`,
+			backfillTimestamp.AsOfSystemTime(),
+		)
+
+		sqlDB.ExpectErr(t, errMsg, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan`, jobFeed.JobID()))
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn, feedTestNoTenants))
+}
+
+func TestAlterChangefeedAddTargetsDuringBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t)
+
+	rnd, _ := randutil.NewTestRand()
+	var maxCheckpointSize int64 = 100
+
+	testFn := func(t *testing.T, db *gosql.DB, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(db)
+		sqlDB.Exec(t, `CREATE TABLE foo(val INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo (val) SELECT * FROM generate_series(0, 999)`)
+
+		sqlDB.Exec(t, `CREATE TABLE bar(val INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO bar (val) SELECT * FROM generate_series(0, 999)`)
+
+		fooDesc := desctestutils.TestingGetPublicTableDescriptor(
+			f.Server().DB(), keys.SystemSQLCodec, "d", "foo")
+		fooTableSpan := fooDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
+
+		knobs := f.Server().(*server.TestServer).Cfg.TestingKnobs.
+			DistSQL.(*execinfra.TestingKnobs).
+			Changefeed.(*TestingKnobs)
+
+		// Ensure Scan Requests are always small enough that we receive multiple
+		// resolvedFoo events during a backfill
+		knobs.FeedKnobs.BeforeScanRequest = func(b *kv.Batch) error {
+			b.Header.MaxSpanRequestKeys = 1 + rnd.Int63n(100)
+			return nil
+		}
+
+		// Emit resolved events for majority of spans. Be extra paranoid and ensure that
+		// we have at least 1 span for which we don't emit resolvedFoo timestamp (to force checkpointing).
+		haveGaps := false
+		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+			if r.Span.Equal(fooTableSpan) {
+				// Do not emit resolved events for the entire table span.
+				// We "simulate" large table by splitting single table span into many parts, so
+				// we want to resolve those sub-spans instead of the entire table span.
+				// However, we have to emit something -- otherwise the entire changefeed
+				// machine would not work.
+				r.Span.EndKey = fooTableSpan.Key.Next()
+				return false
+			}
+			if haveGaps {
+				return rnd.Intn(10) > 7
+			}
+			haveGaps = true
+			return true
+		}
+
+		// Checkpoint progress frequently, and set the checkpoint size limit.
+		changefeedbase.FrontierCheckpointFrequency.Override(
+			context.Background(), &f.Server().ClusterSettings().SV, 1)
+		changefeedbase.FrontierCheckpointMaxBytes.Override(
+			context.Background(), &f.Server().ClusterSettings().SV, maxCheckpointSize)
+
+		registry := f.Server().JobRegistry().(*jobs.Registry)
+		testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo WITH resolved = '100ms'`)
+
+		// Kafka feeds are not buffered, so we have to consume messages.
+		g := ctxgroup.WithContext(context.Background())
+		g.Go(func() error {
+			expectedValues := make([]string, 1000)
+			for j := 0; j <= 999; j++ {
+				expectedValues[j] = fmt.Sprintf(`foo: [%d]->{"after": {"val": %d}}`, j, j)
+			}
+			err := assertPayloadsBaseErr(testFeed, expectedValues, false, false)
+			if err != nil {
+				return err
+			}
+
+			for j := 0; j <= 999; j++ {
+				expectedValues[j] = fmt.Sprintf(`bar: [%d]->{"after": {"val": %d}}`, j, j)
+			}
+			err = assertPayloadsBaseErr(testFeed, expectedValues, false, false)
+			return err
+		})
+
+		defer func() {
+			require.NoError(t, g.Wait())
+			closeFeed(t, testFeed)
+		}()
+
+		jobFeed := testFeed.(cdctest.EnterpriseTestFeed)
+		loadProgress := func() jobspb.Progress {
+			jobID := jobFeed.JobID()
+			job, err := registry.LoadJob(context.Background(), jobID)
+			require.NoError(t, err)
+			return job.Progress()
+		}
+
+		// Wait for non-nil checkpoint.
+		testutils.SucceedsSoon(t, func() error {
+			progress := loadProgress()
+			if p := progress.GetChangefeed(); p != nil && p.Checkpoint != nil && len(p.Checkpoint.Spans) > 0 {
+				return nil
+			}
+			return errors.New("waiting for checkpoint")
+		})
+
+		// Pause the job and read and verify the latest checkpoint information.
+		require.NoError(t, jobFeed.Pause())
+		progress := loadProgress()
+		require.NotNil(t, progress.GetChangefeed())
+		h := progress.GetHighWater()
+		noHighWater := h == nil || h.IsEmpty()
+		require.True(t, noHighWater)
+
+		jobCheckpoint := progress.GetChangefeed().Checkpoint
+		require.Less(t, 0, len(jobCheckpoint.Spans))
+		var checkpoint roachpb.SpanGroup
+		checkpoint.Add(jobCheckpoint.Spans...)
+
+		waitForJobStatus(sqlDB, t, jobFeed.JobID(), `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan`, jobFeed.JobID()))
+
+		// Collect spans we attempt to resolve after when we resume.
+		var resolvedFoo []roachpb.Span
+		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+			if !r.Span.Equal(fooTableSpan) {
+				resolvedFoo = append(resolvedFoo, r.Span)
+			}
+			return false
+		}
+
+		require.NoError(t, jobFeed.Resume())
+
+		// Wait for the high water mark to be non-zero.
+		testutils.SucceedsSoon(t, func() error {
+			prog := loadProgress()
+			if p := prog.GetHighWater(); p != nil && !p.IsEmpty() {
+				return nil
+			}
+			return errors.New("waiting for highwater")
+		})
+
+		// At this point, highwater mark should be set, and previous checkpoint should be gone.
+		progress = loadProgress()
+		require.NotNil(t, progress.GetChangefeed())
+		require.Equal(t, 0, len(progress.GetChangefeed().Checkpoint.Spans))
+
+		// Verify that none of the resolvedFoo spans after resume were checkpointed.
+		for _, sp := range resolvedFoo {
+			require.Falsef(t, checkpoint.Contains(sp.Key), "span should not have been resolved: %s", sp)
+		}
+	}
+
+	t.Run(`kafka`, kafkaTest(testFn, feedTestNoTenants))
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -254,3 +254,10 @@ var AlterChangefeedOptionExpectValues = func() map[string]sql.KVStringOptValidat
 	alterChangefeedOptions[OptSink] = sql.KVStringOptRequireValue
 	return alterChangefeedOptions
 }()
+
+// AlterChangefeedTargetOptions is used to parse target specific alter
+// changefeed options using PlanHookState.TypeAsStringOpts().
+var AlterChangefeedTargetOptions = map[string]sql.KVStringOptValidate{
+	OptInitialScan:   sql.KVStringOptRequireNoValue,
+	OptNoInitialScan: sql.KVStringOptRequireNoValue,
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -754,6 +754,12 @@ message ChangefeedDetails {
   ];
   string sink_uri = 3 [(gogoproto.customname) = "SinkURI"];
   map<string, string> opts = 4;
+  // TODO(sherman): Now that we update the statement time in some situations
+  // while performing an initial scan on newly added targets, StatementTime is
+  // no longer a suitable name for this field. This is because the name
+  // StatementTime gives off an impression that the field indicates the creation
+  // time of the changefeed, which is no longer the case. We should rename this
+  // field to ScanTime instead.
   util.hlc.Timestamp statement_time = 7 [(gogoproto.nullable) = false];
   repeated ChangefeedTargetSpecification target_specifications = 8 [(gogoproto.nullable) = false];
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4410,10 +4410,11 @@ alter_changefeed_cmds:
 
 alter_changefeed_cmd:
   // ALTER CHANGEFEED <job_id> ADD [TABLE] ...
-  ADD changefeed_targets
+  ADD changefeed_targets opt_with_options
   {
     $$.val = &tree.AlterChangefeedAddTarget{
       Targets: $2.targetList(),
+      Options: $3.kvOptions(),
     }
   }
   // ALTER CHANGEFEED <job_id> DROP [TABLE] ...

--- a/pkg/sql/parser/testdata/alter_changefeed
+++ b/pkg/sql/parser/testdata/alter_changefeed
@@ -129,3 +129,35 @@ ALTER CHANGEFEED 123 ADD foo  DROP bar  SET baz = 'qux'  UNSET quux, corge -- no
 ALTER CHANGEFEED (123) ADD (foo)  DROP (bar)  SET baz = ('qux')  UNSET quux, corge -- fully parenthesized
 ALTER CHANGEFEED _ ADD foo  DROP bar  SET baz = '_'  UNSET quux, corge -- literals removed
 ALTER CHANGEFEED 123 ADD _  DROP _  SET _ = 'qux'  UNSET _, _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo WITH opt
+----
+ALTER CHANGEFEED 123 ADD foo WITH opt
+ALTER CHANGEFEED (123) ADD (foo) WITH opt -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo WITH opt -- literals removed
+ALTER CHANGEFEED 123 ADD _ WITH _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt
+----
+ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt
+ALTER CHANGEFEED (123) ADD (foo), (bar), (baz) WITH opt -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo, bar, baz WITH opt -- literals removed
+ALTER CHANGEFEED 123 ADD _, _, _ WITH _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo, bar WITH opt ADD baz WITH opt2
+----
+ALTER CHANGEFEED 123 ADD foo, bar WITH opt  ADD baz WITH opt2 -- normalized!
+ALTER CHANGEFEED (123) ADD (foo), (bar) WITH opt  ADD (baz) WITH opt2 -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo, bar WITH opt  ADD baz WITH opt2 -- literals removed
+ALTER CHANGEFEED 123 ADD _, _ WITH _  ADD _ WITH _ -- identifiers removed
+
+parse
+ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt SET qux = 'quux' DROP corge
+----
+ALTER CHANGEFEED 123 ADD foo, bar, baz WITH opt  SET qux = 'quux'  DROP corge -- normalized!
+ALTER CHANGEFEED (123) ADD (foo), (bar), (baz) WITH opt  SET qux = ('quux')  DROP (corge) -- fully parenthesized
+ALTER CHANGEFEED _ ADD foo, bar, baz WITH opt  SET qux = '_'  DROP corge -- literals removed
+ALTER CHANGEFEED 123 ADD _, _, _ WITH _  SET _ = 'quux'  DROP _ -- identifiers removed

--- a/pkg/sql/sem/tree/alter_changefeed.go
+++ b/pkg/sql/sem/tree/alter_changefeed.go
@@ -59,12 +59,17 @@ var _ AlterChangefeedCmd = &AlterChangefeedUnsetOptions{}
 // AlterChangefeedAddTarget represents an ADD <targets> command
 type AlterChangefeedAddTarget struct {
 	Targets TargetList
+	Options KVOptions
 }
 
 // Format implements the NodeFormatter interface.
 func (node *AlterChangefeedAddTarget) Format(ctx *FmtCtx) {
 	ctx.WriteString(" ADD ")
 	ctx.FormatNode(&node.Targets.Tables)
+	if node.Options != nil {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(&node.Options)
+	}
 }
 
 // AlterChangefeedDropTarget represents an DROP <targets> command


### PR DESCRIPTION
changefeedccl: allow users to perform initial scans on
newly added targets in the ALTER CHANGEFEED statement

References #75895

Currently, when a new target is added to an existing
changefeed through the ALTER CHANGEFEED statement,
no initial scan is performed on the newly added
target. With this change, users can indicate that
they want an initial scan by executing the following
statement:

ALTER CHANGEFEED <job_id> ADD <targets> WITH initial_scan

Users can also explicitly ask for no initial scan by
replacing 'initial_scan' with 'no_initial_scan'.
The default behavior is to perform no initial scans
when new targets are added.

Release note (enterprise change): Users can now
perform initial scans on newly added targets
by executing the following statement:

ALTER CHANGEFEED <job_id> ADD <targets> WITH initial_scan

The default behavior is to perform no initial scans
on newly added targets, but users can explicitly
request this by replacing the 'initial_scan' with
'no_initial_scan'.

Release justification: low danger enhancement to newly
implemented functionality.