### PR TITLE
sql: scan the system.role_members table using a single scan

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -82,6 +82,7 @@ server.web_session.purge.max_deletions_per_cycle	integer	10	the maximum number o
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted
 server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_sessions older than this duration are periodically purged
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
+sql.auth.resolve_membership_single_scan.enabled	boolean	true	determines whether to populate the role membership cache with a single scan
 sql.contention.event_store.capacity	byte size	64 MiB	the in-memory storage capacity per-node of contention event store
 sql.contention.txn_id_cache.max_size	byte size	0 B	the maximum byte size TxnID cache will use (set to 0 to disable)
 sql.cross_db_fks.enabled	boolean	false	if true, creating foreign key references across databases is allowed

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -94,6 +94,7 @@
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>
 <tr><td><code>server.web_session.purge.ttl</code></td><td>duration</td><td><code>1h0m0s</code></td><td>if nonzero, entries in system.web_sessions older than this duration are periodically purged</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.auth.resolve_membership_single_scan.enabled</code></td><td>boolean</td><td><code>true</code></td><td>determines whether to populate the role membership cache with a single scan</td></tr>
 <tr><td><code>sql.contention.event_store.capacity</code></td><td>byte size</td><td><code>64 MiB</code></td><td>the in-memory storage capacity per-node of contention event store</td></tr>
 <tr><td><code>sql.contention.txn_id_cache.max_size</code></td><td>byte size</td><td><code>0 B</code></td><td>the maximum byte size TxnID cache will use (set to 0 to disable)</td></tr>
 <tr><td><code>sql.cross_db_fks.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if true, creating foreign key references across databases is allowed</td></tr>

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -50,8 +50,8 @@ exp,benchmark
 19,Grant/grant_all_on_1_table
 19,Grant/grant_all_on_2_tables
 19,Grant/grant_all_on_3_tables
-17,GrantRole/grant_1_role
-20,GrantRole/grant_2_roles
+13,GrantRole/grant_1_role
+15,GrantRole/grant_2_roles
 2,ORMQueries/activerecord_type_introspection_query
 2,ORMQueries/django_table_introspection_1_table
 2,ORMQueries/django_table_introspection_4_tables
@@ -79,8 +79,8 @@ exp,benchmark
 19,Revoke/revoke_all_on_1_table
 19,Revoke/revoke_all_on_2_tables
 19,Revoke/revoke_all_on_3_tables
-16,RevokeRole/revoke_1_role
-18,RevokeRole/revoke_2_roles
+13,RevokeRole/revoke_1_role
+15,RevokeRole/revoke_2_roles
 1,SystemDatabaseQueries/select_system.users_with_empty_database_Name
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 2,SystemDatabaseQueries/select_system.users_without_schema_Name

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -694,7 +694,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		VirtualSchemas:          virtualSchemas,
 		HistogramWindowInterval: cfg.HistogramWindowInterval(),
 		RangeDescriptorCache:    cfg.distSender.RangeDescriptorCache(),
-		RoleMemberCache:         sql.NewMembershipCache(serverCacheMemoryMonitor.MakeBoundAccount()),
+		RoleMemberCache:         sql.NewMembershipCache(serverCacheMemoryMonitor.MakeBoundAccount(), cfg.stopper),
 		SessionInitCache:        sessioninit.NewCache(serverCacheMemoryMonitor.MakeBoundAccount(), cfg.stopper),
 		RootMemoryMonitor:       rootSQLMemoryMonitor,
 		TestingKnobs:            sqlExecutorTestingKnobs,

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -432,6 +432,7 @@ go_library(
         "//pkg/util/ring",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/syncutil/singleflight",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/tracing",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -401,7 +403,7 @@ func MemberOfWithAdminOption(
 
 	tableVersion := tableDesc.GetVersion()
 	if tableDesc.IsUncommittedVersion() {
-		return resolveMemberOfWithAdminOption(ctx, member, ie, txn)
+		return resolveMemberOfWithAdminOption(ctx, member, ie, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
 	}
 
 	// We loop in case the table version changes while we're looking up memberships.
@@ -428,7 +430,7 @@ func MemberOfWithAdminOption(
 		}
 
 		// Lookup memberships outside the lock.
-		memberships, err := resolveMemberOfWithAdminOption(ctx, member, ie, txn)
+		memberships, err := resolveMemberOfWithAdminOption(ctx, member, ie, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
 		if err != nil {
 			return nil, err
 		}
@@ -451,7 +453,7 @@ func MemberOfWithAdminOption(
 			}
 			if err := roleMembersCache.boundAccount.Grow(ctx, sizeOfEntry); err != nil {
 				// If there is no memory available to cache the entry, we can still
-				// proceed so that the query has a chance to succeed..
+				// proceed so that the query has a chance to succeed.
 				log.Ops.Warningf(ctx, "no memory available to cache role membership info: %v", err)
 			} else {
 				roleMembersCache.userCache[member] = memberships
@@ -464,14 +466,57 @@ func MemberOfWithAdminOption(
 	}
 }
 
+var defaultSingleQueryForRoleMembershipCache = util.ConstantWithMetamorphicTestBool(
+	"resolve-membership-single-scan-enabled",
+	true, /* defaultValue */
+)
+
+var useSingleQueryForRoleMembershipCache = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.auth.resolve_membership_single_scan.enabled",
+	"determines whether to populate the role membership cache with a single scan",
+	defaultSingleQueryForRoleMembershipCache,
+).WithPublic()
+
 // resolveMemberOfWithAdminOption performs the actual recursive role membership lookup.
-// TODO(mberhault): this is the naive way and performs a full lookup for each user,
-// we could save detailed memberships (as opposed to fully expanded) and reuse them
-// across users. We may then want to lookup more than just this user.
 func resolveMemberOfWithAdminOption(
-	ctx context.Context, member security.SQLUsername, ie sqlutil.InternalExecutor, txn *kv.Txn,
+	ctx context.Context,
+	member security.SQLUsername,
+	ie sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	singleQuery bool,
 ) (map[security.SQLUsername]bool, error) {
 	ret := map[security.SQLUsername]bool{}
+	if singleQuery {
+		type membership struct {
+			role    security.SQLUsername
+			isAdmin bool
+		}
+		memberToRoles := make(map[security.SQLUsername][]membership)
+		if err := forEachRoleMembership(ctx, ie, txn, func(role, member security.SQLUsername, isAdmin bool) error {
+			memberToRoles[member] = append(memberToRoles[member], membership{role, isAdmin})
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		// Recurse through all roles associated with the member.
+		var recurse func(u security.SQLUsername)
+		recurse = func(u security.SQLUsername) {
+			for _, membership := range memberToRoles[u] {
+				// If the parent role was seen before, we still might need to update
+				// the isAdmin flag for that role, but there's no need to recurse
+				// through the role's ancestry again.
+				prev, alreadySeen := ret[membership.role]
+				ret[membership.role] = prev || membership.isAdmin
+				if !alreadySeen {
+					recurse(membership.role)
+				}
+			}
+		}
+		recurse(member)
+		return ret, nil
+	}
 
 	// Keep track of members we looked up.
 	visited := map[security.SQLUsername]struct{}{}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -214,30 +214,10 @@ var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
 ` + docs.URL("information-schema.html#administrable_role_authorizations") + `
 https://www.postgresql.org/docs/9.5/infoschema-administrable-role-authorizations.html`,
 	schema: vtable.InformationSchemaAdministrableRoleAuthorizations,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		currentUser := p.SessionData().User()
-		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
-		if err != nil {
-			return err
-		}
-
-		grantee := tree.NewDString(currentUser.Normalized())
-		for roleName, isAdmin := range memberMap {
-			if !isAdmin {
-				// We only show memberships with the admin option.
-				continue
-			}
-
-			if err := addRow(
-				grantee,                                // grantee: always the current user
-				tree.NewDString(roleName.Normalized()), // role_name
-				yesString,                              // is_grantable: always YES
-			); err != nil {
-				return err
-			}
-		}
-
-		return nil
+	populate: func(
+		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
+	) error {
+		return populateRoleHierarchy(ctx, p, addRow, true /* onlyIsAdmin */)
 	},
 }
 
@@ -246,27 +226,40 @@ var informationSchemaApplicableRoles = virtualSchemaTable{
 ` + docs.URL("information-schema.html#applicable_roles") + `
 https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 	schema: vtable.InformationSchemaApplicableRoles,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		currentUser := p.SessionData().User()
-		memberMap, err := p.MemberOfWithAdminOption(ctx, currentUser)
-		if err != nil {
-			return err
-		}
-
-		grantee := tree.NewDString(currentUser.Normalized())
-
-		for roleName, isAdmin := range memberMap {
-			if err := addRow(
-				grantee,                                // grantee: always the current user
-				tree.NewDString(roleName.Normalized()), // role_name
-				yesOrNoDatum(isAdmin),                  // is_grantable
-			); err != nil {
-				return err
-			}
-		}
-
-		return nil
+	populate: func(
+		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
+	) error {
+		return populateRoleHierarchy(ctx, p, addRow, false /* onlyIsAdmin */)
 	},
+}
+
+func populateRoleHierarchy(
+	ctx context.Context, p *planner, addRow func(...tree.Datum) error, onlyIsAdmin bool,
+) error {
+	allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
+	if err != nil {
+		return err
+	}
+	return forEachRoleMembership(
+		ctx, p.ExecCfg().InternalExecutor, p.Txn(),
+		func(role, member security.SQLUsername, isAdmin bool) error {
+			// The ADMIN OPTION is inherited through the role hierarchy, and grantee
+			// is supposed to be the role that has the ADMIN OPTION. The current user
+			// inherits all the ADMIN OPTIONs of its ancestors.
+			isRole := member == p.User()
+			_, hasRole := allRoles[member]
+			if (hasRole || isRole) && (!onlyIsAdmin || isAdmin) {
+				if err := addRow(
+					tree.NewDString(member.Normalized()), // grantee
+					tree.NewDString(role.Normalized()),   // role_name
+					yesOrNoDatum(isAdmin),                // is_grantable
+				); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
 }
 
 var informationSchemaCharacterSets = virtualSchemaTable{

--- a/pkg/sql/logictest/testdata/logic_test/grant_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/grant_in_txn
@@ -88,7 +88,7 @@ query TTT colnames
 SELECT * FROM information_schema.applicable_roles ORDER BY role_name;
 ----
 grantee   role_name  is_grantable
-testuser  role_bar   YES
+role_foo  role_bar   YES
 testuser  role_foo   YES
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -181,17 +181,32 @@ user root
 statement ok
 GRANT testrole TO testuser WITH ADMIN OPTION
 
+statement ok
+CREATE ROLE child_role;
+GRANT testrole to child_role;
+GRANT testuser TO child_role;
+
 query TTB colnames
 SELECT * FROM system.role_members
 ----
-role      member    isAdmin
-admin     root      true
-testrole  testuser  true
-
-user testuser
+role      member      isAdmin
+admin     root        true
+testrole  child_role  false
+testrole  testuser    true
+testuser  child_role  false
 
 statement ok
+SET ROLE child_role
+
+# ADMIN OPTION should be inherited, so this should succeed.
+statement ok
 GRANT testrole TO testuser2 WITH ADMIN OPTION
+
+statement ok
+RESET ROLE;
+DROP ROLE child_role
+
+user testuser
 
 query TTT colnames,rowsort
 SELECT * FROM information_schema.administrable_role_authorizations

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -202,6 +202,14 @@ SET ROLE child_role
 statement ok
 GRANT testrole TO testuser2 WITH ADMIN OPTION
 
+# And we should be able to introspect for ADMIN option. The grantee is
+# the parent role that was given ADMIN OPTION.
+query TTT colnames,rowsort
+SELECT * FROM information_schema.administrable_role_authorizations
+----
+grantee   role_name  is_grantable
+testuser  testrole   YES
+
 statement ok
 RESET ROLE;
 DROP ROLE child_role
@@ -368,6 +376,10 @@ CREATE ROLE rolee
 statement ok
 GRANT roled TO testuser
 
+# Make sure role hierarchy doesn't end up with duplicate rows.
+statement ok
+GRANT rolec TO testuser
+
 statement ok
 GRANT rolea TO roleb WITH ADMIN OPTION
 
@@ -376,17 +388,18 @@ user testuser
 query TTT colnames,rowsort
 SELECT * FROM information_schema.administrable_role_authorizations
 ----
-grantee   role_name  is_grantable
-testuser  rolea      YES
+grantee  role_name  is_grantable
+roleb    rolea      YES
 
 query TTT colnames,rowsort
 SELECT * FROM information_schema.applicable_roles
 ----
 grantee   role_name  is_grantable
-testuser  roled      NO
+roleb     rolea      YES
+rolec     roleb      NO
+roled     rolec      NO
 testuser  rolec      NO
-testuser  roleb      NO
-testuser  rolea      YES
+testuser  roled      NO
 
 query T colnames,rowsort
 SELECT * FROM information_schema.enabled_roles
@@ -413,16 +426,17 @@ GRANT rolea TO rolee
 query TTT colnames,rowsort
 SELECT * FROM information_schema.administrable_role_authorizations
 ----
-grantee   role_name  is_grantable
-testuser  rolea      YES
+grantee  role_name  is_grantable
+roleb    rolea      YES
 
 query TTT colnames,rowsort
 SELECT * FROM information_schema.applicable_roles
 ----
 grantee   role_name  is_grantable
+roleb     rolea      YES
+rolec     roleb      NO
+roled     rolec      NO
 testuser  rolec      NO
-testuser  roleb      NO
-testuser  rolea      YES
 testuser  roled      NO
 
 query T colnames,rowsort
@@ -446,6 +460,7 @@ rolea  roleb     true
 rolea  rolee     false
 roleb  rolec     false
 rolec  roled     false
+rolec  testuser  false
 roled  testuser  false
 
 statement ok

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -554,7 +554,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-auth-members.html`,
 	schema: vtable.PGCatalogAuthMembers,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		return forEachRoleMembership(ctx, p,
+		return forEachRoleMembership(ctx, p.ExecCfg().InternalExecutor, p.Txn(),
 			func(roleName, memberName security.SQLUsername, isAdmin bool) error {
 				return addRow(
 					h.UserOid(roleName),                 // roleid

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -48,190 +48,196 @@ func TestGetUserTimeout(t *testing.T) {
 	// race builds are so slow as to trigger this timeout spuriously.
 	skip.UnderRace(t)
 
-	ctx := context.Background()
+	testutils.RunTrueAndFalse(t, "TestGetUserTimeout/single_scan", func(t *testing.T, singleScanEnabled bool) {
 
-	// unavailableCh is used by the replica command filter
-	// to conditionally block requests and simulate unavailability.
-	var unavailableCh atomic.Value
-	closedCh := make(chan struct{})
-	close(closedCh)
-	unavailableCh.Store(closedCh)
-	knobs := &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
-			select {
-			case <-unavailableCh.Load().(chan struct{}):
-			case <-ctx.Done():
-			}
-			return nil
-		},
-	}
-	params := base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}}
-	s, db, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+		ctx := context.Background()
 
-	// Make a user that must use a password to authenticate.
-	// Default privileges on defaultdb are needed to run simple queries.
-	if _, err := db.Exec(`
+		// unavailableCh is used by the replica command filter
+		// to conditionally block requests and simulate unavailability.
+		var unavailableCh atomic.Value
+		closedCh := make(chan struct{})
+		close(closedCh)
+		unavailableCh.Store(closedCh)
+		knobs := &kvserver.StoreTestingKnobs{
+			TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
+				select {
+				case <-unavailableCh.Load().(chan struct{}):
+				case <-ctx.Done():
+				}
+				return nil
+			},
+		}
+		params := base.TestServerArgs{Knobs: base.TestingKnobs{Store: knobs}}
+		s, db, _ := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(ctx)
+
+		// Make a user that must use a password to authenticate.
+		// Default privileges on defaultdb are needed to run simple queries.
+		if _, err := db.Exec(`
 CREATE USER foo WITH PASSWORD 'testabc';
 GRANT ALL ON DATABASE defaultdb TO foo;
 GRANT admin TO foo`); err != nil {
-		t.Fatal(err)
-	}
-
-	// We'll attempt connections on gateway node 0.
-	fooURL, fooCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-		s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
-	defer fooCleanupFn()
-	barURL, barCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
-		s.ServingSQLAddr(), t.Name(), url.UserPassword("bar", "testabc"), false /* withClientCerts */)
-	defer barCleanupFn()
-	rootURL, rootCleanupFn := sqlutils.PGUrl(t,
-		s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
-	defer rootCleanupFn()
-
-	// Override the timeout built into pgx so we are only subject to
-	// what the server thinks.
-	fooURL.RawQuery += "&connect_timeout=0"
-	barURL.RawQuery += "&connect_timeout=0"
-	rootURL.RawQuery += "&connect_timeout=0"
-
-	t.Log("-- sanity checks --")
-
-	// We use a closure here and below to ensure the defers are run
-	// before the rest of the test.
-
-	func() {
-		// Sanity check: verify that secure mode is enabled: password is
-		// required. If this part fails, this means the test cluster is
-		// not properly configured, and the remainder of the test below
-		// would report false positives.
-		unauthURL := fooURL
-		unauthURL.User = url.User("foo")
-		dbSQL, err := pgxConn(t, unauthURL)
-		if err == nil {
-			defer func() { _ = dbSQL.Close(ctx) }()
-		}
-		if !testutils.IsError(err, "failed SASL auth") {
-			t.Fatalf("expected password error, got %v", err)
-		}
-	}()
-
-	func() {
-		// Sanity check: verify that the new user is able to log in with password.
-		dbSQL, err := pgxConn(t, fooURL)
-		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() { _ = dbSQL.Close(ctx) }()
-		row := dbSQL.QueryRow(ctx, "SELECT current_user")
-		var username string
-		if err := row.Scan(&username); err != nil {
-			t.Fatal(err)
-		}
-		if username != "foo" {
-			t.Fatalf("invalid username: expected foo, got %q", username)
-		}
-	}()
 
-	// Configure the login timeout to just 200ms.
-	if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
-		t.Fatal(err)
-	}
+		_, err := db.Exec(`SET CLUSTER SETTING sql.auth.resolve_membership_single_scan.enabled = $1`, singleScanEnabled)
+		require.NoError(t, err)
 
-	func() {
-		t.Log("-- make ranges unavailable --")
+		// We'll attempt connections on gateway node 0.
+		fooURL, fooCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("foo", "testabc"), false /* withClientCerts */)
+		defer fooCleanupFn()
+		barURL, barCleanupFn := sqlutils.PGUrlWithOptionalClientCerts(t,
+			s.ServingSQLAddr(), t.Name(), url.UserPassword("bar", "testabc"), false /* withClientCerts */)
+		defer barCleanupFn()
+		rootURL, rootCleanupFn := sqlutils.PGUrl(t,
+			s.ServingSQLAddr(), t.Name(), url.User(security.RootUser))
+		defer rootCleanupFn()
 
-		ch := make(chan struct{})
-		unavailableCh.Store(ch)
-		defer close(ch)
+		// Override the timeout built into pgx so we are only subject to
+		// what the server thinks.
+		fooURL.RawQuery += "&connect_timeout=0"
+		barURL.RawQuery += "&connect_timeout=0"
+		rootURL.RawQuery += "&connect_timeout=0"
 
-		t.Log("-- expect no timeout because of cache --")
+		t.Log("-- sanity checks --")
+
+		// We use a closure here and below to ensure the defers are run
+		// before the rest of the test.
 
 		func() {
-			// Now attempt to connect again. Since a previous authentication attempt
-			// for this user occurred, the auth-related info should be cached, so
-			// authentication should work.
+			// Sanity check: verify that secure mode is enabled: password is
+			// required. If this part fails, this means the test cluster is
+			// not properly configured, and the remainder of the test below
+			// would report false positives.
+			unauthURL := fooURL
+			unauthURL.User = url.User("foo")
+			dbSQL, err := pgxConn(t, unauthURL)
+			if err == nil {
+				defer func() { _ = dbSQL.Close(ctx) }()
+			}
+			if !testutils.IsError(err, "failed SASL auth") {
+				t.Fatalf("expected password error, got %v", err)
+			}
+		}()
+
+		func() {
+			// Sanity check: verify that the new user is able to log in with password.
 			dbSQL, err := pgxConn(t, fooURL)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer func() { _ = dbSQL.Close(ctx) }()
-			// A simple query must work even without a system range available.
-			if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
+			row := dbSQL.QueryRow(ctx, "SELECT current_user")
+			var username string
+			if err := row.Scan(&username); err != nil {
 				t.Fatal(err)
 			}
-			var isSuperuser string
-			require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
-			require.Equal(t, "on", isSuperuser)
+			if username != "foo" {
+				t.Fatalf("invalid username: expected foo, got %q", username)
+			}
 		}()
 
-		t.Log("-- expect timeout --")
+		// Configure the login timeout to just 200ms.
+		if _, err := db.Exec(`SET CLUSTER SETTING server.user_login.timeout = '200ms'`); err != nil {
+			t.Fatal(err)
+		}
 
 		func() {
-			// Now attempt to connect with a different user. We're expecting a timeout
-			// within 5 seconds.
-			start := timeutil.Now()
-			dbSQL, err := pgxConn(t, barURL)
-			if err == nil {
+			t.Log("-- make ranges unavailable --")
+
+			ch := make(chan struct{})
+			unavailableCh.Store(ch)
+			defer close(ch)
+
+			t.Log("-- expect no timeout because of cache --")
+
+			func() {
+				// Now attempt to connect again. Since a previous authentication attempt
+				// for this user occurred, the auth-related info should be cached, so
+				// authentication should work.
+				dbSQL, err := pgxConn(t, fooURL)
+				if err != nil {
+					t.Fatal(err)
+				}
 				defer func() { _ = dbSQL.Close(ctx) }()
-			}
-			if !testutils.IsError(err, "internal error while retrieving user account") {
-				t.Fatalf("expected error during connection, got %v", err)
-			}
-			timeoutDur := timeutil.Since(start)
-			if timeoutDur > 5*time.Second {
-				t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
-			}
-		}()
+				// A simple query must work even without a system range available.
+				if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
+					t.Fatal(err)
+				}
+				var isSuperuser string
+				require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
+				require.Equal(t, "on", isSuperuser)
+			}()
 
-		t.Log("-- no timeout for root --")
+			t.Log("-- expect timeout --")
 
-		func() {
-			dbSQL, err := pgxConn(t, rootURL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = dbSQL.Close(ctx) }()
-			// A simple query must work for 'root' even without a system range available.
-			if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
-				t.Fatal(err)
-			}
-			var isSuperuser string
-			require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
-			require.Equal(t, "on", isSuperuser)
-		}()
+			func() {
+				// Now attempt to connect with a different user. We're expecting a timeout
+				// within 5 seconds.
+				start := timeutil.Now()
+				dbSQL, err := pgxConn(t, barURL)
+				if err == nil {
+					defer func() { _ = dbSQL.Close(ctx) }()
+				}
+				if !testutils.IsError(err, "internal error while retrieving user account") {
+					t.Fatalf("expected error during connection, got %v", err)
+				}
+				timeoutDur := timeutil.Since(start)
+				if timeoutDur > 5*time.Second {
+					t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
+				}
+			}()
 
-		t.Log("-- re-enable range, revoke admin for user --")
-	}()
+			t.Log("-- no timeout for root --")
 
-	t.Log("-- removing foo as admin --")
-	_, err := db.Exec(`REVOKE admin FROM foo`)
-	require.NoError(t, err)
-
-	func() {
-		t.Log("-- make ranges unavailable --")
-
-		ch := make(chan struct{})
-		unavailableCh.Store(ch)
-		defer close(ch)
-
-		func() {
-			// Now attempt to connect with foo. We're expecting a timeout within 5
-			// seconds as the membership cache is invalid.
-			start := timeutil.Now()
-			dbSQL, err := pgxConn(t, fooURL)
-			if err == nil {
+			func() {
+				dbSQL, err := pgxConn(t, rootURL)
+				if err != nil {
+					t.Fatal(err)
+				}
 				defer func() { _ = dbSQL.Close(ctx) }()
-			}
-			if !testutils.IsError(err, "internal error while retrieving user account memberships") {
-				t.Fatalf("expected error during connection, got %v", err)
-			}
-			timeoutDur := timeutil.Since(start)
-			if timeoutDur > 5*time.Second {
-				t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
-			}
+				// A simple query must work for 'root' even without a system range available.
+				if _, err := dbSQL.Exec(ctx, "SELECT 1"); err != nil {
+					t.Fatal(err)
+				}
+				var isSuperuser string
+				require.NoError(t, dbSQL.QueryRow(ctx, "SHOW is_superuser").Scan(&isSuperuser))
+				require.Equal(t, "on", isSuperuser)
+			}()
+
+			t.Log("-- re-enable range, revoke admin for user --")
 		}()
-	}()
+
+		t.Log("-- removing foo as admin --")
+		_, err = db.Exec(`REVOKE admin FROM foo`)
+		require.NoError(t, err)
+
+		func() {
+			t.Log("-- make ranges unavailable --")
+
+			ch := make(chan struct{})
+			unavailableCh.Store(ch)
+			defer close(ch)
+
+			func() {
+				// Now attempt to connect with foo. We're expecting a timeout within 5
+				// seconds as the membership cache is invalid.
+				start := timeutil.Now()
+				dbSQL, err := pgxConn(t, fooURL)
+				if err == nil {
+					defer func() { _ = dbSQL.Close(ctx) }()
+				}
+				if !testutils.IsError(err, "internal error while retrieving user account memberships") {
+					t.Fatalf("expected error during connection, got %v", err)
+				}
+				timeoutDur := timeutil.Since(start)
+				if timeoutDur > 5*time.Second {
+					t.Fatalf("timeout lasted for more than 5 second (%s)", timeoutDur)
+				}
+			}()
+		}()
+	})
 }
 
 func pgxConn(t *testing.T, connURL url.URL) (*pgx.Conn, error) {


### PR DESCRIPTION
relates to support case https://github.com/cockroachlabs/support/issues/1463
fixes https://github.com/cockroachdb/cockroach/issues/77452

### sql: use singleflight for role membership lookups

This helps prevent a thundering herd when this cache gets invalidated.

### sql: scan the system.role_members table using a single scan


Release note (sql change): Added a
`sql.auth.resolve_membership_single_scan.enabled` cluster setting, which
changes the query for an internal role membership cache. Previously the
code would recursively look up each role in the membership hierarchy,
leading to multiple queries. With the setting on, it uses a single
query. The setting is true by default.

### sql: fix information_schema role introspection

Release note (bug fix): The information_schema tables
administrable_role_authorizations and applicable_roles were incorrectly
always returning the current user for the grantee column. Now, the
column will contain the correct role that was granted the parent role
given in the role_name column.

Release justification: high priority bug fix 
