### PR TITLE
roachpb: extract keysbase to break some dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -220,6 +220,7 @@
 /pkg/internal/team/          @cockroachdb/test-eng
 /pkg/jobs/                   @cockroachdb/cdc-prs
 /pkg/keys/                   @cockroachdb/kv-prs
+/pkg/keysbase/               @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
 /pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
 /pkg/migration/              @cockroachdb/kv-prs-noreview @cockroachdb/sql-schema

--- a/pkg/keysbase/BUILD.bazel
+++ b/pkg/keysbase/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "keysbase",
+    srcs = ["data.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/keysbase",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/keysbase/data.go
+++ b/pkg/keysbase/data.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keysbase
+
+// KeyMax is a maximum key value which sorts after all other keys.
+var KeyMax = []byte{0xff, 0xff}
+
+// PrefixEnd determines the end key given b as a prefix, that is the key that
+// sorts precisely behind all keys starting with prefix: "1" is added to the
+// final byte and the carry propagated. The special cases of nil and KeyMin
+// always returns KeyMax.
+func PrefixEnd(b []byte) []byte {
+	if len(b) == 0 {
+		return KeyMax
+	}
+	// Switched to "make and copy" pattern in #4963 for performance.
+	end := make([]byte, len(b))
+	copy(end, b)
+	for i := len(end) - 1; i >= 0; i-- {
+		end[i] = end[i] + 1
+		if end[i] != 0 {
+			return end[:i+1]
+		}
+	}
+	// This statement will only be reached if the key is already a maximal byte
+	// string (i.e. already \xff...).
+	return b
+}

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geopb",
+        "//pkg/keysbase",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/storage/enginepb",
         "//pkg/util",

--- a/pkg/sql/inverted/BUILD.bazel
+++ b/pkg/sql/inverted/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/inverted",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/roachpb",
+        "//pkg/keysbase",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
     ],
@@ -18,11 +18,15 @@ go_library(
 go_test(
     name = "inverted_test",
     size = "small",
-    srcs = ["expression_test.go"],
+    srcs = [
+        "dep_test.go",
+        "expression_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":inverted"],
     deps = [
         "//pkg/testutils",
+        "//pkg/testutils/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/leaktest",
         "//pkg/util/treeprinter",

--- a/pkg/sql/inverted/dep_test.go
+++ b/pkg/sql/inverted/dep_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package inverted
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/sql/inverted", true,
+		[]string{
+			"github.com/cockroachdb/cockroach/pkg/roachpb",
+		}, nil,
+	)
+}

--- a/pkg/sql/inverted/expression.go
+++ b/pkg/sql/inverted/expression.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/keysbase"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/cockroachdb/errors"
 )
@@ -100,13 +100,13 @@ type Span struct {
 
 // MakeSingleValSpan constructs a span equivalent to [val, val].
 func MakeSingleValSpan(val EncVal) Span {
-	end := EncVal(roachpb.Key(val).PrefixEnd())
+	end := EncVal(keysbase.PrefixEnd(val))
 	return Span{Start: val, End: end}
 }
 
 // IsSingleVal returns true iff the span is equivalent to [val, val].
 func (s Span) IsSingleVal() bool {
-	return bytes.Equal(roachpb.Key(s.Start).PrefixEnd(), s.End)
+	return bytes.Equal(keysbase.PrefixEnd(s.Start), s.End)
 }
 
 // Equals returns true if this span has the same start and end as the given

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -18,7 +18,7 @@ go_library(
     deps = [
         "//pkg/geo",
         "//pkg/geo/geopb",
-        "//pkg/roachpb",
+        "//pkg/keysbase",
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
@@ -34,6 +34,7 @@ go_test(
     name = "json_test",
     size = "small",
     srcs = [
+        "dep_test.go",
         "encode_test.go",
         "json_test.go",
     ],
@@ -43,6 +44,7 @@ go_test(
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/testutils",
+        "//pkg/testutils/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",

--- a/pkg/util/json/dep_test.go
+++ b/pkg/util/json/dep_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package json
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+)
+
+func TestNoLinkForbidden(t *testing.T) {
+	buildutil.VerifyNoImports(t,
+		"github.com/cockroachdb/cockroach/pkg/util/json", true,
+		[]string{
+			"github.com/cockroachdb/cockroach/pkg/roachpb",
+		}, nil,
+	)
+}

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/keysbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1341,7 +1341,7 @@ func encodeContainingInvertedIndexSpansFromLeaf(
 			// for JSON objects.
 			Start: inverted.EncVal(encoding.EncodeJSONObjectSpanStartAscending(prefix)),
 			// This end key is equal to jsonInvertedIndex + 1.
-			End: inverted.EncVal(roachpb.Key(prefix).PrefixEnd()),
+			End: inverted.EncVal(keysbase.PrefixEnd(prefix)),
 		}, true /* tight */))
 
 	default:


### PR DESCRIPTION
This commit extracts a couple of things out of `roachpb` into new
`keysbase` package in order to break the dependency of `util/json` and
`sql/inverted` on `roachpb` (which is a part of the effort to clean up
the dependencies of `execgen`).

Addresses: #77234.

Release note: None

Release justification: low risk change to clean up the dependencies.