### PR TITLE
sql: don't silently ignore cluster_inflight_traces queries

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1367,10 +1367,10 @@ CREATE TABLE crdb_internal.cluster_inflight_traces (
 	}}},
 	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor,
 		addRow func(...tree.Datum) error) error {
-		// We only want to generate rows when an index constraint is provided on the
-		// query accessing this vtable. This index constraint will provide the
-		// trace_id for which we will collect inflight trace spans from the cluster.
-		return nil
+		// We refuse queries without an index constraint. This index constraint will
+		// provide the trace_id for which we will collect inflight trace spans from
+		// the cluster.
+		return pgerror.New(pgcode.FeatureNotSupported, "a trace_id value needs to be specified")
 	},
 }
 

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -817,7 +817,9 @@ func TestClusterInflightTracesVirtualTable(t *testing.T) {
 	// the query contains an index constraint.
 
 	t.Run("no-index-constraint", func(t *testing.T) {
-		sqlDB.CheckQueryResults(t, `SELECT * from crdb_internal.cluster_inflight_traces`, [][]string{})
+		_, err := sqlDB.DB.ExecContext(ctx, `SELECT * from crdb_internal.cluster_inflight_traces`)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "a trace_id value needs to be specified")
 	})
 
 	t.Run("with-index-constraint", func(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -429,6 +429,9 @@ SELECT * FROM crdb_internal.cluster_inflight_traces WHERE trace_id=123
 ----
 trace_id  node_id  root_op_name  trace_str  jaeger_json
 
+statement error pgcode 0A000 a trace_id value needs to be specified
+SELECT * FROM crdb_internal.cluster_inflight_traces
+
 query IIIIBTIT colnames
 SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
 ----


### PR DESCRIPTION
The crdb_internal.cluster_inflight_traces virtual table only supports
queries that filter by a trace id (for better or worse). Before this
patch, other queries would succeed, but not return any rows. This kind
of quiet disobedience seems harmful. This patch makes such queries
return an error telling you what the deal is.

Release note: None
Release justification: low risk