### PR TITLE
ccl/serverccl/statusccl: increase test timeout for tenant txn id resolution

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -944,7 +944,7 @@ func testTxnIDResolutionRPC(ctx context.Context, t *testing.T, helper *tenantTes
 			"expected a valid txnID, but %+v is found", result)
 		sqlConn.Exec(t, "COMMIT")
 
-		testutils.SucceedsWithin(t, func() error {
+		testutils.SucceedsSoon(t, func() error {
 			resp, err := status.TxnIDResolution(ctx, &serverpb.TxnIDResolutionRequest{
 				CoordinatorID: strconv.Itoa(int(coordinatorNodeID)),
 				TxnIDs:        []uuid.UUID{txnID},
@@ -959,7 +959,7 @@ func testTxnIDResolutionRPC(ctx context.Context, t *testing.T, helper *tenantTes
 					"was not", txnID.String(), coordinatorNodeID)
 			require.NotEqual(t, roachpb.InvalidTransactionFingerprintID, resp.ResolvedTxnIDs[0].TxnFingerprintID)
 			return nil
-		}, 3*time.Second)
+		})
 	}
 
 	t.Run("regular_cluster", func(t *testing.T) {


### PR DESCRIPTION
Hopefully resolves #77371

Previously, Txn ID Resolution test for tenant allowed retries for up to
three seconds. However, since tenant RPC fanout depended on range feed
to populate its internal cache, it might take more than three seconds
for the sqlinstance system to properly update its internal cache. This
might be the root cause of #77371.
This commit relaxes the retry constraints for the Txn ID Resolution test.

Release justification: bug fix to existing functionality
Release note: None