### PR TITLE
kvserver: downgrade & augment "slow raft ready" message

### DIFF
--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -519,7 +519,7 @@ func (s *Store) processReady(rangeID roachpb.RangeID) {
 	// processing time means we'll have starved local replicas of ticks and
 	// remote replicas will likely start campaigning.
 	if elapsed >= defaultReplicaRaftMuWarnThreshold {
-		log.Warningf(ctx, "handle raft ready: %.1fs [applied=%d, batches=%d, state_assertions=%d]",
+		log.Infof(ctx, "handle raft ready: %.1fs [applied=%d, batches=%d, state_assertions=%d]; node might be overloaded",
 			elapsed.Seconds(), stats.entriesProcessed, stats.batchesProcessed, stats.stateAssertions)
 	}
 }


### PR DESCRIPTION
It doesn't rise up to the level of a `Warning`, rather, it is
informational. While I was here, I also added to the message
that seeing it could indicate that the node (or storage) is
overloaded.

Triggered by an internal question[^1] about this message.

[^1]: https://cockroachlabs.slack.com/archives/CHKQGKYEM/p1646245983917929

Release justification: low-risk logging improvement.
Release note: None
