### PR TITLE
backupccl: Backup LATEST file is no longer overwritten

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -1162,7 +1162,7 @@ func readLatestCheckpointFile(
 		checkpoint = strings.TrimSuffix(p, backupManifestChecksumSuffix)
 		checkpointFound = true
 		// We only want the first checkpoint so return an error that it is
-		// listing.
+		// done listing.
 		return cloud.ErrListingDone
 	})
 	// If the list failed because the storage used does not support listing,


### PR DESCRIPTION
This change teaches backup to no longer overwrite or delete the LATEST file, 
and instead write a new version side by side with the old ones. Other functions are
taught to look for these new LATEST files. To make sure that older backup chains
are not broken by this change,we still maintain an overwritten,
non versioned LATEST file in the base directory if it is a mixed cluster. This
logic can be removed in a post 22.1 release when we no longer write to the base directory.

Epic CRDB-7586

Release note (enterprise): LATEST files are no longer overwritten and now versioned
and written in the /metadata/latest directory for non-mixed version clusters.