### PR TITLE
roachtest: log stdout and stderr in sstable corruption test

### DIFF
--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -55,7 +55,7 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(node),
 			"./cockroach debug pebble manifest dump {store-dir}/MANIFEST-* | grep -v added | grep -v deleted | grep \"\\[/Table\"")
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("could not find tables to corrupt: %s\nstdout: %s\nstderr: %s", err, result.Stdout, result.Stderr)
 		}
 		tableSSTs := strings.Split(result.Stdout, "\n")
 		if len(tableSSTs) == 0 {


### PR DESCRIPTION
To aid in debugging #77321, log the contents stdout and stderr if the
manifest dump command fails.

Release justification: Tests only.

Release note: None.