### PR TITLE
spanconfig: add Record constructor and validation

### DIFF
--- a/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
+++ b/pkg/ccl/migrationccl/migrationsccl/seed_tenant_span_configs_external_test.go
@@ -75,7 +75,7 @@ func TestPreSeedSpanConfigsWrittenWhenActive(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, records, 1)
-		require.Equal(t, records[0].Target.GetSpan(), tenantSeedSpan)
+		require.Equal(t, records[0].GetTarget().GetSpan(), tenantSeedSpan)
 	}
 }
 
@@ -144,7 +144,7 @@ func TestSeedTenantSpanConfigs(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, records, 1)
-		require.Equal(t, records[0].Target.GetSpan(), tenantSeedSpan)
+		require.Equal(t, records[0].GetTarget().GetSpan(), tenantSeedSpan)
 	}
 }
 
@@ -200,7 +200,7 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, records, 1)
-		require.Equal(t, records[0].Target.GetSpan(), tenantSeedSpan)
+		require.Equal(t, records[0].GetTarget().GetSpan(), tenantSeedSpan)
 	}
 
 	// Ensure the cluster version bump goes through successfully.
@@ -215,6 +215,6 @@ func TestSeedTenantSpanConfigsWithExistingEntry(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, records, 1)
-		require.Equal(t, records[0].Target.GetSpan(), tenantSeedSpan)
+		require.Equal(t, records[0].GetTarget().GetSpan(), tenantSeedSpan)
 	}
 }

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -208,18 +208,18 @@ func TestDataDriven(t *testing.T) {
 				)
 				require.NoError(t, err)
 				sort.Slice(records, func(i, j int) bool {
-					return records[i].Target.Less(records[j].Target)
+					return records[i].GetTarget().Less(records[j].GetTarget())
 				})
 
 				lines := make([]string, len(records))
 				for i, record := range records {
 					switch {
-					case record.Target.IsSpanTarget():
-						lines[i] = fmt.Sprintf("%-42s %s", record.Target.GetSpan(),
-							spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.Config))
-					case record.Target.IsSystemTarget():
-						lines[i] = fmt.Sprintf("%-42s %s", record.Target.GetSystemTarget(),
-							spanconfigtestutils.PrintSystemSpanConfigDiffedAgainstDefault(record.Config))
+					case record.GetTarget().IsSpanTarget():
+						lines[i] = fmt.Sprintf("%-42s %s", record.GetTarget().GetSpan(),
+							spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.GetConfig()))
+					case record.GetTarget().IsSystemTarget():
+						lines[i] = fmt.Sprintf("%-42s %s", record.GetTarget().GetSystemTarget(),
+							spanconfigtestutils.PrintSystemSpanConfigDiffedAgainstDefault(record.GetConfig()))
 					default:
 						panic("unsupported target type")
 					}

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -161,18 +161,18 @@ func TestDataDriven(t *testing.T) {
 				records, _, err := sqlTranslator.Translate(ctx, descIDs, generateSystemSpanConfigs)
 				require.NoError(t, err)
 				sort.Slice(records, func(i, j int) bool {
-					return records[i].Target.Less(records[j].Target)
+					return records[i].GetTarget().Less(records[j].GetTarget())
 				})
 
 				var output strings.Builder
 				for _, record := range records {
 					switch {
-					case record.Target.IsSpanTarget():
-						output.WriteString(fmt.Sprintf("%-42s %s\n", record.Target.GetSpan(),
-							spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.Config)))
-					case record.Target.IsSystemTarget():
-						output.WriteString(fmt.Sprintf("%-42s %s\n", record.Target.GetSystemTarget(),
-							spanconfigtestutils.PrintSystemSpanConfigDiffedAgainstDefault(record.Config)))
+					case record.GetTarget().IsSpanTarget():
+						output.WriteString(fmt.Sprintf("%-42s %s\n", record.GetTarget().GetSpan(),
+							spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.GetConfig())))
+					case record.GetTarget().IsSystemTarget():
+						output.WriteString(fmt.Sprintf("%-42s %s\n", record.GetTarget().GetSystemTarget(),
+							spanconfigtestutils.PrintSystemSpanConfigDiffedAgainstDefault(record.GetConfig())))
 					default:
 						panic("unsupported target type")
 					}
@@ -185,12 +185,12 @@ func TestDataDriven(t *testing.T) {
 				require.NoError(t, err)
 
 				sort.Slice(records, func(i, j int) bool {
-					return records[i].Target.Less(records[j].Target)
+					return records[i].GetTarget().Less(records[j].GetTarget())
 				})
 				var output strings.Builder
 				for _, record := range records {
-					output.WriteString(fmt.Sprintf("%-42s %s\n", record.Target.GetSpan(),
-						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.Config)))
+					output.WriteString(fmt.Sprintf("%-42s %s\n", record.GetTarget().GetSpan(),
+						spanconfigtestutils.PrintSpanConfigDiffedAgainstDefaults(record.GetConfig())))
 				}
 				return output.String()
 

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -70,12 +70,9 @@ func TestGCTenantRemovesSpanConfigs(t *testing.T) {
 	// keyspace.
 	systemTarget, err := spanconfig.MakeTenantKeyspaceTarget(tenantID, tenantID)
 	require.NoError(t, err)
-	err = tenantKVAccessor.UpdateSpanConfigRecords(ctx, nil /* toDelete */, []spanconfig.Record{
-		{
-			Target: spanconfig.MakeTargetFromSystemTarget(systemTarget),
-			Config: roachpb.SpanConfig{}, // Doesn't matter
-		},
-	})
+	rec, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSystemTarget(systemTarget), roachpb.SpanConfig{})
+	require.NoError(t, err)
+	err = tenantKVAccessor.UpdateSpanConfigRecords(ctx, nil /* toDelete */, []spanconfig.Record{rec})
 	require.NoError(t, err)
 
 	// Ensure there are 2 configs for the tenant -- one that spans its entire

--- a/pkg/migration/migrations/seed_tenant_span_configs.go
+++ b/pkg/migration/migrations/seed_tenant_span_configs.go
@@ -67,12 +67,12 @@ func seedTenantSpanConfigsMigration(
 				Key:    tenantPrefix,
 				EndKey: tenantPrefix.Next(),
 			}
-			toUpsert := []spanconfig.Record{
-				{
-					Target: spanconfig.MakeTargetFromSpan(tenantSeedSpan),
-					Config: tenantSpanConfig,
-				},
+			record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(tenantSeedSpan),
+				tenantSpanConfig)
+			if err != nil {
+				return err
 			}
+			toUpsert := []spanconfig.Record{record}
 			scRecords, err := scKVAccessor.GetSpanConfigRecords(ctx, []spanconfig.Target{tenantTarget})
 			if err != nil {
 				return err

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/cockroachdb/errors"
 )
 
 // StoreMatchesConstraint returns whether a store's attributes or node's
@@ -48,6 +50,49 @@ func (s *SpanConfig) IsEmpty() bool {
 // TTL returns the implies TTL as a time.Duration.
 func (s *SpanConfig) TTL() time.Duration {
 	return time.Duration(s.GCPolicy.TTLSeconds) * time.Second
+}
+
+// ValidateSystemTargetSpanConfig ensures that only protection policies
+// (GCPolicy.ProtectionPolicies) field is set on the underlying
+// roachpb.SpanConfig.
+func (s *SpanConfig) ValidateSystemTargetSpanConfig() error {
+	if s.RangeMinBytes != 0 {
+		return errors.AssertionFailedf("RangeMinBytes set on system span config")
+	}
+	if s.RangeMaxBytes != 0 {
+		return errors.AssertionFailedf("RangeMaxBytes set on system span config")
+	}
+	if s.GCPolicy.TTLSeconds != 0 {
+		return errors.AssertionFailedf("TTLSeconds set on system span config")
+	}
+	if s.GCPolicy.IgnoreStrictEnforcement {
+		return errors.AssertionFailedf("IgnoreStrictEnforcement set on system span config")
+	}
+	if s.GlobalReads {
+		return errors.AssertionFailedf("GlobalReads set on system span config")
+	}
+	if s.NumReplicas != 0 {
+		return errors.AssertionFailedf("NumReplicas set on system span config")
+	}
+	if s.NumVoters != 0 {
+		return errors.AssertionFailedf("NumVoters set on system span config")
+	}
+	if len(s.Constraints) != 0 {
+		return errors.AssertionFailedf("Constraints set on system span config")
+	}
+	if len(s.VoterConstraints) != 0 {
+		return errors.AssertionFailedf("VoterConstraints set on system span config")
+	}
+	if len(s.LeasePreferences) != 0 {
+		return errors.AssertionFailedf("LeasePreferences set on system span config")
+	}
+	if s.RangefeedEnabled {
+		return errors.AssertionFailedf("RangefeedEnabled set on system span config")
+	}
+	if s.ExcludeDataFromBackup {
+		return errors.AssertionFailedf("ExcludeDataFromBackup set on system span config")
+	}
+	return nil
 }
 
 // GetNumVoters returns the number of voting replicas as defined in the

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -185,6 +185,10 @@ message SpanConfig {
   bool exclude_data_from_backup = 11;
 
   // Next ID: 12
+  //
+  // When adding a field, also add a check a to `ValidateSystemTargetSpanConfig`
+  // if it is not expected to be set on a SpanConfig corresponding to a
+  // SystemTarget.
 }
 
 // SystemSpanConfigTarget specifies the target of system span configurations.

--- a/pkg/spanconfig/BUILD.bazel
+++ b/pkg/spanconfig/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "spanconfig",
     srcs = [
         "protectedts_state_reader.go",
+        "record.go",
         "spanconfig.go",
         "systemtarget.go",
         "target.go",
@@ -30,6 +31,7 @@ go_test(
     name = "spanconfig_test",
     srcs = [
         "protectedts_state_reader_test.go",
+        "record_test.go",
         "target_test.go",
     ],
     embed = [":spanconfig"],

--- a/pkg/spanconfig/record.go
+++ b/pkg/spanconfig/record.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfig
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// Record ties a target to its corresponding config.
+type Record struct {
+	// target specifies the target (keyspan(s)) the config applies over.
+	target Target
+
+	// config is the set of attributes that apply over the corresponding target.
+	config roachpb.SpanConfig
+}
+
+// MakeRecord returns a Record with the specified Target and SpanConfig. If the
+// Record targets a SystemTarget, we also validate the SpanConfig.
+func MakeRecord(target Target, cfg roachpb.SpanConfig) (Record, error) {
+	if target.IsSystemTarget() {
+		if err := cfg.ValidateSystemTargetSpanConfig(); err != nil {
+			return Record{},
+				errors.NewAssertionErrorWithWrappedErrf(err, "failed to validate SystemTarget SpanConfig")
+		}
+	}
+	return Record{target: target, config: cfg}, nil
+}
+
+// IsEmpty returns true if the receiver is an empty Record.
+func (r *Record) IsEmpty() bool {
+	return r.target.isEmpty() && r.config.IsEmpty()
+}
+
+// GetTarget returns the Record target.
+func (r *Record) GetTarget() Target {
+	return r.target
+}
+
+// GetConfig returns the Record config.
+func (r *Record) GetConfig() roachpb.SpanConfig {
+	return r.config
+}

--- a/pkg/spanconfig/record_test.go
+++ b/pkg/spanconfig/record_test.go
@@ -1,0 +1,122 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package spanconfig
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+)
+
+// TestRecordSystemTargetValidation checks that a Record with SystemTarget is
+// validated on construction.
+func TestRecordSystemTargetValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		fn          func(scfg *roachpb.SpanConfig)
+		expectedErr string
+	}{
+		{
+			"range-min-bytes",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.RangeMinBytes = 1
+			},
+			"RangeMinBytes set on system span config",
+		},
+		{
+			"range-max-bytes",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.RangeMaxBytes = 1
+			},
+			"RangeMaxBytes set on system span config",
+		},
+		{
+			"gcttl",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.GCPolicy.TTLSeconds = 1
+			},
+			"TTLSeconds set on system span config",
+		},
+		{
+			"ignore-strict-gc",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.GCPolicy.IgnoreStrictEnforcement = true
+			},
+			"IgnoreStrictEnforcement set on system span config",
+		},
+		{
+			"global-reads",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.GlobalReads = true
+			},
+			"GlobalReads set on system span config",
+		},
+		{
+			"num-replicas",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.NumReplicas = 1
+			},
+			"NumReplicas set on system span config",
+		},
+		{
+			"num-voters",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.NumVoters = 1
+			},
+			"NumVoters set on system span config",
+		},
+		{
+			"constraints",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.Constraints = append(scfg.Constraints, roachpb.ConstraintsConjunction{})
+			},
+			"Constraints set on system span config",
+		},
+		{
+			"voter-constraints",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.VoterConstraints = append(scfg.VoterConstraints, roachpb.ConstraintsConjunction{})
+			},
+			"VoterConstraints set on system span config",
+		},
+		{
+			"lease-preferences",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.LeasePreferences = append(scfg.LeasePreferences, roachpb.LeasePreference{})
+			},
+			"LeasePreferences set on system span config",
+		},
+		{
+			"rangefeed-enabled",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.RangefeedEnabled = true
+			},
+			"RangefeedEnabled set on system span config",
+		},
+		{
+			"exclude-data-from-backup",
+			func(scfg *roachpb.SpanConfig) {
+				scfg.ExcludeDataFromBackup = true
+			},
+			"ExcludeDataFromBackup set on system span config",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			emptyScfg := roachpb.SpanConfig{}
+			systemTarget := TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(2),
+				roachpb.MakeTenantID(2))
+			target := MakeTargetFromSystemTarget(systemTarget)
+			_, err := MakeRecord(target, emptyScfg)
+			testutils.IsError(err, tc.expectedErr)
+		})
+	}
+}

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -281,20 +281,6 @@ type Splitter interface {
 	Splits(ctx context.Context, table catalog.TableDescriptor) (int, error)
 }
 
-// Record ties a target to its corresponding config.
-type Record struct {
-	// Target specifies the target (keyspan(s)) the config applies over.
-	Target Target
-
-	// Config is the set of attributes that apply over the corresponding target.
-	Config roachpb.SpanConfig
-}
-
-// IsEmpty returns true if the receiver is an empty Record.
-func (r *Record) IsEmpty() bool {
-	return r.Target.isEmpty() && r.Config.IsEmpty()
-}
-
 // SQLUpdate captures either a descriptor or a protected timestamp update.
 // It is the unit emitted by the SQLWatcher.
 type SQLUpdate struct {
@@ -386,31 +372,43 @@ type Update Record
 
 // Deletion constructs an update that represents a deletion over the given
 // target.
-func Deletion(target Target) Update {
-	return Update{
-		Target: target,
-		Config: roachpb.SpanConfig{}, // delete
+func Deletion(target Target) (Update, error) {
+	record, err := MakeRecord(target, roachpb.SpanConfig{}) // delete
+	if err != nil {
+		return Update{}, err
 	}
+	return Update(record), nil
 }
 
 // Addition constructs an update that represents adding the given config over
 // the given target.
-func Addition(target Target, conf roachpb.SpanConfig) Update {
-	return Update{
-		Target: target,
-		Config: conf,
+func Addition(target Target, conf roachpb.SpanConfig) (Update, error) {
+	record, err := MakeRecord(target, conf)
+	if err != nil {
+		return Update{}, err
 	}
+	return Update(record), nil
 }
 
 // Deletion returns true if the update corresponds to a span config being
 // deleted.
 func (u Update) Deletion() bool {
-	return u.Config.IsEmpty()
+	return u.config.IsEmpty()
 }
 
 // Addition returns true if the update corresponds to a span config being added.
 func (u Update) Addition() bool {
 	return !u.Deletion()
+}
+
+// GetTarget returns the underlying spanconfig.Record target.
+func (u Update) GetTarget() Target {
+	return u.target
+}
+
+// GetConfig returns the underlying spanconfig.Record config.
+func (u Update) GetConfig() roachpb.SpanConfig {
+	return u.config
 }
 
 // ProtectedTSReader is the read-only portion for querying protected

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -279,7 +279,7 @@ func (s *KVSubscriber) handlePartialUpdate(
 	for i := range handlers {
 		handler := &handlers[i] // mutated by invoke
 		for _, ev := range events {
-			target := ev.(*bufferEvent).Update.Target
+			target := ev.(*bufferEvent).Update.GetTarget()
 			handler.invoke(ctx, target.KeyspaceTargeted())
 		}
 	}

--- a/pkg/spanconfig/spanconfigkvsubscriber/spanconfigdecoder_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/spanconfigdecoder_test.go
@@ -71,10 +71,10 @@ func TestDecodeSpanTargets(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.Truef(t, span.Equal(got.Target.GetSpan()),
-		"expected span=%s, got span=%s", span, got.Target.GetSpan())
-	require.Truef(t, conf.Equal(got.Config),
-		"expected config=%s, got config=%s", conf, got.Config)
+	require.Truef(t, span.Equal(got.GetTarget().GetSpan()),
+		"expected span=%s, got span=%s", span, got.GetTarget().GetSpan())
+	require.Truef(t, conf.Equal(got.GetConfig()),
+		"expected config=%s, got config=%s", conf, got.GetConfig())
 }
 
 // TestSpanConfigDecoder verifies that we can decode system target rows stored
@@ -149,9 +149,9 @@ func TestDecodeSystemTargets(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		require.Equal(t, conf, got.Config)
-		require.True(t, got.Target.IsSystemTarget())
-		require.Equal(t, systemTarget, got.Target.GetSystemTarget())
+		require.Equal(t, conf, got.GetConfig())
+		require.True(t, got.GetTarget().IsSystemTarget())
+		require.Equal(t, systemTarget, got.GetTarget().GetSystemTarget())
 	}
 }
 

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -177,9 +177,12 @@ func (s *SQLTranslator) generateSystemSpanConfigRecords(
 				return nil, err
 			}
 		}
-		clusterSystemRecord := spanconfig.Record{
-			Target: spanconfig.MakeTargetFromSystemTarget(systemTarget),
-			Config: roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{ProtectionPolicies: clusterProtections}}}
+		clusterSystemRecord, err := spanconfig.MakeRecord(
+			spanconfig.MakeTargetFromSystemTarget(systemTarget),
+			roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{ProtectionPolicies: clusterProtections}})
+		if err != nil {
+			return nil, err
+		}
 		records = append(records, clusterSystemRecord)
 	}
 
@@ -191,10 +194,12 @@ func (s *SQLTranslator) generateSystemSpanConfigRecords(
 		if err != nil {
 			return nil, err
 		}
-		tenantSystemRecord := spanconfig.Record{
-			Target: spanconfig.MakeTargetFromSystemTarget(systemTarget),
-			Config: roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{
-				ProtectionPolicies: tenantProtection.GetTenantProtections()}},
+		tenantSystemRecord, err := spanconfig.MakeRecord(
+			spanconfig.MakeTargetFromSystemTarget(systemTarget),
+			roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{
+				ProtectionPolicies: tenantProtection.GetTenantProtections()}})
+		if err != nil {
+			return nil, err
 		}
 		records = append(records, tenantSystemRecord)
 	}
@@ -292,10 +297,11 @@ func (s *SQLTranslator) generateSpanConfigurationsForNamedZone(
 	spanConfig := zoneConfig.AsSpanConfig()
 	var records []spanconfig.Record
 	for _, span := range spans {
-		records = append(records, spanconfig.Record{
-			Target: spanconfig.MakeTargetFromSpan(span),
-			Config: spanConfig,
-		})
+		record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(span), spanConfig)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -353,13 +359,15 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 			// there's no data within [/Tenant/<id>/ - /Tenant/<id>/Table/3),
 			// but looking at range boundaries, it's slightly less confusing
 			// this way.
-			records = append(records, spanconfig.Record{
-				Target: spanconfig.MakeTargetFromSpan(roachpb.Span{
+			record, err := spanconfig.MakeRecord(
+				spanconfig.MakeTargetFromSpan(roachpb.Span{
 					Key:    s.codec.TenantPrefix(),
 					EndKey: tableEndKey,
-				}),
-				Config: tableSpanConfig,
-			})
+				}), tableSpanConfig)
+			if err != nil {
+				return nil, err
+			}
+			records = append(records, record)
 		} else {
 			// The same as above, except we have named ranges preceding
 			// `system.descriptor`. Not doing anything special here would mean
@@ -370,13 +378,14 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 			// somewhat useful for understandability reasons and reducing the
 			// (tiny) re-splitting costs when switching between the two
 			// subsystems.
-			records = append(records, spanconfig.Record{
-				Target: spanconfig.MakeTargetFromSpan(roachpb.Span{
-					Key:    keys.SystemConfigSpan.Key,
-					EndKey: tableEndKey,
-				}),
-				Config: tableSpanConfig,
-			})
+			record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(roachpb.Span{
+				Key:    keys.SystemConfigSpan.Key,
+				EndKey: tableEndKey,
+			}), tableSpanConfig)
+			if err != nil {
+				return nil, err
+			}
+			records = append(records, record)
 		}
 
 		return records, nil
@@ -433,12 +442,12 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 		// If there is a "hole" in the spans covered by the subzones array we fill
 		// it using the parent zone configuration.
 		if !prevEndKey.Equal(span.Key) {
-			records = append(records,
-				spanconfig.Record{
-					Target: spanconfig.MakeTargetFromSpan(roachpb.Span{Key: prevEndKey, EndKey: span.Key}),
-					Config: tableSpanConfig,
-				},
-			)
+			record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(
+				roachpb.Span{Key: prevEndKey, EndKey: span.Key}), tableSpanConfig)
+			if err != nil {
+				return nil, err
+			}
+			records = append(records, record)
 		}
 
 		// Add an entry for the subzone.
@@ -451,12 +460,12 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 			subzoneSpanConfig.RangefeedEnabled = true
 			subzoneSpanConfig.GCPolicy.IgnoreStrictEnforcement = true
 		}
-		records = append(records,
-			spanconfig.Record{
-				Target: spanconfig.MakeTargetFromSpan(roachpb.Span{Key: span.Key, EndKey: span.EndKey}),
-				Config: subzoneSpanConfig,
-			},
-		)
+		record, err := spanconfig.MakeRecord(
+			spanconfig.MakeTargetFromSpan(roachpb.Span{Key: span.Key, EndKey: span.EndKey}), subzoneSpanConfig)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
 
 		prevEndKey = span.EndKey
 	}
@@ -464,12 +473,12 @@ func (s *SQLTranslator) generateSpanConfigurationsForTable(
 	// If the last subzone span doesn't cover the entire table's keyspace then
 	// we cover the remaining key range with the table's zone configuration.
 	if !prevEndKey.Equal(tableEndKey) {
-		records = append(records,
-			spanconfig.Record{
-				Target: spanconfig.MakeTargetFromSpan(roachpb.Span{Key: prevEndKey, EndKey: tableEndKey}),
-				Config: tableSpanConfig,
-			},
-		)
+		record, err := spanconfig.MakeRecord(
+			spanconfig.MakeTargetFromSpan(roachpb.Span{Key: prevEndKey, EndKey: tableEndKey}), tableSpanConfig)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }
@@ -636,13 +645,14 @@ func (s *SQLTranslator) maybeGeneratePseudoTableRecords(
 		for _, pseudoTableID := range keys.PseudoTableIDs {
 			tableStartKey := s.codec.TablePrefix(pseudoTableID)
 			tableEndKey := tableStartKey.PrefixEnd()
-			records = append(records, spanconfig.Record{
-				Target: spanconfig.MakeTargetFromSpan(roachpb.Span{
-					Key:    tableStartKey,
-					EndKey: tableEndKey,
-				}),
-				Config: tableSpanConfig,
-			})
+			record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(roachpb.Span{
+				Key:    tableStartKey,
+				EndKey: tableEndKey,
+			}), tableSpanConfig)
+			if err != nil {
+				return nil, err
+			}
+			records = append(records, record)
 		}
 
 		return records, nil
@@ -668,13 +678,15 @@ func (s *SQLTranslator) maybeGenerateScratchRangeRecord(
 			return spanconfig.Record{}, err
 		}
 
-		return spanconfig.Record{
-			Target: spanconfig.MakeTargetFromSpan(roachpb.Span{
+		record, err := spanconfig.MakeRecord(
+			spanconfig.MakeTargetFromSpan(roachpb.Span{
 				Key:    keys.ScratchRangeMin,
 				EndKey: keys.ScratchRangeMax,
-			}),
-			Config: zone.AsSpanConfig(),
-		}, nil
+			}), zone.AsSpanConfig())
+		if err != nil {
+			return spanconfig.Record{}, err
+		}
+		return record, nil
 	}
 
 	return spanconfig.Record{}, nil

--- a/pkg/spanconfig/spanconfigstore/spanconfigstore_test.go
+++ b/pkg/spanconfig/spanconfigstore/spanconfigstore_test.go
@@ -65,9 +65,13 @@ func TestRandomized(t *testing.T) {
 		sp, conf, op := genRandomSpan(), getRandomConf(), getRandomOp()
 		switch op {
 		case "set":
-			return spanconfig.Addition(spanconfig.MakeTargetFromSpan(sp), conf)
+			addition, err := spanconfig.Addition(spanconfig.MakeTargetFromSpan(sp), conf)
+			require.NoError(t, err)
+			return addition
 		case "del":
-			return spanconfig.Deletion(spanconfig.MakeTargetFromSpan(sp))
+			del, err := spanconfig.Deletion(spanconfig.MakeTargetFromSpan(sp))
+			require.NoError(t, err)
+			return del
 		default:
 		}
 		t.Fatalf("unexpected op: %s", op)
@@ -82,11 +86,11 @@ func TestRandomized(t *testing.T) {
 				updates[i] = getRandomUpdate()
 			}
 			sort.Slice(updates, func(i, j int) bool {
-				return updates[i].Target.Less(updates[j].Target)
+				return updates[i].GetTarget().Less(updates[j].GetTarget())
 			})
 			invalid := false
 			for i := 1; i < numUpdates; i++ {
-				if updates[i].Target.GetSpan().Overlaps(updates[i-1].Target.GetSpan()) {
+				if updates[i].GetTarget().GetSpan().Overlaps(updates[i-1].GetTarget().GetSpan()) {
 					invalid = true
 				}
 			}
@@ -113,9 +117,9 @@ func TestRandomized(t *testing.T) {
 		_, _, err := store.apply(false /* dryrun */, updates...)
 		require.NoError(t, err)
 		for _, update := range updates {
-			if testSpan.Overlaps(update.Target.GetSpan()) {
+			if testSpan.Overlaps(update.GetTarget().GetSpan()) {
 				if update.Addition() {
-					expConfig, expFound = update.Config, true
+					expConfig, expFound = update.GetConfig(), true
 				} else {
 					expConfig, expFound = roachpb.SpanConfig{}, false
 				}
@@ -126,11 +130,10 @@ func TestRandomized(t *testing.T) {
 	if !expFound {
 		_ = store.forEachOverlapping(testSpan,
 			func(entry spanConfigEntry) error {
+				record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(entry.span), entry.config)
+				require.NoError(t, err)
 				t.Fatalf("found unexpected entry: %s",
-					spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
-						Target: spanconfig.MakeTargetFromSpan(entry.span),
-						Config: entry.config,
-					}))
+					spanconfigtestutils.PrintSpanConfigRecord(t, record))
 				return nil
 			},
 		)
@@ -139,11 +142,10 @@ func TestRandomized(t *testing.T) {
 		_ = store.forEachOverlapping(testSpan,
 			func(entry spanConfigEntry) error {
 				if !foundEntry.isEmpty() {
+					record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(entry.span), entry.config)
+					require.NoError(t, err)
 					t.Fatalf("expected single overlapping entry, found second: %s",
-						spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
-							Target: spanconfig.MakeTargetFromSpan(entry.span),
-							Config: entry.config,
-						}))
+						spanconfigtestutils.PrintSpanConfigRecord(t, record))
 				}
 				foundEntry = entry
 

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -154,9 +154,9 @@ func (s *Store) applyInternal(
 	systemSpanConfigStoreUpdates := make([]spanconfig.Update, 0, len(updates))
 	for _, update := range updates {
 		switch {
-		case update.Target.IsSpanTarget():
+		case update.GetTarget().IsSpanTarget():
 			spanStoreUpdates = append(spanStoreUpdates, update)
-		case update.Target.IsSystemTarget():
+		case update.GetTarget().IsSystemTarget():
 			systemSpanConfigStoreUpdates = append(systemSpanConfigStoreUpdates, update)
 		default:
 			return nil, nil, errors.AssertionFailedf("unknown target type")
@@ -172,10 +172,12 @@ func (s *Store) applyInternal(
 	}
 
 	for _, entry := range addedEntries {
-		added = append(added, spanconfig.Record{
-			Target: spanconfig.MakeTargetFromSpan(entry.span),
-			Config: entry.config,
-		})
+		record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(entry.span),
+			entry.config)
+		if err != nil {
+			return nil, nil, err
+		}
+		added = append(added, record)
 	}
 
 	deletedSystemTargets, addedSystemSpanConfigRecords, err := s.mu.systemSpanConfigStore.apply(
@@ -203,9 +205,10 @@ func (s *Store) Iterate(f func(spanconfig.Record) error) error {
 	return s.mu.spanConfigStore.forEachOverlapping(
 		keys.EverythingSpan,
 		func(s spanConfigEntry) error {
-			return f(spanconfig.Record{
-				Target: spanconfig.MakeTargetFromSpan(s.span),
-				Config: s.config,
-			})
+			record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(s.span), s.config)
+			if err != nil {
+				return err
+			}
+			return f(record)
 		})
 }

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -89,7 +89,7 @@ func TestDataDriven(t *testing.T) {
 
 				sort.Sort(spanconfig.Targets(deleted))
 				sort.Slice(added, func(i, j int) bool {
-					return added[i].Target.Less(added[j].Target)
+					return added[i].GetTarget().Less(added[j].GetTarget())
 				})
 
 				var b strings.Builder
@@ -128,12 +128,11 @@ func TestDataDriven(t *testing.T) {
 				var results []string
 				_ = store.ForEachOverlappingSpanConfig(ctx, span,
 					func(sp roachpb.Span, conf roachpb.SpanConfig) error {
-						results = append(results,
-							spanconfigtestutils.PrintSpanConfigRecord(t, spanconfig.Record{
-								Target: spanconfig.MakeTargetFromSpan(sp),
-								Config: conf,
-							}),
-						)
+						record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(sp), conf)
+						if err != nil {
+							return err
+						}
+						results = append(results, spanconfigtestutils.PrintSpanConfigRecord(t, record))
 						return nil
 					},
 				)
@@ -155,30 +154,35 @@ func TestStoreClone(t *testing.T) {
 
 	ctx := context.Background()
 
+	makeSpanConfigAddition := func(target spanconfig.Target, conf roachpb.SpanConfig) spanconfig.Update {
+		addition, err := spanconfig.Addition(target, conf)
+		require.NoError(t, err)
+		return addition
+	}
 	updates := []spanconfig.Update{
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSpan(spanconfigtestutils.ParseSpan(t, "[a, b)")),
 			spanconfigtestutils.ParseConfig(t, "A"),
 		),
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSpan(spanconfigtestutils.ParseSpan(t, "[c, d)")),
 			spanconfigtestutils.ParseConfig(t, "C"),
 		),
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSpan(spanconfigtestutils.ParseSpan(t, "[e, f)")),
 			spanconfigtestutils.ParseConfig(t, "E"),
 		),
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()),
 			spanconfigtestutils.ParseConfig(t, "G"),
 		),
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.SystemTenantID, roachpb.MakeTenantID(10),
 			)),
 			spanconfigtestutils.ParseConfig(t, "H"),
 		),
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10),
 			)),
@@ -205,8 +209,9 @@ func TestStoreClone(t *testing.T) {
 	require.Equal(t, len(originalRecords), len(clonedRecords))
 	for i := 0; i < len(originalRecords); i++ {
 		require.True(
-			t, originalRecords[i].Target.Equal(clonedRecords[i].Target),
+			t, originalRecords[i].GetTarget().Equal(clonedRecords[i].GetTarget()),
 		)
-		require.True(t, originalRecords[i].Config.Equal(clonedRecords[i].Config))
+		originalConfig := originalRecords[i].GetConfig()
+		require.True(t, originalConfig.Equal(clonedRecords[i].GetConfig()))
 	}
 }

--- a/pkg/spanconfig/spanconfigstore/systemspanconfigstore_test.go
+++ b/pkg/spanconfig/spanconfigstore/systemspanconfigstore_test.go
@@ -54,41 +54,46 @@ func TestSystemSpanConfigStoreCombine(t *testing.T) {
 	// Ten 20 -> Ten 20: 300
 	//
 	// Span config: 1
+	makeSpanConfigAddition := func(target spanconfig.Target, conf roachpb.SpanConfig) spanconfig.Update {
+		addition, err := spanconfig.Addition(target, conf)
+		require.NoError(t, err)
+		return addition
+	}
 
 	updates := []spanconfig.Update{
-		spanconfig.Addition(
+		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.MakeEntireKeyspaceTarget()),
 			makeSystemSpanConfig(100),
 		),
-		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.SystemTenantID, roachpb.SystemTenantID,
 			),
 		),
 			makeSystemSpanConfig(120),
 		),
-		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.SystemTenantID, roachpb.MakeTenantID(10),
 			),
 		),
 			makeSystemSpanConfig(150),
 		),
-		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10),
 			),
 		),
 			makeSystemSpanConfig(200),
 		),
-		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.MakeTenantID(20), roachpb.MakeTenantID(20),
 			),
 		),
 			makeSystemSpanConfig(300),
 		),
-		spanconfig.Addition(spanconfig.MakeTargetFromSystemTarget(
+		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
 				t, roachpb.SystemTenantID, roachpb.MakeTenantID(30),
 			),

--- a/pkg/spanconfig/spanconfigtestutils/recorder.go
+++ b/pkg/spanconfig/spanconfigtestutils/recorder.go
@@ -66,8 +66,12 @@ func (r *KVAccessorRecorder) UpdateSpanConfigRecords(
 	defer r.mu.Unlock()
 
 	for _, d := range toDelete {
+		del, err := spanconfig.Deletion(d)
+		if err != nil {
+			return err
+		}
 		r.mu.mutations = append(r.mu.mutations, mutation{
-			update:   spanconfig.Deletion(d),
+			update:   del,
 			batchIdx: r.mu.batchCount,
 		})
 	}
@@ -98,8 +102,8 @@ func (r *KVAccessorRecorder) Recording(clear bool) string {
 		if mi.batchIdx != mj.batchIdx { // sort by batch/ts order
 			return mi.batchIdx < mj.batchIdx
 		}
-		if !mi.update.Target.Equal(mj.update.Target) { // sort by target order
-			return mi.update.Target.Less(mj.update.Target)
+		if !mi.update.GetTarget().Equal(mj.update.GetTarget()) { // sort by target order
+			return mi.update.GetTarget().Less(mj.update.GetTarget())
 		}
 
 		return mi.update.Deletion() // sort deletes before upserts
@@ -111,15 +115,15 @@ func (r *KVAccessorRecorder) Recording(clear bool) string {
 	var output strings.Builder
 	for _, m := range r.mu.mutations {
 		if m.update.Deletion() {
-			output.WriteString(fmt.Sprintf("delete %s\n", m.update.Target))
+			output.WriteString(fmt.Sprintf("delete %s\n", m.update.GetTarget()))
 		} else {
 			switch {
-			case m.update.Target.IsSpanTarget():
-				output.WriteString(fmt.Sprintf("upsert %-35s %s\n", m.update.Target,
-					PrintSpanConfigDiffedAgainstDefaults(m.update.Config)))
-			case m.update.Target.IsSystemTarget():
-				output.WriteString(fmt.Sprintf("upsert %-35s %s\n", m.update.Target,
-					PrintSystemSpanConfigDiffedAgainstDefault(m.update.Config)))
+			case m.update.GetTarget().IsSpanTarget():
+				output.WriteString(fmt.Sprintf("upsert %-35s %s\n", m.update.GetTarget(),
+					PrintSpanConfigDiffedAgainstDefaults(m.update.GetConfig())))
+			case m.update.GetTarget().IsSystemTarget():
+				output.WriteString(fmt.Sprintf("upsert %-35s %s\n", m.update.GetTarget(),
+					PrintSystemSpanConfigDiffedAgainstDefault(m.update.GetConfig())))
 			default:
 				panic("unsupported target type")
 			}

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -134,10 +134,10 @@ func ParseSpanConfigRecord(t *testing.T, conf string) spanconfig.Record {
 	if len(parts) != 2 {
 		t.Fatalf("expected single %q separator", ":")
 	}
-	return spanconfig.Record{
-		Target: ParseTarget(t, parts[0]),
-		Config: ParseConfig(t, parts[1]),
-	}
+	record, err := spanconfig.MakeRecord(ParseTarget(t, parts[0]),
+		ParseConfig(t, parts[1]))
+	require.NoError(t, err)
+	return record
 }
 
 // ParseKVAccessorGetArguments is a helper function that parses datadriven
@@ -236,7 +236,9 @@ func ParseStoreApplyArguments(t *testing.T, input string) (updates []spanconfig.
 		switch {
 		case strings.HasPrefix(line, deletePrefix):
 			line = strings.TrimPrefix(line, line[:len(deletePrefix)])
-			updates = append(updates, spanconfig.Deletion(ParseTarget(t, line)))
+			del, err := spanconfig.Deletion(ParseTarget(t, line))
+			require.NoError(t, err)
+			updates = append(updates, del)
 		case strings.HasPrefix(line, setPrefix):
 			line = strings.TrimPrefix(line, line[:len(setPrefix)])
 			entry := ParseSpanConfigRecord(t, line)
@@ -310,7 +312,7 @@ func PrintSpanConfig(config roachpb.SpanConfig) string {
 // above, or the constituent span and config to have been constructed using the
 // Parse{Span,Config} helpers above.
 func PrintSpanConfigRecord(t *testing.T, record spanconfig.Record) string {
-	return fmt.Sprintf("%s:%s", PrintTarget(t, record.Target), PrintSpanConfig(record.Config))
+	return fmt.Sprintf("%s:%s", PrintTarget(t, record.GetTarget()), PrintSpanConfig(record.GetConfig()))
 }
 
 // PrintSystemSpanConfigDiffedAgainstDefault is a helper function that diffs the

--- a/pkg/spanconfig/target.go
+++ b/pkg/spanconfig/target.go
@@ -234,8 +234,8 @@ func RecordsToEntries(records []Record) []roachpb.SpanConfigEntry {
 	entries := make([]roachpb.SpanConfigEntry, 0, len(records))
 	for _, rec := range records {
 		entries = append(entries, roachpb.SpanConfigEntry{
-			Target: rec.Target.ToProto(),
-			Config: rec.Config,
+			Target: rec.GetTarget().ToProto(),
+			Config: rec.GetConfig(),
 		})
 	}
 	return entries
@@ -250,10 +250,11 @@ func EntriesToRecords(entries []roachpb.SpanConfigEntry) ([]Record, error) {
 		if err != nil {
 			return nil, err
 		}
-		records = append(records, Record{
-			Target: target,
-			Config: entry.Config,
-		})
+		record, err := MakeRecord(target, entry.Config)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
 	}
 	return records, nil
 }

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -161,15 +161,14 @@ func CreateTenantRecord(
 	tenantSpanConfig.GCPolicy.IgnoreStrictEnforcement = true
 
 	tenantPrefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(tenID))
-	toUpsert := []spanconfig.Record{
-		{
-			Target: spanconfig.MakeTargetFromSpan(roachpb.Span{
-				Key:    tenantPrefix,
-				EndKey: tenantPrefix.Next(),
-			}),
-			Config: tenantSpanConfig,
-		},
+	record, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(roachpb.Span{
+		Key:    tenantPrefix,
+		EndKey: tenantPrefix.Next(),
+	}), tenantSpanConfig)
+	if err != nil {
+		return err
 	}
+	toUpsert := []spanconfig.Record{record}
 	scKVAccessor := execCfg.SpanConfigKVAccessor.WithTxn(ctx, txn)
 	return scKVAccessor.UpdateSpanConfigRecords(
 		ctx, nil /* toDelete */, toUpsert,
@@ -486,7 +485,7 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Ten
 
 		toDelete := make([]spanconfig.Target, len(records))
 		for i, record := range records {
-			toDelete[i] = record.Target
+			toDelete[i] = record.GetTarget()
 		}
 		return scKVAccessor.UpdateSpanConfigRecords(ctx, toDelete, nil /* toUpsert */)
 	})


### PR DESCRIPTION
This change adds a constructor method that returns
a new `spanconfig.Record` and conditionally performs
some validation if the target is a SystemTarget.

Informs: https://github.com/cockroachdb/cockroach/issues/73727

Release note: None

Release justification: low-risk updates to new functionality