### PR TITLE
cdc: filter schema changes that only backfill hidden columns

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
@@ -306,7 +306,7 @@ func TestTableEventFilter(t *testing.T) {
 			exp: false,
 		},
 		{
-			name: "don't filter end of add NULL-able computed column",
+			name: "don't filter end of add NULL-able visible computed column",
 			p:    defaultTableEventFilter,
 			e: TableEvent{
 				Before: func() catalog.TableDescriptor {


### PR DESCRIPTION
Adding a hash-sharded secondary index creates a hidden computed column.
Hidden columns are included in PublicColumns() as they can be referenced
in select queries, but are not included in changefeeds, so we should not
be backfilling in response to them as there is no visible change.

We were erroneously doing so, which was contributing to errors. This PR
distinguishes between backfills of visible columns and backfills of
merely public ones, which may be hidden or inaccessible.

Release justification: Bug fix.
Release note (bug fix): Fixed a bug when adding a hash-sharded index to a table watched by a changefeed.