### PR TITLE
tracing: fix verbose tag

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -674,7 +674,9 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		if !finishing && !s.mu.finished {
 			addTag("_unfinished", "1")
 		}
-		addTag("_verbose", "1")
+		if s.recordingType() == RecordingVerbose {
+			addTag("_verbose", "1")
+		}
 		if s.mu.recording.dropped {
 			addTag("_dropped", "1")
 		}


### PR DESCRIPTION
The "_verbose" tag was inadvertently reported for a span if whoever is
requesting the span's recording was asking for a verbose recording.
However, it's possible to ask for a verbose recording from a span that's
not recording verbosely, in which case the tag should not be applied.
This patch makes the tag be applied depending on the span's recording
type, not based on what type of recording is requested.

Release note: None
Release justification: bug fix to new functionality