### PR TITLE
build: make release justification checker pre-CI

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -8,7 +8,7 @@ status = ["GitHub CI (Cockroach)"]
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will
 # construct the merge commit in parallel and simply wait for success right
 # before merging.
-pr_status = ["license/cla"]
+pr_status = ["license/cla", "blathers/release-justification-check"]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.
 block_labels = ["do-not-merge"]

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -6,8 +6,6 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
 
-maybe_require_release_justification
-
 tc_start_block "Lint"
 # Disable ccache so that Go doesn't try to install dependencies into GOROOT,
 # where it doesn't have write permissions. (Using ccache busts the Go package

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -307,23 +307,6 @@ generate_ssh_key() {
   fi
 }
 
-maybe_require_release_justification() {
-    # Set this to 1 to require a "release justification" note in the commit message
-    # or the PR description.
-    require_justification=1
-    if [ "$require_justification" = 1 ]; then
-        tc_start_block "Ensure commit message contains a release justification"
-        # Ensure master branch commits have a release justification.
-        if [[ $(git log -n1 | grep -ci "Release justification: \S\+") == 0 ]]; then
-            echo "Build Failed. No Release justification in the commit message or in the PR description." >&2
-            echo "Commits must have a Release justification of the form:" >&2
-            echo "Release justification: <some description of why this commit is safe to add to the release branch.>" >&2
-            exit 1
-        fi
-        tc_end_block "Ensure commit message contains a release justification"
-    fi
-}
-
 # Call this function with one argument, the error message to print if the
 # workspace is dirty.
 check_workspace_clean() {

--- a/build/teamcity/cockroach/ci/tests/lint.sh
+++ b/build/teamcity/cockroach/ci/tests/lint.sh
@@ -7,8 +7,6 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-maybe_require_release_justification
-
 tc_start_block "Run lints"
 run_bazel build/teamcity/cockroach/ci/tests/lint_impl.sh
 tc_end_block "Run lints"


### PR DESCRIPTION
This commit changes the release justification linter to work on PR
descriptions via bors at the time someone types bors r+, in concert with
Blathers, which now posts a GitHub check to every PR with whether the PR
passed release justification checks or not.

Bors now will check the blathers/release-justification-check GitHub
status before adding a PR to the queue. If the check has failed, the PR
will not even be added to the queue. Before, the check only ran once CI
kicked off on a particular PR, which caused PRs that would fail the
release justification to clog up the bors queue pointlessly.

The Blathers PR (see
https://github.com/cockroachlabs/blathers-bot/pull/77) checks the PR
description to see whether it has a Release Justification when a PR is
sent during stability period. The stability period bit is set by setting
the STABILITY_PERIOD environment variable in the Google Cloud Function
deployment for Blathers (see the Blathers README).

Release note: None
Release justification: build-only change