### PR TITLE
sql/importer: add setting to control reader parallelism

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -3797,10 +3797,11 @@ func BenchmarkCSVConvertRecord(b *testing.B) {
 	}()
 
 	importCtx := &parallelImportContext{
-		semaCtx:   &semaCtx,
-		evalCtx:   &evalCtx,
-		tableDesc: tableDesc.ImmutableCopy().(catalog.TableDescriptor),
-		kvCh:      kvCh,
+		semaCtx:    &semaCtx,
+		evalCtx:    &evalCtx,
+		tableDesc:  tableDesc.ImmutableCopy().(catalog.TableDescriptor),
+		kvCh:       kvCh,
+		numWorkers: 1,
 	}
 
 	producer := &csvBenchmarkStream{
@@ -4745,7 +4746,7 @@ func BenchmarkDelimitedConvertRecord(b *testing.B) {
 	r, err := newMysqloutfileReader(&semaCtx, roachpb.MySQLOutfileOptions{
 		RowSeparator:   '\n',
 		FieldSeparator: '\t',
-	}, kvCh, 0, 0,
+	}, kvCh, 0, 1,
 		tableDesc.ImmutableCopy().(catalog.TableDescriptor), nil /* targetCols */, &evalCtx)
 	require.NoError(b, err)
 
@@ -4848,7 +4849,7 @@ func BenchmarkPgCopyConvertRecord(b *testing.B) {
 		Delimiter:  '\t',
 		Null:       `\N`,
 		MaxRowSize: 4096,
-	}, kvCh, 0, 0,
+	}, kvCh, 0, 1,
 		tableDesc.ImmutableCopy().(catalog.TableDescriptor), nil /* targetCols */, &evalCtx)
 	require.NoError(b, err)
 

--- a/pkg/sql/importer/read_import_avro_test.go
+++ b/pkg/sql/importer/read_import_avro_test.go
@@ -602,7 +602,7 @@ func benchmarkAvroImport(b *testing.B, avroOpts roachpb.AvroOptions, testData st
 
 	avro, err := newAvroInputReader(&semaCtx, kvCh,
 		tableDesc.ImmutableCopy().(catalog.TableDescriptor),
-		avroOpts, 0, 0, &evalCtx)
+		avroOpts, 0, 1, &evalCtx)
 	require.NoError(b, err)
 
 	limitStream := &limitAvroStream{


### PR DESCRIPTION
Release note: none.

Release justification: low-risk, adds more configurability.