### PR TITLE
roachpb,kvserver: make ReplicaUnavailableError a wrapping error

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -139,6 +139,7 @@ ALL_TESTS = [
     "//pkg/kv/kvserver/closedts/sidetransport:sidetransport_test",
     "//pkg/kv/kvserver/closedts/tracker:tracker_test",
     "//pkg/kv/kvserver/closedts:closedts_test",
+    "//pkg/kv/kvserver/concurrency/poison:poison_test",
     "//pkg/kv/kvserver/concurrency:concurrency_test",
     "//pkg/kv/kvserver/gc:gc_test",
     "//pkg/kv/kvserver/idalloc:idalloc_test",

--- a/pkg/kv/kvserver/concurrency/poison/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/poison/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -40,5 +40,22 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "poison_test",
+    srcs = ["error_test.go"],
+    data = glob(["testdata/**"]),
+    deps = [
+        ":poison",
+        "//pkg/keys",
+        "//pkg/roachpb",
+        "//pkg/testutils/echotest",
+        "//pkg/util/hlc",
+        "//pkg/util/leaktest",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/concurrency/poison/error.go
+++ b/pkg/kv/kvserver/concurrency/poison/error.go
@@ -40,6 +40,3 @@ func (e *PoisonedError) Format(s fmt.State, verb rune) { errors.FormatError(e, s
 func (e *PoisonedError) Error() string {
 	return fmt.Sprint(e)
 }
-
-// TODO(tbg): need similar init() function that ReplicaUnavailableError has,
-// or PoisonError will not survive network round-trips.

--- a/pkg/kv/kvserver/concurrency/poison/error.go
+++ b/pkg/kv/kvserver/concurrency/poison/error.go
@@ -40,3 +40,6 @@ func (e *PoisonedError) Format(s fmt.State, verb rune) { errors.FormatError(e, s
 func (e *PoisonedError) Error() string {
 	return fmt.Sprint(e)
 }
+
+// TODO(tbg): need similar init() function that ReplicaUnavailableError has,
+// or PoisonError will not survive network round-trips.

--- a/pkg/kv/kvserver/concurrency/poison/error_test.go
+++ b/pkg/kv/kvserver/concurrency/poison/error_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package poison_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/pkg/keys" // to init roachpb.PrettyPrintRange
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoisonedError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	err := errors.DecodeError(ctx, errors.EncodeError(ctx, poison.NewPoisonedError(
+		roachpb.Span{Key: roachpb.Key("a")}, hlc.Timestamp{WallTime: 1},
+	)))
+	require.True(t, errors.HasType(err, (*poison.PoisonedError)(nil)), "%+v", err)
+	var buf redact.StringBuilder
+	buf.Printf("%s", err)
+	echotest.Require(t, string(buf.RedactableString()), filepath.Join("testdata", "poisoned_error.txt"))
+}

--- a/pkg/kv/kvserver/concurrency/poison/testdata/poisoned_error.txt
+++ b/pkg/kv/kvserver/concurrency/poison/testdata/poisoned_error.txt
@@ -1,0 +1,3 @@
+echo
+----
+encountered poisoned latch ‹a›@0.000000001,0

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -494,6 +494,11 @@ func (r *Replica) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
 	return r.closedTimestampPolicyRLocked()
 }
 
+// TripBreaker synchronously trips the breaker.
+func (r *Replica) TripBreaker() {
+	r.breaker.tripSync(errors.New("injected error"))
+}
+
 // GetCircuitBreaker returns the circuit breaker controlling
 // connection attempts to the specified node.
 func (t *RaftTransport) GetCircuitBreaker(

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1227,16 +1227,15 @@ func (r *Replica) refreshProposalsLocked(
 	// request got added in while the probe was about to shut down, there will
 	// be regular attempts at healing the breaker.
 	if maxSlowProposalDuration > 0 && r.breaker.Signal().Err() == nil {
-		log.Warningf(ctx,
-			"have been waiting %.2fs for slow proposal %s",
-			maxSlowProposalDuration.Seconds(), maxSlowProposalDurationRequest,
-		)
+		err := errors.Errorf("have been waiting %.2fs for slow proposal %s",
+			maxSlowProposalDuration.Seconds(), maxSlowProposalDurationRequest)
+		log.Warningf(ctx, "%s", err)
 		// NB: this is async because we're holding lots of locks here, and we want
 		// to avoid having to pass all the information about the replica into the
 		// breaker (since the breaker needs access to this information at will to
 		// power the probe anyway). Over time, we anticipate there being multiple
 		// mechanisms which trip the breaker.
-		r.breaker.TripAsync()
+		r.breaker.TripAsync(err)
 	}
 
 	if log.V(1) && len(reproposals) > 0 {

--- a/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
+++ b/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
@@ -1,3 +1,3 @@
 echo
 ----
-replicas on non-live nodes: (n2,s20):2 (lost quorum: true): raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: replica (n1,s10):1 unable to serve request to r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0]
+replica (n1,s10):1 unable to serve request to r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0]: raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: replicas on non-live nodes: (n2,s20):2 (lost quorum: true): probe failed

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_gogo_protobuf//proto",
         "@com_github_golang_mock//gomock",  # keep
         "@io_etcd_go_etcd_raft_v3//raftpb",
         "@org_golang_google_grpc//metadata",  # keep

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -385,6 +385,7 @@ message ReplicaUnavailableError {
 
   optional roachpb.RangeDescriptor desc = 2 [(gogoproto.nullable) = false];
   optional roachpb.ReplicaDescriptor replica = 4 [(gogoproto.nullable) = false];
+  optional errorspb.EncodedError cause = 5 [(gogoproto.nullable) = false];
 }
 
 // A RaftGroupDeletedError indicates a raft group has been deleted for

--- a/pkg/roachpb/replica_unavailable_error.go
+++ b/pkg/roachpb/replica_unavailable_error.go
@@ -11,27 +11,33 @@
 package roachpb
 
 import (
+	context "context"
 	"fmt"
 
 	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
 )
 
 // NewReplicaUnavailableError initializes a new *ReplicaUnavailableError. It is
 // provided with the range descriptor known to the replica, and the relevant
 // replica descriptor within.
-func NewReplicaUnavailableError(desc *RangeDescriptor, replDesc ReplicaDescriptor) error {
+func NewReplicaUnavailableError(
+	cause error, desc *RangeDescriptor, replDesc ReplicaDescriptor,
+) error {
 	return &ReplicaUnavailableError{
 		Desc:    *desc,
 		Replica: replDesc,
+		Cause:   errors.EncodeError(context.Background(), cause),
 	}
 }
 
 var _ errors.SafeFormatter = (*ReplicaUnavailableError)(nil)
 var _ fmt.Formatter = (*ReplicaUnavailableError)(nil)
+var _ errors.Wrapper = (*ReplicaUnavailableError)(nil)
 
 // SafeFormatError implements errors.SafeFormatter.
 func (e *ReplicaUnavailableError) SafeFormatError(p errors.Printer) error {
-	p.Printf("replica %s unable to serve request to %s", e.Replica, e.Desc)
+	p.Printf("replica %s unable to serve request to %s: %s", e.Replica, e.Desc, e.Unwrap())
 	return nil
 }
 
@@ -41,4 +47,22 @@ func (e *ReplicaUnavailableError) Format(s fmt.State, verb rune) { errors.Format
 // Error implements error.
 func (e *ReplicaUnavailableError) Error() string {
 	return fmt.Sprint(e)
+}
+
+// Unwrap implements errors.Wrapper.
+func (e *ReplicaUnavailableError) Unwrap() error {
+	return errors.DecodeError(context.Background(), e.Cause)
+}
+
+func init() {
+	encode := func(ctx context.Context, err error) (msgPrefix string, safeDetails []string, payload proto.Message) {
+		errors.As(err, &payload) // payload = err.(proto.Message)
+		return "", nil, payload
+	}
+	decode := func(ctx context.Context, cause error, msgPrefix string, safeDetails []string, payload proto.Message) error {
+		return payload.(*ReplicaUnavailableError)
+	}
+	typeName := errors.GetTypeKey((*ReplicaUnavailableError)(nil))
+	errors.RegisterWrapperEncoder(typeName, encode)
+	errors.RegisterWrapperDecoder(typeName, decode)
 }

--- a/pkg/roachpb/replica_unavailable_error.go
+++ b/pkg/roachpb/replica_unavailable_error.go
@@ -31,13 +31,8 @@ var _ fmt.Formatter = (*ReplicaUnavailableError)(nil)
 
 // SafeFormatError implements errors.SafeFormatter.
 func (e *ReplicaUnavailableError) SafeFormatError(p errors.Printer) error {
-	e.printTo(p.Printf)
+	p.Printf("replica %s unable to serve request to %s", e.Replica, e.Desc)
 	return nil
-}
-
-// See https://github.com/cockroachdb/errors/issues/88.
-func (e *ReplicaUnavailableError) printTo(printf func(string, ...interface{})) {
-	printf("replica %s unable to serve request to %s", e.Replica, e.Desc)
 }
 
 // Format implements fmt.Formatter.
@@ -45,9 +40,5 @@ func (e *ReplicaUnavailableError) Format(s fmt.State, verb rune) { errors.Format
 
 // Error implements error.
 func (e *ReplicaUnavailableError) Error() string {
-	var s string
-	e.printTo(func(format string, args ...interface{}) {
-		s = fmt.Sprintf(format, args...)
-	})
-	return s
+	return fmt.Sprint(e)
 }

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -156,8 +156,12 @@ func TestReplicaUnavailableError(t *testing.T) {
 	set.AddReplica(rDesc)
 	desc := roachpb.NewRangeDescriptor(123, roachpb.RKeyMin, roachpb.RKeyMax, set)
 
-	var err = roachpb.NewReplicaUnavailableError(desc, rDesc)
+	errSlowProposal := errors.New("slow proposal")
+	var err = roachpb.NewReplicaUnavailableError(errSlowProposal, desc, rDesc)
 	err = errors.DecodeError(ctx, errors.EncodeError(ctx, err))
+	// Sanity check that Unwrap() was implemented.
+	require.True(t, errors.Is(err, errSlowProposal), "%+v", err)
+	require.True(t, errors.HasType(err, (*roachpb.ReplicaUnavailableError)(nil)), "%+v", err)
 
 	s := fmt.Sprintf("%s\n%s", err, redact.Sprint(err))
 	echotest.Require(t, s, filepath.Join("testdata", "replica_unavailable_error.txt"))

--- a/pkg/roachpb/testdata/replica_unavailable_error.txt
+++ b/pkg/roachpb/testdata/replica_unavailable_error.txt
@@ -1,4 +1,4 @@
 echo
 ----
-replica (n1,s2):3 unable to serve request to r123:/M{in-ax} [(n1,s2):1, next=2, gen=0]
-replica (n1,s2):3 unable to serve request to r123:‹/M{in-ax}› [(n1,s2):1, next=2, gen=0]
+replica (n1,s2):3 unable to serve request to r123:/M{in-ax} [(n1,s2):1, next=2, gen=0]: slow proposal
+replica (n1,s2):3 unable to serve request to r123:‹/M{in-ax}› [(n1,s2):1, next=2, gen=0]: slow proposal


### PR DESCRIPTION
`ReplicaUnavailableError` was previously a leaf error, so the only
way to attach additional information "on the way out" was to wrap *it*
with wrapper errors. This made it difficult to read the messages since
the result and cause were reversed.

This became exacerbated with the recent addition of `PoisonedError`,
which should really be a cause of `ReplicaUnavailableError` too.

In this commit, we make ReplicaUnavailableError a wrapper error and
rearrange breaker errors such that if a PoisonError occurs, it is
a cause of the ReplicaUnavailableError.

The change in `pkg/kv/kvserver/testdata/replica_unavailable_error.txt`
illustrates the improved error users will see (and which will thus be
reported to us).

As a wrapping error, I needed to register the error with
`cockroachdb/errors` to allow for proper encoding/decoding. I'm unsure
whether this worked properly before, but now it definitely does (as it
is tested).

Testing was improved to check for presence of `ReplicaUnavailableError`
in all breaker errors.

Touches https://github.com/cockroachdb/cockroach/issues/33007.

Release justification: UX improvement for existing functionality
Release note: None