### PR TITLE
backupccl: backup correctly tries reading in from base directory if l…

### DIFF
--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -346,11 +346,10 @@ func findLatestFile(
 ) (ioctx.ReadCloserCtx, error) {
 	latestFile, err := exportStore.ReadFile(ctx, latestHistoryDirectory+"/"+latestFileName)
 	if err != nil {
-		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
-			return nil, err
-		}
-
 		latestFile, err = exportStore.ReadFile(ctx, latestFileName)
+		if err != nil {
+			return nil, errors.Wrap(err, "LATEST file could not be read in base or metadata directory")
+		}
 	}
 	return latestFile, err
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9815,3 +9815,24 @@ func TestBackupRestoreSystemUsers(t *testing.T) {
 		})
 	})
 }
+
+// TestUserfileNormalizationIncrementalShowBackup tests to see that file
+// paths given by SHOW BACKUP on Incremental Backups work on userfiles.
+// Specifically we are looking to see that no normalization is needed
+// for filepaths, as userfiles do not support file system semnatics.
+func TestUserfileNormalizationIncrementalShowBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1
+	const userfile = "'userfile:///a'"
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	query := fmt.Sprintf("BACKUP bank TO %s", userfile)
+	sqlDB.Exec(t, query)
+	query = fmt.Sprintf("BACKUP bank TO %s", userfile)
+	sqlDB.Exec(t, query)
+	query = fmt.Sprintf("SHOW BACKUP %s", userfile)
+	sqlDB.Exec(t, query)
+}


### PR DESCRIPTION
…atest/checkpoint files aren't found

Before, we only tried reading from the base directory if we caught a ErrFileDoesNotExist error. However
this does not account for the potential error thrown when the progress/latest directories don't exist.
This changes it so we now correctly retry reading from the base directory.

We also put the latest directory inside of a metadata directory, in order to avoid any potential
conflicts with there being a latest file and latest directory in the same base directory.

Also wraps errors in findLatestFile and readLatestCheckpointFile for more clarity when both base and
latest/progress directories fail to read.

Fixes https://github.com/cockroachdb/cockroach/issues/77312

Epic CRDB-7586

Release justification: Low risk bug fix
Release note: none