### PR TITLE
kvserver: self delegated snapshots

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -52,6 +52,7 @@
 <tr><td><code>kv.replica_circuit_breaker.slow_replication_threshold</code></td><td>duration</td><td><code>1m0s</code></td><td>duration after which slow proposals trip the per-Replica circuit breaker (zero duration disables breakers)</td></tr>
 <tr><td><code>kv.replica_stats.addsst_request_size_factor</code></td><td>integer</td><td><code>50000</code></td><td>the divisor that is applied to addsstable request sizes, then recorded in a leaseholders QPS; 0 means all requests are treated as cost 1</td></tr>
 <tr><td><code>kv.replication_reports.interval</code></td><td>duration</td><td><code>1m0s</code></td><td>the frequency for generating the replication_constraint_stats, replication_stats_report and replication_critical_localities reports (set to 0 to disable)</td></tr>
+<tr><td><code>kv.snapshot_delegation.enabled</code></td><td>boolean</td><td><code>false</code></td><td>set to true to allow snapshots from follower replicas</td></tr>
 <tr><td><code>kv.snapshot_rebalance.max_rate</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the rate limit (bytes/sec) to use for rebalance and upreplication snapshots</td></tr>
 <tr><td><code>kv.snapshot_recovery.max_rate</code></td><td>byte size</td><td><code>32 MiB</code></td><td>the rate limit (bytes/sec) to use for recovery snapshots</td></tr>
 <tr><td><code>kv.transaction.max_intents_bytes</code></td><td>integer</td><td><code>4194304</code></td><td>maximum number of bytes used to track locks in transactions</td></tr>

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/etcd/raft/v3"
 )
@@ -178,6 +179,19 @@ func (h *testClusterStoreRaftMessageHandler) HandleSnapshot(
 		return err
 	}
 	return store.HandleSnapshot(ctx, header, respStream)
+}
+
+func (h *testClusterStoreRaftMessageHandler) HandleDelegatedSnapshot(
+	ctx context.Context,
+	req *kvserverpb.DelegateSnapshotRequest,
+	stream kvserver.DelegateSnapshotResponseStream,
+	span *tracing.Span,
+) error {
+	store, err := h.getStore()
+	if err != nil {
+		return err
+	}
+	return store.HandleDelegatedSnapshot(ctx, req, stream, span)
 }
 
 // testClusterPartitionedRange is a convenient abstraction to create a range on a node

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
@@ -3448,6 +3449,15 @@ func (d errorChannelTestHandler) HandleRaftResponse(
 
 func (errorChannelTestHandler) HandleSnapshot(
 	_ context.Context, _ *kvserverpb.SnapshotRequest_Header, _ kvserver.SnapshotResponseStream,
+) error {
+	panic("unimplemented")
+}
+
+func (errorChannelTestHandler) HandleDelegatedSnapshot(
+	ctx context.Context,
+	req *kvserverpb.DelegateSnapshotRequest,
+	stream kvserver.DelegateSnapshotResponseStream,
+	span *tracing.Span,
 ) error {
 	panic("unimplemented")
 }

--- a/pkg/kv/kvserver/kvserverpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverpb/BUILD.bazel
@@ -36,6 +36,7 @@ proto_library(
         "//pkg/roachpb:roachpb_proto",
         "//pkg/storage/enginepb:enginepb_proto",
         "//pkg/util/hlc:hlc_proto",
+        "//pkg/util/tracing/tracingpb:tracingpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@io_etcd_go_etcd_raft_v3//raftpb:raftpb_proto",
@@ -55,6 +56,7 @@ go_proto_library(
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
+        "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
         "@io_etcd_go_etcd_raft_v3//raftpb",

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -13,11 +13,13 @@ package cockroach.kv.kvserver.kvserverpb;
 option go_package = "kvserverpb";
 
 import "roachpb/errors.proto";
+import "roachpb/internal_raft.proto";
 import "roachpb/metadata.proto";
 import "kv/kvserver/liveness/livenesspb/liveness.proto";
 import "kv/kvserver/kvserverpb/state.proto";
 import "etcd/raft/v3/raftpb/raft.proto";
 import "gogoproto/gogo.proto";
+import "util/tracing/tracingpb/recorded_span.proto";
 
 // RaftHeartbeat is a request that contains the barebones information for a
 // raftpb.MsgHeartbeat raftpb.Message. RaftHeartbeats are coalesced and sent
@@ -212,6 +214,42 @@ message SnapshotResponse {
   Status status = 1;
   string message = 2;
   reserved 3;
+}
+
+// DelegateSnapshotRequest is the request used to delegate send snapshot requests.
+message DelegateSnapshotRequest {
+  uint64 range_id = 1 [(gogoproto.customname) = "RangeID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+
+  // The replica that delegates the snapshot request, in most cases the leader/leaseholder.
+  // The snapshot request should originate from the coordinator.
+  roachpb.ReplicaDescriptor coordinator_replica = 2 [(gogoproto.nullable) = false];
+
+  // The replica receiving the snapshot.
+  roachpb.ReplicaDescriptor recipient_replica = 3 [(gogoproto.nullable) = false];
+
+  // The replica selected to act as the snapshot sender.
+  roachpb.ReplicaDescriptor delegated_sender = 4 [(gogoproto.nullable) = false];
+
+  // The priority of the snapshot.
+  SnapshotRequest.Priority priority = 5;
+
+  // The type of the snapshot.
+  SnapshotRequest.Type type = 6;
+
+  // The Raft term of the coordinator (in most cases the leaseholder) replica.
+  // The term is used during snapshot receiving to reject messages from an older term.
+  uint64 term = 7;
+
+  // The truncated state of the Raft log on the coordinator replica.
+  roachpb.RaftTruncatedState truncated_state = 8;
+}
+
+message DelegateSnapshotResponse {
+  SnapshotResponse snapResponse = 1;
+  // collected_spans stores trace spans recorded during the execution of this
+  // request.
+  repeated util.tracing.tracingpb.RecordedSpan collected_spans = 2 [(gogoproto.nullable) = false];
 }
 
 // ConfChangeContext is encoded in the raftpb.ConfChange.Context field.

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -96,6 +96,15 @@ func (s channelServer) HandleSnapshot(
 	panic("unexpected HandleSnapshot")
 }
 
+func (s channelServer) HandleDelegatedSnapshot(
+	ctx context.Context,
+	req *kvserverpb.DelegateSnapshotRequest,
+	stream kvserver.DelegateSnapshotResponseStream,
+	span *tracing.Span,
+) error {
+	panic("unimplemented")
+}
+
 // raftTransportTestContext contains objects needed to test RaftTransport.
 // Typical usage will add multiple nodes with AddNode, attach channels
 // to at least one store with ListenStore, and send messages with Send.

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -2446,6 +2447,15 @@ func recordRangeEventsInLog(
 	return nil
 }
 
+// getSenderReplica returns a replica descriptor for a follower replica to act as
+// the sender for snapshots.
+// TODO(amy): select a follower based on locality matching.
+func (r *Replica) getSenderReplica(ctx context.Context) (roachpb.ReplicaDescriptor, error) {
+	log.Fatal(ctx, "follower snapshots not implemented")
+	return r.GetReplicaDescriptor()
+}
+
+// TODO(amy): update description when patch for follower snapshots are completed.
 // sendSnapshot sends a snapshot of the replica state to the specified replica.
 // Currently only invoked from replicateQueue and raftSnapshotQueue. Be careful
 // about adding additional calls as generating a snapshot is moderately
@@ -2569,6 +2579,102 @@ func (r *Replica) sendSnapshot(
 		r.reportSnapshotStatus(ctx, recipient.ReplicaID, retErr)
 	}()
 
+	sender, err := r.GetReplicaDescriptor()
+	if err != nil {
+		return err
+	}
+	// Check follower snapshots cluster setting.
+	if followerSnapshotsEnabled.Get(&r.ClusterSettings().SV) {
+		sender, err = r.getSenderReplica(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.VEventf(
+		ctx, 2, "delegating snapshot transmission for %v to %v", recipient, sender,
+	)
+	desc, err := r.GetReplicaDescriptor()
+	if err != nil {
+		return err
+	}
+	status := r.RaftStatus()
+	if status == nil {
+		// This code path is sometimes hit during scatter for replicas that
+		// haven't woken up yet.
+		return &benignError{errors.Wrap(errMarkSnapshotError, "raft status not initialized")}
+	}
+
+	// Create new delegate snapshot request with only required metadata.
+	delegateRequest := &kvserverpb.DelegateSnapshotRequest{
+		RangeID:            r.RangeID,
+		CoordinatorReplica: desc,
+		RecipientReplica:   recipient,
+		Priority:           priority,
+		Type:               snapType,
+		Term:               status.Term,
+		DelegatedSender:    sender,
+	}
+	err = contextutil.RunWithTimeout(
+		ctx, "delegate-snapshot", sendSnapshotTimeout, func(ctx context.Context) error {
+			return r.store.cfg.Transport.DelegateSnapshot(
+				ctx,
+				delegateRequest,
+			)
+		},
+	)
+
+	if err != nil {
+		return errors.Mark(err, errMarkSnapshotError)
+	}
+	return nil
+}
+
+// followerSnapshotsEnabled is used to enable or disable follower snapshots.
+var followerSnapshotsEnabled = func() *settings.BoolSetting {
+	s := settings.RegisterBoolSetting(
+		settings.SystemOnly,
+		"kv.snapshot_delegation.enabled",
+		"set to true to allow snapshots from follower replicas",
+		false,
+	)
+	s.SetVisibility(settings.Public)
+	return s
+}()
+
+// followerSendSnapshot receives a delegate snapshot request and generates the
+// snapshot from this replica. The entire process of generating and transmitting
+// the snapshot is handled, and errors are propagated back to the leaseholder.
+func (r *Replica) followerSendSnapshot(
+	ctx context.Context,
+	recipient roachpb.ReplicaDescriptor,
+	req *kvserverpb.DelegateSnapshotRequest,
+	stream DelegateSnapshotResponseStream,
+) (retErr error) {
+	ctx = r.AnnotateCtx(ctx)
+
+	// TODO(amy): when delegating to different senders, check raft applied state
+	// to determine if this follower replica is fit to send.
+	// Acknowledge that the request has been accepted.
+	if err := stream.Send(
+		&kvserverpb.DelegateSnapshotResponse{
+			SnapResponse: &kvserverpb.SnapshotResponse{
+				Status: kvserverpb.SnapshotResponse_ACCEPTED,
+			},
+		},
+	); err != nil {
+		return err
+	}
+
+	// Throttle snapshot sending.
+	rangeSize := r.GetMVCCStats().Total()
+	cleanup, err := r.store.reserveSendSnapshot(ctx, req, rangeSize)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	snapType := req.Type
 	snap, err := r.GetSnapshot(ctx, snapType, recipient.StoreID)
 	if err != nil {
 		err = errors.Wrapf(err, "%s: failed to generate %s snapshot", r, snapType)
@@ -2583,21 +2689,11 @@ func (r *Replica) sendSnapshot(
 	// the leaseholder and we haven't yet applied the configuration change that's
 	// adding the recipient to the range.
 	if _, ok := snap.State.Desc.GetReplicaDescriptor(recipient.StoreID); !ok {
-		return errors.Wrapf(errMarkSnapshotError,
+		return errors.Wrapf(
+			errMarkSnapshotError,
 			"attempting to send snapshot that does not contain the recipient as a replica; "+
-				"snapshot type: %s, recipient: s%d, desc: %s", snapType, recipient, snap.State.Desc)
-	}
-
-	sender, err := r.GetReplicaDescriptor()
-	if err != nil {
-		return errors.Wrapf(err, "%s: change replicas failed", r)
-	}
-
-	status := r.RaftStatus()
-	if status == nil {
-		// This code path is sometimes hit during scatter for replicas that
-		// haven't woken up yet.
-		return &benignError{errors.Wrap(errMarkSnapshotError, "raft status not initialized")}
+				"snapshot type: %s, recipient: s%d, desc: %s", snapType, recipient, snap.State.Desc,
+		)
 	}
 
 	// We avoid shipping over the past Raft log in the snapshot by changing
@@ -2615,25 +2711,26 @@ func (r *Replica) sendSnapshot(
 	// explicitly for snapshots going out to followers.
 	snap.State.DeprecatedUsingAppliedStateKey = true
 
-	req := kvserverpb.SnapshotRequest_Header{
+	// Create new snapshot request header using the delegate snapshot request.
+	header := kvserverpb.SnapshotRequest_Header{
 		State:                                snap.State,
 		DeprecatedUnreplicatedTruncatedState: true,
 		RaftMessageRequest: kvserverpb.RaftMessageRequest{
-			RangeID:     r.RangeID,
-			FromReplica: sender,
-			ToReplica:   recipient,
+			RangeID:     req.RangeID,
+			FromReplica: req.CoordinatorReplica,
+			ToReplica:   req.RecipientReplica,
 			Message: raftpb.Message{
 				Type:     raftpb.MsgSnap,
-				To:       uint64(recipient.ReplicaID),
-				From:     uint64(sender.ReplicaID),
-				Term:     status.Term,
+				From:     uint64(req.CoordinatorReplica.ReplicaID),
+				To:       uint64(req.RecipientReplica.ReplicaID),
+				Term:     req.Term,
 				Snapshot: snap.RaftSnap,
 			},
 		},
-		RangeSize: r.GetMVCCStats().Total(),
-		Priority:  priority,
+		RangeSize: rangeSize,
+		Priority:  req.Priority,
 		Strategy:  kvserverpb.SnapshotRequest_KV_BATCH,
-		Type:      snapType,
+		Type:      req.Type,
 	}
 	newBatchFn := func() storage.Batch {
 		return r.store.Engine().NewUnindexedBatch(true /* writeOnly */)
@@ -2641,18 +2738,20 @@ func (r *Replica) sendSnapshot(
 	sent := func() {
 		r.store.metrics.RangeSnapshotsGenerated.Inc(1)
 	}
+
 	err = contextutil.RunWithTimeout(
 		ctx, "send-snapshot", sendSnapshotTimeout, func(ctx context.Context) error {
 			return r.store.cfg.Transport.SendSnapshot(
 				ctx,
 				r.store.cfg.StorePool,
-				req,
+				header,
 				snap,
 				newBatchFn,
 				sent,
 				r.store.metrics.RangeSnapshotSentBytes,
 			)
-		})
+		},
+	)
 	if err != nil {
 		if errors.Is(err, errMalformedSnapshot) {
 			tag := fmt.Sprintf("r%d_%s", r.RangeID, snap.SnapUUID.Short())

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -224,6 +224,110 @@ func TestAddRemoveNonVotingReplicasBasic(t *testing.T) {
 	require.Len(t, desc.Replicas().NonVoterDescriptors(), 0)
 }
 
+// TestAddReplicaWithReceiverThrottling tests that outgoing snapshots on the
+// delegated sender will throttle if incoming snapshots on the recipients are
+// blocked.
+func TestAddReplicaWithReceiverThrottling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// blockIncomingSnapshots will block receiving snapshots.
+	blockIncomingSnapshots := make(chan struct{})
+	waitForRebalanceToBlockCh := make(chan struct{})
+	activateBlocking := int64(1)
+	var count int64
+	knobs, ltk := makeReplicationTestKnobs()
+	ltk.storeKnobs.ReceiveSnapshot = func(h *kvserverpb.SnapshotRequest_Header) error {
+		if atomic.LoadInt64(&activateBlocking) > 0 {
+			// Signal waitForRebalanceToBlockCh to indicate the testing knob was hit.
+			close(waitForRebalanceToBlockCh)
+			blockIncomingSnapshots <- struct{}{}
+		}
+		return nil
+	}
+	ltk.storeKnobs.ThrottleEmptySnapshots = true
+	ltk.storeKnobs.BeforeSendSnapshotThrottle = func() {
+		atomic.AddInt64(&count, 1)
+	}
+	ltk.storeKnobs.AfterSendSnapshotThrottle = func() {
+		atomic.AddInt64(&count, -1)
+	}
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(
+		t, 3, base.TestClusterArgs{
+			ServerArgs:      base.TestServerArgs{Knobs: knobs},
+			ReplicationMode: base.ReplicationManual,
+		},
+	)
+
+	defer tc.Stopper().Stop(ctx)
+	scratch := tc.ScratchRange(t)
+	replicationChange := make(chan error, 2)
+	g := ctxgroup.WithContext(ctx)
+
+	// Add a non-voter to the range and expect it to block on blockIncomingSnapshots.
+	g.GoCtx(
+		func(ctx context.Context) error {
+			desc, err := tc.LookupRange(scratch)
+			if err != nil {
+				return err
+			}
+			_, err = tc.Servers[0].DB().AdminChangeReplicas(ctx, scratch, desc,
+				roachpb.MakeReplicationChanges(roachpb.ADD_NON_VOTER, tc.Target(2)),
+			)
+			replicationChange <- err
+			return err
+		},
+	)
+
+	select {
+	case <-waitForRebalanceToBlockCh:
+		// First replication change has hit the testing knob, continue with adding
+		// second voter.
+	case <-replicationChange:
+		t.Fatal("did not expect the replication change to complete")
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for rebalance to block")
+	}
+
+	g.GoCtx(
+		func(ctx context.Context) error {
+			desc, err := tc.LookupRange(scratch)
+			if err != nil {
+				return err
+			}
+			_, err = tc.Servers[0].DB().AdminChangeReplicas(
+				ctx, scratch, desc, roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(1)),
+			)
+			replicationChange <- err
+			return err
+		},
+	)
+
+	require.Eventually(
+		t, func() bool {
+			// Check that there is 1 snapshot waiting on the snapshot send semaphore,
+			// as the other snapshot should currently be throttled in the semaphore.
+			return atomic.LoadInt64(&count) == int64(1)
+		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond,
+	)
+	// Expect that the replication change is blocked on the channel, and the
+	// snapshot is still throttled on the send snapshot semaphore.
+	select {
+	case <-time.After(1 * time.Second):
+		require.Equalf(t, atomic.LoadInt64(&count), int64(1), "expected snapshot to still be blocked.")
+	case <-replicationChange:
+		t.Fatal("did not expect the replication change to complete")
+	}
+
+	// Disable the testing knob for blocking recipient snapshots to finish test.
+	atomic.StoreInt64(&activateBlocking, 0)
+	<-blockIncomingSnapshots
+
+	// Wait for the goroutines to finish.
+	require.NoError(t, g.Wait())
+}
+
 func TestLearnerRaftConfState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/storage_services.proto
+++ b/pkg/kv/kvserver/storage_services.proto
@@ -19,6 +19,7 @@ import "gogoproto/gogo.proto";
 service MultiRaft {
     rpc RaftMessageBatch (stream cockroach.kv.kvserver.kvserverpb.RaftMessageRequestBatch) returns (stream cockroach.kv.kvserver.kvserverpb.RaftMessageResponse) {}
     rpc RaftSnapshot (stream cockroach.kv.kvserver.kvserverpb.SnapshotRequest) returns (stream cockroach.kv.kvserver.kvserverpb.SnapshotResponse) {}
+    rpc DelegateRaftSnapshot(stream cockroach.kv.kvserver.kvserverpb.DelegateSnapshotRequest) returns (stream cockroach.kv.kvserver.kvserverpb.DelegateSnapshotResponse) {}
 }
 
 service PerReplica {

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -395,6 +395,14 @@ type StoreTestingKnobs struct {
 	// IgnoreStrictGCEnforcement is used by tests to op out of strict GC
 	// enforcement.
 	IgnoreStrictGCEnforcement bool
+	// ThrottleEmptySnapshots includes empty snapshots for throttling.
+	ThrottleEmptySnapshots bool
+	// BeforeSendSnapshotThrottle intercepts replicas before entering send
+	// snapshot throttling.
+	BeforeSendSnapshotThrottle func()
+	// AfterSendSnapshotThrottle intercepts replicas after receiving a spot in the
+	// send snapshot semaphore.
+	AfterSendSnapshotThrottle func()
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This commit adds a new rpc stream for sending raft message requests between
replicas which allows for delegating snapshots. Currently this patch implements
the leaseholder delegating to itself, but in future patches the leaseholder
will be able to delegate snapshot sending to follower replicas. A new raft
message request type of `DelegatedSnapshotRequest` includes a header of
nessesary fields from a `SnapshotRequest` and the replica descriptor of the new
sender replica. This allows the leaseholder to fill in snapshot metadata before
delegating to the new sender store to generate the snapshot and transmit it to
the recipient.

Related to https://github.com/cockroachdb/cockroach/issues/42491
Release note: None