### PR TITLE
tracing: add cluster settting controlling span creation

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -184,5 +184,6 @@ timeseries.storage.resolution_30m.ttl	duration	2160h0m0s	the maximum age of time
 trace.debug.enable	boolean	false	if set, traces for recent requests can be seen at https://<ui>/debug/requests
 trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
+trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
 version	version	21.2-88	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -197,6 +197,7 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen at https://<ui>/debug/requests</td></tr>
 <tr><td><code>trace.jaeger.agent</code></td><td>string</td><td><code></code></td><td>the address of a Jaeger agent to receive traces using the Jaeger UDP Thrift protocol, as <host>:<port>. If no port is specified, 6381 will be used.</td></tr>
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
+<tr><td><code>trace.span_registry.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://<ui>/debug/tracez</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
 <tr><td><code>version</code></td><td>version</td><td><code>21.2-88</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12989,8 +12989,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 	// applied at a time, which makes it easier to line up the timing of reproposals.
 	cfg.RaftMaxCommittedSizePerReady = 1
 	// Set up tracing.
-	tracer := tracing.NewTracer()
-	tracer.Configure(ctx, &cfg.Settings.SV)
+	tracer := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&cfg.Settings.SV))
 	cfg.AmbientCtx.Tracer = tracer
 
 	// Below we set txnID to the value of the transaction we're going to force to

--- a/pkg/util/log/trace_client_test.go
+++ b/pkg/util/log/trace_client_test.go
@@ -52,10 +52,9 @@ func TestTrace(t *testing.T) {
 		{
 			name: "zipkin",
 			init: func(ctx context.Context) (context.Context, *tracing.Span) {
-				tr := tracing.NewTracer()
 				st := cluster.MakeTestingClusterSettings()
 				tracing.ZipkinCollector.Override(ctx, &st.SV, "127.0.0.1:9000000")
-				tr.Configure(ctx, &st.SV)
+				tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
 				return tr.StartSpanCtx(context.Background(), "foo")
 			},
 			check: func(t *testing.T, ctx context.Context, sp *tracing.Span, tr *tracing.Tracer) {

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings",
         "//pkg/testutils",
         "//pkg/testutils/grpcutils",
         "//pkg/testutils/serverutils",

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -162,9 +162,17 @@ var ZipkinCollector = settings.RegisterValidatedStringSetting(
 	},
 ).WithPublic()
 
-// enableTracingByDefault controls whether Tracers configured with
-// WithTracingMode(TracingModeFromEnv) generally create spans or not.
-var enableTracingByDefault = envutil.EnvOrDefaultBool("COCKROACH_REAL_SPANS", true)
+// EnableActiveSpansRegistry controls Tracers configured as
+// WithTracingMode(TracingModeFromEnv) (which is the default). When enabled,
+// spans are allocated and registered with the active spans registry until
+// finished. When disabled, span creation is short-circuited for a small
+// performance improvement.
+var EnableActiveSpansRegistry = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"trace.span_registry.enabled",
+	"if set, ongoing traces can be seen at https://<ui>/debug/tracez",
+	envutil.EnvOrDefaultBool("COCKROACH_REAL_SPANS", true),
+).WithPublic()
 
 // panicOnUseAfterFinish, if set, causes use of a span after Finish() to panic
 // if detected.
@@ -268,8 +276,6 @@ type Tracer struct {
 	noopSpan        *Span
 	sterileNoopSpan *Span
 
-	tracingDefault TracingMode
-
 	// backardsCompatibilityWith211, if set, makes the Tracer
 	// work with 21.1 remote nodes.
 	//
@@ -291,6 +297,11 @@ type Tracer struct {
 	// for all spans that the parent Tracer creates.
 	otelTracer unsafe.Pointer
 
+	// activeSpansRegistryEnabled controls whether spans are created and
+	// registered with activeSpansRegistry until they're Finish()ed. If not
+	// enabled, span creation is generally a no-op unless a recording span is
+	// explicitly requested.
+	activeSpansRegistryEnabled bool
 	// activeSpans is a map that references all non-Finish'ed local root spans,
 	// i.e. those for which no WithParent(<non-nil>) option was supplied.
 	activeSpansRegistry *SpanRegistry
@@ -518,11 +529,10 @@ func (t *Tracer) SetRedactable(to bool) {
 	atomic.StoreInt32(&t._redactable, n)
 }
 
-// NewTracer creates a Tracer. It initially tries to run with minimal overhead
-// and collects essentially nothing; use Configure() to enable various tracing
-// backends.
+// NewTracer creates a Tracer with default options.
+//
+// See NewTracerWithOpt() for controlling various configuration options.
 func NewTracer() *Tracer {
-
 	var defaultSpanReusePercent uint32
 	if reuseSpans {
 		defaultSpanReusePercent = uint32(spanReusePercent)
@@ -531,8 +541,9 @@ func NewTracer() *Tracer {
 	}
 
 	t := &Tracer{
-		stack:               string(debug.Stack()),
-		activeSpansRegistry: makeSpanRegistry(),
+		stack:                      string(debug.Stack()),
+		activeSpansRegistryEnabled: true,
+		activeSpansRegistry:        makeSpanRegistry(),
 		// These might be overridden in NewTracerWithOpt.
 		panicOnUseAfterFinish: panicOnUseAfterFinish,
 		debugUseAfterFinish:   debugUseAfterFinish,
@@ -572,9 +583,6 @@ func NewTracerWithOpt(ctx context.Context, opts ...TracerOption) *Tracer {
 	}
 
 	t := NewTracer()
-	if o.sv != nil {
-		t.configure(ctx, o.sv)
-	}
 	if o.useAfterFinishOpt != nil {
 		t.panicOnUseAfterFinish = o.useAfterFinishOpt.panicOnUseAfterFinish
 		t.debugUseAfterFinish = o.useAfterFinishOpt.debugUseAfterFinish
@@ -583,7 +591,10 @@ func NewTracerWithOpt(ctx context.Context, opts ...TracerOption) *Tracer {
 		t.spanReusePercent = *o.spanReusePercent
 	}
 	t.testing = o.knobs
-	t.tracingDefault = TracingMode(o.tracingDefault)
+	t.activeSpansRegistryEnabled = o.tracingDefault != TracingModeOnDemand
+	if o.sv != nil {
+		t.configure(ctx, o.sv, o.tracingDefault)
+	}
 	return t
 }
 
@@ -591,7 +602,7 @@ func NewTracerWithOpt(ctx context.Context, opts ...TracerOption) *Tracer {
 type tracerOptions struct {
 	sv                *settings.Values
 	knobs             TracerTestingKnobs
-	tracingDefault    tracingModeOpt
+	tracingDefault    TracingMode
 	useAfterFinishOpt *useAfterFinishOpt
 	// spanReusePercent, if not nil, controls the probability of span reuse. A
 	// negative value indicates that the default should come from the environment.
@@ -640,7 +651,7 @@ type tracingModeOpt TracingMode
 var _ TracerOption = tracingModeOpt(TracingModeFromEnv)
 
 func (o tracingModeOpt) apply(opt *tracerOptions) {
-	opt.tracingDefault = o
+	opt.tracingDefault = TracingMode(o)
 }
 
 // WithTracingMode configures the Tracer's tracing mode.
@@ -683,7 +694,7 @@ func WithUseAfterFinishOpt(panicOnUseAfterFinish, debugUseAfterFinish bool) Trac
 
 // configure sets up the Tracer according to the cluster settings (and keeps
 // it updated if they change).
-func (t *Tracer) configure(ctx context.Context, sv *settings.Values) {
+func (t *Tracer) configure(ctx context.Context, sv *settings.Values, tracingDefault TracingMode) {
 	// traceProvider is captured by the function below.
 	var traceProvider *otelsdk.TracerProvider
 
@@ -694,6 +705,17 @@ func (t *Tracer) configure(ctx context.Context, sv *settings.Values) {
 		otlpCollectorAddr := openTelemetryCollector.Get(sv)
 		zipkinAddr := ZipkinCollector.Get(sv)
 		enableRedactable := enableTraceRedactable.Get(sv)
+
+		switch tracingDefault {
+		case TracingModeFromEnv:
+			t.activeSpansRegistryEnabled = EnableActiveSpansRegistry.Get(sv)
+		case TracingModeOnDemand:
+			t.activeSpansRegistryEnabled = false
+		case TracingModeActiveSpansRegistry:
+			t.activeSpansRegistryEnabled = true
+		default:
+			panic(fmt.Sprintf("unrecognized tracing option: %v", tracingDefault))
+		}
 
 		t.SetRedactable(enableRedactable)
 
@@ -774,6 +796,7 @@ func (t *Tracer) configure(ctx context.Context, sv *settings.Values) {
 
 	reconfigure(ctx)
 
+	EnableActiveSpansRegistry.SetOnChange(sv, reconfigure)
 	enableNetTrace.SetOnChange(sv, reconfigure)
 	openTelemetryCollector.SetOnChange(sv, reconfigure)
 	ZipkinCollector.SetOnChange(sv, reconfigure)
@@ -991,16 +1014,8 @@ func (t *Tracer) StartSpanCtx(
 // AlwaysTrace returns true if operations should be traced regardless of the
 // context.
 func (t *Tracer) AlwaysTrace() bool {
-	switch t.tracingDefault {
-	case TracingModeFromEnv:
-		if enableTracingByDefault {
-			return true
-		}
-	case TracingModeActiveSpansRegistry:
+	if t.activeSpansRegistryEnabled {
 		return true
-	case TracingModeOnDemand:
-	default:
-		panic(fmt.Sprintf("unrecognized tracing option: %v", t.tracingDefault))
 	}
 	otelTracer := t.getOtelTracer()
 	return t.useNetTrace() || otelTracer != nil

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -573,7 +573,7 @@ func NewTracerWithOpt(ctx context.Context, opts ...TracerOption) *Tracer {
 
 	t := NewTracer()
 	if o.sv != nil {
-		t.Configure(ctx, o.sv)
+		t.configure(ctx, o.sv)
 	}
 	if o.useAfterFinishOpt != nil {
 		t.panicOnUseAfterFinish = o.useAfterFinishOpt.panicOnUseAfterFinish
@@ -681,9 +681,9 @@ func WithUseAfterFinishOpt(panicOnUseAfterFinish, debugUseAfterFinish bool) Trac
 	}
 }
 
-// Configure sets up the Tracer according to the cluster settings (and keeps
+// configure sets up the Tracer according to the cluster settings (and keeps
 // it updated if they change).
-func (t *Tracer) Configure(ctx context.Context, sv *settings.Values) {
+func (t *Tracer) configure(ctx context.Context, sv *settings.Values) {
 	// traceProvider is captured by the function below.
 	var traceProvider *otelsdk.TracerProvider
 


### PR DESCRIPTION
This patch adds the trace.span_registry.enable cluster setting to
controls whether tracing spans are created and registered with the
active spans registry. The cluster setting defaults to true, just like
the env var before it. The point of the patch is to allow one to stop
span creation at runtime if anything goes awry.

Release note: None
Release justification: low-risk updates to new functionality