### PR TITLE
kvserver: fix race that caused truncator to truncate non-alive replica

### DIFF
--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -109,15 +109,12 @@ import (
 // - v22.1 and v22.2: If the setting has been changed to false the v22.1 nodes
 //   will do strongly coupled truncation and the v22.2 will do loosely
 //   coupled. This co-existence is correct.
-//
-// TODO(sumeer): flip the default back to true after
-// https://github.com/cockroachdb/cockroach/issues/77030 is fixed.
 var looselyCoupledTruncationEnabled = func() *settings.BoolSetting {
 	s := settings.RegisterBoolSetting(
 		settings.SystemOnly,
 		"kv.raft_log.loosely_coupled_truncation.enabled",
 		"set to true to loosely couple the raft log truncation",
-		false)
+		true)
 	s.SetVisibility(settings.Reserved)
 	return s
 }()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3511,14 +3511,15 @@ func (s *storeForTruncatorImpl) acquireReplicaForTruncator(
 		// can ignore it.
 		return nil
 	}
+	r.raftMu.Lock()
 	if isAlive := func() bool {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		return r.mu.destroyStatus.IsAlive()
 	}(); !isAlive {
+		r.raftMu.Unlock()
 		return nil
 	}
-	r.raftMu.Lock()
 	return (*raftTruncatorReplica)(r)
 }
 


### PR DESCRIPTION
This was causing truncated state to be written to such a
replica, which would then get picked up as the
HardState.Commit value when a different replica was later
added back for the same range. See
https://github.com/cockroachdb/cockroach/issues/77030#issuecomment-1058111368
for the detailed explanation.

Also restore the default value of
kv.raft_log.loosely_coupled_truncation.enabled to true.

Fixes #77030

Release justification: Bug fix.
Release note: None