### PR TITLE
sql: add cluster setting to limit max size of serialized session

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1756,6 +1756,7 @@ func (ex *connExecutor) sessionStateBase64() (tree.Datum, error) {
 	_, isNoTxn := ex.machine.CurState().(stateNoTxn)
 	state, err := serializeSessionState(
 		!isNoTxn, ex.extraTxnState.prepStmtsNamespace, ex.sessionData(),
+		ex.server.cfg,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -11,6 +11,7 @@
 package sql
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -19,8 +20,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/lib/pq/oid"
+)
+
+var maxSerializedSessionSize = settings.RegisterByteSizeSetting(
+	settings.TenantReadOnly,
+	"sql.session_transfer.max_session_size",
+	"if set to non-zero, then serializing a session will fail if it requires more"+
+		"than the specified size",
+	0,
+	settings.NonNegativeInt,
 )
 
 // SerializeSessionState is a wrapper for serializeSessionState, and uses the
@@ -31,6 +42,7 @@ func (p *planner) SerializeSessionState() (*tree.DBytes, error) {
 		!evalCtx.TxnImplicit,
 		evalCtx.PreparedStatementState,
 		p.SessionData(),
+		p.ExecCfg(),
 	)
 }
 
@@ -39,7 +51,10 @@ func (p *planner) SerializeSessionState() (*tree.DBytes, error) {
 // NOTE: This is used within an observer statement directly, and should not rely
 // on the planner because those statements do not get planned.
 func serializeSessionState(
-	inExplicitTxn bool, prepStmtsState tree.PreparedStatementState, sd *sessiondata.SessionData,
+	inExplicitTxn bool,
+	prepStmtsState tree.PreparedStatementState,
+	sd *sessiondata.SessionData,
+	execCfg *ExecutorConfig,
 ) (*tree.DBytes, error) {
 	if inExplicitTxn {
 		return nil, pgerror.Newf(
@@ -78,6 +93,16 @@ func serializeSessionState(
 	b, err := protoutil.Marshal(&m)
 	if err != nil {
 		return nil, err
+	}
+
+	maxSize := maxSerializedSessionSize.Get(&execCfg.Settings.SV)
+	if maxSize > 0 && int64(len(b)) > maxSize {
+		return nil, pgerror.Newf(
+			pgcode.ProgramLimitExceeded,
+			"serialized session size %s exceeds max allowed size %s",
+			humanizeutil.IBytes(int64(len(b))),
+			humanizeutil.IBytes(maxSize),
+		)
 	}
 
 	return tree.NewDBytes(tree.DBytes(b)), nil

--- a/pkg/sql/testdata/session_migration/max_size
+++ b/pkg/sql/testdata/session_migration/max_size
@@ -1,0 +1,16 @@
+exec
+SET CLUSTER SETTING sql.session_transfer.max_session_size = '2KB'
+----
+
+let $large_string
+SELECT repeat('s', 5000)
+----
+
+exec
+PREPARE q AS SELECT '$large_string'
+----
+
+exec
+SELECT encode(crdb_internal.serialize_session(), 'hex')
+----
+ERROR: crdb_internal.serialize_session(): serialized session size 5.0 KiB exceeds max allowed size 2.0 KiB (SQLSTATE 54000)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/77302

The sql.session_transfer.max_session_size cluster setting can be used to
limit the max size of a session that is serialized using
crdb_internal.serialize_session.

No release note since this is not a public setting.

Release justification: high priority fix for new functionality.

Release note: None