### PR TITLE
loqrecovery: fix json field name in replica info file

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -47,7 +47,7 @@ message ReplicaInfo {
   uint64 raft_applied_index = 4;
   uint64 raft_committed_index = 5;
   repeated DescriptorChangeInfo raft_log_descriptor_changes = 6 [(gogoproto.nullable) = false,
-    (gogoproto.jsontag) = ",omitempty"];
+    (gogoproto.jsontag) = "raft_log_descriptor_changes,omitempty"];
 }
 
 // Collection of replica information gathered from a collect-info run on a single node.


### PR DESCRIPTION
Previously protobuf used camelcase name for repeated field
for descriptor change. This was wrong as it was not parsed
correctly by marshaller.
This fix adds explicit name to proto specification to avoid
default name generation.

Release justification: This change is low risk as it fixes
a bug in new functionality.

Release note: None

Fixes #77282