### PR TITLE
jobs: Set a timeout when executing schedules.

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/contextutil",
         "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/json",

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -307,7 +308,15 @@ func (s *jobScheduler) executeSchedules(
 			continue
 		}
 
+		timeout := schedulerScheduleExecutionTimeout.Get(&s.Settings.SV)
 		if processErr := withSavePoint(ctx, txn, func() error {
+			if timeout > 0 {
+				return contextutil.RunWithTimeout(
+					ctx, fmt.Sprintf("process-schedule-%d", schedule.ScheduleID()), timeout,
+					func(ctx context.Context) error {
+						return s.processSchedule(ctx, schedule, numRunning, stats, txn)
+					})
+			}
 			return s.processSchedule(ctx, schedule, numRunning, stats, txn)
 		}); processErr != nil {
 			if errors.HasType(processErr, (*savePointError)(nil)) {
@@ -426,6 +435,9 @@ func (sf *syncCancelFunc) withCancelOnDisabled(
 
 func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 	_ = stopper.RunAsyncTask(ctx, "job-scheduler", func(ctx context.Context) {
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
 		initialDelay := getInitialScanDelay(s.TestingKnobs)
 		log.Infof(ctx, "waiting %v before scheduled jobs daemon start", initialDelay)
 
@@ -453,7 +465,6 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 				}); err != nil {
 					log.Errorf(ctx, "error executing schedules: %+v", err)
 				}
-
 			}
 		}
 	})
@@ -477,7 +488,14 @@ var schedulerMaxJobsPerIterationSetting = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"jobs.scheduler.max_jobs_per_iteration",
 	"how many schedules to start per iteration; setting to 0 turns off this limit",
-	10,
+	5,
+)
+
+var schedulerScheduleExecutionTimeout = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"jobs.scheduler.schedule_execution.timeout",
+	"sets a timeout on for schedule execution; 0 disables timeout",
+	30*time.Second,
 )
 
 // Returns the amount of time to wait before starting initial scan.


### PR DESCRIPTION
Improve jobs system resilience to misbehaving schedules, which take
unreasonable time to execute.

Job scheduler now sets a timeout when executing each schedule.
Scheduled jobs must ensure that they complete their execution within
specified timeout.  This does not imply that you cannot have long running
scheduled jobs.

Failed execution due to timeout are handled based on schedule policy.
The timeout is controlled via the `jobs.scheduler.schedule_execution.timeout` setting,
and can be disabled by setting timeout value to 0.

Release Notes: Improve jobs system resilience to scheduled jobs that
may lock up jobs/scheduled job table for long periods of time.  Each schedule
now has a limited amount of time to complete its execution.  The timeout
is controlled via  `jobs.scheduler.schedule_execution.timeout` setting.

Release Justification: System stability improvement.