### PR TITLE
spanconfigkvsubscriber: conditionally ignore ProtectionPolicies

### DIFF
--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -195,6 +195,12 @@ type Reconciler interface {
 type Store interface {
 	StoreWriter
 	StoreReader
+	// ForEachOverlappingSpanConfig invokes the supplied callback on each
+	// span config that overlaps with the supplied span. In addition to the
+	// SpanConfig, the span it applies over is passed into the callback as well.
+	ForEachOverlappingSpanConfig(
+		context.Context, roachpb.Span, func(roachpb.Span, roachpb.SpanConfig) error,
+	) error
 }
 
 // StoreWriter is the write-only portion of the Store interface.

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -10,9 +10,172 @@
 
 package spanconfigkvsubscriber
 
-import "context"
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
 
 // TestingRunInner exports the inner run method for testing purposes.
 func (s *KVSubscriber) TestingRunInner(ctx context.Context) error {
 	return s.rfc.Run(ctx)
+}
+
+func TestGetProtectionTimestamps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tableSpan := func(tableID uint32) roachpb.Span {
+		return roachpb.Span{
+			Key:    keys.SystemSQLCodec.TablePrefix(tableID),
+			EndKey: keys.SystemSQLCodec.TablePrefix(tableID).PrefixEnd(),
+		}
+	}
+
+	makeSpanAndSpanConfigWithProtectionPolicies := func(span roachpb.Span,
+		pp []roachpb.ProtectionPolicy,
+	) spanAndSpanConfig {
+		return spanAndSpanConfig{
+			span: span,
+			cfg: roachpb.SpanConfig{
+				GCPolicy: roachpb.GCPolicy{
+					ProtectionPolicies: pp,
+				},
+			},
+		}
+	}
+
+	ctx := context.Background()
+	ts1 := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+	ts2 := ts1.Add(1, 0)
+	ts3 := ts2.Add(1, 0)
+	ts4 := ts3.Add(1, 0)
+
+	sp42 := tableSpan(42)
+	sp43 := tableSpan(43)
+	sp4243 := roachpb.Span{Key: sp42.Key, EndKey: sp43.EndKey}
+
+	sp42Cfg := makeSpanAndSpanConfigWithProtectionPolicies(sp42, []roachpb.ProtectionPolicy{
+		{ProtectedTimestamp: ts1},
+		{ProtectedTimestamp: ts2, IgnoreIfExcludedFromBackup: true},
+	})
+
+	sp43Cfg := makeSpanAndSpanConfigWithProtectionPolicies(sp43, []roachpb.ProtectionPolicy{
+		{ProtectedTimestamp: ts3, IgnoreIfExcludedFromBackup: true},
+		{ProtectedTimestamp: ts4},
+	})
+	// Mark sp43 as excluded from backup.
+	sp43Cfg.cfg.ExcludeDataFromBackup = true
+
+	subscriber := New(
+		nil, /* clock */
+		nil, /* rangeFeedFactory */
+		keys.SpanConfigurationsTableID,
+		1<<20, /* 1 MB */
+		roachpb.SpanConfig{},
+		nil,
+	)
+	m := &manualStore{
+		spanAndConfigs: []spanAndSpanConfig{sp42Cfg, sp43Cfg},
+	}
+	subscriber.mu.internal = m
+
+	for _, testCase := range []struct {
+		name string
+		test func(t *testing.T, m *manualStore, subscriber *KVSubscriber)
+	}{
+		{
+			"span not excluded from backup",
+			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
+				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp42)
+				require.NoError(t, err)
+				sort.SliceIsSorted(protections, func(i, j int) bool {
+					return protections[i].Less(protections[j])
+				})
+				require.Equal(t, []hlc.Timestamp{ts1, ts2}, protections)
+			},
+		},
+		{
+			"span excluded from backup",
+			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
+				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp43)
+				require.NoError(t, err)
+				sort.SliceIsSorted(protections, func(i, j int) bool {
+					return protections[i].Less(protections[j])
+				})
+				require.Equal(t, []hlc.Timestamp{ts4}, protections)
+			},
+		},
+		{
+			"span across two table spans",
+			func(t *testing.T, m *manualStore, subscriber *KVSubscriber) {
+				protections, _, err := subscriber.GetProtectionTimestamps(ctx, sp4243)
+				require.NoError(t, err)
+				sort.SliceIsSorted(protections, func(i, j int) bool {
+					return protections[i].Less(protections[j])
+				})
+				require.Equal(t, []hlc.Timestamp{ts1, ts2, ts4}, protections)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.test(t, m, subscriber)
+		})
+	}
+}
+
+var _ spanconfig.Store = &manualStore{}
+
+type spanAndSpanConfig struct {
+	span roachpb.Span
+	cfg  roachpb.SpanConfig
+}
+
+type manualStore struct {
+	spanAndConfigs []spanAndSpanConfig
+}
+
+// Apply implements the spanconfig.Store interface.
+func (m *manualStore) Apply(
+	context.Context, bool, ...spanconfig.Update,
+) (deleted []spanconfig.Target, added []spanconfig.Record) {
+	panic("unimplemented")
+}
+
+// NeedsSplit implements the spanconfig.Store interface.
+func (m *manualStore) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) bool {
+	panic("unimplemented")
+}
+
+// ComputeSplitKey implements the spanconfig.Store interface.
+func (m *manualStore) ComputeSplitKey(context.Context, roachpb.RKey, roachpb.RKey) roachpb.RKey {
+	panic("unimplemented")
+}
+
+// GetSpanConfigForKey implements the spanconfig.Store interface.
+func (m *manualStore) GetSpanConfigForKey(
+	context.Context, roachpb.RKey,
+) (roachpb.SpanConfig, error) {
+	panic("unimplemented")
+}
+
+// ForEachOverlappingSpanConfig implements the spanconfig.Store interface.
+func (m *manualStore) ForEachOverlappingSpanConfig(
+	_ context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,
+) error {
+	for _, spanAndConfig := range m.spanAndConfigs {
+		if spanAndConfig.span.Overlaps(span) {
+			if err := f(spanAndConfig.span, spanAndConfig.cfg); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -115,9 +115,7 @@ func (s *Store) Apply(
 	return deleted, added
 }
 
-// ForEachOverlappingSpanConfig invokes the supplied callback on each
-// span config that overlaps with the supplied span. In addition to the
-// SpanConfig, the s	pan it applies over is passed into the callback as well.
+// ForEachOverlappingSpanConfig is part of the spanconfig.Store interface.
 func (s *Store) ForEachOverlappingSpanConfig(
 	ctx context.Context, span roachpb.Span, f func(roachpb.Span, roachpb.SpanConfig) error,
 ) error {


### PR DESCRIPTION
This change teaches the `GetProtectionTimestamps` method in the KVSubscriber
to ignore ProtectionPolicies that were written by a backup, and apply to a span
that has been marked as excluded from backup. This ensures that the ProtectionPolicy
written by a backup does not holdup GC on the span since it will not be exporting its
row data.

Informs: https://github.com/cockroachdb/cockroach/issues/73536

Release note: None

Release justification: low risk update to new functionality