### PR TITLE
flowinfra: add the flow ID tag to the context of remote flows

### DIFF
--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -34,11 +34,7 @@ type FlowCtx struct {
 
 	Cfg *ServerConfig
 
-	// ID is a unique identifier for a remote flow. It is mainly used as a key
-	// into the flowRegistry. Since local flows do not need to exist in the flow
-	// registry (no inbound stream connections need to be performed), they are not
-	// assigned ids. This is done for performance reasons, as local flows are
-	// more likely to be dominated by setup time.
+	// ID is a unique identifier for a flow.
 	ID execinfrapb.FlowID
 
 	// EvalCtx is used by all the processors in the flow to evaluate expressions.

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -90,6 +90,10 @@ func (m *mockFlow) IsLocal() bool {
 	panic("not implemented")
 }
 
+func (m *mockFlow) HasInboundStreams() bool {
+	panic("not implemented")
+}
+
 func (m *mockFlow) IsVectorized() bool {
 	panic("not implemented")
 }


### PR DESCRIPTION
**execinfra: update the stale comment**

As of https://github.com/cockroachdb/cockroach/commit/a7118807d9ca68a9643e30abb9c07d41acb7809c, we're always generating
the FlowID.

Release note: None

Release justification: comment only change.

**flowinfra: add the flow ID tag to the context of remote flows**

Previously `Flow.IsLocal` method was overloaded and confusing - it was
returning whether a particular flow has any inbound streams whereas its
name implied that it would return `true` only for a single flow of the
local-only query. This led to a couple of very minor and subtle bugs
(for example, not adding FlowID as the tag to the context of the remote
flows). This has now been fixed by disambiguating `IsLocal` and
introducing `HasInboundStreams` method to the `Flow` interface.

Release note: None

Release justification: low risk bug fix.