### PR TITLE
spanconfig: implement the ProtectedTSReader interface on the KVSubscriber

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -200,6 +200,7 @@ ALL_TESTS = [
     "//pkg/spanconfig/spanconfigkvaccessor:spanconfigkvaccessor_test",
     "//pkg/spanconfig/spanconfigkvsubscriber:spanconfigkvsubscriber_test",
     "//pkg/spanconfig/spanconfigmanager:spanconfigmanager_test",
+    "//pkg/spanconfig/spanconfigptsreader:spanconfigptsreader_test",
     "//pkg/spanconfig/spanconfigreconciler:spanconfigreconciler_test",
     "//pkg/spanconfig/spanconfigsqltranslator:spanconfigsqltranslator_test",
     "//pkg/spanconfig/spanconfigsqlwatcher:spanconfigsqlwatcher_test",

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -47,6 +47,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 			Store: &kvserver.StoreTestingKnobs{
 				DisableMergeQueue: true,
 				DisableSplitQueue: true,
+				DisableGCQueue:    true,
 			},
 			SpanConfig: &spanconfig.TestingKnobs{
 				StoreKVSubscriberOverride: mockSubscriber,
@@ -116,6 +117,12 @@ func (m *mockSpanConfigSubscriber) GetSpanConfigForKey(
 	ctx context.Context, key roachpb.RKey,
 ) (roachpb.SpanConfig, error) {
 	return m.Store.GetSpanConfigForKey(ctx, key)
+}
+
+func (m *mockSpanConfigSubscriber) GetProtectionTimestamps(
+	context.Context, roachpb.Span,
+) ([]hlc.Timestamp, hlc.Timestamp, error) {
+	panic("unimplemented")
 }
 
 func (m *mockSpanConfigSubscriber) LastUpdated() hlc.Timestamp {

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -483,12 +483,14 @@ func (r *Replica) MaybeUnquiesceAndWakeLeader() bool {
 	return r.maybeUnquiesceAndWakeLeaderLocked()
 }
 
-func (r *Replica) ReadProtectedTimestamps(ctx context.Context) {
+func (r *Replica) ReadProtectedTimestamps(ctx context.Context) error {
 	var ts cachedProtectedTimestampState
 	defer r.maybeUpdateCachedProtectedTS(&ts)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	ts = r.readProtectedTimestampsRLocked(ctx)
+	var err error
+	ts, err = r.readProtectedTimestampsRLocked(ctx)
+	return err
 }
 
 // ClosedTimestampPolicy returns the closed timestamp policy of the range, which

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -180,7 +180,11 @@ func (mgcq *mvccGCQueue) shouldQueue(
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score.
 	_, conf := repl.DescAndSpanConfig()
-	canGC, _, gcTimestamp, oldThreshold, newThreshold := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
+	canGC, _, gcTimestamp, oldThreshold, newThreshold, err := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
+	if err != nil {
+		log.VErrEventf(ctx, 2, "failed to check protected timestamp for gc: %v", err)
+		return false, 0
+	}
 	if !canGC {
 		return false, 0
 	}
@@ -525,7 +529,10 @@ func (mgcq *mvccGCQueue) process(
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score and updated GC
 	// threshold.
-	canGC, cacheTimestamp, gcTimestamp, oldThreshold, newThreshold := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
+	canGC, cacheTimestamp, gcTimestamp, oldThreshold, newThreshold, err := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
+	if err != nil {
+		return false, err
+	}
 	if !canGC {
 		return false, nil
 	}

--- a/pkg/kv/kvserver/protectedts/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/spanconfig",
         "//pkg/util/hlc",
         "//pkg/util/metric",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/protectedts/protectedts.go
+++ b/pkg/kv/kvserver/protectedts/protectedts.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -115,6 +116,7 @@ type Iterator func(*ptpb.Record) (wantMore bool)
 // by any Records at a given asOf can move its GC threshold up to that
 // timestamp less its GC TTL.
 type Cache interface {
+	spanconfig.ProtectedTSReader
 
 	// Iterate examines the records with spans which overlap with [from, to).
 	// Nil values for from or to are equivalent to Key{}. The order of records
@@ -177,4 +179,10 @@ func (c *emptyCache) QueryRecord(
 
 func (c *emptyCache) Refresh(_ context.Context, asOf hlc.Timestamp) error {
 	return nil
+}
+
+func (c *emptyCache) GetProtectionTimestamps(
+	context.Context, roachpb.Span,
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, err error) {
+	return protectionTimestamps, (*hlc.Clock)(c).Now(), nil
 }

--- a/pkg/kv/kvserver/protectedts/ptcache/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptcache/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
-        "//pkg/spanconfig",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/protectedts/ptcache/cache.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -74,7 +73,6 @@ func New(config Config) *Cache {
 }
 
 var _ protectedts.Cache = (*Cache)(nil)
-var _ spanconfig.ProtectedTSReader = (*Cache)(nil)
 
 // Iterate is part of the protectedts.Cache interface.
 func (c *Cache) Iterate(
@@ -132,7 +130,7 @@ func (c *Cache) Refresh(ctx context.Context, asOf hlc.Timestamp) error {
 // interface.
 func (c *Cache) GetProtectionTimestamps(
 	ctx context.Context, sp roachpb.Span,
-) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp) {
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, err error) {
 	readAt := c.Iterate(ctx,
 		sp.Key,
 		sp.EndKey,
@@ -140,7 +138,7 @@ func (c *Cache) GetProtectionTimestamps(
 			protectionTimestamps = append(protectionTimestamps, rec.Timestamp)
 			return true
 		})
-	return protectionTimestamps, readAt
+	return protectionTimestamps, readAt, nil
 }
 
 // Start starts the periodic fetching of the Cache. A Cache must not be used

--- a/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache_test.go
@@ -403,7 +403,8 @@ func TestGetProtectionTimestamps(t *testing.T) {
 				r3, _ := protect(t, s, p, ts(6), sp42)
 				require.NoError(t, c.Refresh(ctx, s.Clock().Now()))
 
-				protectionTimestamps, _ := c.GetProtectionTimestamps(ctx, sp42)
+				protectionTimestamps, _, err := c.GetProtectionTimestamps(ctx, sp42)
+				require.NoError(t, err)
 				sort.Slice(protectionTimestamps, func(i, j int) bool {
 					return protectionTimestamps[i].Less(protectionTimestamps[j])
 				})
@@ -417,7 +418,8 @@ func TestGetProtectionTimestamps(t *testing.T) {
 				r1, _ := protect(t, s, p, ts(5), sp43)
 				r2, _ := protect(t, s, p, ts(10), sp44)
 				require.NoError(t, c.Refresh(ctx, s.Clock().Now()))
-				protectionTimestamps, _ := c.GetProtectionTimestamps(ctx, sp42)
+				protectionTimestamps, _, err := c.GetProtectionTimestamps(ctx, sp42)
+				require.NoError(t, err)
 				require.Equal(t, []hlc.Timestamp(nil), protectionTimestamps)
 				cleanup(r1, r2)
 			},
@@ -435,7 +437,8 @@ func TestGetProtectionTimestamps(t *testing.T) {
 				r6, _ := protect(t, s, p, ts(20), sp44)
 				require.NoError(t, c.Refresh(ctx, s.Clock().Now()))
 
-				protectionTimestamps, _ := c.GetProtectionTimestamps(ctx, sp4243)
+				protectionTimestamps, _, err := c.GetProtectionTimestamps(ctx, sp4243)
+				require.NoError(t, err)
 				sort.Slice(protectionTimestamps, func(i, j int) bool {
 					return protectionTimestamps[i].Less(protectionTimestamps[j])
 				})

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -103,7 +103,6 @@ go_library(
         "//pkg/kv/kvserver/loqrecovery",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
         "//pkg/kv/kvserver/protectedts",
-        "//pkg/kv/kvserver/protectedts/ptcache",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptprovider",
         "//pkg/kv/kvserver/protectedts/ptreconcile",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptcache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptprovider"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptreconcile"
 	serverrangefeed "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
@@ -135,7 +134,7 @@ type Server struct {
 	replicationReporter *reports.Reporter
 	protectedtsProvider protectedts.Provider
 
-	spanConfigSubscriber *spanconfigkvsubscriber.KVSubscriber
+	spanConfigSubscriber spanconfig.KVSubscriber
 
 	sqlServer *SQLServer
 
@@ -513,7 +512,79 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	systemConfigWatcher := systemconfigwatcher.New(
 		keys.SystemSQLCodec, clock, rangeFeedFactory, &cfg.DefaultZoneConfig,
 	)
-	protectedTSReader := spanconfigptsreader.NewAdapter(protectedtsProvider.(*ptprovider.Provider).Cache.(*ptcache.Cache))
+
+	var spanConfig struct {
+		// kvAccessor powers the span configuration RPCs and the host tenant's
+		// reconciliation job.
+		kvAccessor spanconfig.KVAccessor
+		// subscriber is used by stores to subscribe to span configuration updates.
+		subscriber spanconfig.KVSubscriber
+		// kvAccessorForTenantRecords is when creating/destroying secondary
+		// tenant records.
+		kvAccessorForTenantRecords spanconfig.KVAccessor
+	}
+	if !cfg.SpanConfigsDisabled {
+		spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
+		if spanConfigKnobs != nil && spanConfigKnobs.StoreKVSubscriberOverride != nil {
+			spanConfig.subscriber = spanConfigKnobs.StoreKVSubscriberOverride
+		} else {
+			// We use the span configs infra to control whether rangefeeds are
+			// enabled on a given range. At the moment this only applies to
+			// system tables (on both host and secondary tenants). We need to
+			// consider two things:
+			// - The sql-side reconciliation process runs asynchronously. When
+			//   the config for a given range is requested, we might not yet have
+			//   it, thus falling back to the static config below.
+			// - Various internal subsystems rely on rangefeeds to function.
+			//
+			// Consequently, we configure our static fallback config to actually
+			// allow rangefeeds. As the sql-side reconciliation process kicks
+			// off, it'll install the actual configs that we'll later consult.
+			// For system table ranges we install configs that allow for
+			// rangefeeds. Until then, we simply allow rangefeeds when a more
+			// targeted config is not found.
+			fallbackConf := cfg.DefaultZoneConfig.AsSpanConfig()
+			fallbackConf.RangefeedEnabled = true
+			// We do the same for opting out of strict GC enforcement; it
+			// really only applies to user table ranges
+			fallbackConf.GCPolicy.IgnoreStrictEnforcement = true
+
+			spanConfig.subscriber = spanconfigkvsubscriber.New(
+				clock,
+				rangeFeedFactory,
+				keys.SpanConfigurationsTableID,
+				1<<20, /* 1 MB */
+				fallbackConf,
+				spanConfigKnobs,
+			)
+		}
+
+		scKVAccessor := spanconfigkvaccessor.New(
+			db, internalExecutor, cfg.Settings,
+			systemschema.SpanConfigurationsTableName.FQString(),
+		)
+		spanConfig.kvAccessor, spanConfig.kvAccessorForTenantRecords = scKVAccessor, scKVAccessor
+	} else {
+		// If the spanconfigs infrastructure is disabled, there should be no
+		// reconciliation jobs or RPCs issued against the infrastructure. Plug
+		// in a disabled spanconfig.KVAccessor that would error out for
+		// unexpected use.
+		spanConfig.kvAccessor = spanconfigkvaccessor.DisabledKVAccessor
+
+		// Use a no-op accessor where tenant records are created/destroyed.
+		spanConfig.kvAccessorForTenantRecords = spanconfigkvaccessor.NoopKVAccessor
+
+		spanConfig.subscriber = spanconfigkvsubscriber.NewNoopSubscriber(clock)
+	}
+
+	var protectedTSReader spanconfig.ProtectedTSReader
+	if cfg.TestingKnobs.SpanConfig != nil &&
+		cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs).ProtectedTSReaderOverrideFn != nil {
+		fn := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs).ProtectedTSReaderOverrideFn
+		protectedTSReader = fn(clock)
+	} else {
+		protectedTSReader = spanconfigptsreader.NewAdapter(protectedtsProvider.(*ptprovider.Provider).Cache, spanConfig.subscriber)
+	}
 
 	storeCfg := kvserver.StoreConfig{
 		DefaultSpanConfig:        cfg.DefaultZoneConfig.AsSpanConfig(),
@@ -544,71 +615,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		KVMemoryMonitor:          kvMemoryMonitor,
 		RangefeedBudgetFactory:   rangeReedBudgetFactory,
 		SystemConfigProvider:     systemConfigWatcher,
-	}
-
-	var spanConfig struct {
-		// kvAccessor powers the span configuration RPCs and the host tenant's
-		// reconciliation job.
-		kvAccessor spanconfig.KVAccessor
-		// subscriber is used by stores to subsribe to span configuration
-		// updates.
-		subscriber *spanconfigkvsubscriber.KVSubscriber
-		// kvAccessorForTenantRecords is when creating/destroying secondary
-		// tenant records.
-		kvAccessorForTenantRecords spanconfig.KVAccessor
-	}
-	storeCfg.SpanConfigsDisabled = cfg.SpanConfigsDisabled
-	if !cfg.SpanConfigsDisabled {
-		spanConfigKnobs, _ := cfg.TestingKnobs.SpanConfig.(*spanconfig.TestingKnobs)
-		if spanConfigKnobs != nil && spanConfigKnobs.StoreKVSubscriberOverride != nil {
-			storeCfg.SpanConfigSubscriber = spanConfigKnobs.StoreKVSubscriberOverride
-		} else {
-			// We use the span configs infra to control whether rangefeeds are
-			// enabled on a given range. At the moment this only applies to
-			// system tables (on both host and secondary tenants). We need to
-			// consider two things:
-			// - The sql-side reconciliation process runs asynchronously. When
-			//   the config for a given range is requested, we might not yet have
-			//   it, thus falling back to the static config below.
-			// - Various internal subsystems rely on rangefeeds to function.
-			//
-			// Consequently, we configure our static fallback config to actually
-			// allow rangefeeds. As the sql-side reconciliation process kicks
-			// off, it'll install the actual configs that we'll later consult.
-			// For system table ranges we install configs that allow for
-			// rangefeeds. Until then, we simply allow rangefeeds when a more
-			// targeted config is not found.
-			fallbackConf := storeCfg.DefaultSpanConfig
-			fallbackConf.RangefeedEnabled = true
-			// We do the same for opting out of strict GC enforcement; it
-			// really only applies to user table ranges
-			fallbackConf.GCPolicy.IgnoreStrictEnforcement = true
-
-			spanConfig.subscriber = spanconfigkvsubscriber.New(
-				clock,
-				rangeFeedFactory,
-				keys.SpanConfigurationsTableID,
-				1<<20, /* 1 MB */
-				fallbackConf,
-				spanConfigKnobs,
-			)
-			storeCfg.SpanConfigSubscriber = spanConfig.subscriber
-		}
-
-		scKVAccessor := spanconfigkvaccessor.New(
-			db, internalExecutor, cfg.Settings,
-			systemschema.SpanConfigurationsTableName.FQString(),
-		)
-		spanConfig.kvAccessor, spanConfig.kvAccessorForTenantRecords = scKVAccessor, scKVAccessor
-	} else {
-		// If the spanconfigs infrastructure is disabled, there should be no
-		// reconciliation jobs or RPCs issued against the infrastructure. Plug
-		// in a disabled spanconfig.KVAccessor that would error out for
-		// unexpected use.
-		spanConfig.kvAccessor = spanconfigkvaccessor.DisabledKVAccessor
-
-		// Use a no-op accessor where tenant records are created/destroyed.
-		spanConfig.kvAccessorForTenantRecords = spanconfigkvaccessor.NoopKVAccessor
+		SpanConfigSubscriber:     spanConfig.subscriber,
+		SpanConfigsDisabled:      cfg.SpanConfigsDisabled,
 	}
 
 	if storeTestingKnobs := cfg.TestingKnobs.Store; storeTestingKnobs != nil {
@@ -1418,8 +1426,10 @@ func (s *Server) PreStart(ctx context.Context) error {
 	}
 
 	if !s.cfg.SpanConfigsDisabled && s.spanConfigSubscriber != nil {
-		if err := s.spanConfigSubscriber.Start(ctx, s.stopper); err != nil {
-			return err
+		if subscriber, ok := s.spanConfigSubscriber.(*spanconfigkvsubscriber.KVSubscriber); ok {
+			if err := subscriber.Start(ctx, s.stopper); err != nil {
+				return err
+			}
 		}
 	}
 	// Start garbage collecting system events.

--- a/pkg/spanconfig/protectedts_state_reader.go
+++ b/pkg/spanconfig/protectedts_state_reader.go
@@ -51,19 +51,19 @@ func (p *ProtectedTimestampStateReader) GetProtectionPoliciesForCluster() []roac
 // TenantProtectedTimestamps represents all the protections that apply to a
 // tenant's keyspace.
 type TenantProtectedTimestamps struct {
-	protections []roachpb.ProtectionPolicy
-	tenantID    roachpb.TenantID
+	Protections []roachpb.ProtectionPolicy
+	TenantID    roachpb.TenantID
 }
 
 // GetTenantProtections returns the ProtectionPolicies that apply to this tenant.
 func (t *TenantProtectedTimestamps) GetTenantProtections() []roachpb.ProtectionPolicy {
-	return t.protections
+	return t.Protections
 }
 
 // GetTenantID returns the tenant ID of the tenant that the protected timestamp
 // records target.
 func (t *TenantProtectedTimestamps) GetTenantID() roachpb.TenantID {
-	return t.tenantID
+	return t.TenantID
 }
 
 // GetProtectionPoliciesForTenants returns all the protected timestamps that
@@ -77,7 +77,7 @@ func (p *ProtectedTimestampStateReader) GetProtectionPoliciesForTenants() []Tena
 // apply to a particular tenant's keyspace.
 func (p *ProtectedTimestampStateReader) ProtectionExistsForTenant(tenantID roachpb.TenantID) bool {
 	for _, tp := range p.tenantProtections {
-		if tp.tenantID.Equal(tenantID) {
+		if tp.TenantID.Equal(tenantID) {
 			return true
 		}
 	}
@@ -120,6 +120,6 @@ func (p *ProtectedTimestampStateReader) loadProtectedTimestampRecords(ptsState p
 
 	for tenID, tenantProtections := range tenantProtections {
 		p.tenantProtections = append(p.tenantProtections,
-			TenantProtectedTimestamps{tenantID: tenID, protections: tenantProtections})
+			TenantProtectedTimestamps{TenantID: tenID, Protections: tenantProtections})
 	}
 }

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -48,10 +48,12 @@ type KVAccessor interface {
 	WithTxn(context.Context, *kv.Txn) KVAccessor
 }
 
-// KVSubscriber presents a consistent[1] snapshot of a StoreReader that's
-// incrementally maintained with changes made to the global span configurations
-// state (system.span_configurations). The maintenance happens transparently;
-// callers can subscribe to learn about what key spans may have seen a
+// KVSubscriber presents a consistent[1] snapshot of a StoreReader and
+// ProtectedTSReader that's incrementally maintained with changes made to the
+// global span configurations state (system.span_configurations). The
+// maintenance happens transparently.
+//
+// Callers can subscribe to learn about what key spans may have seen a
 // configuration change. After learning about a span update through a callback
 // invocation, subscribers can consult the embedded StoreReader to retrieve an
 // up-to-date[2] config for the updated span. The callback is called in a single
@@ -66,10 +68,11 @@ type KVAccessor interface {
 // StoreReader for the given span would still retrieve the last config observed
 // for the span[3].
 //
-// [1]: The contents of the StoreReader at t1 corresponds exactly to the
-//      contents of the global span configuration state at t0 where t0 <= t1. If
-//      the StoreReader is read from at t2 where t2 > t1, it's guaranteed to
-//      observe a view of the global state at t >= t0.
+// [1]: The contents of the StoreReader and ProtectedTSReader at t1 corresponds
+//      exactly to the contents of the global span configuration state at t0
+//      where t0 <= t1. If the StoreReader or ProtectedTSReader is read from at
+//      t2 where t2 > t1, it's guaranteed to observe a view of the global state
+//      at t >= t0.
 // [2]: For the canonical KVSubscriber implementation, this is typically lagging
 //      by the closed timestamp target duration.
 // [3]: The canonical KVSubscriber implementation is bounced whenever errors
@@ -77,6 +80,8 @@ type KVAccessor interface {
 //      (typically through a coarsely targeted [min,max) span).
 type KVSubscriber interface {
 	StoreReader
+	ProtectedTSReader
+
 	LastUpdated() hlc.Timestamp
 	Subscribe(func(ctx context.Context, updated roachpb.Span))
 }
@@ -406,7 +411,7 @@ type ProtectedTSReader interface {
 	// part of the given key span. The time at which this protected timestamp
 	// state is valid is returned as well.
 	GetProtectionTimestamps(ctx context.Context, sp roachpb.Span) (
-		protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp,
+		protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, _ error,
 	)
 }
 
@@ -421,7 +426,7 @@ type emptyProtectedTSReader hlc.Clock
 // GetProtectionTimestamps is part of the spanconfig.ProtectedTSReader
 // interface.
 func (r *emptyProtectedTSReader) GetProtectionTimestamps(
-	_ context.Context, _ roachpb.Span,
-) ([]hlc.Timestamp, hlc.Timestamp) {
-	return nil, (*hlc.Clock)(r).Now()
+	context.Context, roachpb.Span,
+) ([]hlc.Timestamp, hlc.Timestamp, error) {
+	return nil, (*hlc.Clock)(r).Now(), nil
 }

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "spanconfigkvsubscriber",
     srcs = [
+        "dummy.go",
         "kvsubscriber.go",
         "spanconfigdecoder.go",
     ],

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -1,0 +1,69 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigkvsubscriber
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// noopKVSubscriber is a KVSubscriber that no-ops and is always up-to-date.
+// Intended for tests that do not make use of the span configurations
+// infrastructure.
+type noopKVSubscriber struct {
+	clock *hlc.Clock
+}
+
+var _ spanconfig.KVSubscriber = &noopKVSubscriber{}
+
+// NewNoopSubscriber returns a new no-op KVSubscriber.
+func NewNoopSubscriber(clock *hlc.Clock) spanconfig.KVSubscriber {
+	return &noopKVSubscriber{
+		clock: clock,
+	}
+}
+
+// Subscribe is part of the spanconfig.KVSubsriber interface.
+func (n *noopKVSubscriber) Subscribe(func(context.Context, roachpb.Span)) {}
+
+// LastUpdated is part of the spanconfig.KVSubscriber interface.
+func (n *noopKVSubscriber) LastUpdated() hlc.Timestamp {
+	return n.clock.Now()
+}
+
+// NeedsSplit is part of the spanconfig.KVSubscriber interface.
+func (n *noopKVSubscriber) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) bool {
+	return false
+}
+
+// ComputeSplitKey is part of the spanconfig.KVSubscriber interface.
+func (n *noopKVSubscriber) ComputeSplitKey(
+	context.Context, roachpb.RKey, roachpb.RKey,
+) roachpb.RKey {
+	return roachpb.RKey{}
+}
+
+// GetSpanConfigForKey is part of the spanconfig.KVSubscriber interface.
+func (n *noopKVSubscriber) GetSpanConfigForKey(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, error) {
+	return roachpb.SpanConfig{}, nil
+}
+
+// GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.
+func (n *noopKVSubscriber) GetProtectionTimestamps(
+	context.Context, roachpb.Span,
+) ([]hlc.Timestamp, hlc.Timestamp, error) {
+	return nil, n.LastUpdated(), nil
+}

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -90,7 +90,7 @@ type KVSubscriber struct {
 		// populated while the exposed spanconfig.StoreReader appears static.
 		// Once sufficiently caught up, the fresh spanconfig.Store is swapped in
 		// and the old discarded. See type-level comment for more details.
-		internal spanconfig.Store
+		internal *spanconfigstore.Store
 		handlers []handler
 	}
 }
@@ -206,6 +206,26 @@ func (s *KVSubscriber) GetSpanConfigForKey(
 	defer s.mu.RUnlock()
 
 	return s.mu.internal.GetSpanConfigForKey(ctx, key)
+}
+
+// GetProtectionTimestamps is part of the spanconfig.KVSubscriber interface.
+func (s *KVSubscriber) GetProtectionTimestamps(
+	ctx context.Context, sp roachpb.Span,
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, _ error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if err := s.mu.internal.ForEachOverlappingSpanConfig(ctx, sp,
+		func(_ roachpb.Span, config roachpb.SpanConfig) error {
+			for _, protection := range config.GCPolicy.ProtectionPolicies {
+				protectionTimestamps = append(protectionTimestamps, protection.ProtectedTimestamp)
+			}
+			return nil
+		}); err != nil {
+		return nil, hlc.Timestamp{}, err
+	}
+
+	return protectionTimestamps, s.mu.lastUpdated, nil
 }
 
 func (s *KVSubscriber) handleUpdate(ctx context.Context, u rangefeedcache.Update) {

--- a/pkg/spanconfig/spanconfigptsreader/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigptsreader/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "spanconfigptsreader",
@@ -6,10 +6,28 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/kv/kvserver/protectedts/ptcache",
+        "//pkg/kv/kvserver/protectedts",
+        "//pkg/roachpb",
+        "//pkg/spanconfig",
+        "//pkg/testutils",
+        "//pkg/util/hlc",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "spanconfigptsreader_test",
+    srcs = ["adapter_test.go"],
+    embed = [":spanconfigptsreader"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
         "//pkg/spanconfig",
         "//pkg/util/hlc",
-        "@com_github_cockroachdb_errors//:errors",
+        "//pkg/util/leaktest",
+        "//pkg/util/stop",
+        "//pkg/util/uuid",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/spanconfig/spanconfigptsreader/adapter.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter.go
@@ -12,10 +12,12 @@ package spanconfigptsreader
 
 import (
 	"context"
+	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptcache"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
@@ -36,21 +38,20 @@ import (
 //
 // TODO(arul): In 22.2, we would have completely migrated away from the old
 //  subsystem, and we'd be able to get rid of this interface.
-//
-// TODO(arul): Add the KVSubscriber here as well and actually encapsulate PTS
-// information from both these sources as described above; This will happen once
-// we make the KVSubscriber implement the spanconfig.ProtectedTSReader
-// interface.
 type adapter struct {
-	cache *ptcache.Cache
+	cache        protectedts.Cache
+	kvSubscriber spanconfig.KVSubscriber
 }
 
 var _ spanconfig.ProtectedTSReader = &adapter{}
 
 // NewAdapter returns an adapter that implements spanconfig.ProtectedTSReader.
-func NewAdapter(cache *ptcache.Cache) spanconfig.ProtectedTSReader {
+func NewAdapter(
+	cache protectedts.Cache, kvSubscriber spanconfig.KVSubscriber,
+) spanconfig.ProtectedTSReader {
 	return &adapter{
-		cache: cache,
+		cache:        cache,
+		kvSubscriber: kvSubscriber,
 	}
 }
 
@@ -58,21 +59,43 @@ func NewAdapter(cache *ptcache.Cache) spanconfig.ProtectedTSReader {
 // interface.
 func (a *adapter) GetProtectionTimestamps(
 	ctx context.Context, sp roachpb.Span,
-) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp) {
-	return a.cache.GetProtectionTimestamps(ctx, sp)
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, err error) {
+	cacheTimestamps, cacheFreshness, err := a.cache.GetProtectionTimestamps(ctx, sp)
+	if err != nil {
+		return nil, hlc.Timestamp{}, err
+	}
+	subscriberTimestamps, subscriberFreshness, err := a.kvSubscriber.GetProtectionTimestamps(ctx, sp)
+	if err != nil {
+		return nil, hlc.Timestamp{}, err
+	}
+
+	// The freshness of the adapter is the minimum freshness of the Cache and
+	// KVSubscriber.
+	subscriberFreshness.Backward(cacheFreshness)
+	return append(subscriberTimestamps, cacheTimestamps...), subscriberFreshness, nil
 }
 
 // TestingRefreshPTSState refreshes the in-memory protected timestamp state to
 // at least asOf.
-// TODO(arul): Once we wrap the KVSubscriber in this adapter interface, we'll
-// need to ensure that the subscriber is at-least as caught up as the supplied
-// asOf timestamp as well.
 func TestingRefreshPTSState(
-	ctx context.Context, protectedTSReader spanconfig.ProtectedTSReader, asOf hlc.Timestamp,
+	ctx context.Context,
+	t *testing.T,
+	protectedTSReader spanconfig.ProtectedTSReader,
+	asOf hlc.Timestamp,
 ) error {
 	a, ok := protectedTSReader.(*adapter)
 	if !ok {
-		return errors.AssertionFailedf("could not convert protectedts.Provider to ptprovider.Provider")
+		return errors.AssertionFailedf("could not convert protectedTSReader to adapter")
 	}
+	testutils.SucceedsSoon(t, func() error {
+		_, fresh, err := a.GetProtectionTimestamps(ctx, roachpb.Span{})
+		if err != nil {
+			return err
+		}
+		if fresh.Less(asOf) {
+			return errors.AssertionFailedf("KVSubscriber fresh as of %s; not caught up to %s", fresh, asOf)
+		}
+		return nil
+	})
 	return a.cache.Refresh(ctx, asOf)
 }

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -1,0 +1,167 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfigptsreader
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdapter ensures that the spanconfigptsreader.adapter correctly returns
+// protected timestamp information
+func TestAdapter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ts := func(nanos int) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: int64(nanos),
+		}
+	}
+	validateProtectedTimestamps := func(expected, actual []hlc.Timestamp) {
+		sort.Slice(actual, func(i, j int) bool {
+			return actual[i].Less(actual[j])
+		})
+		require.Equal(t, expected, actual)
+	}
+
+	mc := &manualCache{}
+	ms := &manualSubscriber{}
+
+	adapter := NewAdapter(mc, ms)
+	ctx := context.Background()
+
+	// Setup with an empty subscriber and cache; ensure no records are returned
+	// and the freshness timestamp is the minimum of the two.
+	mc.asOf = ts(10)
+	ms.updatedTS = ts(14)
+	timestamps, asOf, err := adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+	require.Empty(t, timestamps)
+	require.Equal(t, ts(10), asOf)
+
+	// Forward the freshness of the cache past the subscriber's.
+	mc.asOf = ts(18)
+	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+	require.Empty(t, timestamps)
+	require.Equal(t, ts(14), asOf)
+
+	// Add some records to the cache; ensure they're returned.
+	mc.protectedTimestamps = append(mc.protectedTimestamps, ts(6), ts(10))
+	mc.asOf = ts(20)
+
+	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+	require.Equal(t, ts(14), asOf)
+	validateProtectedTimestamps([]hlc.Timestamp{ts(6), ts(10)}, timestamps)
+
+	// Add some records to the subscriber, ensure they're returned as well.
+	ms.protectedTimestamps = append(ms.protectedTimestamps, ts(7), ts(12))
+	ms.updatedTS = ts(19)
+	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+	require.Equal(t, ts(19), asOf)
+	validateProtectedTimestamps([]hlc.Timestamp{ts(6), ts(7), ts(10), ts(12)}, timestamps)
+
+	// Clear out records from the cache, bump its freshness.
+	mc.protectedTimestamps = nil
+	mc.asOf = ts(22)
+	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+	require.Equal(t, ts(19), asOf)
+	validateProtectedTimestamps([]hlc.Timestamp{ts(7), ts(12)}, timestamps)
+
+	// Clear out records from the subscriber, bump its freshness.
+	ms.protectedTimestamps = nil
+	ms.updatedTS = ts(25)
+	timestamps, asOf, err = adapter.GetProtectionTimestamps(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+	require.Equal(t, ts(22), asOf)
+	require.Empty(t, timestamps)
+}
+
+type manualSubscriber struct {
+	protectedTimestamps []hlc.Timestamp
+	updatedTS           hlc.Timestamp
+}
+
+var _ spanconfig.KVSubscriber = &manualSubscriber{}
+
+func (m *manualSubscriber) GetProtectionTimestamps(
+	context.Context, roachpb.Span,
+) ([]hlc.Timestamp, hlc.Timestamp, error) {
+	return m.protectedTimestamps, m.updatedTS, nil
+}
+
+func (m *manualSubscriber) Start(context.Context, *stop.Stopper) error {
+	panic("unimplemented")
+}
+
+func (m *manualSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
+	panic("unimplemented")
+}
+
+func (m *manualSubscriber) ComputeSplitKey(
+	context.Context, roachpb.RKey, roachpb.RKey,
+) roachpb.RKey {
+	panic("unimplemented")
+}
+
+func (m *manualSubscriber) GetSpanConfigForKey(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, error) {
+	panic("unimplemented")
+}
+
+func (m *manualSubscriber) LastUpdated() hlc.Timestamp {
+	return m.updatedTS
+}
+
+func (m *manualSubscriber) Subscribe(callback func(context.Context, roachpb.Span)) {
+	panic("unimplemented")
+}
+
+type manualCache struct {
+	asOf                hlc.Timestamp
+	protectedTimestamps []hlc.Timestamp
+}
+
+var _ protectedts.Cache = (*manualCache)(nil)
+
+func (c *manualCache) GetProtectionTimestamps(
+	context.Context, roachpb.Span,
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, err error) {
+	return c.protectedTimestamps, c.asOf, nil
+}
+
+func (c *manualCache) Iterate(
+	_ context.Context, start, end roachpb.Key, it protectedts.Iterator,
+) hlc.Timestamp {
+	panic("unimplemented")
+}
+
+func (c *manualCache) Refresh(ctx context.Context, asOf hlc.Timestamp) error {
+	panic("unimplemented")
+}
+
+func (c *manualCache) QueryRecord(context.Context, uuid.UUID) (exists bool, asOf hlc.Timestamp) {
+	panic("unimplemented")
+}

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -33,16 +33,6 @@ func (s *Store) TestingApplyInternal(
 	return s.applyInternal(dryrun, updates...)
 }
 
-// TestingSpanConfigStoreForEachOverlapping exports an internal method on the
-// spanConfigStore for testing purposes.
-func (s *Store) TestingSpanConfigStoreForEachOverlapping(
-	span roachpb.Span, f func(spanConfigEntry) error,
-) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.mu.spanConfigStore.forEachOverlapping(span, f)
-}
-
 // TestDataDriven runs datadriven tests against the Store interface.
 // The syntax is as follows:
 //
@@ -136,12 +126,12 @@ func TestDataDriven(t *testing.T) {
 				span := spanconfigtestutils.ParseSpan(t, spanStr)
 
 				var results []string
-				_ = store.TestingSpanConfigStoreForEachOverlapping(span,
-					func(entry spanConfigEntry) error {
+				_ = store.ForEachOverlappingSpanConfig(ctx, span,
+					func(sp roachpb.Span, conf roachpb.SpanConfig) error {
 						results = append(results,
 							spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
-								Target: spanconfig.MakeTargetFromSpan(entry.span),
-								Config: entry.config,
+								Target: spanconfig.MakeTargetFromSpan(sp),
+								Config: conf,
 							}),
 						)
 						return nil

--- a/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs_overlap
+++ b/pkg/spanconfig/spanconfigstore/testdata/batched/system_span_configs_overlap
@@ -1,0 +1,49 @@
+apply
+set [b,d):A
+set {entire-keyspace}:X
+set [e,g):B
+----
+added {entire-keyspace}:X
+added [b,d):A
+added [e,g):B
+
+# Span encompassing all spans we have inserted.
+overlapping span=[a,j)
+----
+[b,d):A+X
+[e,g):B+X
+
+apply
+set [g,i):C
+----
+added [g,i):C
+
+# Span encompassing all spans we have inserted.
+overlapping span=[a,i)
+----
+[b,d):A+X
+[e,g):B+X
+[g,i):C+X
+
+# Span straddling first and second span.
+overlapping span=[b,e)
+----
+[b,d):A+X
+
+# Straddling all 3 spans.
+overlapping span=[c,h)
+----
+[b,d):A+X
+[e,g):B+X
+[g,i):C+X
+
+apply
+set {source=1,target=1}:Y
+----
+added {source=1,target=1}:Y
+
+overlapping span=[a,i)
+----
+[b,d):A+X+Y
+[e,g):B+X+Y
+[g,i):C+X+Y

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // TestingKnobs provide fine-grained control over the various span config
@@ -69,6 +70,10 @@ type TestingKnobs struct {
 	// ReconcilerInitialInterceptor, if set, is invoked at the very outset of
 	// the reconciliation process.
 	ReconcilerInitialInterceptor func()
+
+	// ProtectedTSReaderOverrideFn returns a ProtectedTSReader which is used to
+	// override the ProtectedTSReader used when setting up a new store.
+	ProtectedTSReaderOverrideFn func(clock *hlc.Clock) ProtectedTSReader
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This patch makes the `KVSubscriber` implement the `ProtectedTSReader`
interface. This allows the GC queue to consult protected timestamp
information reconciled by sql tenants when making GC decisions.

We also initialize the `spanconfigptsreader.adapter` struct with a
KVSubscriber now. The adapter was conceived with the intention to
encapsulate PTS information from both the old and new subsystem for
release 22.1 behind a single source for the GC queue to consume.
Threading in the KVSubscriber actually achieves this. We return the
minimum freshness of the cache and KVSubscriber to the GC queue from
the adapter.

Release justification: bug fixes and low risk updates to new
functionality

Release note: None