### PR TITLE
kv/bulk: use cluster setting for split-after size

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -199,8 +199,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	evalCtx := sip.FlowCtx.EvalCtx
 	db := sip.FlowCtx.Cfg.DB
 	var err error
-	sip.batcher, err = bulk.MakeStreamSSTBatcher(ctx, db, evalCtx.Settings,
-		func() int64 { return bulk.IngestFileSize(evalCtx.Settings) })
+	sip.batcher, err = bulk.MakeStreamSSTBatcher(ctx, db, evalCtx.Settings)
 	if err != nil {
 		sip.MoveToDraining(errors.Wrap(err, "creating stream sst batcher"))
 		return

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -93,9 +93,6 @@ func MakeBulkAdder(
 	if opts.StepBufferSize == 0 {
 		opts.StepBufferSize = 32 << 20
 	}
-	if opts.SSTSize == nil {
-		opts.SSTSize = func() int64 { return 16 << 20 }
-	}
 	if opts.SplitAndScatterAfter == nil {
 		// splitting _before_ hitting max reduces chance of auto-splitting after the
 		// range is full and is more expensive to split/move.
@@ -108,7 +105,6 @@ func MakeBulkAdder(
 		name: opts.Name,
 		sink: SSTBatcher{
 			db:                     db,
-			maxSize:                opts.SSTSize,
 			rc:                     rangeCache,
 			settings:               settings,
 			skipDuplicates:         opts.SkipDuplicates,

--- a/pkg/kv/bulk/setting.go
+++ b/pkg/kv/bulk/setting.go
@@ -16,21 +16,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 )
 
-// IngestBatchSize is a cluster setting that controls the maximum size of the
-// payload in an AddSSTable request.
-var IngestBatchSize = func() *settings.ByteSizeSetting {
-	s := settings.RegisterByteSizeSetting(
+var (
+	// IngestBatchSize controls the size of ingest ssts.
+	IngestBatchSize = settings.RegisterByteSizeSetting(
 		settings.TenantWritable,
 		"kv.bulk_ingest.batch_size",
 		"the maximum size of the payload in an AddSSTable request",
 		16<<20,
 	)
-	return s
-}()
+)
 
-// IngestFileSize determines the target size files sent via AddSSTable requests.
+// ingestFileSize determines the target size files sent via AddSSTable requests.
 // It returns the smaller of the IngestBatchSize and Raft command size settings.
-func IngestFileSize(st *cluster.Settings) int64 {
+func ingestFileSize(st *cluster.Settings) int64 {
 	desiredSize := IngestBatchSize.Get(&st.SV)
 	maxCommandSize := kvserver.MaxCommandSize.Get(&st.SV)
 	if desiredSize > maxCommandSize {

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -40,6 +40,13 @@ var (
 		400*1<<10, // 400 Kib
 	)
 
+	splitAfter = settings.RegisterByteSizeSetting(
+		settings.TenantWritable,
+		"bulkio.ingest.scatter_after_size",
+		"amount of data added to any one range after which a new range should be split off and scattered",
+		48<<20,
+	)
+
 	ingestDelay = settings.RegisterDurationSetting(
 		settings.TenantWritable,
 		"bulkio.ingest.flush_delay",
@@ -67,10 +74,9 @@ func (b sz) SafeFormat(w redact.SafePrinter, _ rune) {
 // it to attempt to flush SSTs before they cross range boundaries to minimize
 // expensive on-split retries.
 type SSTBatcher struct {
-	db         *kv.DB
-	rc         *rangecache.RangeCache
-	settings   *cluster.Settings
-	splitAfter func() int64
+	db       *kv.DB
+	rc       *rangecache.RangeCache
+	settings *cluster.Settings
 
 	// disallowShadowingBelow is described on roachpb.AddSSTableRequest.
 	disallowShadowingBelow hlc.Timestamp
@@ -98,6 +104,8 @@ type SSTBatcher struct {
 
 	// writeAtBatchTS is passed to the writeAtBatchTs argument to db.AddSStable.
 	writeAtBatchTS bool
+
+	initialSplitDone bool
 
 	// The rest of the fields accumulated state as opposed to configuration. Some,
 	// like totalRows, are accumulated _across_ batches and are not reset between
@@ -344,23 +352,26 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		// minimizes impact on other adders (e.g. causing extra SST splitting).
 		//
 		// We only do this splitting if the caller expects the sst_batcher to
-		// split and scatter the data as it ingests it (which is the case when
-		// splitAfter) is set.
-		if b.flushCounts.total == 1 && b.splitAfter != nil {
+		// split and scatter the data as it ingests it i.e. splitAfter > 0.
+		if b.flushCounts.total == 1 && splitAfter.Get(&b.settings.SV) > 0 && !b.initialSplitDone {
 			if splitAt, err := keys.EnsureSafeSplitKey(start); err != nil {
-				log.Warningf(ctx, "%v", err)
+				log.Warningf(ctx, "failed to generate split key to separate ingestion span: %v", err)
 			} else {
+				if log.V(1) {
+					log.Infof(ctx, "splitting on first flush to separate ingestion span using key %v", start)
+				}
 				// NB: Passing 'hour' here is technically illegal until 19.2 is
 				// active, but the value will be ignored before that, and we don't
 				// have access to the cluster version here.
 				reply, err := b.db.SplitAndScatter(ctx, splitAt, hour)
 				if err != nil {
-					log.Warningf(ctx, "%v", err)
-				}
-				b.flushCounts.splitWait += reply.Timing.Split
-				b.flushCounts.scatterWait += reply.Timing.Scatter
-				if reply.Stats != nil {
-					b.flushCounts.scatterMoved += reply.Stats.Total()
+					log.Warningf(ctx, "failed ot split at first key to separate ingestion span: %v", err)
+				} else {
+					b.flushCounts.splitWait += reply.Timing.Split
+					b.flushCounts.scatterWait += reply.Timing.Scatter
+					if reply.Stats != nil {
+						b.flushCounts.scatterMoved += reply.Stats.Total()
+					}
 				}
 			}
 		}
@@ -400,8 +411,8 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 			b.lastFlushKey = append(b.lastFlushKey[:0], b.flushKey...)
 			b.flushedToCurrentRange = size
 		}
-		if b.splitAfter != nil {
-			if splitAfter := b.splitAfter(); b.flushedToCurrentRange > splitAfter && nextKey != nil {
+		if splitSize := splitAfter.Get(&b.settings.SV); splitSize > 0 {
+			if b.flushedToCurrentRange > splitSize && nextKey != nil {
 				if splitAt, err := keys.EnsureSafeSplitKey(nextKey); err != nil {
 					log.Warningf(ctx, "%v", err)
 				} else {

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -132,7 +132,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 
 			ts := hlc.Timestamp{WallTime: 100}
 			b, err := bulk.MakeBulkAdder(
-				ctx, kvDB, mockCache, s.ClusterSettings(), ts, kvserverbase.BulkAdderOptions{MinBufferSize: batchSize(), SSTSize: batchSize}, nil, /* bulkMon */
+				ctx, kvDB, mockCache, s.ClusterSettings(), ts, kvserverbase.BulkAdderOptions{MinBufferSize: batchSize()}, nil, /* bulkMon */
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -25,11 +25,6 @@ type BulkAdderOptions struct {
 	// behalf of which it is adding data.
 	Name string
 
-	// SplitAndScatterAfter is the number of bytes which if added without hitting
-	// an existing split will cause the adder to split and scatter the next span.
-	// A function returning -1 is interpreted as indicating not to split.
-	SplitAndScatterAfter func() int64
-
 	// MinBufferSize is the initial size of the BulkAdder buffer. It indicates the
 	// amount of memory we require to be able to buffer data before flushing for
 	// SST creation.
@@ -78,10 +73,6 @@ type BulkAdderOptions struct {
 	// sample of the overall input.
 	InitialSplitsIfUnordered int
 }
-
-// DisableExplicitSplits can be returned by a SplitAndScatterAfter function to
-// indicate that the SSTBatcher should not issue explicit splits.
-const DisableExplicitSplits = -1
 
 // BulkAdderFactory describes a factory function for BulkAdders.
 type BulkAdderFactory func(

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -25,11 +25,6 @@ type BulkAdderOptions struct {
 	// behalf of which it is adding data.
 	Name string
 
-	// SSTSize is the size at which an SST will be flushed and a new one started.
-	// SSTs are also split during a buffer flush to avoid spanning range bounds so
-	// they may be smaller than this limit.
-	SSTSize func() int64
-
 	// SplitAndScatterAfter is the number of bytes which if added without hitting
 	// an existing split will cause the adder to split and scatter the next span.
 	// A function returning -1 is interpreted as indicating not to split.

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -120,6 +120,7 @@ var retiredSettings = map[string]struct{}{
 	"server.declined_reservation_timeout":                              {},
 	"bulkio.backup.resolve_destination_in_job.enabled":                 {},
 	"sql.defaults.experimental_hash_sharded_indexes.enabled":           {},
+	"schemachanger.backfiller.max_sst_size":                            {},
 }
 
 // register adds a setting to the registry.

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/bulk",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -355,8 +354,6 @@ func ingestKvs(
 		isPK[tableAndIndex{tableID: t.Desc.ID, indexID: t.Desc.PrimaryIndex.ID}] = true
 	}
 
-	flushSize := func() int64 { return bulk.IngestFileSize(flowCtx.Cfg.Settings) }
-
 	// We create two bulk adders so as to combat the excessive flushing of small
 	// SSTs which was observed when using a single adder for both primary and
 	// secondary index kvs. The number of secondary index kvs are small, and so we
@@ -375,7 +372,6 @@ func ingestKvs(
 		MinBufferSize:            minBufferSize,
 		MaxBufferSize:            maxBufferSize,
 		StepBufferSize:           stepSize,
-		SSTSize:                  flushSize,
 		InitialSplitsIfUnordered: int(spec.InitialSplits),
 		WriteAtBatchTimestamp:    writeAtBatchTimestamp,
 	})
@@ -393,7 +389,6 @@ func ingestKvs(
 		MinBufferSize:            minBufferSize,
 		MaxBufferSize:            maxBufferSize,
 		StepBufferSize:           stepSize,
-		SSTSize:                  flushSize,
 		InitialSplitsIfUnordered: int(spec.InitialSplits),
 		WriteAtBatchTimestamp:    writeAtBatchTimestamp,
 	})

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -72,11 +72,6 @@ var backfillerBufferIncrementSize = settings.RegisterByteSizeSetting(
 	"schemachanger.backfiller.buffer_increment", "the size by which the BulkAdder attempts to grow its buffer before flushing", 32<<20,
 )
 
-var backillerSSTSize = settings.RegisterByteSizeSetting(
-	settings.TenantWritable,
-	"schemachanger.backfiller.max_sst_size", "target size for ingested files during backfills", 16<<20,
-)
-
 func newIndexBackfiller(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
@@ -190,10 +185,8 @@ func (ib *indexBackfiller) ingestIndexEntries(
 
 	minBufferSize := backfillerBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	maxBufferSize := func() int64 { return backfillerMaxBufferSize.Get(&ib.flowCtx.Cfg.Settings.SV) }
-	sstSize := func() int64 { return backillerSSTSize.Get(&ib.flowCtx.Cfg.Settings.SV) }
 	stepSize := backfillerBufferIncrementSize.Get(&ib.flowCtx.Cfg.Settings.SV)
 	opts := kvserverbase.BulkAdderOptions{
-		SSTSize:                  sstSize,
 		MinBufferSize:            minBufferSize,
 		MaxBufferSize:            maxBufferSize,
 		StepBufferSize:           stepSize,


### PR DESCRIPTION

Release note: none.

Release justification: low-risk cleanup that adds configurability.