### PR TITLE
util/log: remove Safe in favor of redact.Safe

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -108,6 +108,7 @@ go_library(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_google_btree//:btree",
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_shopify_sarama//:sarama",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type changeAggregator struct {
@@ -1349,7 +1350,7 @@ func (cf *changeFrontier) noteAggregatorProgress(d rowenc.EncDatum) error {
 		if !resolved.Timestamp.IsEmpty() && resolved.Timestamp.Less(cf.highWaterAtStart) {
 			logcrash.ReportOrPanic(cf.Ctx, &cf.flowCtx.Cfg.Settings.SV,
 				`got a span level timestamp %s for %s that is less than the initial high-water %s`,
-				log.Safe(resolved.Timestamp), resolved.Span, log.Safe(cf.highWaterAtStart))
+				redact.Safe(resolved.Timestamp), resolved.Span, redact.Safe(cf.highWaterAtStart))
 			continue
 		}
 		if err := cf.forwardFrontier(resolved); err != nil {

--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/tracing",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_trace_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_trace_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,7 +58,7 @@ func testTenantTracesAreRedactedImpl(t *testing.T, redactable bool) {
 				EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
 					TestingEvalFilter: func(args kvserverbase.FilterArgs) *roachpb.Error {
 						log.Eventf(args.Ctx, "%v", sensitiveString)
-						log.Eventf(args.Ctx, "%v", log.Safe(visibleString))
+						log.Eventf(args.Ctx, "%v", redact.Safe(visibleString))
 						return nil
 					},
 				},

--- a/pkg/cli/mt_proxy.go
+++ b/pkg/cli/mt_proxy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/spf13/cobra"
 )
 
@@ -147,7 +148,7 @@ func waitForSignals(
 			}
 
 			log.Ops.Shoutf(ctx, severity.ERROR,
-				"received signal '%s' during shutdown, initiating hard shutdown", log.Safe(sig))
+				"received signal '%s' during shutdown, initiating hard shutdown", redact.Safe(sig))
 			panic("terminate")
 		case <-stopper.IsStopped():
 			const msgDone = "server shutdown completed"

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -398,7 +399,7 @@ func handleNodeDecommissionSelf(
 			cliflags.NodeDecommissionSelf.Name)
 	}
 
-	log.Infof(ctx, "%s node %d", log.Safe(command), localNodeID)
+	log.Infof(ctx, "%s node %d", redact.Safe(command), localNodeID)
 	return []roachpb.NodeID{localNodeID}, nil
 }
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -888,7 +888,7 @@ func waitForShutdown(
 			// shutdown process.
 			log.Ops.Shoutf(shutdownCtx, severity.ERROR,
 				"received signal '%s' during shutdown, initiating hard shutdown%s",
-				log.Safe(sig), log.Safe(hardShutdownHint))
+				redact.Safe(sig), redact.Safe(hardShutdownHint))
 			handleSignalDuringShutdown(sig)
 			panic("unreachable")
 
@@ -1187,7 +1187,7 @@ func setupAndInitializeLoggingAndProfiling(
 				"- %s\n"+
 				"- %s",
 			build.MakeIssueURL(53404),
-			log.Safe(docs.URL("secure-a-cluster.html")),
+			redact.Safe(docs.URL("secure-a-cluster.html")),
 		)
 	}
 
@@ -1201,7 +1201,7 @@ func setupAndInitializeLoggingAndProfiling(
 				"For more information, see:\n\n" +
 				"- %s"
 			log.Shoutf(ctx, severity.WARNING, warningString,
-				log.Safe(docs.URL("cockroach-start.html#locality")))
+				redact.Safe(docs.URL("cockroach-start.html#locality")))
 		}
 	}
 

--- a/pkg/gossip/infostore.go
+++ b/pkg/gossip/infostore.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type stringMatcher interface {
@@ -253,7 +254,7 @@ func (is *infoStore) addInfo(key string, i *Info) error {
 		if highWaterStamp, ok := is.highWaterStamps[i.NodeID]; ok && highWaterStamp >= i.OrigStamp {
 			// Report both timestamps in the crash.
 			log.Fatalf(context.Background(),
-				"high water stamp %d >= %d", log.Safe(highWaterStamp), log.Safe(i.OrigStamp))
+				"high water stamp %d >= %d", redact.Safe(highWaterStamp), redact.Safe(i.OrigStamp))
 		}
 	}
 	// Update info map.

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -609,7 +609,7 @@ func (ds *DistSender) getRoutingInfo(
 		}
 		if !containsFn(returnToken.Desc(), descKey) {
 			log.Fatalf(ctx, "programming error: range resolution returning non-matching descriptor: "+
-				"desc: %s, key: %s, reverse: %t", returnToken.Desc(), descKey, log.Safe(useReverseScan))
+				"desc: %s, key: %s, reverse: %t", returnToken.Desc(), descKey, redact.Safe(useReverseScan))
 		}
 	}
 
@@ -764,7 +764,7 @@ func (ds *DistSender) Send(
 		// We already verified above that the batch contains only scan requests of the same type.
 		// Such a batch should never need splitting.
 		log.Fatalf(ctx, "batch with MaxSpanRequestKeys=%d, TargetBytes=%d needs splitting",
-			log.Safe(ba.MaxSpanRequestKeys), log.Safe(ba.TargetBytes))
+			redact.Safe(ba.MaxSpanRequestKeys), redact.Safe(ba.TargetBytes))
 	}
 	var singleRplChunk [1]*roachpb.BatchResponse
 	rplChunks := singleRplChunk[:0:1]

--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 //go:generate mockgen -destination=mocks_generated_test.go --package=rangefeed . DB
@@ -299,7 +300,7 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 		}
 		if err != nil && ctx.Err() == nil && restartLogEvery.ShouldLog() {
 			log.Warningf(ctx, "rangefeed failed %d times, restarting: %v",
-				log.Safe(i), err)
+				redact.Safe(i), err)
 		}
 		if ctx.Err() != nil {
 			log.VEventf(ctx, 1, "exiting rangefeed")

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -86,6 +86,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_kr_pretty//:pretty",
         "@org_golang_x_time//rate",

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 func init() {
@@ -268,10 +269,10 @@ func PushTxn(
 			s = "failed to push"
 		}
 		log.Infof(ctx, "%s %s (push type=%s) %s: %s (pushee last active: %s)",
-			args.PusherTxn.Short(), log.Safe(s),
-			log.Safe(pushType),
+			args.PusherTxn.Short(), redact.Safe(s),
+			redact.Safe(pushType),
 			args.PusheeTxn.Short(),
-			log.Safe(reason),
+			redact.Safe(reason),
 			reply.PusheeTxn.LastActive())
 	}
 

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -568,7 +569,7 @@ func (bq *baseQueue) Async(
 	ctx context.Context, opName string, wait bool, fn func(ctx context.Context, h queueHelper),
 ) {
 	if log.V(3) {
-		log.InfofDepth(ctx, 2, "%s", log.Safe(opName))
+		log.InfofDepth(ctx, 2, "%s", redact.Safe(opName))
 	}
 	opName += " (" + bq.name + ")"
 	bgCtx := bq.AnnotateCtx(context.Background())
@@ -581,7 +582,7 @@ func (bq *baseQueue) Async(
 		func(ctx context.Context) {
 			fn(ctx, baseQueueHelper{bq})
 		}); err != nil && bq.addLogN.ShouldLog() {
-		log.Infof(ctx, "rate limited in %s: %s", log.Safe(opName), err)
+		log.Infof(ctx, "rate limited in %s: %s", redact.Safe(opName), err)
 	}
 }
 

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
@@ -120,29 +121,29 @@ func wrapNumbersAsSafe(v ...interface{}) {
 	for i := range v {
 		switch v[i].(type) {
 		case uint:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case uint8:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case uint16:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case uint32:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case uint64:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case int:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case int8:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case int16:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case int32:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case int64:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case float32:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		case float64:
-			v[i] = log.Safe(v[i])
+			v[i] = redact.Safe(v[i])
 		default:
 		}
 	}

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/tracker"
 )
@@ -707,14 +708,14 @@ func (rlq *raftLogQueue) process(
 
 	// Can and should the raft logs be truncated?
 	if !decision.ShouldTruncate() {
-		log.VEventf(ctx, 3, "%s", log.Safe(decision.String()))
+		log.VEventf(ctx, 3, "%s", redact.Safe(decision.String()))
 		return false, nil
 	}
 
 	if n := decision.NumNewRaftSnapshots(); log.V(1) || n > 0 && rlq.logSnapshots.ShouldProcess(timeutil.Now()) {
-		log.Infof(ctx, "%v", log.Safe(decision.String()))
+		log.Infof(ctx, "%v", redact.Safe(decision.String()))
 	} else {
-		log.VEventf(ctx, 1, "%v", log.Safe(decision.String()))
+		log.VEventf(ctx, 1, "%v", redact.Safe(decision.String()))
 	}
 	b := &kv.Batch{}
 	truncRequest := &roachpb.TruncateLogRequest{

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1303,7 +1303,7 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 			pretty.Diff(diskState, r.mu.state))
 		r.mu.state.Desc, diskState.Desc = nil, nil
 		log.Fatalf(ctx, "on-disk and in-memory state diverged: %s",
-			log.Safe(pretty.Diff(diskState, r.mu.state)))
+			redact.Safe(pretty.Diff(diskState, r.mu.state)))
 	}
 	if r.isInitializedRLocked() {
 		if !r.startKey.Equal(r.mu.state.Desc.StartKey) {

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -253,7 +253,7 @@ func (r *Replica) CheckConsistency(
 				if !haveDelta {
 					return resp, nil
 				}
-				log.Fatalf(ctx, "found a delta of %+v", log.Safe(delta))
+				log.Fatalf(ctx, "found a delta of %+v", redact.Safe(delta))
 			}
 		}
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/redact"
 	"github.com/kr/pretty"
 	"golang.org/x/time/rate"
 )
@@ -226,7 +227,7 @@ func (r *Replica) leasePostApplyLocked(
 		switch {
 		case s2 < s1:
 			log.Fatalf(ctx, "lease sequence inversion, prevLease=%s, newLease=%s",
-				log.Safe(prevLease), log.Safe(newLease))
+				redact.Safe(prevLease), redact.Safe(newLease))
 		case s2 == s1:
 			// If the sequence numbers are the same, make sure they're actually
 			// the same lease. This can happen when callers are using
@@ -234,13 +235,13 @@ func (r *Replica) leasePostApplyLocked(
 			// splitPostApply. It can also happen during lease extensions.
 			if !prevLease.Equivalent(*newLease) {
 				log.Fatalf(ctx, "sequence identical for different leases, prevLease=%s, newLease=%s",
-					log.Safe(prevLease), log.Safe(newLease))
+					redact.Safe(prevLease), redact.Safe(newLease))
 			}
 		case s2 == s1+1:
 			// Lease sequence incremented by 1. Expected case.
 		case s2 > s1+1 && jumpOpt == assertNoLeaseJump:
 			log.Fatalf(ctx, "lease sequence jump, prevLease=%s, newLease=%s",
-				log.Safe(prevLease), log.Safe(newLease))
+				redact.Safe(prevLease), redact.Safe(newLease))
 		}
 	}
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"go.etcd.io/etcd/raft/v3/tracker"
@@ -1023,7 +1024,7 @@ func maybeFatalOnRaftReadyErr(ctx context.Context, expl string, err error) (remo
 	case errors.Is(err, apply.ErrRemoved):
 		return true
 	default:
-		log.FatalfDepth(ctx, 1, "%s: %+v", log.Safe(expl), err)
+		log.FatalfDepth(ctx, 1, "%s: %+v", redact.Safe(expl), err)
 		panic("unreachable")
 	}
 }

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/redact"
 )
 
 // addToTSCacheChecked adds the specified timestamp to the timestamp cache
@@ -346,7 +347,7 @@ func (r *Replica) applyTimestampCache(
 			if conflictingTxn != uuid.Nil {
 				conflictMsg = "conflicting txn: " + conflictingTxn.Short()
 			}
-			log.VEventf(ctx, 2, "bumped write timestamp to %s; %s", bumpedTS, log.Safe(conflictMsg))
+			log.VEventf(ctx, 2, "bumped write timestamp to %s; %s", bumpedTS, redact.Safe(conflictMsg))
 		}
 	}
 	return bumped

--- a/pkg/kv/kvserver/stateloader/BUILD.bazel
+++ b/pkg/kv/kvserver/stateloader/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
 )

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
@@ -422,7 +423,7 @@ func (rsl StateLoader) SynthesizeHardState(
 
 	if oldHS.Commit > newHS.Commit {
 		return errors.Newf("can't decrease HardState.Commit from %d to %d",
-			log.Safe(oldHS.Commit), log.Safe(newHS.Commit))
+			redact.Safe(oldHS.Commit), redact.Safe(newHS.Commit))
 	}
 	if oldHS.Term > newHS.Term {
 		// The existing HardState is allowed to be ahead of us, which is

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1879,9 +1879,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 				return errors.AssertionFailedf(
 					"found RangeDescriptor for range %d at generation %d which does not"+
 						" contain this store %d",
-					log.Safe(desc.RangeID),
-					log.Safe(desc.Generation),
-					log.Safe(s.StoreID()))
+					redact.Safe(desc.RangeID),
+					redact.Safe(desc.Generation),
+					redact.Safe(s.StoreID()))
 			}
 
 			rep, err := newReplica(ctx, &desc, s, replicaDesc.ReplicaID)
@@ -1908,9 +1908,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			} else {
 				return errors.AssertionFailedf("found newly constructed replica"+
 					" for range %d at generation %d with an invalid tenant ID in store %d",
-					log.Safe(desc.RangeID),
-					log.Safe(desc.Generation),
-					log.Safe(s.StoreID()))
+					redact.Safe(desc.RangeID),
+					redact.Safe(desc.Generation),
+					redact.Safe(s.StoreID()))
 			}
 
 			if _, ok := desc.GetReplicaDescriptor(s.StoreID()); !ok {

--- a/pkg/kv/kvserver/tscache/BUILD.bazel
+++ b/pkg/kv/kvserver/tscache/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_andy_kimball_arenaskl//:arenaskl",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvserver/tscache/interval_skl.go
+++ b/pkg/kv/kvserver/tscache/interval_skl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // rangeOptions are passed to AddRange to indicate the bounds of the range. By
@@ -259,7 +260,7 @@ func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, val cacheValue
 			msg := fmt.Sprintf("inverted range (issue #32149): key lens = [%d,%d), diff @ index %d",
 				len(from), len(to), d)
 			log.Errorf(context.Background(), "%s, [%s,%s)", msg, from, to)
-			panic(log.Safe(msg))
+			panic(redact.Safe(msg))
 		case cmp == 0:
 			// Starting key is same as ending key, so just add single node.
 			if opt == (excludeFrom | excludeTo) {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -427,6 +427,7 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//proto",

--- a/pkg/server/debug/logspy.go
+++ b/pkg/server/debug/logspy.go
@@ -155,7 +155,7 @@ func (spy *logSpy) run(ctx context.Context, w io.Writer, opts logSpyOptions) (er
 			entry := log.MakeLegacyEntry(
 				ctx, severity.WARNING, channel.DEV,
 				0 /* depth */, true, /* redactable */
-				"%d messages were dropped", log.Safe(dropped))
+				"%d messages were dropped", redact.Safe(dropped))
 			err = errors.CombineErrors(err, interceptor.outputEntry(w, entry))
 		}
 	}()

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -43,12 +44,12 @@ func TestRedactRecordingForTenant(t *testing.T) {
 		t.Helper()
 		tags := (&logtags.Buffer{}).
 			Add("tag_sensitive", tagSensitive).
-			Add("tag_not_sensitive", log.Safe(tagNotSensitive))
+			Add("tag_not_sensitive", redact.Safe(tagNotSensitive))
 		ctx := logtags.WithTags(context.Background(), tags)
 		tracer := tracing.NewTracer()
 		tracer.SetRedactable(true)
 		ctx, sp := tracer.StartSpanCtx(ctx, "foo", tracing.WithRecording(tracing.RecordingVerbose))
-		log.Eventf(ctx, "%s %s", msgSensitive, log.Safe(msgNotSensitive))
+		log.Eventf(ctx, "%s %s", msgSensitive, redact.Safe(msgNotSensitive))
 		sp.SetTag("all_span_tags_are_stripped", attribute.StringValue("because_no_redactability"))
 		rec := sp.FinishAndGetRecording(tracing.RecordingVerbose)
 		require.Len(t, rec, 1)

--- a/pkg/server/settingswatcher/BUILD.bazel
+++ b/pkg/server/settingswatcher/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // SettingsWatcher is used to watch for cluster settings changes with a
@@ -240,11 +241,11 @@ func (s *SettingsWatcher) handleKV(
 	if !s.codec.ForSystemTenant() {
 		setting, ok := settings.Lookup(name, settings.LookupForLocalAccess, s.codec.ForSystemTenant())
 		if !ok {
-			log.Warningf(ctx, "unknown setting %s, skipping update", log.Safe(name))
+			log.Warningf(ctx, "unknown setting %s, skipping update", redact.Safe(name))
 			return nil
 		}
 		if setting.Class() != settings.TenantWritable {
-			log.Warningf(ctx, "ignoring read-only setting %s", log.Safe(name))
+			log.Warningf(ctx, "ignoring read-only setting %s", redact.Safe(name))
 			return nil
 		}
 	}
@@ -291,7 +292,7 @@ func (s *SettingsWatcher) setLocked(ctx context.Context, key string, val setting
 	}
 
 	if err := s.mu.updater.Set(ctx, key, val); err != nil {
-		log.Warningf(ctx, "failed to set setting %s to %s: %v", log.Safe(key), val.Value, err)
+		log.Warningf(ctx, "failed to set setting %s to %s: %v", redact.Safe(key), val.Value, err)
 	}
 }
 
@@ -299,7 +300,7 @@ func (s *SettingsWatcher) setLocked(ctx context.Context, key string, val setting
 func (s *SettingsWatcher) setDefaultLocked(ctx context.Context, key string) {
 	setting, ok := settings.Lookup(key, settings.LookupForLocalAccess, s.codec.ForSystemTenant())
 	if !ok {
-		log.Warningf(ctx, "failed to find setting %s, skipping update", log.Safe(key))
+		log.Warningf(ctx, "failed to find setting %s, skipping update", redact.Safe(key))
 		return
 	}
 	ws, ok := setting.(settings.NonMaskedSetting)

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // applyJoinNode implements apply join: the execution component of correlated
@@ -81,11 +81,11 @@ func newApplyJoinNode(
 ) (planNode, error) {
 	switch joinType {
 	case descpb.RightOuterJoin, descpb.FullOuterJoin:
-		return nil, errors.AssertionFailedf("unsupported right outer apply join: %d", log.Safe(joinType))
+		return nil, errors.AssertionFailedf("unsupported right outer apply join: %d", redact.Safe(joinType))
 	case descpb.ExceptAllJoin, descpb.IntersectAllJoin:
-		return nil, errors.AssertionFailedf("unsupported apply set op: %d", log.Safe(joinType))
+		return nil, errors.AssertionFailedf("unsupported apply set op: %d", redact.Safe(joinType))
 	case descpb.RightSemiJoin, descpb.RightAntiJoin:
-		return nil, errors.AssertionFailedf("unsupported right semi/anti apply join: %d", log.Safe(joinType))
+		return nil, errors.AssertionFailedf("unsupported right semi/anti apply join: %d", redact.Safe(joinType))
 	}
 
 	return &applyJoinNode{

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/iterutil",
-        "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -27,8 +27,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // ColumnDefDescs contains the non-error return values for MakeColumnDefDescs.
@@ -409,7 +409,7 @@ func (desc *wrapper) collectConstraintInfo(
 			if err != nil {
 				return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 					"error resolving table %d referenced in foreign key",
-					log.Safe(fk.ReferencedTableID))
+					redact.Safe(fk.ReferencedTableID))
 			}
 			referencedColumnNames, err := other.NamesForColumnIDs(fk.ReferencedColumnIDs)
 			if err != nil {
@@ -445,7 +445,7 @@ func (desc *wrapper) collectConstraintInfo(
 				col, err := desc.FindColumnWithID(colID)
 				if err != nil {
 					return nil, errors.NewAssertionErrorWithWrappedErrf(err,
-						"error finding column %d in table %s", log.Safe(colID), desc.Name)
+						"error finding column %d in table %s", redact.Safe(colID), desc.Name)
 				}
 				detail.Columns = append(detail.Columns, col.GetName())
 			}

--- a/pkg/sql/colencoding/BUILD.bazel
+++ b/pkg/sql/colencoding/BUILD.bazel
@@ -19,10 +19,10 @@ go_library(
         "//pkg/util",
         "//pkg/util/duration",
         "//pkg/util/encoding",
-        "//pkg/util/log",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -24,8 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // DecodeKeyValsToCols decodes the values that are part of the key, writing the
@@ -99,7 +99,7 @@ func decodeTableKeyToCol(
 	scratch []byte,
 ) (_ []byte, _ bool, retScratch []byte, _ error) {
 	if (dir != descpb.IndexDescriptor_ASC) && (dir != descpb.IndexDescriptor_DESC) {
-		return nil, false, scratch, errors.AssertionFailedf("invalid direction: %d", log.Safe(dir))
+		return nil, false, scratch, errors.AssertionFailedf("invalid direction: %d", redact.Safe(dir))
 	}
 	var isNull bool
 	if key, isNull = encoding.DecodeIfNull(key); isNull {

--- a/pkg/sql/colexec/colexecbase/distinct.go
+++ b/pkg/sql/colexec/colexecbase/distinct.go
@@ -146,7 +146,7 @@ func (h *UpsertDistinctHelper) MaybeEmitErrorOnDup(origLen, updatedLen int) {
 	if h.ErrorOnDup != "" && origLen > updatedLen {
 		// At least one duplicate row was removed from the batch, so we raise an
 		// error.
-		// TODO(yuzefovich): ErrorOnDup could be passed via log.Safe() if there
+		// TODO(yuzefovich): ErrorOnDup could be passed via redact.Safe() if there
 		// was a guarantee that it does not contain PII.
 		colexecerror.ExpectedError(pgerror.Newf(pgcode.CardinalityViolation, "%s", h.ErrorOnDup))
 	}

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_marusama_semaphore//:semaphore",
         "@io_opentelemetry_go_otel//attribute",

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // RowChannelBufSize is the default buffer size of a RowChannel.
@@ -418,7 +419,7 @@ func (rb *rowSourceBase) consumerDone() {
 func (rb *rowSourceBase) consumerClosed(name string) {
 	status := ConsumerStatus(atomic.LoadUint32((*uint32)(&rb.ConsumerStatus)))
 	if status == ConsumerClosed {
-		logcrash.ReportOrPanic(context.Background(), nil, "%s already closed", log.Safe(name))
+		logcrash.ReportOrPanic(context.Background(), nil, "%s already closed", redact.Safe(name))
 	}
 	atomic.StoreUint32((*uint32)(&rb.ConsumerStatus), uint32(ConsumerClosed))
 }

--- a/pkg/sql/max_one_row.go
+++ b/pkg/sql/max_one_row.go
@@ -57,7 +57,7 @@ func (m *max1RowNode) Next(params runParams) (bool, error) {
 		var secondOk bool
 		secondOk, err = m.plan.Next(params)
 		if secondOk {
-			// TODO(knz): m.errorText could be passed via log.Safe if there
+			// TODO(knz): m.errorText could be passed via redact.Safe if there
 			// was a guarantee that it does not contain PII. Or better yet,
 			// the caller would construct an `error` object to return here
 			// instead of a string.

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -35,8 +35,8 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/buildutil",
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -46,9 +46,9 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
-        "//pkg/util/log",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // ParallelScanResultThreshold is the number of results up to which, if the
@@ -195,7 +195,7 @@ func (b *Builder) build(e opt.Expr) (_ execPlan, err error) {
 	rel, ok := e.(memo.RelExpr)
 	if !ok {
 		return execPlan{}, errors.AssertionFailedf(
-			"building execution for non-relational operator %s", log.Safe(e.Op()),
+			"building execution for non-relational operator %s", redact.Safe(e.Op()),
 		)
 	}
 
@@ -215,7 +215,7 @@ func (b *Builder) build(e opt.Expr) (_ execPlan, err error) {
 func (b *Builder) BuildScalar() (tree.TypedExpr, error) {
 	scalar, ok := b.e.(opt.ScalarExpr)
 	if !ok {
-		return nil, errors.AssertionFailedf("BuildScalar cannot be called for non-scalar operator %s", log.Safe(b.e.Op()))
+		return nil, errors.AssertionFailedf("BuildScalar cannot be called for non-scalar operator %s", redact.Safe(b.e.Op()))
 	}
 	var ctx buildScalarCtx
 	md := b.mem.Metadata()

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -41,8 +41,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type execPlan struct {
@@ -107,7 +107,7 @@ func (ep *execPlan) makeBuildScalarCtx() buildScalarCtx {
 func (ep *execPlan) getNodeColumnOrdinal(col opt.ColumnID) exec.NodeColumnOrdinal {
 	ord, ok := ep.outputCols.Get(int(col))
 	if !ok {
-		panic(errors.AssertionFailedf("column %d not in input", log.Safe(col)))
+		panic(errors.AssertionFailedf("column %d not in input", redact.Safe(col)))
 	}
 	return exec.NodeColumnOrdinal(ord)
 }
@@ -1290,7 +1290,7 @@ func joinOpToJoinType(op opt.Operator) descpb.JoinType {
 		return descpb.LeftAntiJoin
 
 	default:
-		panic(errors.AssertionFailedf("not a join op %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("not a join op %s", redact.Safe(op)))
 	}
 }
 
@@ -1535,7 +1535,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	case opt.ExceptAllOp:
 		typ, all = tree.ExceptOp, true
 	default:
-		panic(errors.AssertionFailedf("invalid operator %s", log.Safe(set.Op())))
+		panic(errors.AssertionFailedf("invalid operator %s", redact.Safe(set.Op())))
 	}
 
 	hardLimit := uint64(0)

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type buildScalarCtx struct {
@@ -92,7 +92,7 @@ func init() {
 func (b *Builder) buildScalar(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {
 	fn := scalarBuildFuncMap[scalar.Op()]
 	if fn == nil {
-		return nil, errors.AssertionFailedf("unsupported op %s", log.Safe(scalar.Op()))
+		return nil, errors.AssertionFailedf("unsupported op %s", redact.Safe(scalar.Op()))
 	}
 	return fn(b, ctx, scalar)
 }
@@ -128,7 +128,7 @@ func (b *Builder) indexedVar(
 ) tree.TypedExpr {
 	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
-		panic(errors.AssertionFailedf("cannot map variable %d to an indexed var", log.Safe(colID)))
+		panic(errors.AssertionFailedf("cannot map variable %d to an indexed var", redact.Safe(colID)))
 	}
 	return ctx.ivh.IndexedVarWithType(idx, md.ColumnMeta(colID).Type)
 }
@@ -211,7 +211,7 @@ func (b *Builder) buildBoolean(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree
 		return tree.NewTypedIsNotNullExpr(expr), nil
 
 	default:
-		panic(errors.AssertionFailedf("invalid op %s", log.Safe(scalar.Op())))
+		panic(errors.AssertionFailedf("invalid op %s", redact.Safe(scalar.Op())))
 	}
 }
 

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -43,10 +43,10 @@ go_library(
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/json",
-        "//pkg/util/log",
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // BuildConstraints returns a constraint.Set that represents the given scalar
@@ -405,7 +405,7 @@ func (cb *constraintsBuilder) buildConstraintForTupleInequality(
 	case opt.GeOp:
 		less, boundary = false, includeBoundary
 	default:
-		panic(errors.AssertionFailedf("unsupported operator type %s", log.Safe(e.Op())))
+		panic(errors.AssertionFailedf("unsupported operator type %s", redact.Safe(e.Op())))
 	}
 	// Disallow NULLs on the first column.
 	startKey, startBoundary := constraint.MakeKey(tree.DNull), excludeBoundary

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -26,8 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // RelExpr is implemented by all operators tagged as Relational. Relational
@@ -750,7 +750,7 @@ func (m *MutationPrivate) MapToInputCols(cols opt.ColSet) opt.ColSet {
 	tabCols.ForEach(func(t opt.ColumnID) {
 		id := m.MapToInputID(t)
 		if id == 0 {
-			panic(errors.AssertionFailedf("could not find input column for %d", log.Safe(t)))
+			panic(errors.AssertionFailedf("could not find input column for %d", redact.Safe(t)))
 		}
 		inCols.Add(id)
 	})

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 var fdAnnID = opt.NewTableAnnID()
@@ -698,7 +698,7 @@ func (b *logicalPropsBuilder) buildSetProps(setNode RelExpr, rel *props.Relation
 		len(setPrivate.OutCols) != len(setPrivate.RightCols) {
 		panic(errors.AssertionFailedf(
 			"lists in SetPrivate are not all the same length. new:%d, left:%d, right:%d",
-			log.Safe(len(setPrivate.OutCols)), log.Safe(len(setPrivate.LeftCols)), log.Safe(len(setPrivate.RightCols)),
+			redact.Safe(len(setPrivate.OutCols)), redact.Safe(len(setPrivate.LeftCols)), redact.Safe(len(setPrivate.RightCols)),
 		))
 	}
 

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -19,9 +19,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // Memo is a data structure for efficiently storing a forest of query plans.
@@ -365,7 +365,7 @@ func (m *Memo) SetBestProps(
 				"cannot overwrite %s / %s (%.9g) with %s / %s (%.9g)",
 				e.RequiredPhysical(),
 				e.ProvidedPhysical(),
-				log.Safe(e.Cost()),
+				redact.Safe(e.Cost()),
 				required.String(),
 				provided.String(), // Call String() so provided doesn't escape.
 				cost,

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 var statsAnnID = opt.NewTableAnnID()
@@ -379,7 +379,7 @@ func (sb *statisticsBuilder) colStatFromInput(
 		return &props.ColumnStatistic{Cols: colSet, DistinctCount: 1}, sb.statsFromChild(e, 0 /* childIdx */)
 	}
 
-	panic(errors.AssertionFailedf("unsupported operator type %s", log.Safe(e.Op())))
+	panic(errors.AssertionFailedf("unsupported operator type %s", redact.Safe(e.Op())))
 }
 
 // colStat gets a column statistic for the given set of columns if it exists.
@@ -474,7 +474,7 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 		return sb.colStatLeaf(colSet, &rel.Stats, &rel.FuncDeps, rel.NotNullCols)
 	}
 
-	panic(errors.AssertionFailedf("unrecognized relational expression type: %v", log.Safe(e.Op())))
+	panic(errors.AssertionFailedf("unrecognized relational expression type: %v", redact.Safe(e.Op())))
 }
 
 // colStatLeaf creates a column statistic for a given column set (if it doesn't
@@ -2654,7 +2654,7 @@ func (sb *statisticsBuilder) copyColStat(
 ) *props.ColumnStatistic {
 	if !inputColStat.Cols.SubsetOf(colSet) {
 		panic(errors.AssertionFailedf(
-			"copyColStat colSet: %v inputColSet: %v\n", log.Safe(colSet), log.Safe(inputColStat.Cols),
+			"copyColStat colSet: %v inputColSet: %v\n", redact.Safe(colSet), redact.Safe(inputColStat.Cols),
 		))
 	}
 	colStat, _ := s.ColStats.Add(colSet)
@@ -2842,7 +2842,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 
 	default:
 		if !opt.IsJoinOp(e) {
-			panic(errors.AssertionFailedf("rowsProcessed not supported for operator type %v", log.Safe(e.Op())))
+			panic(errors.AssertionFailedf("rowsProcessed not supported for operator type %v", redact.Safe(e.Op())))
 		}
 
 		leftCols := e.Child(0).(RelExpr).Relational().OutputCols
@@ -2884,7 +2884,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 			case *FullJoinExpr:
 				e = e.Memo().MemoizeFullJoin(t.Left, t.Right, on, &t.JoinPrivate)
 			default:
-				panic(errors.AssertionFailedf("join type %v not handled", log.Safe(e.Op())))
+				panic(errors.AssertionFailedf("join type %v not handled", redact.Safe(e.Op())))
 			}
 		}
 		return e.Relational().Stats.RowCount

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // InferType derives the type of the given scalar expression. The result is
@@ -31,7 +31,7 @@ func InferType(mem *Memo, e opt.ScalarExpr) *types.T {
 
 	fn := typingFuncMap[e.Op()]
 	if fn == nil {
-		panic(errors.AssertionFailedf("type inference for %v is not yet implemented", log.Safe(e.Op())))
+		panic(errors.AssertionFailedf("type inference for %v is not yet implemented", redact.Safe(e.Op())))
 	}
 	return fn(e)
 }
@@ -48,7 +48,7 @@ func InferUnaryType(op opt.Operator, inputType *types.T) *types.T {
 			return o.ReturnType
 		}
 	}
-	panic(errors.AssertionFailedf("could not find type for unary expression %s", log.Safe(op)))
+	panic(errors.AssertionFailedf("could not find type for unary expression %s", redact.Safe(op)))
 }
 
 // InferBinaryType infers the return type of a binary expression, given the type
@@ -56,7 +56,7 @@ func InferUnaryType(op opt.Operator, inputType *types.T) *types.T {
 func InferBinaryType(op opt.Operator, leftType, rightType *types.T) *types.T {
 	o, ok := FindBinaryOverload(op, leftType, rightType)
 	if !ok {
-		panic(errors.AssertionFailedf("could not find type for binary expression %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("could not find type for binary expression %s", redact.Safe(op)))
 	}
 	return o.ReturnType
 }
@@ -93,7 +93,7 @@ func BinaryOverloadExists(op opt.Operator, leftType, rightType *types.T) bool {
 func BinaryAllowsNullArgs(op opt.Operator, leftType, rightType *types.T) bool {
 	o, ok := FindBinaryOverload(op, leftType, rightType)
 	if !ok {
-		panic(errors.AssertionFailedf("could not find overload for binary expression %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("could not find overload for binary expression %s", redact.Safe(op)))
 	}
 	return o.NullableArgs
 }
@@ -230,7 +230,7 @@ func typeVariable(mem *Memo, e opt.ScalarExpr) *types.T {
 	variable := e.(*VariableExpr)
 	typ := mem.Metadata().ColumnMeta(variable.Col).Type
 	if typ == nil {
-		panic(errors.AssertionFailedf("column %d does not have type", log.Safe(variable.Col)))
+		panic(errors.AssertionFailedf("column %d does not have type", redact.Safe(variable.Col)))
 	}
 	return typ
 }

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -51,9 +51,9 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/json",
-        "//pkg/util/log",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -86,6 +86,7 @@ go_test(
         "//pkg/util/log",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // CommuteInequality swaps the operands of an inequality comparison expression,
@@ -38,7 +38,7 @@ func (c *CustomFuncs) CommuteInequality(
 	case opt.LtOp:
 		return c.f.ConstructGt(right, left)
 	}
-	panic(errors.AssertionFailedf("called commuteInequality with operator %s", log.Safe(op)))
+	panic(errors.AssertionFailedf("called commuteInequality with operator %s", redact.Safe(op)))
 }
 
 // NormalizeTupleEquality remaps the elements of two tuples compared for

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // HasHoistableSubquery returns true if the given scalar expression contains a
@@ -326,7 +326,7 @@ func (c *CustomFuncs) ConstructNonApplyJoin(
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
 		return c.f.ConstructAntiJoin(left, right, on, private)
 	}
-	panic(errors.AssertionFailedf("unexpected join operator: %v", log.Safe(joinOp)))
+	panic(errors.AssertionFailedf("unexpected join operator: %v", redact.Safe(joinOp)))
 }
 
 // ConstructApplyJoin constructs the apply join operator that corresponds
@@ -344,7 +344,7 @@ func (c *CustomFuncs) ConstructApplyJoin(
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
 		return c.f.ConstructAntiJoinApply(left, right, on, private)
 	}
-	panic(errors.AssertionFailedf("unexpected join operator: %v", log.Safe(joinOp)))
+	panic(errors.AssertionFailedf("unexpected join operator: %v", redact.Safe(joinOp)))
 }
 
 // EnsureKey finds the shortest strong key for the input expression. If no
@@ -603,7 +603,7 @@ func (c *CustomFuncs) TranslateNonIgnoreAggs(
 				// we translate that into Count.
 				// TestAllAggsIgnoreNullsOrNullOnEmpty verifies that this assumption is
 				// true.
-				panic(errors.AssertionFailedf("can't decorrelate with aggregate %s", log.Safe(agg.Op())))
+				panic(errors.AssertionFailedf("can't decorrelate with aggregate %s", redact.Safe(agg.Op())))
 			}
 
 			if projections == nil {

--- a/pkg/sql/opt/norm/decorrelate_funcs_test.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // TestAllAggsIgnoreNullsOrNullOnEmpty verifies the assumption made in
@@ -29,7 +29,7 @@ func TestAllAggsIgnoreNullsOrNullOnEmpty(t *testing.T) {
 		}
 		if !opt.AggregateIgnoresNulls(op) && !opt.AggregateIsNullOnEmpty(op) {
 			panic(errors.AssertionFailedf(
-				"%s does not ignore nulls and is not null on empty", log.Safe(op),
+				"%s does not ignore nulls and is not null on empty", redact.Safe(op),
 			))
 		}
 	}

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // ReplaceFunc is the callback function passed to the Factory.Replace method.
@@ -400,7 +400,7 @@ func (f *Factory) ConstructJoin(
 	case opt.AntiJoinApplyOp:
 		return f.ConstructAntiJoinApply(left, right, on, private)
 	}
-	panic(errors.AssertionFailedf("unexpected join operator: %v", log.Safe(joinOp)))
+	panic(errors.AssertionFailedf("unexpected join operator: %v", redact.Safe(joinOp)))
 }
 
 // ConstructConstVal constructs one of the constant value operators from the

--- a/pkg/sql/opt/norm/groupby_funcs.go
+++ b/pkg/sql/opt/norm/groupby_funcs.go
@@ -17,8 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // RemoveGroupingCols returns a new grouping private struct with the given
@@ -62,7 +62,7 @@ func (c *CustomFuncs) makeAggCols(
 			outAgg = c.f.ConstructFirstAgg(varExpr)
 
 		default:
-			panic(errors.AssertionFailedf("unrecognized aggregate operator type: %v", log.Safe(aggOp)))
+			panic(errors.AssertionFailedf("unrecognized aggregate operator type: %v", redact.Safe(aggOp)))
 		}
 
 		outAggs[i] = c.f.ConstructAggregationsItem(outAgg, id)

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // ----------------------------------------------------------------------
@@ -46,7 +46,7 @@ func (c *CustomFuncs) ConstructNonLeftJoin(
 	case opt.FullJoinOp:
 		return c.f.ConstructRightJoin(left, right, on, private)
 	}
-	panic(errors.AssertionFailedf("unexpected join operator: %v", log.Safe(joinOp)))
+	panic(errors.AssertionFailedf("unexpected join operator: %v", redact.Safe(joinOp)))
 }
 
 // SimplifyNotNullEquality simplifies an expression of the following form:

--- a/pkg/sql/opt/norm/project_set_funcs.go
+++ b/pkg/sql/opt/norm/project_set_funcs.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // unnestFuncs maps function names that are supported by
@@ -143,7 +143,7 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 				}
 				if len(vals) != 1 {
 					panic(errors.AssertionFailedf(
-						"ValueGenerator didn't return exactly one value: %v", log.Safe(vals)))
+						"ValueGenerator didn't return exactly one value: %v", redact.Safe(vals)))
 				}
 				val := c.f.ConstructConstVal(vals[0], vals[0].ResolvedType())
 				addValToOutRows(val, j, i)

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // NeedSortedUniqueList returns true if the given list is composed entirely of
@@ -112,7 +112,7 @@ func (c *CustomFuncs) IsConstValueEqual(const1, const2 opt.ScalarExpr) bool {
 		datum2 := const2.(*memo.ConstExpr).Value
 		return datum1.Compare(c.f.evalCtx, datum2) == 0
 	default:
-		panic(errors.AssertionFailedf("unexpected Op type: %v", log.Safe(op1)))
+		panic(errors.AssertionFailedf("unexpected Op type: %v", redact.Safe(op1)))
 	}
 }
 

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // Operator describes the type of operation that a memo expression performs.
@@ -334,7 +334,7 @@ func AggregateIgnoresNulls(op Operator) bool {
 		return false
 
 	default:
-		panic(errors.AssertionFailedf("unhandled op %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("unhandled op %s", redact.Safe(op)))
 	}
 }
 
@@ -359,7 +359,7 @@ func AggregateIsNullOnEmpty(op Operator) bool {
 		return false
 
 	default:
-		panic(errors.AssertionFailedf("unhandled op %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("unhandled op %s", redact.Safe(op)))
 	}
 }
 
@@ -389,7 +389,7 @@ func AggregateIsNeverNullOnNonNullInput(op Operator) bool {
 		return false
 
 	default:
-		panic(errors.AssertionFailedf("unhandled op %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("unhandled op %s", redact.Safe(op)))
 	}
 }
 
@@ -439,7 +439,7 @@ func AggregatesCanMerge(inner, outer Operator) bool {
 		return false
 
 	default:
-		panic(errors.AssertionFailedf("unhandled ops: %s, %s", log.Safe(inner), log.Safe(outer)))
+		panic(errors.AssertionFailedf("unhandled ops: %s, %s", redact.Safe(inner), redact.Safe(outer)))
 	}
 }
 
@@ -461,7 +461,7 @@ func AggregateIgnoresDuplicates(op Operator) bool {
 		return false
 
 	default:
-		panic(errors.AssertionFailedf("unhandled op %s", log.Safe(op)))
+		panic(errors.AssertionFailedf("unhandled op %s", redact.Safe(op)))
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -80,8 +80,8 @@ go_library(
         "//pkg/util",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -32,8 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // buildScalar builds a set of memo groups that represent the given scalar
@@ -748,7 +748,7 @@ func (b *Builder) constructComparison(
 		}
 		return b.factory.ConstructOverlaps(left, right)
 	}
-	panic(errors.AssertionFailedf("unhandled comparison operator: %s", log.Safe(cmp.Operator)))
+	panic(errors.AssertionFailedf("unhandled comparison operator: %s", redact.Safe(cmp.Operator)))
 }
 
 func (b *Builder) constructBinary(
@@ -790,7 +790,7 @@ func (b *Builder) constructBinary(
 	case treebin.JSONFetchTextPath:
 		return b.factory.ConstructFetchTextPath(left, right)
 	}
-	panic(errors.AssertionFailedf("unhandled binary operator: %s", log.Safe(bin)))
+	panic(errors.AssertionFailedf("unhandled binary operator: %s", redact.Safe(bin)))
 }
 
 func (b *Builder) constructUnary(
@@ -808,7 +808,7 @@ func (b *Builder) constructUnary(
 	case tree.UnaryCbrt:
 		return b.factory.ConstructUnaryCbrt(input)
 	}
-	panic(errors.AssertionFailedf("unhandled unary operator: %s", log.Safe(un)))
+	panic(errors.AssertionFailedf("unhandled unary operator: %s", redact.Safe(un)))
 }
 
 // ScalarBuilder is a specialized variant of Builder that can be used to create

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // scope is used for the build process and maintains the variables that have
@@ -1431,7 +1431,7 @@ func analyzeWindowFrame(s *scope, windowDef *tree.WindowDef) error {
 			if !types.IsAdditiveType(requiredType) {
 				return pgerror.Newf(pgcode.Windowing,
 					"RANGE with offset PRECEDING/FOLLOWING is not supported for column type %s",
-					log.Safe(requiredType))
+					redact.Safe(requiredType))
 			}
 			if types.IsDateTimeType(requiredType) {
 				// Spec: for datetime ordering columns, the required type is an 'interval'.

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 )
 
 // sqlFnInfo stores information about a tree.SQLClass function, which is a
@@ -58,7 +58,7 @@ func (b *Builder) buildSQLFn(
 	for i := range exprs {
 		if !memo.CanExtractConstDatum(info.args[i]) {
 			panic(unimplemented.NewWithIssuef(49448, "non-constant argument passed to %s\n",
-				log.Safe(info.def.Name),
+				redact.Safe(info.def.Name),
 			))
 		}
 		exprs[i] = memo.ExtractConstDatum(info.args[i])

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -32,8 +32,8 @@ go_library(
         "//pkg/sql/opt/props",
         "//pkg/sql/sem/tree",
         "//pkg/util/buildutil",
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // CanProvide returns true if the given operator returns rows that can
@@ -343,7 +343,7 @@ func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.Col
 			equivCols := fds.ComputeEquivClosure(opt.MakeColSet(col))
 			remappedCol, ok := equivCols.Intersection(outCols).Next(0)
 			if !ok {
-				panic(errors.AssertionFailedf("no output column equivalent to %d", log.Safe(col)))
+				panic(errors.AssertionFailedf("no output column equivalent to %d", redact.Safe(col)))
 			}
 			if result == nil {
 				result = make(opt.Ordering, i, len(provided))
@@ -400,7 +400,7 @@ func checkRequired(expr memo.RelExpr, required *props.OrderingChoice) {
 
 	// Verify that the ordering only refers to output columns.
 	if !required.SubsetOfCols(rel.OutputCols) {
-		panic(errors.AssertionFailedf("required ordering refers to non-output columns (op %s)", log.Safe(expr.Op())))
+		panic(errors.AssertionFailedf("required ordering refers to non-output columns (op %s)", redact.Safe(expr.Op())))
 	}
 
 	// Verify that columns in a column group are equivalent.
@@ -448,7 +448,7 @@ func checkProvided(expr memo.RelExpr, required *props.OrderingChoice, provided o
 	fds := &expr.Relational().FuncDeps
 	if trimmed := trimProvided(provided, required, fds); len(trimmed) != len(provided) {
 		panic(errors.AssertionFailedf(
-			"provided %s can be trimmed to %s (FDs: %s)", log.Safe(provided), log.Safe(trimmed), log.Safe(fds),
+			"provided %s can be trimmed to %s (FDs: %s)", redact.Safe(provided), redact.Safe(trimmed), redact.Safe(fds),
 		))
 	}
 }

--- a/pkg/sql/opt/props/BUILD.bazel
+++ b/pkg/sql/opt/props/BUILD.bazel
@@ -27,9 +27,9 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
-        "//pkg/util/log",
         "//pkg/util/timetz",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_olekukonko_tablewriter//:tablewriter",
     ],
 )

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // FuncDepSet is a set of functional dependencies (FDs) that encode useful
@@ -1596,15 +1596,15 @@ func (f *FuncDepSet) Verify() {
 		fd := &f.deps[i]
 
 		if fd.from.Intersects(fd.to) {
-			panic(errors.AssertionFailedf("expected FD determinant and dependants to be disjoint: %s (%d)", log.Safe(f), log.Safe(i)))
+			panic(errors.AssertionFailedf("expected FD determinant and dependants to be disjoint: %s (%d)", redact.Safe(f), redact.Safe(i)))
 		}
 
 		if fd.isConstant() {
 			if i != 0 {
-				panic(errors.AssertionFailedf("expected constant FD to be first FD in set: %s (%d)", log.Safe(f), log.Safe(i)))
+				panic(errors.AssertionFailedf("expected constant FD to be first FD in set: %s (%d)", redact.Safe(f), redact.Safe(i)))
 			}
 			if !fd.strict {
-				panic(errors.AssertionFailedf("expected constant FD to be strict: %s", log.Safe(f)))
+				panic(errors.AssertionFailedf("expected constant FD to be strict: %s", redact.Safe(f)))
 			}
 		}
 
@@ -1614,11 +1614,11 @@ func (f *FuncDepSet) Verify() {
 			}
 
 			if fd.from.Len() != 1 {
-				panic(errors.AssertionFailedf("expected equivalence determinant to be single col: %s (%d)", log.Safe(f), log.Safe(i)))
+				panic(errors.AssertionFailedf("expected equivalence determinant to be single col: %s (%d)", redact.Safe(f), redact.Safe(i)))
 			}
 
 			if !f.ComputeEquivClosure(fd.from).Equals(fd.from.Union(fd.to)) {
-				panic(errors.AssertionFailedf("expected equivalence dependants to be its closure: %s (%d)", log.Safe(f), log.Safe(i)))
+				panic(errors.AssertionFailedf("expected equivalence dependants to be its closure: %s (%d)", redact.Safe(f), redact.Safe(i)))
 			}
 		}
 	}
@@ -1632,7 +1632,7 @@ func (f *FuncDepSet) Verify() {
 			allCols := f.ColSet()
 			allCols.UnionWith(f.key)
 			if !f.ComputeClosure(f.key).Equals(allCols) {
-				panic(errors.AssertionFailedf("expected closure of FD key to include all known cols: %s", log.Safe(f)))
+				panic(errors.AssertionFailedf("expected closure of FD key to include all known cols: %s", redact.Safe(f)))
 			}
 		}
 
@@ -1804,7 +1804,7 @@ func (f *FuncDepSet) addDependency(from, to opt.ColSet, strict, equiv bool) {
 	// Delegate constant dependency.
 	if from.Empty() {
 		if !strict {
-			panic(errors.AssertionFailedf("expected constant FD to be strict: %s", log.Safe(f)))
+			panic(errors.AssertionFailedf("expected constant FD to be strict: %s", redact.Safe(f)))
 		}
 		f.AddConstants(to)
 		return

--- a/pkg/sql/opt/props/verify.go
+++ b/pkg/sql/opt/props/verify.go
@@ -12,8 +12,8 @@ package props
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // Verify runs consistency checks against the shared properties, in order to
@@ -57,11 +57,11 @@ func (r *Relational) Verify() {
 
 	if !r.NotNullCols.SubsetOf(r.OutputCols) {
 		panic(errors.AssertionFailedf("not null cols %s not a subset of output cols %s",
-			log.Safe(r.NotNullCols), log.Safe(r.OutputCols)))
+			redact.Safe(r.NotNullCols), redact.Safe(r.OutputCols)))
 	}
 	if r.OuterCols.Intersects(r.OutputCols) {
 		panic(errors.AssertionFailedf("outer cols %s intersect output cols %s",
-			log.Safe(r.OuterCols), log.Safe(r.OutputCols)))
+			redact.Safe(r.OuterCols), redact.Safe(r.OutputCols)))
 	}
 	if r.FuncDeps.HasMax1Row() {
 		if r.Cardinality.Max > 1 {
@@ -72,7 +72,7 @@ func (r *Relational) Verify() {
 	if r.IsAvailable(PruneCols) {
 		if !r.Rule.PruneCols.SubsetOf(r.OutputCols) {
 			panic(errors.AssertionFailedf("prune cols %s must be a subset of output cols %s",
-				log.Safe(r.Rule.PruneCols), log.Safe(r.OutputCols)))
+				redact.Safe(r.Rule.PruneCols), redact.Safe(r.OutputCols)))
 		}
 	}
 }
@@ -86,12 +86,12 @@ func (r *Relational) VerifyAgainst(other *Relational) {
 	}
 
 	if !r.OutputCols.Equals(other.OutputCols) {
-		panic(errors.AssertionFailedf("output cols mismatch: %s vs %s", log.Safe(r.OutputCols), log.Safe(other.OutputCols)))
+		panic(errors.AssertionFailedf("output cols mismatch: %s vs %s", redact.Safe(r.OutputCols), redact.Safe(other.OutputCols)))
 	}
 
 	if r.Cardinality.Max < other.Cardinality.Min ||
 		r.Cardinality.Min > other.Cardinality.Max {
-		panic(errors.AssertionFailedf("cardinality mismatch: %s vs %s", log.Safe(r.Cardinality), log.Safe(other.Cardinality)))
+		panic(errors.AssertionFailedf("cardinality mismatch: %s vs %s", redact.Safe(r.Cardinality), redact.Safe(other.Cardinality)))
 	}
 
 	// NotNullCols, FuncDeps are best effort, so they might differ.

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_tools//container/intsets",
     ],
 )

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -23,8 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/tools/container/intsets"
 )
 
@@ -548,7 +548,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		// Optsteps uses MaxCost to suppress nodes in the memo. When a node with
 		// MaxCost is added to the memo, it can lead to an obscure crash with an
 		// unknown node. We'd rather detect this early.
-		panic(errors.AssertionFailedf("node %s with MaxCost added to the memo", log.Safe(candidate.Op())))
+		panic(errors.AssertionFailedf("node %s with MaxCost added to the memo", redact.Safe(candidate.Op())))
 	}
 
 	if c.perturbation != 0 {

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 	"github.com/lib/pq/oid"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -281,7 +282,7 @@ func (c *conn) serveImpl(
 	defer func() { _ = c.conn.Close() }()
 
 	if c.sessionArgs.User.IsRootUser() || c.sessionArgs.User.IsNodeUser() {
-		ctx = logtags.AddTag(ctx, "user", log.Safe(c.sessionArgs.User))
+		ctx = logtags.AddTag(ctx, "user", redact.Safe(c.sessionArgs.User))
 	} else {
 		ctx = logtags.AddTag(ctx, "user", c.sessionArgs.User)
 	}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 var queryCacheEnabled = settings.RegisterBoolSetting(
@@ -352,7 +353,7 @@ func (opc *optPlanningCtx) reset() {
 
 func (opc *optPlanningCtx) log(ctx context.Context, msg string) {
 	if log.VDepth(1, 1) {
-		log.InfofDepth(ctx, 1, "%s: %s", log.Safe(msg), opc.p.stmt)
+		log.InfofDepth(ctx, 1, "%s: %s", redact.Safe(msg), opc.p.stmt)
 	} else {
 		log.Event(ctx, msg)
 	}

--- a/pkg/sql/rowenc/BUILD.bazel
+++ b/pkg/sql/rowenc/BUILD.bazel
@@ -31,11 +31,11 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/json",
-        "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/unique",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -23,9 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // EncodingDirToDatumEncoding returns an equivalent descpb.DatumEncoding for the given
@@ -254,15 +254,15 @@ func (ed *EncDatum) EnsureDecoded(typ *types.T, a *tree.DatumAlloc) error {
 	case descpb.DatumEncoding_VALUE:
 		ed.Datum, rem, err = valueside.Decode(a, typ, ed.encoded)
 	default:
-		return errors.AssertionFailedf("unknown encoding %d", log.Safe(ed.encoding))
+		return errors.AssertionFailedf("unknown encoding %d", redact.Safe(ed.encoding))
 	}
 	if err != nil {
-		return errors.Wrapf(err, "error decoding %d bytes", log.Safe(len(ed.encoded)))
+		return errors.Wrapf(err, "error decoding %d bytes", redact.Safe(len(ed.encoded)))
 	}
 	if len(rem) != 0 {
 		ed.Datum = nil
 		return errors.AssertionFailedf(
-			"%d trailing bytes in encoded value: %+v", log.Safe(len(rem)), rem)
+			"%d trailing bytes in encoded value: %+v", redact.Safe(len(rem)), rem)
 	}
 	return nil
 }

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -269,7 +269,7 @@ func (d *distinct) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 				// Row is a duplicate input to an Upsert operation, so raise
 				// an error.
 				//
-				// TODO(knz): errorOnDup could be passed via log.Safe() if
+				// TODO(knz): errorOnDup could be passed via redact.Safe() if
 				// there was a guarantee that it does not contain PII. Or
 				// better yet, the caller would construct an `error` object to
 				// return here instead of a string.
@@ -319,7 +319,7 @@ func (d *sortedDistinct) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 		if matched {
 			if d.errorOnDup != "" {
 				// Row is a duplicate input to an Upsert operation, so raise an error.
-				// TODO(knz): errorOnDup could be passed via log.Safe() if
+				// TODO(knz): errorOnDup could be passed via redact.Safe() if
 				// there was a guarantee that it does not contain PII.
 				err = pgerror.Newf(pgcode.CardinalityViolation, "%s", d.errorOnDup)
 				d.MoveToDraining(err)

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -163,7 +163,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
-        "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pretty",
         "//pkg/util/ring",

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // Function names are used in expressions in the FuncExpr node.
@@ -67,7 +67,7 @@ func (fn *ResolvableFunctionReference) Resolve(
 func WrapFunction(n string) ResolvableFunctionReference {
 	fd, ok := FunDefs[n]
 	if !ok {
-		panic(errors.AssertionFailedf("function %s() not defined", log.Safe(n)))
+		panic(errors.AssertionFailedf("function %s() not defined", redact.Safe(n)))
 	}
 	return ResolvableFunctionReference{fd}
 }

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // IndexedVarContainer provides the implementation of TypeCheck, Eval, and
@@ -167,7 +167,7 @@ func (h *IndexedVarHelper) AppendSlot() int {
 func (h *IndexedVarHelper) checkIndex(idx int) {
 	if idx < 0 || idx >= len(h.vars) {
 		panic(errors.AssertionFailedf(
-			"invalid var index %d (columns: %d)", log.Safe(idx), log.Safe(len(h.vars))))
+			"invalid var index %d (columns: %d)", redact.Safe(idx), redact.Safe(len(h.vars))))
 	}
 }
 
@@ -245,17 +245,17 @@ var unboundContainer = &unboundContainerType{}
 
 // IndexedVarEval is part of the IndexedVarContainer interface.
 func (*unboundContainerType) IndexedVarEval(idx int, _ *EvalContext) (Datum, error) {
-	return nil, errors.AssertionFailedf("unbound ordinal reference @%d", log.Safe(idx+1))
+	return nil, errors.AssertionFailedf("unbound ordinal reference @%d", redact.Safe(idx+1))
 }
 
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
 func (*unboundContainerType) IndexedVarResolvedType(idx int) *types.T {
-	panic(errors.AssertionFailedf("unbound ordinal reference @%d", log.Safe(idx+1)))
+	panic(errors.AssertionFailedf("unbound ordinal reference @%d", redact.Safe(idx+1)))
 }
 
 // IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
 func (*unboundContainerType) IndexedVarNodeFormatter(idx int) NodeFormatter {
-	panic(errors.AssertionFailedf("unbound ordinal reference @%d", log.Safe(idx+1)))
+	panic(errors.AssertionFailedf("unbound ordinal reference @%d", redact.Safe(idx+1)))
 }
 
 type typeContainer struct {

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/lib/pq/oid"
 )
 
@@ -1068,7 +1068,7 @@ func checkReturn(
 			if des != nil && !typ.ResolvedType().Equivalent(des) {
 				return false, nil, nil, errors.AssertionFailedf(
 					"desired constant value type %s but set type %s",
-					log.Safe(des), log.Safe(typ.ResolvedType()),
+					redact.Safe(des), redact.Safe(typ.ResolvedType()),
 				)
 			}
 			s.typedExprs[i] = typ

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -26,8 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // SelectStatement represents any SELECT statement.
@@ -984,7 +984,7 @@ func (node *WindowFrameBound) Format(ctx *FmtCtx) {
 	case treewindow.UnboundedFollowing:
 		ctx.WriteString("UNBOUNDED FOLLOWING")
 	default:
-		panic(errors.AssertionFailedf("unhandled case: %d", log.Safe(node.BoundType)))
+		panic(errors.AssertionFailedf("unhandled case: %d", redact.Safe(node.BoundType)))
 	}
 }
 

--- a/pkg/sql/sem/tree/treewindow/BUILD.bazel
+++ b/pkg/sql/sem/tree/treewindow/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )

--- a/pkg/sql/sem/tree/treewindow/constants.go
+++ b/pkg/sql/sem/tree/treewindow/constants.go
@@ -11,8 +11,8 @@
 package treewindow
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // WindowFrameMode indicates which mode of framing is used.
@@ -133,7 +133,7 @@ func (node WindowFrameExclusion) String() string {
 	case ExcludeTies:
 		return "EXCLUDE TIES"
 	default:
-		panic(errors.AssertionFailedf("unhandled case: %d", log.Safe(node)))
+		panic(errors.AssertionFailedf("unhandled case: %d", redact.Safe(node)))
 	}
 }
 
@@ -163,6 +163,6 @@ func WindowModeName(mode WindowFrameMode) string {
 	case GROUPS:
 		return "GROUPS"
 	default:
-		panic(errors.AssertionFailedf("unhandled case: %d", log.Safe(mode)))
+		panic(errors.AssertionFailedf("unhandled case: %d", redact.Safe(mode)))
 	}
 }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -24,9 +24,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/text/language"
 )
 
@@ -795,7 +795,7 @@ func (expr *CoalesceExpr) TypeCheck(
 ) (TypedExpr, error) {
 	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Exprs...)
 	if err != nil {
-		return nil, decorateTypeCheckError(err, "incompatible %s expressions", log.Safe(expr.Name))
+		return nil, decorateTypeCheckError(err, "incompatible %s expressions", redact.Safe(expr.Name))
 	}
 
 	for i, subExpr := range typedSubExprs {

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -19,8 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // IndexedRows are rows with the corresponding indices.
@@ -212,7 +212,7 @@ func (wfr *WindowFrameRun) FrameStartIdx(ctx context.Context, evalCtx *EvalConte
 		default:
 			return 0, errors.AssertionFailedf(
 				"unexpected WindowFrameBoundType in RANGE mode: %d",
-				log.Safe(wfr.Frame.Bounds.StartBound.BoundType))
+				redact.Safe(wfr.Frame.Bounds.StartBound.BoundType))
 		}
 	case treewindow.ROWS:
 		switch wfr.Frame.Bounds.StartBound.BoundType {
@@ -239,7 +239,7 @@ func (wfr *WindowFrameRun) FrameStartIdx(ctx context.Context, evalCtx *EvalConte
 		default:
 			return 0, errors.AssertionFailedf(
 				"unexpected WindowFrameBoundType in ROWS mode: %d",
-				log.Safe(wfr.Frame.Bounds.StartBound.BoundType))
+				redact.Safe(wfr.Frame.Bounds.StartBound.BoundType))
 		}
 	case treewindow.GROUPS:
 		switch wfr.Frame.Bounds.StartBound.BoundType {
@@ -268,7 +268,7 @@ func (wfr *WindowFrameRun) FrameStartIdx(ctx context.Context, evalCtx *EvalConte
 		default:
 			return 0, errors.AssertionFailedf(
 				"unexpected WindowFrameBoundType in GROUPS mode: %d",
-				log.Safe(wfr.Frame.Bounds.StartBound.BoundType))
+				redact.Safe(wfr.Frame.Bounds.StartBound.BoundType))
 		}
 	default:
 		return 0, errors.AssertionFailedf("unexpected WindowFrameMode: %d", wfr.Frame.Mode)
@@ -406,7 +406,7 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 		default:
 			return 0, errors.AssertionFailedf(
 				"unexpected WindowFrameBoundType in RANGE mode: %d",
-				log.Safe(wfr.Frame.Bounds.EndBound.BoundType))
+				redact.Safe(wfr.Frame.Bounds.EndBound.BoundType))
 		}
 	case treewindow.ROWS:
 		if wfr.Frame.Bounds.EndBound == nil {
@@ -437,7 +437,7 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 		default:
 			return 0, errors.AssertionFailedf(
 				"unexpected WindowFrameBoundType in ROWS mode: %d",
-				log.Safe(wfr.Frame.Bounds.EndBound.BoundType))
+				redact.Safe(wfr.Frame.Bounds.EndBound.BoundType))
 		}
 	case treewindow.GROUPS:
 		if wfr.Frame.Bounds.EndBound == nil {
@@ -471,11 +471,11 @@ func (wfr *WindowFrameRun) FrameEndIdx(ctx context.Context, evalCtx *EvalContext
 		default:
 			return 0, errors.AssertionFailedf(
 				"unexpected WindowFrameBoundType in GROUPS mode: %d",
-				log.Safe(wfr.Frame.Bounds.EndBound.BoundType))
+				redact.Safe(wfr.Frame.Bounds.EndBound.BoundType))
 		}
 	default:
 		return 0, errors.AssertionFailedf(
-			"unexpected WindowFrameMode: %d", log.Safe(wfr.Frame.Mode))
+			"unexpected WindowFrameMode: %d", redact.Safe(wfr.Frame.Mode))
 	}
 }
 

--- a/pkg/util/hlc/BUILD.bazel
+++ b/pkg/util/hlc/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // TODO(Tobias): Figure out if it would make sense to save some
@@ -339,8 +340,8 @@ func (c *Clock) checkPhysicalClock(ctx context.Context, oldTime, newTime int64) 
 			log.Fatalf(
 				ctx,
 				"detected forward time jump of %f seconds is not allowed with tolerance of %f seconds",
-				log.Safe(float64(-interval)/1e9),
-				log.Safe(float64(toleratedForwardClockJump)/1e9),
+				redact.Safe(float64(-interval)/1e9),
+				redact.Safe(float64(toleratedForwardClockJump)/1e9),
 			)
 		}
 	}
@@ -384,8 +385,8 @@ func (c *Clock) enforceWallTimeWithinBoundLocked() {
 		log.Fatalf(
 			context.TODO(),
 			"wall time %d is not allowed to be greater than upper bound of %d.",
-			log.Safe(c.mu.timestamp.WallTime),
-			log.Safe(c.mu.wallTimeUpperBound),
+			redact.Safe(c.mu.timestamp.WallTime),
+			redact.Safe(c.mu.wallTimeUpperBound),
 		)
 	}
 }

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -276,15 +276,15 @@ func (l *sinkInfo) getStartLines(now time.Time) []*buffer {
 	f := l.formatter
 	messages := make([]*buffer, 0, 6)
 	messages = append(messages,
-		makeStartLine(f, "file created at: %s", Safe(now.Format("2006/01/02 15:04:05"))),
+		makeStartLine(f, "file created at: %s", redact.Safe(now.Format("2006/01/02 15:04:05"))),
 		makeStartLine(f, "running on machine: %s", fullHostName),
-		makeStartLine(f, "binary: %s", Safe(build.GetInfo().Short())),
+		makeStartLine(f, "binary: %s", redact.Safe(build.GetInfo().Short())),
 		makeStartLine(f, "arguments: %s", os.Args),
 	)
 
 	// Including a non-ascii character in the first 1024 bytes of the log helps
 	// viewers that attempt to guess the character encoding.
-	messages = append(messages, makeStartLine(f, "log format (utf8=\u2713): %s", Safe(f.formatterName())))
+	messages = append(messages, makeStartLine(f, "log format (utf8=\u2713): %s", redact.Safe(f.formatterName())))
 
 	if strings.HasPrefix(f.formatterName(), "crdb-") {
 		// For the crdb file formats, suggest the structure of each log line.

--- a/pkg/util/log/logcrash/BUILD.bazel
+++ b/pkg/util/log/logcrash/BUILD.bazel
@@ -37,7 +37,6 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/util",
         "//pkg/util/leaktest",
-        "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/util/log/logcrash/crash_reporting_packet_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_packet_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/redact"
 	sentry "github.com/getsentry/sentry-go"
@@ -93,7 +92,7 @@ func TestCrashReportingPacket(t *testing.T) {
 	func() {
 		defer expectPanic("before server start")
 		defer logcrash.RecoverAndReportPanic(ctx, &st.SV)
-		panic(log.Safe(panicPre))
+		panic(redact.Safe(panicPre))
 	}()
 
 	func() {
@@ -101,7 +100,7 @@ func TestCrashReportingPacket(t *testing.T) {
 		defer logcrash.RecoverAndReportPanic(ctx, &st.SV)
 		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 		s.Stopper().Stop(ctx)
-		panic(log.Safe(panicPost))
+		panic(redact.Safe(panicPost))
 	}()
 
 	const prefix = "crash_reporting_packet_test.go:"

--- a/pkg/util/log/logcrash/crash_reporting_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -131,7 +130,7 @@ Wraps: (2) interface conversion: interface {} is nil, not int
 Error types: (1) *safedetails.withSafeDetails (2) *runtime.TypeAssertionError`,
 		},
 		{
-			err: errors.Newf("I like %s and my pin code is %v or %v", log.Safe("A"), "1234", log.Safe("9999")),
+			err: errors.Newf("I like %s and my pin code is %v or %v", redact.Safe("A"), "1234", redact.Safe("9999")),
 			expErr: `I like A and my pin code is ` + rm + ` or 9999
 (1) attached stack trace
   -- stack trace:
@@ -151,7 +150,7 @@ Wraps: (2) I like A and my pin code is ` + rm + ` or 9999
 Error types: (1) *withstack.withStack (2) *errutil.leafError`,
 		},
 		{
-			err: errors.Wrapf(context.Canceled, "this is preserved: %d", log.Safe(6)),
+			err: errors.Wrapf(context.Canceled, "this is preserved: %d", redact.Safe(6)),
 			expErr: `this is preserved: 6: context canceled
 (1) attached stack trace
   -- stack trace:

--- a/pkg/util/log/redact.go
+++ b/pkg/util/log/redact.go
@@ -138,11 +138,6 @@ func maybeRedactEntry(payload entryPayload, editor redactEditor) (res entryPaylo
 	return res
 }
 
-// Safe constructs a SafeFormatter / SafeMessager.
-// This is obsolete. Use redact.Safe directly.
-// TODO(knz): Remove this.
-var Safe = redact.Safe
-
 func init() {
 	// We consider booleans and numeric values to be always safe for
 	// reporting. A log call can opt out by using redact.Unsafe() around

--- a/pkg/util/mon/BUILD.bazel
+++ b/pkg/util/mon/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // BoundAccount and BytesMonitor together form the mechanism by which
@@ -423,7 +424,7 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 		logcrash.ReportOrPanic(
 			ctx, &mm.settings.SV,
 			"%s: unexpected %d leftover bytes",
-			log.Safe(mm.name), log.Safe(mm.mu.curAllocated))
+			redact.Safe(mm.name), redact.Safe(mm.mu.curAllocated))
 		mm.releaseBytes(ctx, mm.mu.curAllocated)
 	}
 

--- a/pkg/util/quotapool/BUILD.bazel
+++ b/pkg/util/quotapool/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/quotapool/config.go
+++ b/pkg/util/quotapool/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/redact"
 )
 
 // Option is used to configure a quotapool.
@@ -72,10 +73,10 @@ func OnSlowAcquisition(threshold time.Duration, f SlowAcquisitionFunc) Option {
 // LogSlowAcquisition is a SlowAcquisitionFunc.
 func LogSlowAcquisition(ctx context.Context, poolName string, r Request, start time.Time) func() {
 	log.Warningf(ctx, "have been waiting %s attempting to acquire %s quota",
-		timeutil.Since(start), log.Safe(poolName))
+		timeutil.Since(start), redact.Safe(poolName))
 	return func() {
 		log.Infof(ctx, "acquired %s quota after %s",
-			log.Safe(poolName), timeutil.Since(start))
+			redact.Safe(poolName), timeutil.Since(start))
 	}
 }
 


### PR DESCRIPTION
My desire to make this change is to break the dependency of `treewindow`
on `util/log` (which is a part of the effort to clean up the
dependencies of `execgen`).

Addresses: #77234.

Release note: None

Release justification: low risk change to clean up the dependencies
a bit.