### PR TITLE
roachtest: Increase import size for sst-corruption

### DIFF
--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -43,7 +43,7 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// to have multiple ranges, and some sstables with only table keys.
 			t.Status("importing tpcc fixture")
 			c.Run(ctx, workloadNode,
-				"./cockroach workload fixtures import tpcc --warehouses=100 --fks=false --checks=false")
+				"./cockroach workload fixtures import tpcc --warehouses=500 --fks=false --checks=false")
 			return nil
 		})
 		m.Wait()


### PR DESCRIPTION
On rare occasion(s), the grep for an sstable containing table
could fail, presumably due to the lack of ample sstables containing
table keys. This change bumps up the tpcc warehouse count for the
import to reduce the likelihood of this happening.

Fixes #77077. Hopefully.

Release note: None.