### PR TITLE
kv/bulk: fix presplit condition

### DIFF
--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -251,7 +251,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 
 	// If this is the first flush and is due to size, if it was unsorted then
 	// create initial splits if requested before flushing.
-	if b.flushCounts.total == 0 && forSize && b.initialSplits != 0 && !b.sorted {
+	if b.flushCounts.total == 1 && forSize && b.initialSplits != 0 && !b.sorted {
 		if err := b.createInitialSplits(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
I moved this code just before it merged to avoid a repeated sort, but
that meant it now was *after* the increment of total flushes a few lines
above, so its flush count == 0 check became wrong.

Release note: none.

Release justification: low risk bug fix.