### PR TITLE
ui: add hot ranges page in Db Console

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3344,6 +3344,7 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range. | [reserved](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
+| store_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | store_id indicates the Store ID where range is stored. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -1832,6 +1832,9 @@
           "type": "string",
           "x-go-name": "SchemaName"
         },
+        "store_id": {
+          "$ref": "#/definitions/StoreID"
+        },
         "table_name": {
           "type": "string",
           "x-go-name": "TableName"

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -435,6 +435,7 @@ type hotRangeInfo struct {
 	IndexName         string           `json:"index_name"`
 	SchemaName        string           `json:"schema_name"`
 	ReplicaNodeIDs    []roachpb.NodeID `json:"replica_node_ids"`
+	StoreID           roachpb.StoreID  `json:"store_id"`
 }
 
 // swagger:operation GET /ranges/hot/ listHotRanges
@@ -514,6 +515,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 				IndexName:         r.IndexName,
 				ReplicaNodeIDs:    r.ReplicaNodeIds,
 				SchemaName:        r.SchemaName,
+				StoreID:           r.StoreID,
 			}
 		}
 		return hotRangeInfos, nil

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1237,6 +1237,12 @@ message HotRangesResponseV2 {
     ];
     // schema_name provides the name of schema (if exists) for table in current range.
     string schema_name = 9;
+    // store_id indicates the Store ID where range is stored.
+    int32 store_id = 10 [
+      (gogoproto.customname) = "StoreID",
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"
+    ];
   }
   // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2244,6 +2244,7 @@ func (s *statusServer) HotRangesV2(
 						IndexName:         indexName,
 						ReplicaNodeIds:    replicaNodeIDs,
 						LeaseholderNodeID: r.LeaseholderNodeID,
+						StoreID:           store.StoreID,
 					})
 				}
 			}

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -71,6 +71,7 @@ import SessionDetails from "src/views/sessions/sessionDetails";
 import TransactionDetails from "src/views/transactions/transactionDetails";
 import StatementsDiagnosticsHistoryView from "src/views/reports/containers/statementDiagnosticsHistory";
 import { RedirectToStatementDetails } from "src/routes/RedirectToStatementDetails";
+import HotRangesPage from "src/views/hotRanges/index";
 import "styl/app.styl";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
@@ -349,7 +350,8 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   path={`/reports/statements/diagnosticshistory`}
                   component={StatementsDiagnosticsHistoryView}
                 />
-
+                {/* hot ranges */}
+                <Route exact path={`/hotranges`} component={HotRangesPage} />
                 {/* old route redirects */}
                 <Redirect
                   exact

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -17,6 +17,8 @@ import {
   CachedDataReducerState,
   KeyedCachedDataReducer,
   KeyedCachedDataReducerState,
+  PaginatedCachedDataReducer,
+  PaginatedCachedDataReducerState,
 } from "./cachedDataReducer";
 import * as api from "src/util/api";
 import { VersionList } from "src/interfaces/cockroachlabs";
@@ -99,7 +101,19 @@ const databaseDetailsReducerObj = new KeyedCachedDataReducer(
   "databaseDetails",
   databaseRequestToID,
 );
+
+const hotRangesRequestToID = (req: api.HotRangesRequestMessage) =>
+  req.page_token;
+
+export const hotRangesReducerObj = new PaginatedCachedDataReducer(
+  api.getHotRanges,
+  "hotRanges",
+  hotRangesRequestToID,
+);
+
 export const refreshDatabaseDetails = databaseDetailsReducerObj.refresh;
+
+export const refreshHotRanges = hotRangesReducerObj.refresh;
 
 // NOTE: We encode the db and table name so we can combine them as a string.
 // TODO(maxlang): there's probably a nicer way to do this
@@ -371,6 +385,7 @@ export interface APIReducersState {
     api.StatementDiagnosticsReportsResponseMessage
   >;
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
+  hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -408,6 +423,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [statementDiagnosticsReportsReducerObj.actionNamespace]:
     statementDiagnosticsReportsReducerObj.reducer,
   [userSQLRolesReducerObj.actionNamespace]: userSQLRolesReducerObj.reducer,
+  [hotRangesReducerObj.actionNamespace]: hotRangesReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.spec.ts
@@ -17,6 +17,10 @@ import {
   CachedDataReducerState,
   KeyedCachedDataReducer,
   KeyedCachedDataReducerState,
+  WithPaginationRequest,
+  WithPaginationResponse,
+  PaginatedCachedDataReducer,
+  PaginatedCachedDataReducerState,
 } from "./cachedDataReducer";
 
 describe("basic cachedDataReducer", function() {
@@ -330,6 +334,236 @@ describe("keyed cachedDataReducer", function() {
         expected = new KeyedCachedDataReducerState<Response>();
         expected[id] = new CachedDataReducerState<Response>();
         assert.deepEqual(state, expected);
+      });
+    });
+  });
+});
+
+describe.only("PaginatedCachedDataReducer", function() {
+  class Request implements WithPaginationRequest {
+    constructor(
+      public request: string,
+      public page_size: number,
+      public page_token: string,
+    ) {}
+  }
+
+  class Response implements WithPaginationResponse {
+    constructor(public response: string, public next_page_token: string) {}
+  }
+
+  const apiEndpointMockFactory: (
+    totalPages: number,
+    pageSize: number,
+  ) => (req: Request) => Promise<Response> = (
+    totalPages: number = 5,
+    pageSize: number = 10,
+  ) => {
+    let requestCounter = 0;
+    return (req = new Request(null, pageSize, requestCounter.toString())) => {
+      if (requestCounter < totalPages) {
+        requestCounter++;
+      }
+      return new Promise((resolve, _reject) => {
+        resolve(
+          new Response(`${req.request}-${requestCounter}`, `${requestCounter}`),
+        );
+      });
+    };
+  };
+
+  const requestToID = (req: Request) => req.page_token;
+
+  let expected: PaginatedCachedDataReducerState<Response>;
+
+  describe("reducerObj", function() {
+    const actionNamespace = "paginatedKey";
+    const totalPagesNum = 5;
+    const testReducerObj = new PaginatedCachedDataReducer<Request, Response>(
+      apiEndpointMockFactory(totalPagesNum, 10),
+      actionNamespace,
+      requestToID,
+    );
+
+    describe("actions", function() {
+      it("requestData() creates the correct action type.", function() {
+        const request = new Request("testRequestRequest", undefined, undefined);
+        const requestAction = testReducerObj.cachedDataReducer.requestData(
+          request,
+        );
+        assert.equal(
+          requestAction.type,
+          testReducerObj.cachedDataReducer.REQUEST,
+        );
+        assert.deepEqual(requestAction.payload, { request });
+      });
+
+      it("receiveData() creates the correct action type.", function() {
+        const response = new Response("testResponse", "1");
+        const request = new Request("testRequestRequest", 5, undefined);
+        const receiveAction = testReducerObj.cachedDataReducer.receiveData(
+          response,
+          request,
+        );
+        assert.equal(
+          receiveAction.type,
+          testReducerObj.cachedDataReducer.RECEIVE,
+        );
+        assert.deepEqual(receiveAction.payload, { request, data: response });
+      });
+
+      it("errorData() creates the correct action type.", function() {
+        const error = new Error();
+        const request = new Request("testRequestRequest", 5, undefined);
+        const errorAction = testReducerObj.cachedDataReducer.errorData(
+          error,
+          request,
+        );
+        assert.equal(errorAction.type, testReducerObj.cachedDataReducer.ERROR);
+        assert.deepEqual(errorAction.payload, { request, data: error });
+      });
+
+      it("invalidateData() creates the correct action type.", function() {
+        const request = new Request("testRequestRequest", 5, undefined);
+        const invalidateAction = testReducerObj.cachedDataReducer.invalidateData(
+          request,
+        );
+        assert.equal(
+          invalidateAction.type,
+          testReducerObj.cachedDataReducer.INVALIDATE,
+        );
+        assert.deepEqual(invalidateAction.payload, { request });
+      });
+    });
+
+    const reducer = testReducerObj.reducer;
+    const testMoment = moment();
+    testReducerObj.setTimeSource(() => testMoment);
+
+    describe("paginated reducer", function() {
+      let state: PaginatedCachedDataReducerState<Response>;
+      let id: string;
+      let request: Request;
+      beforeEach(() => {
+        state = reducer(undefined, { type: "unknown" });
+        id = Math.random().toString();
+        request = new Request(id, 10, id);
+      });
+
+      it("should have the correct default value.", function() {
+        expected = new PaginatedCachedDataReducerState<Response>();
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch requestData", function() {
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.requestData(request),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.requestedAt = testMoment;
+        expected.inFlight = true;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch receiveData", function() {
+        const expectedResponse = new Response(null, "1");
+
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.receiveData(
+            expectedResponse,
+            request,
+          ),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.valid = false;
+        expected.inFlight = true;
+        expected.data[id] = expectedResponse;
+        expected.lastError = null;
+        expected.setAt = testMoment;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch errorData", function() {
+        const e = new Error();
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.errorData(e, request),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.lastError = e;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch invalidateData", function() {
+        state = reducer(
+          state,
+          testReducerObj.cachedDataReducer.invalidateData(request),
+        );
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.valid = false;
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch cleanData", function() {
+        state = reducer(state, testReducerObj.clearData(request));
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.data = {};
+        expected.valid = false;
+        expected.setAt = undefined;
+        expected.requestedAt = undefined;
+        console.log("state", JSON.stringify(state, undefined, 2));
+        console.log("expected", JSON.stringify(expected, undefined, 2));
+        assert.deepEqual(state, expected);
+      });
+
+      it("should correctly dispatch receiveCompleted", function() {
+        state = reducer(state, testReducerObj.receiveCompleted(request));
+        expected = new PaginatedCachedDataReducerState<Response>();
+        expected.valid = true;
+        expected.inFlight = false;
+        expected.setAt = testMoment;
+        expected.lastError = null;
+        assert.deepEqual(state, expected);
+      });
+    });
+
+    describe("refresh", function() {
+      let state: PaginatedCachedDataReducerState<Response>;
+      let id: string;
+      let request: Request;
+
+      beforeEach(() => {
+        state = reducer(undefined, undefined);
+        id = Math.random().toString();
+        request = new Request(id, 10, "");
+      });
+
+      const mockDispatch = <A extends Action>(action: A): A => {
+        state = testReducerObj.reducer(state, action);
+        return undefined;
+      };
+
+      it("correctly dispatches refresh", function() {
+        const pageState = new PaginatedCachedDataReducerState<Response>();
+        pageState.valid = true;
+        pageState.lastError = null;
+        pageState.setAt = testMoment;
+        pageState.requestedAt = testMoment;
+
+        const expectedPageTokens = Array(totalPagesNum)
+          .fill("")
+          .map((_, i) => `${i + 1}`)
+          .concat(["", id]);
+
+        return testReducerObj
+          .refresh(request, s => s[id])(mockDispatch, () => state, undefined)
+          .then(() => {
+            Object.keys(state.data).forEach(k => {
+              assert.isTrue(expectedPageTokens.some(t => t === k));
+            });
+          });
       });
     });
   });

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -27,6 +27,15 @@ import { APIRequestFn } from "src/util/api";
 
 import { PayloadAction, WithRequest } from "src/interfaces/action";
 
+export interface WithPaginationRequest {
+  page_size: number;
+  page_token: string;
+}
+
+export interface WithPaginationResponse {
+  next_page_token: string;
+}
+
 // CachedDataReducerState is used to track the state of the cached data.
 export class CachedDataReducerState<TResponseMessage> {
   data?: TResponseMessage; // the latest data received
@@ -41,6 +50,22 @@ export class CachedDataReducerState<TResponseMessage> {
 // that is associated with a key.
 export class KeyedCachedDataReducerState<TResponseMessage> {
   [id: string]: CachedDataReducerState<TResponseMessage>;
+}
+
+export class PaginatedCachedDataReducerState<TResponseMessage> {
+  // the latest data received
+  data?: {
+    [id: string]: TResponseMessage;
+  };
+  inFlight = false; // true if a request is in flight
+  valid = false; // true if data has been received and has not been invalidated
+  requestedAt?: moment.Moment; // Timestamp when data was last requested.
+  setAt?: moment.Moment; // Timestamp when this data was last updated.
+  lastError?: Error; // populated with the most recent error, if the last request failed
+
+  constructor() {
+    this.data = {};
+  }
 }
 
 /**
@@ -366,4 +391,205 @@ export class KeyedCachedDataReducer<
         return state;
     }
   };
+}
+
+export class PaginatedCachedDataReducer<
+  TRequest extends WithPaginationRequest,
+  TResponseMessage extends WithPaginationResponse,
+  TActionNamespace extends string = string
+> {
+  cachedDataReducer: CachedDataReducer<
+    TRequest,
+    TResponseMessage,
+    TActionNamespace
+  >;
+
+  CLEAR_DATA: string; // clear previously received data.
+  RECEIVE_COMPLETED: string; // action indicates that there's no more data to receive.
+
+  constructor(
+    protected apiEndpoint: APIRequestFn<TRequest, TResponseMessage>,
+    public actionNamespace: TActionNamespace,
+    private requestToID: (req: TRequest) => string,
+    private pageLimit: number = 1000,
+    protected invalidationPeriod?: moment.Duration,
+    protected requestTimeout?: moment.Duration,
+  ) {
+    this.cachedDataReducer = new CachedDataReducer<
+      TRequest,
+      TResponseMessage,
+      TActionNamespace
+    >(apiEndpoint, actionNamespace, invalidationPeriod, requestTimeout);
+
+    this.CLEAR_DATA = `cockroachui/CachedDataReducer/${actionNamespace}/CLEAR_DATA`;
+    this.RECEIVE_COMPLETED = `cockroachui/CachedDataReducer/${actionNamespace}/RECEIVE_COMPLETED`;
+  }
+
+  // receiveCompleted is an action creator to indicate that there is no more data to receive.
+  receiveCompleted = (
+    request?: TRequest,
+  ): PayloadAction<WithRequest<Error, TRequest>> => {
+    return {
+      type: this.RECEIVE_COMPLETED,
+      payload: { request },
+    };
+  };
+
+  // clearData is an action creator to delete previously received data.
+  clearData = (
+    request?: TRequest,
+  ): PayloadAction<WithRequest<Error, TRequest>> => {
+    return {
+      type: this.CLEAR_DATA,
+      payload: { request },
+    };
+  };
+
+  reducer = (
+    state = new PaginatedCachedDataReducerState<TResponseMessage>(),
+    action: Action,
+  ): PaginatedCachedDataReducerState<TResponseMessage> => {
+    if (_.isNil(action)) {
+      return state;
+    }
+
+    switch (action.type) {
+      case this.cachedDataReducer.REQUEST:
+        // A request is in progress.
+        state = _.clone(state);
+        state.requestedAt = this.timeSource();
+        state.inFlight = true;
+        return state;
+      case this.cachedDataReducer.RECEIVE: {
+        // The results of a request have been received.
+        const { request, data } = (action as PayloadAction<
+          WithRequest<TResponseMessage, TRequest>
+        >).payload;
+        const id = this.requestToID(request);
+        state = _.clone(state);
+        state.inFlight = true;
+        state.data[id] = data;
+        state.valid = false;
+        state.setAt = this.timeSource();
+        state.lastError = null;
+        return state;
+      }
+      case this.RECEIVE_COMPLETED: {
+        state = _.clone(state);
+        state.inFlight = false;
+        state.setAt = this.timeSource();
+        state.valid = true;
+        state.lastError = null;
+        return state;
+      }
+      case this.CLEAR_DATA: {
+        state = _.clone(state);
+        state.data = {};
+        state.inFlight = false;
+        state.setAt = undefined;
+        state.requestedAt = undefined;
+        state.valid = false;
+        return state;
+      }
+      case this.cachedDataReducer.ERROR: {
+        // A request failed.
+        const { payload: error } = action as PayloadAction<
+          WithRequest<Error, TRequest>
+        >;
+        state = _.clone(state);
+        state.inFlight = false;
+        state.lastError = error.data;
+        state.valid = false;
+        return state;
+      }
+      case this.cachedDataReducer.INVALIDATE:
+        // The data is invalidated.
+        state = _.clone(state);
+        state.valid = false;
+        return state;
+      default:
+        return state;
+    }
+  };
+
+  refresh = <S>(
+    req?: TRequest,
+    stateAccessor = (state: any, _: TRequest) =>
+      state.cachedData[this.actionNamespace],
+  ): ThunkAction<any, S, any, Action> => {
+    return async (
+      dispatch: ThunkDispatch<S, unknown, Action>,
+      getState: () => S,
+    ) => {
+      // Override page_token and page_size fields to ensure that the exact same
+      // pagination params are used across the entire app because all the results
+      // are stored in the single store's slice. The current implementation doesn't
+      // support requesting data with different page sizes or calls to an arbitrary page.
+      req.page_token = "";
+      req.page_size = this.pageLimit;
+
+      const state: PaginatedCachedDataReducerState<TResponseMessage> = stateAccessor(
+        getState(),
+        req,
+      );
+      if (
+        state &&
+        (state.inFlight || (this.invalidationPeriod && state.valid))
+      ) {
+        return;
+      }
+
+      // clean up previously received data to ensure that fresh data won't be mixed with
+      // previously invalidated data.
+      dispatch(this.clearData(req));
+
+      let hasMoreData = true;
+      while (hasMoreData) {
+        dispatch(this.cachedDataReducer.requestData(req));
+        try {
+          const resp = await this.apiEndpoint(req, this.requestTimeout);
+          dispatch(this.cachedDataReducer.receiveData(resp, req));
+          if (req.page_token === resp.next_page_token) {
+            // there's no more data to request since next page token is the same as current one.
+            hasMoreData = false;
+            dispatch(this.receiveCompleted(req));
+          } else {
+            req.page_token = resp.next_page_token;
+          }
+        } catch (error) {
+          // duplicate the same error handling as in base CachedDataReducer#refresh method.
+          if (error.message === "Unauthorized") {
+            // TODO(couchand): This is an unpleasant dependency snuck in here...
+            const { location } = createHashHistory();
+            if (location && !location.pathname.startsWith("/login")) {
+              dispatch(push(getLoginPage(location)));
+            }
+          }
+          setTimeout(
+            () => dispatch(this.cachedDataReducer.errorData(error, req)),
+            1000,
+          );
+          break;
+        } finally {
+          // Invalidate data after the invalidation period if one exists.
+          if (this.invalidationPeriod) {
+            setTimeout(
+              () => dispatch(this.cachedDataReducer.invalidateData(req)),
+              this.invalidationPeriod.asMilliseconds(),
+            );
+          }
+        }
+      }
+    };
+  };
+
+  /**
+   * setTimeSource overrides the source of timestamps used by this component.
+   * Intended for use in tests only.
+   */
+  setTimeSource(timeSource: { (): moment.Moment }) {
+    this.timeSource = timeSource;
+  }
+
+  private timeSource: { (): moment.Moment } = () => moment();
 }

--- a/pkg/ui/workspaces/db-console/src/redux/hotRanges.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/hotRanges.ts
@@ -1,0 +1,45 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { AdminUIState } from "src/redux/state";
+import { createSelector } from "reselect";
+import { cockroach } from "src/js/protos";
+
+const hotRangesState = (state: AdminUIState) => state.cachedData.hotRanges;
+
+export const hotRangesSelector = createSelector(hotRangesState, hotRanges =>
+  Object.values(hotRanges?.data || {})
+    .reduce<cockroach.server.serverpb.HotRangesResponseV2["ranges"]>(
+      (acc, v) => [...acc, ...v.ranges],
+      [],
+    )
+    // filter out ranges with 0 QPS
+    .filter(v => v?.qps && v.qps > 0),
+);
+
+export const lastErrorSelector = createSelector(
+  hotRangesState,
+  hotRanges => hotRanges?.lastError,
+);
+
+export const isValidSelector = createSelector(
+  hotRangesState,
+  hotRanges => hotRanges?.valid,
+);
+
+export const lastSetAtSelector = createSelector(
+  hotRangesState,
+  hotRanges => hotRanges?.setAt,
+);
+
+export const isLoadingSelector = createSelector(
+  hotRangesState,
+  hotRanges => hotRanges?.inFlight,
+);

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
@@ -51,6 +51,11 @@ export class Sidebar extends React.Component<SidebarProps> {
       // Do not show Network Latency for single node cluster.
       isHidden: () => this.props.isSingleNodeCluster,
     },
+    {
+      path: "/hotranges",
+      text: "Hot ranges",
+      activeFor: ["/hotranges"],
+    },
     { path: "/jobs", text: "Jobs", activeFor: [] },
     {
       path: "/debug",

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
@@ -1,0 +1,13 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+.hotranges-heading-container
+  display flex
+  justify-content space-between

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -1,0 +1,194 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { Tooltip } from "antd";
+import moment from "moment";
+import {
+  ColumnDescriptor,
+  SortedTable,
+  Pagination,
+  ResultsPerPageLabel,
+  SortSetting,
+} from "@cockroachlabs/cluster-ui";
+import classNames from "classnames/bind";
+import styles from "./hotRanges.module.styl";
+import { cockroach } from "src/js/protos";
+
+const PAGE_SIZE = 50;
+const cx = classNames.bind(styles);
+
+interface HotRangesTableProps {
+  hotRangesList: cockroach.server.serverpb.HotRangesResponseV2.IHotRange[];
+  lastUpdate?: string;
+}
+
+const HotRangesTable = ({ hotRangesList }: HotRangesTableProps) => {
+  const [pagination, setPagination] = useState({
+    pageSize: PAGE_SIZE,
+    current: 1,
+  });
+  const [sortSetting, setSortSetting] = useState({
+    ascending: true,
+    columnTitle: null,
+  });
+  const getCurrentDateTime = () => {
+    const nowUtc = moment.utc();
+    return (
+      nowUtc.format("MMM DD, YYYY") +
+      " at " +
+      nowUtc.format("h:mm A") +
+      " (UTC)"
+    );
+  };
+
+  if (hotRangesList.length === 0) {
+    return <div>No hot ranges</div>;
+  }
+  const columns: ColumnDescriptor<
+    cockroach.server.serverpb.HotRangesResponseV2.IHotRange
+  >[] = [
+    {
+      name: "rangeId",
+      title: (
+        <Tooltip placement="bottom" title="Range ID">
+          Range ID
+        </Tooltip>
+      ),
+      cell: (val: cockroach.server.serverpb.HotRangesResponseV2.IHotRange) => (
+        <Link to={`/reports/range/${val.range_id}`}>{val.range_id}</Link>
+      ),
+      sort: val => val.range_id,
+    },
+    {
+      name: "qps",
+      title: (
+        <Tooltip placement="bottom" title="QPS">
+          QPS
+        </Tooltip>
+      ),
+      cell: val => <>{val.qps}</>,
+      sort: val => val.qps,
+    },
+    {
+      name: "nodes",
+      title: (
+        <Tooltip placement="bottom" title="Nodes">
+          Nodes
+        </Tooltip>
+      ),
+      cell: val => (
+        <Link to={`/node/${val.replica_node_ids[0]}`}>
+          {val.replica_node_ids.join(", ")}
+        </Link>
+      ),
+      sort: val => val.replica_node_ids[0],
+    },
+
+    {
+      name: "storeId",
+      title: (
+        <Tooltip placement="bottom" title="Store ID">
+          Store ID
+        </Tooltip>
+      ),
+      cell: val => <>{val.store_id}</>,
+      sort: val => val.store_id,
+    },
+    {
+      name: "leasholder",
+      title: (
+        <Tooltip placement="bottom" title="Leaseholder">
+          Leaseholder
+        </Tooltip>
+      ),
+      cell: val => <>{val.leaseholder_node_id}</>,
+      sort: val => val.leaseholder_node_id,
+    },
+    {
+      name: "database",
+      title: (
+        <Tooltip placement="bottom" title="Database">
+          Database
+        </Tooltip>
+      ),
+      cell: val => <>{val.database_name}</>,
+      sort: val => val.database_name,
+    },
+    {
+      name: "table",
+      title: (
+        <Tooltip placement="bottom" title="Table">
+          Table
+        </Tooltip>
+      ),
+      cell: val => (
+        <Link to={`/database/${val.database_name}/table/${val.table_name}`}>
+          {val.table_name}
+        </Link>
+      ),
+      sort: val => val.table_name,
+    },
+    {
+      name: "index",
+      title: (
+        <Tooltip placement="bottom" title="Index">
+          Index
+        </Tooltip>
+      ),
+      cell: val => <>{val.index_name}</>,
+      sort: val => val.index_name,
+    },
+  ];
+
+  return (
+    <div>
+      <div className={cx("hotranges-heading-container")}>
+        <h4>
+          <ResultsPerPageLabel
+            pagination={{
+              ...pagination,
+              total: hotRangesList.length,
+            }}
+            pageName="hot ranges"
+          />
+        </h4>
+        <div>Last update: {getCurrentDateTime()}</div>
+      </div>
+      <SortedTable
+        data={hotRangesList}
+        columns={columns}
+        className={cx("hotranges-table")}
+        sortSetting={sortSetting}
+        onChangeSortSetting={(ss: SortSetting) =>
+          setSortSetting({
+            ascending: ss.ascending,
+            columnTitle: ss.columnTitle,
+          })
+        }
+        pagination={pagination}
+      />
+      <Pagination
+        pageSize={PAGE_SIZE}
+        current={pagination.current}
+        total={hotRangesList.length}
+        onChange={(page: number, pageSize?: number) =>
+          setPagination({
+            pageSize,
+            current: page,
+          })
+        }
+      />
+    </div>
+  );
+};
+
+export default HotRangesTable;

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
@@ -1,0 +1,98 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment";
+import { cockroach } from "src/js/protos";
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { Helmet } from "react-helmet";
+import { refreshHotRanges } from "../../redux/apiReducers";
+import HotRangesTable from "./hotRangesTable";
+import ErrorBoundary from "../app/components/errorMessage/errorBoundary";
+import { Loading, Text, Anchor } from "@cockroachlabs/cluster-ui";
+import classNames from "classnames/bind";
+import styles from "./hotRanges.module.styl";
+import {
+  hotRangesSelector,
+  isLoadingSelector,
+  isValidSelector,
+  lastErrorSelector,
+  lastSetAtSelector,
+} from "src/redux/hotRanges";
+
+const cx = classNames.bind(styles);
+const HotRangesRequest = cockroach.server.serverpb.HotRangesRequest;
+
+const HotRangesPage = () => {
+  const dispatch = useDispatch();
+  const hotRanges = useSelector(hotRangesSelector);
+  const isValid = useSelector(isValidSelector);
+  const lastError = useSelector(lastErrorSelector);
+  const lastSetAt = useSelector(lastSetAtSelector);
+  const isLoading = useSelector(isLoadingSelector);
+
+  useEffect(() => {
+    if (!isValid) {
+      dispatch(refreshHotRanges(HotRangesRequest.create()));
+    }
+  }, [dispatch, isValid]);
+
+  useEffect(() => {
+    dispatch(
+      refreshHotRanges(
+        HotRangesRequest.create({
+          page_size: 1000,
+        }),
+      ),
+    );
+  }, [dispatch]);
+
+  const formatCurrentDateTime = (datetime: moment.Moment) => {
+    return (
+      datetime.format("MMM DD, YYYY") +
+      " at " +
+      datetime.format("h:mm A") +
+      " (UTC)"
+    );
+  };
+  // TODO(santamaura): add url to anchor once it's available
+  return (
+    <div className="section">
+      <Helmet title="Hot Ranges" />
+      <h1 className="base-heading">Hot ranges</h1>
+      <Text className={cx("hotranges-description")}>
+        The hot ranges table shows ranges receiving a high number of reads or
+        writes. By default the table is sorted by
+        <br />
+        ranges with the highest QPS (Queries Per Second). Use this information
+        to...
+        <Anchor href="" target="_blank">
+          {" "}
+          Learn more
+        </Anchor>
+      </Text>
+      <ErrorBoundary>
+        <Loading
+          loading={isLoading}
+          error={lastError}
+          render={() => (
+            <HotRangesTable
+              hotRangesList={hotRanges}
+              lastUpdate={lastSetAt && formatCurrentDateTime(lastSetAt?.utc())}
+            />
+          )}
+          page={undefined}
+        />
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default HotRangesPage;

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -333,8 +333,7 @@ func (l *loggerT) outputLogEntry(entry logEntry) {
 				// The sink was not accepting entries at this level. Nothing to do.
 				continue
 			}
-			format := formatParsers[s.formatter.formatterName()]
-			if err := s.sink.output(bufs.b[i].Bytes(), sinkOutputOptions{extraFlush: extraFlush, forceSync: isFatal, format: format}); err != nil {
+			if err := s.sink.output(bufs.b[i].Bytes(), sinkOutputOptions{extraFlush: extraFlush, forceSync: isFatal}); err != nil {
 				if !s.criticality {
 					// An error on this sink is not critical. Just report
 					// the error and move on.

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -385,6 +385,7 @@ func newHTTPSinkInfo(c logconfig.HTTPSinkConfig) (*sinkInfo, error) {
 		unsafeTLS:         *c.UnsafeTLS,
 		timeout:           *c.Timeout,
 		disableKeepAlives: *c.DisableKeepAlives,
+		contentType:       info.formatter.contentType(),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/util/log/format_crdb_v1.go
+++ b/pkg/util/log/format_crdb_v1.go
@@ -37,6 +37,8 @@ func (formatCrdbV1) formatEntry(entry logEntry) *buffer {
 
 func (formatCrdbV1) doc() string { return formatCrdbV1CommonDoc(false /* withCounter */) }
 
+func (formatCrdbV1) contentType() string { return "text/plain" }
+
 func formatCrdbV1CommonDoc(withCounter bool) string {
 	var buf strings.Builder
 
@@ -167,6 +169,8 @@ func (formatCrdbV1WithCounter) formatEntry(entry logEntry) *buffer {
 
 func (formatCrdbV1WithCounter) doc() string { return formatCrdbV1CommonDoc(true /* withCounter */) }
 
+func (formatCrdbV1WithCounter) contentType() string { return "text/plain" }
+
 // formatCrdbV1TTY is like formatCrdbV1 and includes VT color codes if
 // the stderr output is a TTY and -nocolor is not passed on the
 // command line.
@@ -192,6 +196,8 @@ func (formatCrdbV1TTY) doc() string {
 	return "Same textual format as `" + formatCrdbV1{}.formatterName() + "`." + ttyFormatDoc
 }
 
+func (formatCrdbV1TTY) contentType() string { return "text/plain" }
+
 // formatCrdbV1ColorWithCounter is like formatCrdbV1WithCounter and
 // includes VT color codes if the stderr output is a TTY and -nocolor
 // is not passed on the command line.
@@ -210,6 +216,8 @@ func (formatCrdbV1TTYWithCounter) formatEntry(entry logEntry) *buffer {
 func (formatCrdbV1TTYWithCounter) doc() string {
 	return "Same textual format as `" + formatCrdbV1WithCounter{}.formatterName() + "`." + ttyFormatDoc
 }
+
+func (formatCrdbV1TTYWithCounter) contentType() string { return "text/plain" }
 
 // formatEntryInternalV1 renders a log entry.
 // Log lines are colorized depending on severity.

--- a/pkg/util/log/format_crdb_v2.go
+++ b/pkg/util/log/format_crdb_v2.go
@@ -40,6 +40,8 @@ func (formatCrdbV2) formatEntry(entry logEntry) *buffer {
 
 func (formatCrdbV2) doc() string { return formatCrdbV2CommonDoc() }
 
+func (formatCrdbV2) contentType() string { return "text/plain" }
+
 func formatCrdbV2CommonDoc() string {
 	var buf strings.Builder
 
@@ -187,6 +189,8 @@ func (formatCrdbV2TTY) formatEntry(entry logEntry) *buffer {
 func (formatCrdbV2TTY) doc() string {
 	return "Same textual format as `" + formatCrdbV2{}.formatterName() + "`." + ttyFormatDoc
 }
+
+func (formatCrdbV2TTY) contentType() string { return "text/plain" }
 
 // formatEntryInternalV2 renders a log entry.
 // Log lines are colorized depending on severity.

--- a/pkg/util/log/format_json.go
+++ b/pkg/util/log/format_json.go
@@ -31,6 +31,8 @@ func (f formatFluentJSONCompact) formatEntry(entry logEntry) *buffer {
 	return formatJSON(entry, true /* fluent */, tagCompact)
 }
 
+func (formatFluentJSONCompact) contentType() string { return "application/json" }
+
 type formatFluentJSONFull struct{}
 
 func (formatFluentJSONFull) formatterName() string { return "json-fluent" }
@@ -40,6 +42,8 @@ func (f formatFluentJSONFull) formatEntry(entry logEntry) *buffer {
 }
 
 func (formatFluentJSONFull) doc() string { return formatJSONDoc(true /* fluent */, tagVerbose) }
+
+func (formatFluentJSONFull) contentType() string { return "application/json" }
 
 type formatJSONCompact struct{}
 
@@ -51,6 +55,8 @@ func (f formatJSONCompact) formatEntry(entry logEntry) *buffer {
 
 func (formatJSONCompact) doc() string { return formatJSONDoc(false /* fluent */, tagCompact) }
 
+func (formatJSONCompact) contentType() string { return "application/json" }
+
 type formatJSONFull struct{}
 
 func (formatJSONFull) formatterName() string { return "json" }
@@ -60,6 +66,8 @@ func (f formatJSONFull) formatEntry(entry logEntry) *buffer {
 }
 
 func (formatJSONFull) doc() string { return formatJSONDoc(false /* fluent */, tagVerbose) }
+
+func (formatJSONFull) contentType() string { return "application/json" }
 
 func formatJSONDoc(forFluent bool, tags tagChoice) string {
 	var buf strings.Builder

--- a/pkg/util/log/formats.go
+++ b/pkg/util/log/formats.go
@@ -17,6 +17,10 @@ type logFormatter interface {
 	// formatEntry formats a logEntry into a newly allocated *buffer.
 	// The caller is responsible for calling putBuffer() afterwards.
 	formatEntry(entry logEntry) *buffer
+
+	// contentType is the MIME content-type field to use on
+	// transports which use this metadata.
+	contentType() string
 }
 
 var formatParsers = map[string]string{

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -214,7 +214,7 @@ func TestHTTPSinkContentTypeJSON(t *testing.T) {
 	address := "http://localhost" // testBase appends the port
 	timeout := 5 * time.Second
 	tb := true
-	format := "json"
+	format := "json-fluent"
 	expectedContentType := "application/json"
 	defaults := logconfig.HTTPDefaults{
 		Address: &address,
@@ -232,7 +232,7 @@ func TestHTTPSinkContentTypeJSON(t *testing.T) {
 		t.Log(body)
 		contentType := header.Get("Content-Type")
 		if contentType != expectedContentType {
-			return errors.Newf("mismatched content type: expected %s, got %s")
+			return errors.Newf("mismatched content type: expected %s, got %s", expectedContentType, contentType)
 		}
 		return nil
 	}
@@ -266,7 +266,7 @@ func TestHTTPSinkContentTypePlainText(t *testing.T) {
 		t.Log(body)
 		contentType := header.Get("Content-Type")
 		if contentType != expectedContentType {
-			return errors.Newf("mismatched content type: expected %s, got %s")
+			return errors.Newf("mismatched content type: expected %s, got %s", expectedContentType, contentType)
 		}
 		return nil
 	}

--- a/pkg/util/log/intercept.go
+++ b/pkg/util/log/intercept.go
@@ -73,6 +73,7 @@ type formatInterceptor struct{}
 
 func (formatInterceptor) formatterName() string { return "json-intercept" }
 func (formatInterceptor) doc() string           { return "internal only" }
+func (formatInterceptor) contentType() string   { return "application/json" }
 func (formatInterceptor) formatEntry(entry logEntry) *buffer {
 	pEntry := entry.convertToLegacy()
 	buf := getBuffer()

--- a/pkg/util/log/sinks.go
+++ b/pkg/util/log/sinks.go
@@ -31,8 +31,6 @@ type sinkOutputOptions struct {
 	// forceSync forces synchronous operation of this output operation.
 	// That is, it will block until the output has been handled.
 	forceSync bool
-	// format specifies the log entry format (e.g. json etc.).
-	format string
 }
 
 // logSink abstracts the destination of logging events, after all


### PR DESCRIPTION
This change adds a new page in Db Console - Hot Ranges that display list
of hot ranges in the cluster and some useful information related to each
range. The main goal of this page is to help eliminate root cause of
hot ranges.

This page uses already implemented hot ranges API (V2) that provides
all necessary data to show.

Release note (ui change): add Hot Ranges page and link to it on the sidebar

Release justification: bug fixes and low-risk updates to new functionality

This PR is mostly based on https://github.com/cockroachdb/cockroach/pull/75073 with additional changes to apply server side pagination.

Resolves: https://github.com/cockroachdb/cockroach/issues/40536

<img width="1398" alt="Screen Shot 2022-03-03 at 17 19 31" src="https://user-images.githubusercontent.com/3106437/156594563-32a50245-0572-4b0c-b7cd-368e6ba1910c.png">


