### PR TITLE
server: optionally serve http traffic when forwarded from https

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -328,6 +328,7 @@ go_test(
         "pagination_test.go",
         "purge_auth_session_test.go",
         "servemode_test.go",
+        "server_http_test.go",
         "server_import_ts_test.go",
         "server_systemlog_gc_test.go",
         "server_test.go",

--- a/pkg/server/server_http_test.go
+++ b/pkg/server/server_http_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -72,5 +73,143 @@ func TestHSTS(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Empty(t, resp.Header.Get(hstsHeaderKey))
+	}
+}
+
+func TestRedirectWhenForwardedHTTPS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	httpClient, err := s.GetHTTPClient()
+	require.NoError(t, err)
+	defer httpClient.CloseIdleConnections()
+
+	secureClient, err := s.GetAuthenticatedHTTPClient(false)
+	require.NoError(t, err)
+	defer secureClient.CloseIdleConnections()
+
+	urlsToTest := []string{"/", "/_status/vars", "/index.html"}
+
+	adminURLHTTPS := s.AdminURL()
+	adminURLHTTP := strings.Replace(adminURLHTTPS, "https", "http", 1)
+
+	for _, u := range urlsToTest {
+		req, err := http.NewRequest("GET", adminURLHTTP+u, nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Forwarded-Proto", "https")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, 307)
+
+		resp, err = secureClient.Get(adminURLHTTPS + u)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, 200)
+	}
+
+	_, err = db.Exec("SET cluster setting server.accept_https_forwarded.enabled = true")
+	require.NoError(t, err)
+
+	for _, u := range urlsToTest {
+		req, err := http.NewRequest("GET", adminURLHTTP+u, nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Forwarded-For", "https")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, 200)
+
+		resp, err = secureClient.Get(adminURLHTTPS + u)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, 200)
+	}
+	_, err = db.Exec("SET cluster setting server.accept_https_forwarded.enabled = false")
+	require.NoError(t, err)
+
+	for _, u := range urlsToTest {
+		req, err := http.NewRequest("GET", adminURLHTTP+u, nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Forwarded-Proto", "https")
+
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, 307)
+
+		resp, err = secureClient.Get(adminURLHTTPS + u)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, 200)
+	}
+}
+
+func Test_getForwardedProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		args http.Header
+		want string
+	}{
+		{
+			"empty header",
+			http.Header{},
+			"",
+		},
+		{
+			"x-forwarded-proto header contains https",
+			http.Header{
+				"x-forwarded-proto": []string{"https"},
+			},
+			"https",
+		},
+		{
+			"x-forwarded-proto header is empty",
+			http.Header{
+				"x-forwarded-proto": []string{""},
+			},
+			"",
+		},
+		{
+			"forwarded header contains proto",
+			http.Header{
+				"forwarded": []string{"for=192.0.2.60;proto=https;by=203.0.113.43"},
+			},
+			"https",
+		},
+		{
+			"forwarded header contains proto at head",
+			http.Header{
+				"forwarded": []string{"proto=https;by=203.0.113.43"},
+			},
+			"https",
+		},
+		{
+			"forwarded header contains proto at tail",
+			http.Header{
+				"forwarded": []string{"for=192.0.2.60;by=203.0.113.43;proto=https"},
+			},
+			"https",
+		},
+		{
+			"forwarded header contains proto only",
+			http.Header{
+				"forwarded": []string{"proto=https"},
+			},
+			"https",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getForwardedProtocol(tt.args.h); got != tt.want {
+				t.Errorf("getForwardedProtocol() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Note: Please ignore the first commit in this PR, I used it as a base since it has a test file already, it will be merged separately here: #77244

Could potentially resolve: https://github.com/cockroachdb/helm-charts/issues/228

----

This change allows CRDB to serve HTTP traffic with the
`server.accept_https_forwarded.enabled` cluster setting is enabled
*and* the request contains an `X-Forwarded-Proto` header with the value
`https`, or a `Forwarded` header containing the directive:
`proto=https`.

The aim is to enable easier use of the DB Console behind load balancers.

Release justification: opt-in feature that unblocks customers with load
balancers using DB Console

Release note (ops change, security update, ui change): When an operator
configures CRDB to serve HTTP traffic behind a load balancer, often they
would like to terminate TLS at the load balancer and have the load
balancer use HTTP to talk to the DB since that traffic will sit within
their private network instead of the public internet. Enabling the
`server.accept_http_forwarded.enabled` cluster setting will instruct
CRDB to inspect the `X-Forwarded-Proto` or `Forwarded` headers and allow
traffic over HTTP when the protocol is `https`.