### PR TITLE
storage: add experimental MVCC range key primitives

### DIFF
--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -200,6 +200,21 @@ func (s *testIterator) curKV() storage.MVCCKeyValue {
 	return s.kvs[s.cur]
 }
 
+// HasPointAndRange implements SimpleMVCCIterator.
+func (s *testIterator) HasPointAndRange() (bool, bool) {
+	panic("not implemented")
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (s *testIterator) RangeBounds() roachpb.Span {
+	panic("not implemented")
+}
+
+// RangeTombstones implements SimpleMVCCIterator.
+func (s *testIterator) RangeKeys() []storage.MVCCRangeKeyValue {
+	panic("not implemented")
+}
+
 func TestInitResolvedTSScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	startKey := roachpb.RKey("d")

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -176,6 +176,21 @@ func (i *MVCCIterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()
 }
 
+// HasPointAndRange implements SimpleMVCCIterator.
+func (i *MVCCIterator) HasPointAndRange() (bool, bool) {
+	panic("not implemented")
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (i *MVCCIterator) RangeBounds() roachpb.Span {
+	panic("not implemented")
+}
+
+// RangeKeys implements SimpleMVCCIterator.
+func (i *MVCCIterator) RangeKeys() []storage.MVCCRangeKeyValue {
+	panic("not implemented")
+}
+
 // ComputeStats is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) ComputeStats(
 	start, end roachpb.Key, nowNanos int64,
@@ -476,6 +491,11 @@ func (s spanSetReader) ConsistentIterators() bool {
 	return s.r.ConsistentIterators()
 }
 
+// SupportsRangeKeys implements the storage.Reader interface.
+func (s spanSetReader) SupportsRangeKeys() bool {
+	return s.r.SupportsRangeKeys()
+}
+
 // PinEngineStateForIterators implements the storage.Reader interface.
 func (s spanSetReader) PinEngineStateForIterators() error {
 	return s.r.PinEngineStateForIterators()
@@ -587,6 +607,18 @@ func (s spanSetWriter) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 		return err
 	}
 	return s.w.ClearMVCCIteratorRange(start, end)
+}
+
+func (s spanSetWriter) ExperimentalPutMVCCRangeKey(storage.MVCCRangeKey, storage.MVCCValue) error {
+	panic("not implemented")
+}
+
+func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
+	panic("not implemented")
+}
+
+func (s spanSetWriter) ExperimentalClearAllMVCCRangeKeys(start, end roachpb.Key) error {
+	panic("not implemented")
 }
 
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -41,12 +41,91 @@ func init() {
 
 // SimpleMVCCIterator is an interface for iterating over key/value pairs in an
 // engine. SimpleMVCCIterator implementations are thread safe unless otherwise
-// noted. SimpleMVCCIterator is a subset of the functionality offered by MVCCIterator.
+// noted. SimpleMVCCIterator is a subset of the functionality offered by
+// MVCCIterator.
+//
+// The iterator exposes both point keys and range keys. Range keys are only
+// emitted when enabled via IterOptions.KeyTypes. Currently, all range keys are
+// MVCC range tombstones, and this is enforced during writes.
+//
+// Range keys and point keys exist separately in Pebble. A specific key position
+// can have both a point key and multiple range keys overlapping it. Their
+// properties are accessed via:
+//
+// HasPointAndRange(): Key types present at the current position.
+// UnsafeKey():        Current position (point key if any).
+// UnsafeValue():      Current point key value (if any).
+// RangeBounds():      Start,end bounds of range keys at current position.
+// RangeKeys():        All range keys/values overlapping current position.
+//
+// Consider the following point keys and range keys:
+//
+//     4: a4  b4
+//     3: [-------)
+//     2: [-------)
+//     1:     b1  c1
+//        a   b   c
+//
+// Range keys cover a span between two roachpb.Key bounds (start inclusive, end
+// exclusive) and contain timestamp/value pairs. They overlap *all* point key
+// versions within their key bounds regardless of timestamp. For example, when
+// the iterator is positioned on b@4, it will also expose [a-c)@3 and [a-c)@2.
+//
+// During iteration with IterKeyTypePointsAndRanges, range keys are emitted at
+// their start key and at every overlapping point key. For example, iterating
+// across the above span would emit this sequence:
+//
+// UnsafeKey HasPointAndRange UnsafeValue RangeKeys
+// a         false,true       -           [a-c)@3 [a-c)@2
+// a@4       true,true        a4          [a-c)@3 [a-c)@2
+// b@4       true,true        b4          [a-c)@3 [a-c)@2
+// b@1       true,true        b1          [a-c)@3 [a-c)@2
+// c@1       true,false       c1          -
+//
+// MVCCIterator reverse iteration yields the above sequence in reverse.
+// Notably, bare range keys are still emitted at their start key (not end key),
+// so they will be emitted last in this example.
+//
+// When using SeekGE within range key bounds, the iterator may land on the bare
+// range key first, unless seeking exactly to an existing point key. E.g.:
+//
+// SeekGE UnsafeKey HasPointAndRange UnsafeValue RangeKeys
+// b      b         false,true       -           [a-c)@3 [a-c)@2
+// b@5    b@5       false,true       -           [a-c)@3 [a-c)@2
+// b@4    b@4       true,true        b@4         [a-c)@3 [a-c)@2
+// b@3    b@3       false,true       -           [a-c)@3 [a-c)@2
+//
+// Note that intents (with timestamp 0) encode to a bare roachpb.Key, so they
+// will be colocated with a range key start bound. For example, if there was an
+// intent on a in the above example, then both SeekGE(a) and forward iteration
+// would land on a@0 and [a-c)@3,[a-c)@2 simultaneously, instead of the bare
+// range keys first.
+//
+// Range keys do not have a stable, discrete identity, and should be
+// considered a continuum: they may be merged or fragmented by other range key
+// writes, split and merged along with CRDB ranges, partially removed by GC,
+// and truncated by iterator bounds.
+//
+// Range keys are fragmented by Pebble such that all overlapping range keys
+// between two keys form a stack of range key fragments at different timestamps.
+// For example, writing [a-e)@1 and [c-g)@2 will yield this fragment structure:
+//
+//     2:     |---|---|
+//     1: |---|---|
+//        a   c   e   g
+//
+// Fragmentation makes all range key properties local, which avoids incurring
+// unnecessary access costs across SSTs and CRDB ranges. It is deterministic
+// on the current range key state, and does not depend on write history.
+// Stacking allows easy access to all range keys overlapping a point key.
+//
+// TODO(erikgrinaker): Write a tech note on range keys and link it here.
 type SimpleMVCCIterator interface {
 	// Close frees up resources held by the iterator.
 	Close()
-	// SeekGE advances the iterator to the first key in the engine which
-	// is >= the provided key.
+	// SeekGE advances the iterator to the first key in the engine which is >= the
+	// provided key. This may be in the middle of a bare range key straddling the
+	// seek key.
 	SeekGE(key MVCCKey)
 	// Valid must be called after any call to Seek(), Next(), Prev(), or
 	// similar methods. It returns (true, nil) if the iterator points to
@@ -56,15 +135,23 @@ type SimpleMVCCIterator interface {
 	// range, or (false, err) if an error has occurred. Valid() will
 	// never return true with a non-nil error.
 	Valid() (bool, error)
-	// Next advances the iterator to the next key/value in the
-	// iteration. After this call, Valid() will be true if the
-	// iterator was not positioned at the last key.
+	// Next advances the iterator to the next key in the iteration. After this
+	// call, Valid() will be true if the iterator was not positioned at the last
+	// key.
 	Next()
 	// NextKey advances the iterator to the next MVCC key. This operation is
 	// distinct from Next which advances to the next version of the current key
 	// or the next key if the iterator is currently located at the last version
 	// for a key. NextKey must not be used to switch iteration direction from
 	// reverse iteration to forward iteration.
+	//
+	// If NextKey() lands on a bare range key, it is possible that there exists a
+	// versioned point key at the start key too. Calling NextKey() again would
+	// skip over this point key, since the start key was already emitted. If the
+	// caller wants to see it, it must call Next() to check for it. Note that
+	// this is not the case with intents: they don't have a timestamp, so the
+	// encoded key is identical to the range key's start bound, and they will
+	// be emitted together at that position.
 	NextKey()
 	// UnsafeKey returns the same value as Key, but the memory is invalidated on
 	// the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
@@ -72,6 +159,21 @@ type SimpleMVCCIterator interface {
 	// UnsafeValue returns the same value as Value, but the memory is
 	// invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
 	UnsafeValue() []byte
+	// HasPointAndRange returns whether the current iterator position has a point
+	// key and/or a range key. If Valid() returns true, one of these will be true,
+	// otherwise they are both false. For details on range keys, see comment on
+	// SimpleMVCCIterator.
+	HasPointAndRange() (bool, bool)
+	// RangeBounds returns the range bounds for the current range key, or an
+	// empty span if there are none. The returned keys are only valid until the
+	// next iterator call.
+	RangeBounds() roachpb.Span
+	// RangeKeys returns all range keys (with different timestamps) at the current
+	// key position, or an empty list if there are none. When at a point key, it
+	// will return all range keys overlapping that point key. The keys are only
+	// valid until the next iterator operation. For details on range keys, see
+	// comment on SimpleMVCCIterator.
+	RangeKeys() []MVCCRangeKeyValue
 }
 
 // IteratorStats is returned from {MVCCIterator,EngineIterator}.Stats.
@@ -103,15 +205,19 @@ type IteratorStats struct {
 // MVCCKey.Timestamp.IsEmpty()).
 //
 // MVCCIterator implementations are thread safe unless otherwise noted.
+//
+// For details on range keys and iteration, see comment on SimpleMVCCIterator.
 type MVCCIterator interface {
 	SimpleMVCCIterator
 
-	// SeekLT advances the iterator to the first key in the engine which
-	// is < the provided key.
+	// SeekLT advances the iterator to the first key in the engine which is < the
+	// provided key. Unlike SeekGE, when calling SeekLT within range key bounds
+	// this will not land on the seek key, but rather on the closest point key
+	// overlapping the range key or the range key's start bound.
 	SeekLT(key MVCCKey)
-	// Prev moves the iterator backward to the previous key/value
-	// in the iteration. After this call, Valid() will be true if the
-	// iterator was not positioned at the first key.
+	// Prev moves the iterator backward to the previous key in the iteration.
+	// After this call, Valid() will be true if the iterator was not positioned at
+	// the first key.
 	Prev()
 
 	// SeekIntentGE is a specialized version of SeekGE(MVCCKey{Key: key}), when
@@ -121,7 +227,9 @@ type MVCCIterator interface {
 	// keys by avoiding the need to iterate over many deleted intents.
 	SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID)
 
-	// Key returns the current key.
+	// Key returns the current key position. This may be a point key, or
+	// the current position inside a range key (typically the start key
+	// or the seek key when using SeekGE within its bounds).
 	Key() MVCCKey
 	// UnsafeRawKey returns the current raw key which could be an encoded
 	// MVCCKey, or the more general EngineKey (for a lock table key).
@@ -140,7 +248,7 @@ type MVCCIterator interface {
 	// currently used by callers who pass around key information as a []byte --
 	// this seems avoidable, and we should consider cleaning up the callers.
 	UnsafeRawMVCCKey() []byte
-	// Value returns the current value as a byte slice.
+	// Value returns the current point key value as a byte slice.
 	Value() []byte
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
@@ -278,6 +386,18 @@ type IterOptions struct {
 	// use such an iterator is to use it in concert with an iterator without
 	// timestamp hints, as done by MVCCIncrementalIterator.
 	MinTimestampHint, MaxTimestampHint hlc.Timestamp
+	// KeyTypes specifies the types of keys to surface: point and/or range keys.
+	// Use HasPointAndRange() to determine which key type is present at a given
+	// iterator position, and RangeBounds() and RangeKeys() to access range keys.
+	// Defaults to IterKeyTypePointsOnly. For more details on range keys, see
+	// comment on SimpleMVCCIterator.
+	//
+	// Range keys are only supported for use with MVCCIterators. Enabling them
+	// for EngineIterators will error.
+	//
+	// TODO(erikgrinaker): Consider separating the options structs for
+	// EngineIterator and MVCCIterator.
+	KeyTypes IterKeyType
 	// useL6Filters allows the caller to opt into reading filter blocks for
 	// L6 sstables. Only for use with Prefix = true. Helpful if a lot of prefix
 	// Seeks are expected in quick succession, that are also likely to not
@@ -287,6 +407,20 @@ type IterOptions struct {
 	// this is a one-time Seek (where loading the data block directly is better).
 	useL6Filters bool
 }
+
+// IterKeyType configures which types of keys an iterator should surface.
+//
+// TODO(erikgrinaker): Combine this with MVCCIterKind somehow.
+type IterKeyType = pebble.IterKeyType
+
+const (
+	// IterKeyTypePointsOnly iterates over point keys only.
+	IterKeyTypePointsOnly = pebble.IterKeyTypePointsOnly
+	// IterKeyTypePointsAndRanges iterates over both point and range keys.
+	IterKeyTypePointsAndRanges = pebble.IterKeyTypePointsAndRanges
+	// IterKeyTypeRangesOnly iterates over only range keys.
+	IterKeyTypeRangesOnly = pebble.IterKeyTypeRangesOnly
+)
 
 // MVCCIterKind is used to inform Reader about the kind of iteration desired
 // by the caller.
@@ -457,15 +591,18 @@ type Reader interface {
 	// NewEngineIterator returns a new instance of an EngineIterator over this
 	// engine. The caller must invoke EngineIterator.Close() when finished
 	// with the iterator to free resources. The caller can change IterOptions
-	// after this function returns.
+	// after this function returns. EngineIterators do not support range keys.
 	NewEngineIterator(opts IterOptions) EngineIterator
 	// ConsistentIterators returns true if the Reader implementation guarantees
 	// that the different iterators constructed by this Reader will see the same
-	// underlying Engine state. NB: this only applies to iterators without
-	// timestamp hints (see IterOptions), i.e., even if this returns true, those
-	// iterators can be "inconsistent" in terms of seeing a different engine
-	// state. The only exception to this is a Reader created using NewSnapshot.
+	// underlying Engine state. This is not true about Batch writes: new iterators
+	// will see new writes made to the batch, existing iterators won't.
 	ConsistentIterators() bool
+	// SupportsRangeKeys returns true if the Reader implementation supports
+	// range keys.
+	//
+	// TODO(erikgrinaker): Remove this after 22.2.
+	SupportsRangeKeys() bool
 
 	// PinEngineStateForIterators ensures that the state seen by iterators
 	// without timestamp hints (see IterOptions) is pinned and will not see
@@ -566,6 +703,49 @@ type Writer interface {
 	// from the storage engine. It is safe to modify the contents of the arguments
 	// after it returns.
 	ClearMVCCIteratorRange(start, end roachpb.Key) error
+
+	// ExperimentalClearMVCCRangeKey deletes an MVCC range key from start
+	// (inclusive) to end (exclusive) at the given timestamp. For any range key
+	// that straddles the start and end boundaries, only the segments within the
+	// boundaries will be cleared. Range keys at other timestamps are unaffected.
+	// Clears are idempotent.
+	//
+	// This method is primarily intended for MVCC garbage collection and similar
+	// internal use.
+	//
+	// This method is EXPERIMENTAL: range keys are under active development, and
+	// have severe limitations including being ignored by all KV and MVCC APIs and
+	// only being stored in memory.
+	ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error
+
+	// ExperimentalClearAllMVCCRangeKeys deletes all MVCC range keys (i.e. all
+	// versions) from start (inclusive) to end (exclusive). For any range key
+	// that straddles the start and end boundaries, only the segments within the
+	// boundaries will be cleared. Clears are idempotent.
+	//
+	// This method is primarily intended for MVCC garbage collection and similar
+	// internal use.
+	//
+	// This method is EXPERIMENTAL: range keys are under active development, and
+	// have severe limitations including being ignored by all KV and MVCC APIs and
+	// only being stored in memory.
+	ExperimentalClearAllMVCCRangeKeys(start, end roachpb.Key) error
+
+	// ExperimentalPutMVCCRangeKey writes an MVCC range key. It will replace any
+	// overlapping range keys at the given timestamp (even partial overlap). Only
+	// MVCC range tombstones, i.e. an empty value, are currently allowed (other
+	// kinds will need additional handling in MVCC APIs and elsewhere, e.g. stats
+	// and GC).
+	//
+	// Range keys must be accessed using special iterator options and methods,
+	// see SimpleMVCCIterator.RangeKeys() for details.
+	//
+	// TODO(erikgrinaker): Write a tech note on range keys and link it here.
+	//
+	// This method is EXPERIMENTAL: range keys are under active development, and
+	// have severe limitations including being ignored by all KV and MVCC APIs and
+	// only being stored in memory.
+	ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error
 
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1765,8 +1766,9 @@ func TestEngineIteratorVisibility(t *testing.T) {
 				eng := NewDefaultInMemForTesting()
 				defer eng.Close()
 
-				// Write initial point key.
+				// Write initial point and range keys.
 				require.NoError(t, eng.PutMVCC(pointKey("a", 1), stringValue("a1")))
+				require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 1), MVCCValue{}))
 
 				// Set up two readers: one regular and one which will be pinned.
 				r := tc.makeReader(eng)
@@ -1779,6 +1781,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 				// Create an iterator. This will see the old engine state regardless
 				// of the type of reader.
 				opts := IterOptions{
+					KeyTypes:   IterKeyTypePointsAndRanges,
 					LowerBound: keys.LocalMax,
 					UpperBound: keys.MaxKey,
 				}
@@ -1795,13 +1798,17 @@ func TestEngineIteratorVisibility(t *testing.T) {
 
 				// Write a new key to the engine, and set up the expected results.
 				require.NoError(t, eng.PutMVCC(pointKey("a", 2), stringValue("a2")))
+				require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 2), MVCCValue{}))
 
-				expectOld := []MVCCKeyValue{
+				expectOld := []interface{}{
 					pointKV("a", 1, "a1"),
+					rangeKV("b", "c", 1, MVCCValue{}),
 				}
-				expectNew := []MVCCKeyValue{
+				expectNew := []interface{}{
 					pointKV("a", 2, "a2"),
 					pointKV("a", 1, "a1"),
+					rangeKV("b", "c", 2, MVCCValue{}),
+					rangeKV("b", "c", 1, MVCCValue{}),
 				}
 
 				// The existing (old) iterator should all see the old engine state,
@@ -1830,24 +1837,30 @@ func TestEngineIteratorVisibility(t *testing.T) {
 					require.Equal(t, expectNew, scanIter(t, iterPinned))
 				}
 
-				// If the reader is also a writer, check write interactions. In
-				// particular, a Batch should read its own writes for any new iterators,
-				// but not for any existing iterators.
+				// If the reader is also a writer, check interactions with writes.
+				// In particular, a Batch should read its own writes for any new
+				// iterators, but not for any existing iterators.
 				if tc.canWrite {
 					w, ok := r.(Writer)
 					require.Equal(t, tc.canWrite, ok)
 
-					// Write a new key to the writer (not engine), and set up expected
-					// results.
+					// Write a new point and range key to the writer (not engine), and set
+					// up expected results.
 					require.NoError(t, w.PutMVCC(pointKey("a", 3), stringValue("a3")))
-					expectNewAndOwn := []MVCCKeyValue{
+					require.NoError(t, w.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 3), MVCCValue{}))
+					expectNewAndOwn := []interface{}{
 						pointKV("a", 3, "a3"),
 						pointKV("a", 2, "a2"),
 						pointKV("a", 1, "a1"),
+						rangeKV("b", "c", 3, MVCCValue{}),
+						rangeKV("b", "c", 2, MVCCValue{}),
+						rangeKV("b", "c", 1, MVCCValue{}),
 					}
-					expectOldAndOwn := []MVCCKeyValue{
+					expectOldAndOwn := []interface{}{
 						pointKV("a", 3, "a3"),
 						pointKV("a", 1, "a1"),
+						rangeKV("b", "c", 3, MVCCValue{}),
+						rangeKV("b", "c", 1, MVCCValue{}),
 					}
 
 					// The existing iterators should see the same state as before these
@@ -1886,23 +1899,289 @@ func TestEngineIteratorVisibility(t *testing.T) {
 	}
 }
 
-// scanIter scans all point KVs from the iterator.
-func scanIter(t *testing.T, iter MVCCIterator) []MVCCKeyValue {
+// TestEngineRangeKeyMutations tests that range key mutations work as expected,
+// both for the engine directly and for batches.
+func TestEngineRangeKeyMutations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "batch", func(t *testing.T, useBatch bool) {
+		eng := NewDefaultInMemForTesting()
+		defer eng.Close()
+
+		rw := ReadWriter(eng)
+		if useBatch {
+			rw = eng.NewBatch()
+			defer rw.Close()
+		}
+
+		require.True(t, rw.SupportsRangeKeys())
+
+		// Check errors for invalid, empty, and zero-length range keys. Not
+		// exhaustive, since we assume validation dispatches to
+		// MVCCRangeKey.Validate() which is tested separately.
+		empty := MVCCRangeKey{}
+		invalid := rangeKey("b", "a", 1)
+		zeroLength := rangeKey("a", "a", 1)
+
+		require.Error(t, rw.ExperimentalPutMVCCRangeKey(empty, MVCCValue{}))
+		require.Error(t, rw.ExperimentalPutMVCCRangeKey(invalid, MVCCValue{}))
+		require.Error(t, rw.ExperimentalPutMVCCRangeKey(zeroLength, MVCCValue{}))
+
+		require.Error(t, rw.ExperimentalClearMVCCRangeKey(empty))
+		require.Error(t, rw.ExperimentalClearMVCCRangeKey(invalid))
+		require.Error(t, rw.ExperimentalClearMVCCRangeKey(zeroLength))
+
+		require.Error(t, rw.ExperimentalClearAllMVCCRangeKeys(empty.StartKey, empty.EndKey))
+		require.Error(t, rw.ExperimentalClearAllMVCCRangeKeys(invalid.StartKey, invalid.EndKey))
+		require.Error(t, rw.ExperimentalClearAllMVCCRangeKeys(zeroLength.StartKey, zeroLength.EndKey))
+
+		// Check that non-tombstone values error.
+		require.Error(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "b", 1), stringValue("foo")))
+
+		// Check that nothing got written during the errors above.
+		require.Empty(t, scanRangeKeys(t, rw))
+
+		// Write some range keys and read the fragmented keys back.
+		for _, rangeKey := range []MVCCRangeKey{
+			rangeKey("a", "d", 1),
+			rangeKey("f", "h", 1),
+			rangeKey("c", "g", 2),
+		} {
+			require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{}))
+		}
+		require.Equal(t, []MVCCRangeKeyValue{
+			rangeKV("a", "c", 1, MVCCValue{}),
+			rangeKV("c", "d", 2, MVCCValue{}),
+			rangeKV("c", "d", 1, MVCCValue{}),
+			rangeKV("d", "f", 2, MVCCValue{}),
+			rangeKV("f", "g", 2, MVCCValue{}),
+			rangeKV("f", "g", 1, MVCCValue{}),
+			rangeKV("g", "h", 1, MVCCValue{}),
+		}, scanRangeKeys(t, rw))
+
+		// Clear the f-g portion of [f-h)@1, twice for idempotency. This should not
+		// affect any other range keys, apart from removing the fragment boundary
+		// at f for [d-g)@2.
+		require.NoError(t, rw.ExperimentalClearMVCCRangeKey(rangeKey("f", "g", 1)))
+		require.NoError(t, rw.ExperimentalClearMVCCRangeKey(rangeKey("f", "g", 1)))
+		require.Equal(t, []MVCCRangeKeyValue{
+			rangeKV("a", "c", 1, MVCCValue{}),
+			rangeKV("c", "d", 2, MVCCValue{}),
+			rangeKV("c", "d", 1, MVCCValue{}),
+			rangeKV("d", "g", 2, MVCCValue{}),
+			rangeKV("g", "h", 1, MVCCValue{}),
+		}, scanRangeKeys(t, rw))
+
+		// Write [e-f)@2 on top of existing [d-g)@2. This should be a noop.
+		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("e", "f", 2), MVCCValue{}))
+		require.Equal(t, []MVCCRangeKeyValue{
+			rangeKV("a", "c", 1, MVCCValue{}),
+			rangeKV("c", "d", 2, MVCCValue{}),
+			rangeKV("c", "d", 1, MVCCValue{}),
+			rangeKV("d", "g", 2, MVCCValue{}),
+			rangeKV("g", "h", 1, MVCCValue{}),
+		}, scanRangeKeys(t, rw))
+
+		// Clear all range keys in the [c-f) span.
+		require.NoError(t, rw.ExperimentalClearAllMVCCRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+		require.Equal(t, []MVCCRangeKeyValue{
+			rangeKV("a", "c", 1, MVCCValue{}),
+			rangeKV("f", "g", 2, MVCCValue{}),
+			rangeKV("g", "h", 1, MVCCValue{}),
+		}, scanRangeKeys(t, rw))
+
+		// Write another range key to bridge the [c-g)@1 gap.
+		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("c", "g", 1), MVCCValue{}))
+		require.Equal(t, []MVCCRangeKeyValue{
+			rangeKV("a", "f", 1, MVCCValue{}),
+			rangeKV("f", "g", 2, MVCCValue{}),
+			rangeKV("f", "g", 1, MVCCValue{}),
+			rangeKV("g", "h", 1, MVCCValue{}),
+		}, scanRangeKeys(t, rw))
+
+		// Writing a range key [a-f)@2 which abuts [f-g)@2 should not merge if it
+		// has a different value (local timestamp).
+		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 2), withLocalTS(MVCCValue{}, 7)))
+		require.Equal(t, []MVCCRangeKeyValue{
+			rangeKV("a", "f", 2, withLocalTS(MVCCValue{}, 7)),
+			rangeKV("a", "f", 1, MVCCValue{}),
+			rangeKV("f", "g", 2, MVCCValue{}),
+			rangeKV("f", "g", 1, MVCCValue{}),
+			rangeKV("g", "h", 1, MVCCValue{}),
+		}, scanRangeKeys(t, rw))
+
+		// If using a batch, make sure nothing has been written to the engine, then
+		// commit the batch and make sure it gets written to the engine.
+		if useBatch {
+			require.Empty(t, scanRangeKeys(t, eng))
+			require.NoError(t, rw.(Batch).Commit(true))
+			require.Equal(t, []MVCCRangeKeyValue{
+				rangeKV("a", "f", 2, withLocalTS(MVCCValue{}, 7)),
+				rangeKV("a", "f", 1, MVCCValue{}),
+				rangeKV("f", "g", 2, MVCCValue{}),
+				rangeKV("f", "g", 1, MVCCValue{}),
+				rangeKV("g", "h", 1, MVCCValue{}),
+			}, scanRangeKeys(t, eng))
+		}
+	})
+}
+
+// TestEngineRangeKeysUnsupported tests that engines without range key
+// support behave as expected, i.e. writes fail but reads degrade gracefully.
+func TestEngineRangeKeysUnsupported(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Set up an engine with a version that doesn't support range keys.
+	version := clusterversion.ByKey(clusterversion.EnsurePebbleFormatVersionRangeKeys - 1)
+	st := cluster.MakeTestingClusterSettingsWithVersions(version, version, true)
+
+	eng := NewDefaultInMemForTesting(Settings(st))
+	defer eng.Close()
+
+	require.NoError(t, eng.PutMVCC(pointKey("a", 1), stringValue("a1")))
+
+	batch := eng.NewBatch()
+	defer batch.Close()
+	snapshot := eng.NewSnapshot()
+	defer snapshot.Close()
+	readOnly := eng.NewReadOnly(StandardDurability)
+	defer readOnly.Close()
+
+	writers := map[string]Writer{
+		"engine": eng,
+		"batch":  batch,
+	}
+	readers := map[string]Reader{
+		"engine":   eng,
+		"batch":    batch,
+		"snapshot": snapshot,
+		"readonly": readOnly,
+	}
+
+	// Range key puts should error, but clears are noops (since old databases
+	// cannot contain range keys by definition).
+	for name, w := range writers {
+		t.Run(fmt.Sprintf("write/%s", name), func(t *testing.T) {
+			rangeKey := rangeKey("a", "b", 2)
+			err := w.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "range keys not supported")
+			require.NoError(t, w.ExperimentalClearMVCCRangeKey(rangeKey))
+			require.NoError(t, w.ExperimentalClearAllMVCCRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
+		})
+	}
+
+	// All range key iterators should degrade gracefully to point key iterators,
+	// and be empty for IterKeyTypeRangesOnly.
+	keyTypes := map[string]IterKeyType{
+		"PointsOnly":      IterKeyTypePointsOnly,
+		"PointsAndRanges": IterKeyTypePointsAndRanges,
+		"RangesOnly":      IterKeyTypeRangesOnly,
+	}
+	for name, r := range readers {
+		for keyTypeName, keyType := range keyTypes {
+			t.Run(fmt.Sprintf("read/%s/%s", name, keyTypeName), func(t *testing.T) {
+				require.False(t, r.SupportsRangeKeys())
+
+				iter := r.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+					KeyTypes:   keyType,
+					UpperBound: keys.MaxKey,
+				})
+				defer iter.Close()
+
+				iter.SeekGE(pointKey("a", 0))
+
+				ok, err := iter.Valid()
+				require.NoError(t, err)
+
+				if keyType == IterKeyTypeRangesOnly {
+					// With RangesOnly, the iterator must be empty.
+					require.False(t, ok)
+					hasPoint, hasRange := iter.HasPointAndRange()
+					require.False(t, hasPoint)
+					require.False(t, hasRange)
+					return
+				}
+
+				require.True(t, ok)
+				require.Equal(t, pointKey("a", 1), iter.UnsafeKey())
+				require.Equal(t, stringValueRaw("a1"), iter.UnsafeValue())
+
+				hasPoint, hasRange := iter.HasPointAndRange()
+				require.True(t, hasPoint)
+				require.False(t, hasRange)
+				require.Empty(t, iter.RangeBounds())
+				require.Empty(t, iter.RangeKeys())
+
+				// Exhaust the iterator.
+				iter.Next()
+				ok, err = iter.Valid()
+				require.NoError(t, err)
+				require.False(t, ok)
+			})
+		}
+	}
+}
+
+// scanRangeKeys scans all range keys from the reader.
+func scanRangeKeys(t *testing.T, r Reader) []MVCCRangeKeyValue {
 	t.Helper()
 
+	iter := r.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+		KeyTypes:   IterKeyTypeRangesOnly,
+		LowerBound: keys.LocalMax,
+		UpperBound: keys.MaxKey,
+	})
+	defer iter.Close()
 	iter.SeekGE(MVCCKey{Key: keys.LocalMax})
 
-	var keys []MVCCKeyValue
+	var rangeKeys []MVCCRangeKeyValue
 	for {
 		ok, err := iter.Valid()
 		require.NoError(t, err)
 		if !ok {
 			break
 		}
-		keys = append(keys, MVCCKeyValue{
-			Key:   iter.Key(),
-			Value: iter.Value(),
-		})
+		for _, rangeKey := range iter.RangeKeys() {
+			rangeKeys = append(rangeKeys, rangeKey.Clone())
+		}
+		iter.Next()
+	}
+	return rangeKeys
+}
+
+// scanIter scans all point/range keys from the iterator, and returns a combined
+// slice of MVCCRangeKeyValue and MVCCKeyValue in order.
+func scanIter(t *testing.T, iter MVCCIterator) []interface{} {
+	t.Helper()
+
+	iter.SeekGE(MVCCKey{Key: keys.LocalMax})
+
+	var keys []interface{}
+	var prevRangeStart roachpb.Key
+	for {
+		ok, err := iter.Valid()
+		require.NoError(t, err)
+		if !ok {
+			break
+		}
+		hasPoint, hasRange := iter.HasPointAndRange()
+		if hasRange {
+			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
+				for _, rk := range iter.RangeKeys() {
+					keys = append(keys, rk.Clone())
+				}
+				prevRangeStart = bounds.Key.Clone()
+			}
+		}
+		if hasPoint {
+			keys = append(keys, MVCCKeyValue{
+				Key:   iter.Key(),
+				Value: iter.Value(),
+			})
+		}
 		iter.Next()
 	}
 	return keys

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -120,6 +120,19 @@ type intentInterleavingIter struct {
 	// - intentKey!=nil, iterValid=false, cmp=-dir.
 	// - If both are invalid. cmp is undefined and valid=false.
 	intentCmp int
+	// When intentCmp == 0, this will be set to indicate whether iter is on an
+	// unversioned position on a bare range key copositioned with the intent.
+	// This will never happen in the forward direction due to
+	// maybeSkipIntentRangeKey(). In the reverse direction, if an intent is
+	// located on the start key of an overlapping range key, then we cannot step
+	// iter past the range key to satisfy the usual intentCmp < 0 condition,
+	// because we need the range keys to be exposed via e.g. RangeKeys(). We
+	// therefore also have to consider isCurAtIntentIter to be true when iter is
+	// positioned on a bare unversioned range key colocated with an intent,
+	// i.e. i.dir < 0 && i.intentCmp == 0 && i.iterBareRangeAtIntent.
+	//
+	// NB: This value is not valid for intentCmp != 0.
+	iterBareRangeAtIntent bool
 	// The current direction. +1 for forward, -1 for reverse.
 	dir   int
 	valid bool
@@ -200,8 +213,17 @@ func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator
 	// bound for prefix iteration, though since they don't need to, most callers
 	// don't.
 
-	iiIter := intentInterleavingIterPool.Get().(*intentInterleavingIter)
 	intentOpts := opts
+
+	// There cannot be any range keys across the lock table, so create the intent
+	// iterator for point keys only, or return a normal MVCC iterator if only
+	// range keys are requested.
+	if intentOpts.KeyTypes == IterKeyTypeRangesOnly {
+		return reader.NewMVCCIterator(MVCCKeyIterKind, opts)
+	}
+	intentOpts.KeyTypes = IterKeyTypePointsOnly
+
+	iiIter := intentInterleavingIterPool.Get().(*intentInterleavingIter)
 	intentKeyBuf := iiIter.intentKeyBuf
 	intentLimitKeyBuf := iiIter.intentLimitKeyBuf
 	if opts.LowerBound != nil {
@@ -233,7 +255,8 @@ func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator
 	if reader.ConsistentIterators() {
 		iter = reader.NewMVCCIterator(MVCCKeyIterKind, opts)
 	} else {
-		iter = newPebbleIterator(nil, intentIter.GetRawIter(), opts, StandardDurability)
+		iter = newPebbleIterator(
+			nil, intentIter.GetRawIter(), opts, StandardDurability, reader.SupportsRangeKeys())
 	}
 
 	*iiIter = intentInterleavingIter{
@@ -299,6 +322,62 @@ func (i *intentInterleavingIter) makeLowerLimitKey() roachpb.Key {
 	return i.intentLimitKeyBuf
 }
 
+// maybeSkipIntentRangeKey will step iter once forwards if iter is positioned on
+// a bare range key with the same key position (either start key or seek key) as
+// the current intentIter intent.
+//
+// This is necessary when intentIter lands on a new intent, to ensure iter is
+// positioned on the provisional value instead of the bare range key. This must
+// be done after positioning both iterators.
+//
+// NB: This is called before computePos(), and can't rely on intentCmp.
+//
+// REQUIRES: i.dir > 0
+func (i *intentInterleavingIter) maybeSkipIntentRangeKey() error {
+	if util.RaceEnabled && i.dir < 0 {
+		i.err = errors.AssertionFailedf("maybeSkipIntentRangeKey called in reverse")
+		i.valid = false
+		return i.err
+	}
+	if i.iterValid && i.intentKey != nil {
+		if hasPoint, hasRange := i.iter.HasPointAndRange(); hasRange && !hasPoint {
+			// iter may be on a bare range key that will cover the provisional value,
+			// in which case we can step onto it. We guard against emitting the wrong
+			// range key for the intent if the provisional value turns out to be
+			// missing by:
+			//
+			// 1. Before we step, make sure iter isn't ahead of intentIter. We have
+			//    to do a key comparison anyway in case intentIter is ahead of iter.
+			// 2. After we step, make sure we're on a point key covered by a range key.
+			//    We don't need a key comparison (but do so under race), because if
+			//    the provisional value is missing then we'll either land on a
+			//    different point key below the range key (which will emit the
+			//    correct range key), or we'll land on a different bare range key.
+			//
+			// TODO(erikgrinaker): in cases where we don't step iter, we can save
+			// the result of the comparison in i.intentCmp to avoid another one.
+			if intentCmp := i.intentKey.Compare(i.iterKey.Key); intentCmp < 0 {
+				i.err = errors.Errorf("iter ahead of provisional value for intent %s (at %s)",
+					i.intentKey, i.iterKey)
+				i.valid = false
+				return i.err
+			} else if intentCmp == 0 {
+				i.iter.Next()
+				if err := i.tryDecodeKey(); err != nil {
+					return err
+				}
+				hasPoint, hasRange = i.iter.HasPointAndRange()
+				if !hasPoint || !hasRange || (util.RaceEnabled && !i.iterKey.Key.Equal(i.intentKey)) {
+					i.err = errors.Errorf("iter not on provisional value for intent %s", i.intentKey)
+					i.valid = false
+					return i.err
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 	i.dir = +1
 	i.valid = true
@@ -338,6 +417,9 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 		if err = i.tryDecodeLockKey(iterState, err); err != nil {
 			return
 		}
+		if err := i.maybeSkipIntentRangeKey(); err != nil {
+			return
+		}
 	}
 	i.computePos()
 }
@@ -365,6 +447,9 @@ func (i *intentInterleavingIter) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID
 	}
 	iterState, err := i.intentIter.SeekEngineKeyGEWithLimit(engineKey, limitKey)
 	if err = i.tryDecodeLockKey(iterState, err); err != nil {
+		return
+	}
+	if err := i.maybeSkipIntentRangeKey(); err != nil {
 		return
 	}
 	i.computePos()
@@ -414,6 +499,47 @@ func (i *intentInterleavingIter) computePos() {
 		i.intentCmp = i.dir
 	} else {
 		i.intentCmp = i.intentKey.Compare(i.iterKey.Key)
+		if i.intentCmp == 0 {
+			// We have to handle the case where intentIter is on an intent and iter is
+			// on a bare range key at the same key position.
+			//
+			// In the forward direction, this should never happen: the caller should
+			// have called maybeSkipIntentRangeKey() to step onto the provisional
+			// value (or a later key). The provisional value will be covered by the
+			// same range keys as the intent. We assert this and go on.
+			//
+			// In the reverse direction, there are two cases:
+			//
+			// In the typical case, iter will be on the range key's unversioned start
+			// key. We cannot move past this to satisfy intentCmp < 0 (the usual
+			// condition for isCurAtIntentIter), because we need to expose those range
+			// keys via e.g. RangeKeys().
+			//
+			// However, there is also the case where we're on a versioned key position
+			// following a versioned SeekGE call, i.e. we're in the middle of
+			// switching directions during a Prev() call. For example, we're on
+			// position b@3 of [a-c)@3 with an intent at b. In this case, we should
+			// not be considered located on the intent yet -- we'll land on it after a
+			// subsequent Prev() call.
+			//
+			// We track this as iterBareRangeKeyAtIntent, assuming intentCmp == 0:
+			//
+			// hasRange && !hasPoint && Timestamp.IsEmpty()
+			if i.dir > 0 {
+				if util.RaceEnabled {
+					if hasPoint, hasRange := i.iter.HasPointAndRange(); hasRange && !hasPoint {
+						i.err = errors.AssertionFailedf(
+							"unexpected bare range key for intent in forward direction at: %s", i.iterKey)
+						i.valid = false
+						return
+					}
+				}
+				i.iterBareRangeAtIntent = false
+			} else {
+				hasPoint, hasRange := i.iter.HasPointAndRange()
+				i.iterBareRangeAtIntent = !hasPoint && hasRange && i.iterKey.Timestamp.IsEmpty()
+			}
+		}
 	}
 }
 
@@ -482,7 +608,7 @@ func (i *intentInterleavingIter) Next() {
 	}
 	if i.dir < 0 {
 		// Switching from reverse to forward iteration.
-		isCurAtIntent := i.isCurAtIntentIter()
+		isCurAtIntent := i.isCurAtIntentIterReverse()
 		i.dir = +1
 		if !i.valid {
 			// Both iterators are exhausted, since intentKey is synchronized with
@@ -500,13 +626,17 @@ func (i *intentInterleavingIter) Next() {
 			if err = i.tryDecodeLockKey(iterState, err); err != nil {
 				return
 			}
+			if err := i.maybeSkipIntentRangeKey(); err != nil {
+				return
+			}
 			i.computePos()
 			return
 		}
 		// At least one of the iterators is not exhausted.
 		if isCurAtIntent {
 			// iter precedes the intentIter, so must be at the lowest version of the
-			// preceding key or exhausted. So step it forward. It will now point to
+			// preceding key, at a bare range key whose start key is colocated with
+			// the intent, or exhausted. So step it forward. It will now point to
 			// a key that is the same as the intent key since an intent always has a
 			// corresponding provisional value, and provisional values must have a
 			// higher timestamp than any committed value on a key. Note that the
@@ -526,8 +656,10 @@ func (i *intentInterleavingIter) Next() {
 			}
 			if util.RaceEnabled {
 				cmp := i.intentKey.Compare(i.iterKey.Key)
-				if cmp != 0 {
-					i.err = errors.Errorf("intent has no provisional value, cmp: %d", cmp)
+				hasPoint, hasRange := i.iter.HasPointAndRange()
+				if cmp != 0 || (hasRange && !hasPoint) {
+					i.err = errors.Errorf("intent has no provisional value, cmp:%d hasRange:%t hasPoint:%t",
+						cmp, hasRange, hasPoint)
 					i.valid = false
 					return
 				}
@@ -547,6 +679,7 @@ func (i *intentInterleavingIter) Next() {
 			if err = i.tryDecodeLockKey(iterState, err); err != nil {
 				return
 			}
+			// NB: doesn't need maybeSkipIntentRangeKey() as intentCmp > 0.
 			i.intentCmp = +1
 			if util.RaceEnabled && iterState == pebble.IterValid {
 				cmp := i.intentKey.Compare(i.iterKey.Key)
@@ -561,7 +694,7 @@ func (i *intentInterleavingIter) Next() {
 	if !i.valid {
 		return
 	}
-	if i.intentCmp <= 0 {
+	if i.isCurAtIntentIterForward() {
 		// The iterator is positioned at an intent in intentIter. iter must be
 		// positioned at the provisional value. Note that the code below does not
 		// specifically care if a bug (external to this code) violates the
@@ -585,6 +718,7 @@ func (i *intentInterleavingIter) Next() {
 		if err = i.tryDecodeLockKey(iterState, err); err != nil {
 			return
 		}
+		// NB: doesn't need maybeSkipIntentRangeKey() as intentCmp > 0.
 		i.intentCmp = +1
 		if util.RaceEnabled && i.intentKey != nil {
 			cmp := i.intentKey.Compare(i.iterKey.Key)
@@ -608,6 +742,9 @@ func (i *intentInterleavingIter) Next() {
 			limitKey := i.makeUpperLimitKey()
 			iterState, err := i.intentIter.NextEngineKeyWithLimit(limitKey)
 			if err = i.tryDecodeLockKey(iterState, err); err != nil {
+				return
+			}
+			if err := i.maybeSkipIntentRangeKey(); err != nil {
 				return
 			}
 		}
@@ -647,6 +784,9 @@ func (i *intentInterleavingIter) NextKey() {
 		if err := i.tryDecodeLockKey(iterState, err); err != nil {
 			return
 		}
+		if err := i.maybeSkipIntentRangeKey(); err != nil {
+			return
+		}
 		i.computePos()
 		return
 	}
@@ -664,9 +804,19 @@ func (i *intentInterleavingIter) NextKey() {
 			return
 		}
 	}
+	if err := i.maybeSkipIntentRangeKey(); err != nil {
+		return
+	}
 	i.computePos()
 }
 
+// TODO(erikgrinaker): Consider computing this once and storing it as a struct
+// field when repositioning the iterator, instead of repeatedly calling it. The
+// forward/reverse methods are called at least once per step, with two more
+// calls for UnsafeKey() and UnsafeValue(), and this has a measurable cost
+// (especially in the reverse direction).
+//
+// gcassert:inline
 func (i *intentInterleavingIter) isCurAtIntentIter() bool {
 	// When both iter and intentIter are exhausted, the return value is
 	// immaterial since this function won't be called. We examine the remaining
@@ -685,9 +835,20 @@ func (i *intentInterleavingIter) isCurAtIntentIter() bool {
 	// - iter is exhausted: intentCmp > 0. Returns true.
 	// - intentIter is exhausted: intentCmp < 0. Returns false.
 	// - Neither is exhausted:
-	//   - intentCmp <= 0. Returns false.
 	//   - intentCmp > 0. Returns true.
-	return (i.dir > 0 && i.intentCmp <= 0) || (i.dir < 0 && i.intentCmp > 0)
+	//   - intentCmp = 0. Returns false unless copositioned with bare range key.
+	//   - intentCmp < 0. Returns false.
+	return (i.dir > 0 && i.isCurAtIntentIterForward()) || (i.dir < 0 && i.isCurAtIntentIterReverse())
+}
+
+// gcassert:inline
+func (i *intentInterleavingIter) isCurAtIntentIterForward() bool {
+	return i.intentCmp <= 0
+}
+
+// gcassert:inline
+func (i *intentInterleavingIter) isCurAtIntentIterReverse() bool {
+	return i.intentCmp > 0 || (i.intentCmp == 0 && i.iterBareRangeAtIntent)
 }
 
 func (i *intentInterleavingIter) UnsafeKey() MVCCKey {
@@ -719,6 +880,66 @@ func (i *intentInterleavingIter) Value() []byte {
 		return i.intentIter.Value()
 	}
 	return i.iter.Value()
+}
+
+// HasPointAndRange implements SimpleMVCCIterator.
+func (i *intentInterleavingIter) HasPointAndRange() (bool, bool) {
+	if !i.valid {
+		return false, false
+	}
+	var hasPoint, hasRange bool
+	if i.iterValid {
+		hasPoint, hasRange = i.iter.HasPointAndRange()
+	}
+	if i.isCurAtIntentIter() {
+		// When hasRange and i.dir > 0, i.iter must be at a provisional value, so
+		// hasPoint must be true for i.iter and the range must also cover the intent.
+		if util.RaceEnabled && hasRange && i.dir > 0 {
+			if !hasPoint {
+				i.err = errors.AssertionFailedf("iter not on provisional value for intent %s", i.intentKey)
+				i.valid = false
+				return false, false
+			} else if bounds := i.iter.RangeBounds(); !bounds.ContainsKey(i.intentKey) {
+				i.err = errors.AssertionFailedf("iter range key %s does not cover intent %s",
+					bounds, i.intentKey)
+				i.valid = false
+				return false, false
+			}
+		}
+
+		hasPoint = true
+		// In the reverse direction, if the intent itself does not overlap a range
+		// key, then iter may be positioned on an earlier range key. Otherwise, iter
+		// will always be positioned on the correct range key.
+		//
+		// Note the following implications:
+		//
+		//   hasRange → i.iterValid
+		//   i.isCurAtIntentIter() && i.dir < 0 → i.intentCmp > 0 ||
+		//		(i.intentCmp == 0 && i.iterBareRangeAtIntent)
+		//
+		// TODO(erikgrinaker): consider optimizing this comparison.
+		if hasRange && i.dir < 0 {
+			hasRange = i.intentCmp == 0 || i.iter.RangeBounds().EndKey.Compare(i.intentKey) > 0
+		}
+	}
+	return hasPoint, hasRange
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (i *intentInterleavingIter) RangeBounds() roachpb.Span {
+	if _, hasRange := i.HasPointAndRange(); !hasRange {
+		return roachpb.Span{}
+	}
+	return i.iter.RangeBounds()
+}
+
+// RangeKeys implements SimpleMVCCIterator.
+func (i *intentInterleavingIter) RangeKeys() []MVCCRangeKeyValue {
+	if _, hasRange := i.HasPointAndRange(); !hasRange {
+		return []MVCCRangeKeyValue{}
+	}
+	return i.iter.RangeKeys()
 }
 
 func (i *intentInterleavingIter) Close() {
@@ -797,7 +1018,7 @@ func (i *intentInterleavingIter) Prev() {
 	}
 	if i.dir > 0 {
 		// Switching from forward to reverse iteration.
-		isCurAtIntent := i.isCurAtIntentIter()
+		isCurAtIntent := i.isCurAtIntentIterForward()
 		i.dir = -1
 		if !i.valid {
 			// Both iterators are exhausted, so step both backward.
@@ -821,12 +1042,15 @@ func (i *intentInterleavingIter) Prev() {
 		if isCurAtIntent {
 			// iter is after the intentIter, so must be at the provisional value.
 			// Step it backward. It will now point to a key that is before the
-			// intent key. Note that the code below does not specifically care if a
-			// bug (external to this code) violates the invariant that the
-			// provisional value is the highest timestamp key, but it does care that
-			// there is a timestamped value for this key (which it checks below).
-			// The internal invariant of this iterator implementation will ensure
-			// that iter is pointing to the highest timestamped key.
+			// intent key, or a range key whose start key is colocated with the
+			// intent, or be exhausted.
+			//
+			// Note that the code below does not specifically care if a bug (external
+			// to this code) violates the invariant that the provisional value is the
+			// highest timestamp key, but it does care that there is a timestamped
+			// value for this key (which it checks below). The internal invariant of
+			// this iterator implementation will ensure that iter is pointing to the
+			// highest timestamped key.
 			if i.intentCmp != 0 {
 				i.err = errors.Errorf("iter not at provisional value, cmp: %d", i.intentCmp)
 				i.valid = false
@@ -836,15 +1060,7 @@ func (i *intentInterleavingIter) Prev() {
 			if err := i.tryDecodeKey(); err != nil {
 				return
 			}
-			i.intentCmp = +1
-			if util.RaceEnabled && i.iterValid {
-				cmp := i.intentKey.Compare(i.iterKey.Key)
-				if cmp <= 0 {
-					i.err = errors.Errorf("intentIter should be after iter, cmp: %d", cmp)
-					i.valid = false
-					return
-				}
-			}
+			i.computePos()
 		} else {
 			// The intentIter is after the iter. We don't know whether the iter key
 			// has an intent. Note that the iter could itself be positioned at an
@@ -854,21 +1070,25 @@ func (i *intentInterleavingIter) Prev() {
 			if err = i.tryDecodeLockKey(iterState, err); err != nil {
 				return
 			}
-			if i.intentKey == nil {
-				i.intentCmp = -1
-			} else {
-				i.intentCmp = i.intentKey.Compare(i.iterKey.Key)
-			}
+			i.computePos()
 		}
 	}
 	if !i.valid {
 		return
 	}
-	if i.intentCmp > 0 {
+	if i.isCurAtIntentIterReverse() {
 		// The iterator is positioned at an intent in intentIter, and iter is
-		// exhausted or positioned at a versioned value of a preceding key.
+		// exhausted, positioned at a versioned value of a preceding key, or
+		// positioned on the start of a range key colocated with the intent.
 		// Stepping intentIter backward will ensure that intentKey is <= the key
-		// of iter (when neither is exhausted).
+		// of iter (when neither is exhausted), but we may also need to step
+		// off the bare range key if there is one.
+		if i.iterBareRangeAtIntent {
+			i.iter.Prev()
+			if err := i.tryDecodeKey(); err != nil {
+				return
+			}
+		}
 		var limitKey roachpb.Key
 		if i.iterValid {
 			limitKey = i.makeLowerLimitKey()
@@ -889,7 +1109,7 @@ func (i *intentInterleavingIter) Prev() {
 		// iterValid == true. So positioned at iter.
 		i.intentCmp = -1
 		if i.intentKey != nil {
-			i.intentCmp = i.intentKey.Compare(i.iterKey.Key)
+			i.computePos()
 			if i.intentCmp > 0 {
 				i.err = errors.Errorf("intentIter should not be after iter")
 				i.valid = false

--- a/pkg/storage/intent_reader_writer.go
+++ b/pkg/storage/intent_reader_writer.go
@@ -158,7 +158,7 @@ func (imr *intentInterleavingReader) NewMVCCIterator(
 		iterKind == MVCCKeyAndIntentsIterKind {
 		panic("cannot ask for interleaved intents when specifying timestamp hints")
 	}
-	if iterKind == MVCCKeyIterKind {
+	if iterKind == MVCCKeyIterKind || opts.KeyTypes == IterKeyTypeRangesOnly {
 		return imr.wrappableReader.NewMVCCIterator(MVCCKeyIterKind, opts)
 	}
 	return newIntentInterleavingIterator(imr.wrappableReader, opts)

--- a/pkg/storage/multi_iterator.go
+++ b/pkg/storage/multi_iterator.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
 const invalidIdxSentinel = -1
@@ -90,6 +91,21 @@ func (f *multiIterator) UnsafeKey() MVCCKey {
 // invalidated on the next call to {NextKey,Seek}.
 func (f *multiIterator) UnsafeValue() []byte {
 	return f.iters[f.currentIdx].UnsafeValue()
+}
+
+// HasPointAndRange implements SimpleMVCCIterator.
+func (f *multiIterator) HasPointAndRange() (bool, bool) {
+	panic("not implemented")
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (f *multiIterator) RangeBounds() roachpb.Span {
+	panic("not implemented")
+}
+
+// RangeKeys implements SimpleMVCCIterator.
+func (f *multiIterator) RangeKeys() []MVCCRangeKeyValue {
+	panic("not implemented")
 }
 
 // Next advances the iterator to the next key/value in the iteration. After this

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -101,6 +101,21 @@ type MVCCKeyValue struct {
 	Value []byte
 }
 
+// MVCCRangeKeyValue contains the raw bytes of the value for a key.
+type MVCCRangeKeyValue struct {
+	RangeKey MVCCRangeKey
+	Value    []byte
+}
+
+// Clone returns a copy of the MVCCRangeKeyValue.
+func (r MVCCRangeKeyValue) Clone() MVCCRangeKeyValue {
+	r.RangeKey = r.RangeKey.Clone()
+	if r.Value != nil {
+		r.Value = append([]byte{}, r.Value...)
+	}
+	return r
+}
+
 // optionalValue represents an optional roachpb.Value. It is preferred
 // over a *roachpb.Value to avoid the forced heap allocation.
 type optionalValue struct {
@@ -3402,7 +3417,8 @@ func MVCCResolveWriteIntentRange(
 		mvccIter = rw.NewMVCCIterator(MVCCKeyIterKind, iterOpts)
 	} else {
 		// For correctness, we need mvccIter to be consistent with engineIter.
-		mvccIter = newPebbleIterator(nil, engineIter.GetRawIter(), iterOpts, StandardDurability)
+		mvccIter = newPebbleIterator(
+			nil, engineIter.GetRawIter(), iterOpts, StandardDurability, rw.SupportsRangeKeys())
 	}
 	iterAndBuf := GetBufUsingIter(mvccIter)
 	defer func() {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -58,16 +60,27 @@ import (
 // resolve_intent t=<name> k=<key> [status=<txnstatus>] [clockWhilePending=<int>[,<int>]]
 // check_intent   k=<key> [none]
 //
-// cput      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [cond=<string>]
-// del       [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key>
-// del_range [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [max=<max>] [returnKeys]
-// increment [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inc=<val>]
-// put       [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
-// get       [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]]
-// scan      [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [avoidExcess] [allowEmpty]
+// cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw] [cond=<string>]
+// del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key>
+// del_range      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [max=<max>] [returnKeys]
+// increment      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inc=<val>]
+// put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
+// put_rangekey   ts=<int>[,<int>] [localTS=<int>[,<int>]] k=<key> end=<key>
+// get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]]
+// scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [avoidExcess] [allowEmpty]
+//
+// iter_new       [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly]
+// iter_seek_ge   k=<key> [ts=<int>[,<int>]]
+// iter_seek_lt   k=<key> [ts=<int>[,<int>]]
+// iter_seek_intent_ge k=<key> txn=<name>
+// iter_next
+// iter_next_key
+// iter_prev
+// iter_scan      [reverse]
 //
 // merge     [ts=<int>[,<int>]] k=<key> v=<string> [raw]
 //
+// clear				  k=<key> [ts=<int>[,<int>]]
 // clear_range    k=<key> end=<key>
 //
 // Where `<key>` can be a simple string, or a string
@@ -106,19 +119,53 @@ func TestMVCCHistories(t *testing.T) {
 
 	datadriven.Walk(t, testutils.TestDataPath(t, "mvcc_histories"), func(t *testing.T, path string) {
 		// We start from a clean slate in every test file.
-		engine, err := Open(ctx, InMemory(), CacheSize(1<<20 /* 1 MiB */))
+		engine, err := Open(ctx, InMemory(), CacheSize(1<<20 /* 1 MiB */), ForTesting)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer engine.Close()
+
+		if strings.HasSuffix(path, "_norace") {
+			skip.UnderRace(t)
+		}
 
 		if strings.Contains(path, "_disable_local_timestamps") {
 			localTimestampsEnabled.Override(ctx, &engine.settings.SV, false)
 		}
 
 		reportDataEntries := func(buf *redact.StringBuilder) error {
-			hasData := false
-			err := engine.MVCCIterate(span.Key, span.EndKey, MVCCKeyAndIntentsIterKind, func(r MVCCKeyValue) error {
+			var hasData bool
+
+			iter := engine.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+				KeyTypes:   IterKeyTypeRangesOnly,
+				LowerBound: span.Key,
+				UpperBound: span.EndKey,
+			})
+			defer iter.Close()
+			iter.SeekGE(MVCCKey{Key: span.Key})
+			for {
+				if ok, err := iter.Valid(); err != nil {
+					return err
+				} else if !ok {
+					break
+				}
+				hasData = true
+				buf.Printf("rangekey: %s/[", iter.RangeBounds())
+				for i, rangeKV := range iter.RangeKeys() {
+					val, err := DecodeMVCCValue(rangeKV.Value)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if i > 0 {
+						buf.Printf(" ")
+					}
+					buf.Printf("%s=%s", rangeKV.RangeKey.Timestamp, val)
+				}
+				buf.Printf("]\n")
+				iter.Next()
+			}
+
+			err = engine.MVCCIterate(span.Key, span.EndKey, MVCCKeyAndIntentsIterKind, func(r MVCCKeyValue) error {
 				hasData = true
 				if r.Key.Timestamp.IsEmpty() {
 					// Meta is at timestamp zero.
@@ -145,6 +192,7 @@ func TestMVCCHistories(t *testing.T) {
 		}
 
 		e := newEvalCtx(ctx, engine)
+		defer e.close()
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			// We'll be overriding cmd/cmdargs below, because the
@@ -429,15 +477,26 @@ var commands = map[string]cmd{
 	// TODO(nvanbenschoten): test "resolve_intent_range".
 	"check_intent": {typReadOnly, cmdCheckIntent},
 
-	"clear_range": {typDataUpdate, cmdClearRange},
-	"cput":        {typDataUpdate, cmdCPut},
-	"del":         {typDataUpdate, cmdDelete},
-	"del_range":   {typDataUpdate, cmdDeleteRange},
-	"get":         {typReadOnly, cmdGet},
-	"increment":   {typDataUpdate, cmdIncrement},
-	"merge":       {typDataUpdate, cmdMerge},
-	"put":         {typDataUpdate, cmdPut},
-	"scan":        {typReadOnly, cmdScan},
+	"clear":        {typDataUpdate, cmdClear},
+	"clear_range":  {typDataUpdate, cmdClearRange},
+	"cput":         {typDataUpdate, cmdCPut},
+	"del":          {typDataUpdate, cmdDelete},
+	"del_range":    {typDataUpdate, cmdDeleteRange},
+	"get":          {typReadOnly, cmdGet},
+	"increment":    {typDataUpdate, cmdIncrement},
+	"merge":        {typDataUpdate, cmdMerge},
+	"put":          {typDataUpdate, cmdPut},
+	"put_rangekey": {typDataUpdate, cmdPutRangeKey},
+	"scan":         {typReadOnly, cmdScan},
+
+	"iter_new":            {typReadOnly, cmdIterNew},
+	"iter_seek_ge":        {typReadOnly, cmdIterSeekGE},
+	"iter_seek_lt":        {typReadOnly, cmdIterSeekLT},
+	"iter_seek_intent_ge": {typReadOnly, cmdIterSeekIntentGE},
+	"iter_next":           {typReadOnly, cmdIterNext},
+	"iter_next_key":       {typReadOnly, cmdIterNextKey},
+	"iter_prev":           {typReadOnly, cmdIterPrev},
+	"iter_scan":           {typReadOnly, cmdIterScan},
 }
 
 func cmdTxnAdvance(e *evalCtx) error {
@@ -616,6 +675,12 @@ func cmdCheckIntent(e *evalCtx) error {
 		}
 	}
 	return nil
+}
+
+func cmdClear(e *evalCtx) error {
+	key := e.getKey()
+	ts := e.getTs(nil)
+	return e.engine.ClearMVCC(MVCCKey{Key: key, Timestamp: ts})
 }
 
 func cmdClearRange(e *evalCtx) error {
@@ -870,6 +935,197 @@ func cmdScan(e *evalCtx) error {
 	return err
 }
 
+func cmdPutRangeKey(e *evalCtx) error {
+	var rangeKey MVCCRangeKey
+	rangeKey.StartKey, rangeKey.EndKey = e.getKeyRange()
+	rangeKey.Timestamp = e.getTs(nil)
+	var value MVCCValue
+	value.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp(e.getTsWithName("localTs"))
+
+	return e.withWriter("put_rangekey", func(rw ReadWriter) error {
+		return rw.ExperimentalPutMVCCRangeKey(rangeKey, value)
+	})
+}
+
+func cmdIterNew(e *evalCtx) error {
+	var opts IterOptions
+	opts.Prefix = e.hasArg("prefix")
+	if e.hasArg("k") {
+		opts.LowerBound, opts.UpperBound = e.getKeyRange()
+	}
+	if len(opts.UpperBound) == 0 {
+		opts.UpperBound = keys.MaxKey
+	}
+	kind := MVCCKeyAndIntentsIterKind
+	if e.hasArg("kind") {
+		var arg string
+		e.scanArg("kind", &arg)
+		switch arg {
+		case "keys":
+			kind = MVCCKeyIterKind
+		case "keysAndIntents":
+			kind = MVCCKeyAndIntentsIterKind
+		default:
+			return errors.Errorf("unknown iterator kind %s", arg)
+		}
+	}
+	if e.hasArg("types") {
+		var arg string
+		e.scanArg("types", &arg)
+		switch arg {
+		case "pointsOnly":
+			opts.KeyTypes = IterKeyTypePointsOnly
+		case "pointsAndRanges":
+			opts.KeyTypes = IterKeyTypePointsAndRanges
+		case "rangesOnly":
+			opts.KeyTypes = IterKeyTypeRangesOnly
+		default:
+			return errors.Errorf("unknown key type %s", arg)
+		}
+	}
+
+	var r, closeReader Reader
+	rType := util.ConstantWithMetamorphicTestChoice(
+		fmt.Sprintf("iter-reader@%s", filepath.Base(e.td.Pos)),
+		"engine", "readonly", "batch", "snapshot").(string)
+	switch rType {
+	case "engine":
+		r = e.engine
+	case "readonly":
+		r = e.engine.NewReadOnly(StandardDurability)
+	case "batch":
+		r = e.engine.NewBatch()
+		closeReader = r
+	case "snapshot":
+		r = e.engine.NewSnapshot()
+		closeReader = r
+	default:
+		return errors.Errorf("unknown reader type %s", rType)
+	}
+
+	if e.iter != nil {
+		e.iter.Close()
+	}
+	e.iter = &iterWithCloseReader{
+		MVCCIterator: r.NewMVCCIterator(kind, opts),
+		closeReader:  closeReader,
+	}
+	return nil
+}
+
+func cmdIterSeekGE(e *evalCtx) error {
+	key := e.getKey()
+	ts := e.getTs(nil)
+	e.iter.SeekGE(MVCCKey{Key: key, Timestamp: ts})
+	printIter(e)
+	return nil
+}
+
+func cmdIterSeekIntentGE(e *evalCtx) error {
+	key := e.getKey()
+	var txnName string
+	e.scanArg("txn", &txnName)
+	txn := e.txns[txnName]
+	e.iter.SeekIntentGE(key, txn.ID)
+	printIter(e)
+	return nil
+}
+
+func cmdIterSeekLT(e *evalCtx) error {
+	key := e.getKey()
+	ts := e.getTs(nil)
+	e.iter.SeekLT(MVCCKey{Key: key, Timestamp: ts})
+	printIter(e)
+	return nil
+}
+
+func cmdIterNext(e *evalCtx) error {
+	e.iter.Next()
+	printIter(e)
+	return nil
+}
+
+func cmdIterNextKey(e *evalCtx) error {
+	e.iter.NextKey()
+	printIter(e)
+	return nil
+}
+
+func cmdIterPrev(e *evalCtx) error {
+	e.iter.Prev()
+	printIter(e)
+	return nil
+}
+
+func cmdIterScan(e *evalCtx) error {
+	reverse := e.hasArg("reverse")
+	for {
+		printIter(e)
+		if ok, err := e.iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			return nil
+		}
+		if reverse {
+			e.iter.Prev()
+		} else {
+			e.iter.Next()
+		}
+	}
+}
+
+func printIter(e *evalCtx) {
+	e.results.buf.Printf("%s:", e.td.Cmd)
+	defer e.results.buf.Printf("\n")
+
+	hasPoint, hasRange := e.iter.HasPointAndRange()
+	ok, err := e.iter.Valid()
+	if err != nil {
+		e.results.buf.Printf(" err=%v", err)
+		return
+	}
+	if !ok {
+		if hasPoint || hasRange {
+			e.t.Fatalf("invalid iterator gave hasPoint=%t hasRange=%t", hasPoint, hasRange)
+		}
+		e.results.buf.Print(" .")
+		return
+	}
+	if !hasPoint && !hasRange {
+		e.t.Fatalf("valid iterator at %s without point nor range keys", e.iter.UnsafeKey())
+	}
+
+	if hasPoint {
+		if !e.iter.UnsafeKey().IsValue() {
+			meta := enginepb.MVCCMetadata{}
+			if err := protoutil.Unmarshal(e.iter.UnsafeValue(), &meta); err != nil {
+				e.Fatalf("%v", err)
+			}
+			e.results.buf.Printf(" %s=%+v", e.iter.UnsafeKey(), &meta)
+		} else {
+			value, err := DecodeMVCCValue(e.iter.UnsafeValue())
+			if err != nil {
+				e.Fatalf("%v", err)
+			}
+			e.results.buf.Printf(" %s=%s", e.iter.UnsafeKey(), value)
+		}
+	}
+	if hasRange {
+		e.results.buf.Printf(" %s/[", e.iter.RangeBounds())
+		for i, rangeKV := range e.iter.RangeKeys() {
+			value, err := DecodeMVCCValue(rangeKV.Value)
+			if err != nil {
+				e.Fatalf("%v", err)
+			}
+			if i > 0 {
+				e.results.buf.Printf(" ")
+			}
+			e.results.buf.Printf("%s=%s", rangeKV.RangeKey.Timestamp, value)
+		}
+		e.results.buf.Printf("]")
+	}
+}
+
 // formatStats formats MVCC stats.
 func formatStats(ms enginepb.MVCCStats, delta bool) string {
 	// Split stats into field pairs. Subindex 1 is key, 2 is value.
@@ -928,6 +1184,7 @@ type evalCtx struct {
 	}
 	ctx        context.Context
 	engine     Engine
+	iter       MVCCIterator
 	t          *testing.T
 	td         *datadriven.TestData
 	txns       map[string]*roachpb.Transaction
@@ -942,6 +1199,13 @@ func newEvalCtx(ctx context.Context, engine Engine) *evalCtx {
 		txns:       make(map[string]*roachpb.Transaction),
 		txnCounter: uint128.FromInts(0, 1),
 	}
+}
+
+func (e *evalCtx) close() {
+	if e.iter != nil {
+		e.iter.Close()
+	}
+	// engine is passed in, so it's the caller's responsibility to close it.
 }
 
 func (e *evalCtx) getTxnStatus() roachpb.TransactionStatus {
@@ -1174,5 +1438,19 @@ func toKey(s string) roachpb.Key {
 		return key
 	default:
 		return roachpb.Key(s)
+	}
+}
+
+// iterWithCloseReader will close the underlying reader when the
+// iterator is closed.
+type iterWithCloseReader struct {
+	MVCCIterator
+	closeReader Reader
+}
+
+func (i *iterWithCloseReader) Close() {
+	i.MVCCIterator.Close()
+	if i.closeReader != nil {
+		i.closeReader.Close()
 	}
 }

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -488,6 +488,21 @@ func (i *MVCCIncrementalIterator) UnsafeKey() MVCCKey {
 	return i.iter.UnsafeKey()
 }
 
+// HasPointAndRange implements SimpleMVCCIterator.
+func (i *MVCCIncrementalIterator) HasPointAndRange() (bool, bool) {
+	panic("not implemented")
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (i *MVCCIncrementalIterator) RangeBounds() roachpb.Span {
+	panic("not implemented")
+}
+
+// RangeKeys implements SimpleMVCCIterator.
+func (i *MVCCIncrementalIterator) RangeKeys() []MVCCRangeKeyValue {
+	panic("not implemented")
+}
+
 // UnsafeValue returns the same value as Value, but the memory is invalidated on
 // the next call to {Next,Reset,Close}.
 func (i *MVCCIncrementalIterator) UnsafeValue() []byte {

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -336,3 +336,71 @@ func decodeMVCCTimestampSuffix(encodedTS []byte) (hlc.Timestamp, error) {
 	}
 	return decodeMVCCTimestamp(encodedTS[:encodedLen-1])
 }
+
+// MVCCRangeKey is a versioned key span.
+type MVCCRangeKey struct {
+	StartKey  roachpb.Key
+	EndKey    roachpb.Key
+	Timestamp hlc.Timestamp
+}
+
+// Clone returns a copy of the range key.
+func (k MVCCRangeKey) Clone() MVCCRangeKey {
+	// k is already a copy, but byte slices must be cloned.
+	k.StartKey = k.StartKey.Clone()
+	k.EndKey = k.EndKey.Clone()
+	return k
+}
+
+// Compare returns -1 if this key is less than the given key, 0 if they're
+// equal, or 1 if this is greater. Comparison is by start,timestamp,end, where
+// larger timestamps sort before smaller ones except empty ones which sort first
+// (like elsewhere in MVCC).
+func (k MVCCRangeKey) Compare(o MVCCRangeKey) int {
+	if c := k.StartKey.Compare(o.StartKey); c != 0 {
+		return c
+	}
+	if k.Timestamp.IsEmpty() && !o.Timestamp.IsEmpty() {
+		return -1
+	} else if !k.Timestamp.IsEmpty() && o.Timestamp.IsEmpty() {
+		return 1
+	} else if c := k.Timestamp.Compare(o.Timestamp); c != 0 {
+		return -c // timestamps sort in reverse
+	}
+	return k.EndKey.Compare(o.EndKey)
+}
+
+// String formats the range key.
+func (k MVCCRangeKey) String() string {
+	s := roachpb.Span{Key: k.StartKey, EndKey: k.EndKey}.String()
+	if !k.Timestamp.IsEmpty() {
+		s += fmt.Sprintf("/%s", k.Timestamp)
+	}
+	return s
+}
+
+// Validate returns an error if the range key is invalid.
+//
+// This validation is for writing range keys (or checking existing range keys),
+// not for filters/bounds, so e.g. specifying an empty start key is invalid even
+// though it would be valid to start a range key scan at an empty start key.
+func (k MVCCRangeKey) Validate() (err error) {
+	defer func() {
+		err = errors.Wrapf(err, "invalid range key %s", k)
+	}()
+
+	switch {
+	case len(k.StartKey) == 0:
+		// We don't allow an empty start key, because we don't allow writing point
+		// keys at the empty key. The first valid key is 0x00.
+		return errors.Errorf("no start key")
+	case len(k.EndKey) == 0:
+		return errors.Errorf("no end key")
+	case k.Timestamp.IsEmpty():
+		return errors.Errorf("no timestamp")
+	case k.StartKey.Compare(k.EndKey) >= 0:
+		return errors.Errorf("start key %s is at or after end key %s", k.StartKey, k.EndKey)
+	default:
+		return nil
+	}
+}

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -382,6 +382,97 @@ func BenchmarkDecodeMVCCKey(b *testing.B) {
 	benchmarkDecodeMVCCKeyResult = mvccKey // avoid compiler optimizing away function call
 }
 
+func TestMVCCRangeKeyString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testcases := map[string]struct {
+		rk     MVCCRangeKey
+		expect string
+	}{
+		"empty":           {MVCCRangeKey{}, "/Min"},
+		"only start":      {MVCCRangeKey{StartKey: roachpb.Key("foo")}, "foo"},
+		"only end":        {MVCCRangeKey{EndKey: roachpb.Key("foo")}, "{/Min-foo}"},
+		"only timestamp":  {MVCCRangeKey{Timestamp: hlc.Timestamp{Logical: 1}}, "/Min/0,1"},
+		"only span":       {MVCCRangeKey{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("z")}, "{a-z}"},
+		"all":             {MVCCRangeKey{StartKey: roachpb.Key("a"), EndKey: roachpb.Key("z"), Timestamp: hlc.Timestamp{Logical: 1}}, "{a-z}/0,1"},
+		"all overlapping": {MVCCRangeKey{StartKey: roachpb.Key("ab"), EndKey: roachpb.Key("af"), Timestamp: hlc.Timestamp{Logical: 1}}, "a{b-f}/0,1"},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.rk.String())
+		})
+	}
+}
+
+func TestMVCCRangeKeyCompare(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ab1 := MVCCRangeKey{roachpb.Key("a"), roachpb.Key("b"), hlc.Timestamp{Logical: 1}}
+	ac1 := MVCCRangeKey{roachpb.Key("a"), roachpb.Key("c"), hlc.Timestamp{Logical: 1}}
+	ac2 := MVCCRangeKey{roachpb.Key("a"), roachpb.Key("c"), hlc.Timestamp{Logical: 2}}
+	bc0 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("c"), hlc.Timestamp{Logical: 0}}
+	bc1 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("c"), hlc.Timestamp{Logical: 1}}
+	bc3 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("c"), hlc.Timestamp{Logical: 3}}
+	bd4 := MVCCRangeKey{roachpb.Key("b"), roachpb.Key("d"), hlc.Timestamp{Logical: 4}}
+
+	testcases := map[string]struct {
+		a      MVCCRangeKey
+		b      MVCCRangeKey
+		expect int
+	}{
+		"equal":                 {ac1, ac1, 0},
+		"start lt":              {ac1, bc1, -1},
+		"start gt":              {bc1, ac1, 1},
+		"end lt":                {ab1, ac1, -1},
+		"end gt":                {ac1, ab1, 1},
+		"time lt":               {ac2, ac1, -1}, // MVCC timestamps sort in reverse order
+		"time gt":               {ac1, ac2, 1},  // MVCC timestamps sort in reverse order
+		"empty time lt set":     {bc0, bc1, -1}, // empty MVCC timestamps sort before non-empty
+		"set time gt empty":     {bc1, bc0, 1},  // empty MVCC timestamps sort before non-empty
+		"start time precedence": {ac2, bc3, -1}, // a before b, but 3 before 2; key takes precedence
+		"time end precedence":   {bd4, bc3, -1}, // c before d, but 4 before 3; time takes precedence
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expect, tc.a.Compare(tc.b))
+		})
+	}
+}
+
+func TestMVCCRangeKeyValidate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	a := roachpb.Key("a")
+	b := roachpb.Key("b")
+	blank := roachpb.Key("")
+	ts1 := hlc.Timestamp{Logical: 1}
+
+	testcases := map[string]struct {
+		rangeKey  MVCCRangeKey
+		expectErr string // empty if no error
+	}{
+		"valid":            {MVCCRangeKey{StartKey: a, EndKey: b, Timestamp: ts1}, ""},
+		"empty":            {MVCCRangeKey{}, "/Min: no start key"},
+		"no start":         {MVCCRangeKey{EndKey: b, Timestamp: ts1}, "{/Min-b}/0,1: no start key"},
+		"no end":           {MVCCRangeKey{StartKey: a, Timestamp: ts1}, "a/0,1: no end key"},
+		"no timestamp":     {MVCCRangeKey{StartKey: a, EndKey: b}, "{a-b}: no timestamp"},
+		"blank start":      {MVCCRangeKey{StartKey: blank, EndKey: b, Timestamp: ts1}, "{/Min-b}/0,1: no start key"},
+		"end at start":     {MVCCRangeKey{StartKey: a, EndKey: a, Timestamp: ts1}, `a{-}/0,1: start key "a" is at or after end key "a"`},
+		"end before start": {MVCCRangeKey{StartKey: b, EndKey: a, Timestamp: ts1}, `{b-a}/0,1: start key "b" is at or after end key "a"`},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.rangeKey.Validate()
+			if tc.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			}
+		})
+	}
+}
+
 func pointKey(key string, ts int) MVCCKey {
 	return MVCCKey{Key: roachpb.Key(key), Timestamp: hlc.Timestamp{WallTime: int64(ts)}}
 }
@@ -390,5 +481,27 @@ func pointKV(key string, ts int, value string) MVCCKeyValue {
 	return MVCCKeyValue{
 		Key:   pointKey(key, ts),
 		Value: stringValueRaw(value),
+	}
+}
+
+func rangeKey(start, end string, ts int) MVCCRangeKey {
+	return MVCCRangeKey{
+		StartKey:  roachpb.Key(start),
+		EndKey:    roachpb.Key(end),
+		Timestamp: hlc.Timestamp{WallTime: int64(ts)},
+	}
+}
+
+func rangeKV(start, end string, ts int, v MVCCValue) MVCCRangeKeyValue {
+	valueBytes, err := EncodeMVCCValue(v)
+	if err != nil {
+		panic(err)
+	}
+	if valueBytes == nil {
+		valueBytes = []byte{}
+	}
+	return MVCCRangeKeyValue{
+		RangeKey: rangeKey(start, end, ts),
+		Value:    valueBytes,
 	}
 }

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -245,3 +245,8 @@ func stringValueRaw(s string) []byte {
 	}
 	return b
 }
+
+func withLocalTS(v MVCCValue, ts int) MVCCValue {
+	v.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp{WallTime: int64(ts)}
+	return v
+}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -591,6 +591,8 @@ func DefaultPebbleOptions() *pebble.Options {
 		TablePropertyCollectors:     PebbleTablePropertyCollectors,
 		BlockPropertyCollectors:     PebbleBlockPropertyCollectors,
 	}
+	// Used for experimental MVCC range tombstones.
+	opts.Experimental.RangeKeys = new(pebble.RangeKeysArena)
 	// Automatically flush 10s after the first range tombstone is added to a
 	// memtable. This ensures that we can reclaim space even when there's no
 	// activity on the database generating flushes.
@@ -735,6 +737,13 @@ type Pebble struct {
 		syncutil.Mutex
 		flushCompletedCallback func()
 	}
+
+	// supportsRangeKeys is 1 if the database supports range keys. It must
+	// be accessed atomically.
+	//
+	// TODO(erikgrinaker): Remove this after 22.2 when all databases support it.
+	supportsRangeKeys int32
+
 	// closer is populated when the database is opened. The closer is associated
 	// with the filesyetem
 	closer io.Closer
@@ -976,6 +985,9 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 			return nil, err
 		}
 	}
+	if p.db.FormatMajorVersion() >= pebble.FormatRangeKeys {
+		atomic.StoreInt32(&p.supportsRangeKeys, 1)
+	}
 
 	return p, nil
 }
@@ -1132,7 +1144,7 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIt
 		return iter
 	}
 
-	iter := newPebbleIterator(p.db, nil, opts, StandardDurability)
+	iter := newPebbleIterator(p.db, nil, opts, StandardDurability, p.SupportsRangeKeys())
 	if iter == nil {
 		panic("couldn't create a new iterator")
 	}
@@ -1144,7 +1156,10 @@ func (p *Pebble) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions) MVCCIt
 
 // NewEngineIterator implements the Engine interface.
 func (p *Pebble) NewEngineIterator(opts IterOptions) EngineIterator {
-	iter := newPebbleIterator(p.db, nil, opts, StandardDurability)
+	if opts.KeyTypes != IterKeyTypePointsOnly {
+		panic("EngineIterator does not support range keys")
+	}
+	iter := newPebbleIterator(p.db, nil, opts, StandardDurability, p.SupportsRangeKeys())
 	if iter == nil {
 		panic("couldn't create a new iterator")
 	}
@@ -1154,6 +1169,11 @@ func (p *Pebble) NewEngineIterator(opts IterOptions) EngineIterator {
 // ConsistentIterators implements the Engine interface.
 func (p *Pebble) ConsistentIterators() bool {
 	return false
+}
+
+// SupportsRangeKeys implements the Engine interface.
+func (p *Pebble) SupportsRangeKeys() bool {
+	return atomic.LoadInt32(&p.supportsRangeKeys) == 1
 }
 
 // PinEngineStateForIterators implements the Engine interface.
@@ -1254,6 +1274,60 @@ func (p *Pebble) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 		return err
 	}
 	return batch.Commit(true)
+}
+
+// ExperimentalClearMVCCRangeKey implements the Engine interface.
+func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+	if !p.SupportsRangeKeys() {
+		// These databases cannot contain range keys, so clearing is a noop.
+		return nil
+	}
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	return p.db.Experimental().RangeKeyUnset(
+		EncodeMVCCKeyPrefix(rangeKey.StartKey),
+		EncodeMVCCKeyPrefix(rangeKey.EndKey),
+		EncodeMVCCTimestampSuffix(rangeKey.Timestamp),
+		pebble.Sync)
+}
+
+// ExperimentalClearAllMVCCRangeKeys implements the Engine interface.
+func (p *Pebble) ExperimentalClearAllMVCCRangeKeys(start, end roachpb.Key) error {
+	if !p.SupportsRangeKeys() {
+		return nil // noop
+	}
+	rangeKey := MVCCRangeKey{StartKey: start, EndKey: end, Timestamp: hlc.MinTimestamp}
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	return p.db.Experimental().RangeKeyDelete(
+		EncodeMVCCKeyPrefix(start), EncodeMVCCKeyPrefix(end), pebble.Sync)
+}
+
+// ExperimentalPutMVCCRangeKey implements the Engine interface.
+func (p *Pebble) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+	if !p.SupportsRangeKeys() {
+		return errors.Errorf("range keys not supported by Pebble database version %s",
+			p.db.FormatMajorVersion())
+	}
+	if err := rangeKey.Validate(); err != nil {
+		return err
+	}
+	// NB: all MVCC APIs currently assume all range keys are range tombstones.
+	if !value.IsTombstone() {
+		return errors.New("range keys can only be MVCC range tombstones")
+	}
+	valueBytes, err := EncodeMVCCValue(value)
+	if err != nil {
+		return errors.Wrapf(err, "failed to encode MVCC value for range key %s", rangeKey)
+	}
+	return p.db.Experimental().RangeKeySet(
+		EncodeMVCCKeyPrefix(rangeKey.StartKey),
+		EncodeMVCCKeyPrefix(rangeKey.EndKey),
+		EncodeMVCCTimestampSuffix(rangeKey.Timestamp),
+		valueBytes,
+		pebble.Sync)
 }
 
 // Merge implements the Engine interface.
@@ -1614,7 +1688,7 @@ func (p *Pebble) NewUnindexedBatch(writeOnly bool) Batch {
 func (p *Pebble) NewSnapshot() Reader {
 	return &pebbleSnapshot{
 		snapshot: p.db.NewSnapshot(),
-		settings: p.settings,
+		parent:   p,
 	}
 }
 
@@ -1813,6 +1887,9 @@ func (p *Pebble) SetMinVersion(version roachpb.Version) error {
 		if err := p.db.RatchetFormatMajorVersion(formatVers); err != nil {
 			return errors.Wrap(err, "ratcheting format major version")
 		}
+		if formatVers >= pebble.FormatRangeKeys {
+			atomic.StoreInt32(&p.supportsRangeKeys, 1)
+		}
 	}
 	return nil
 }
@@ -1996,13 +2073,13 @@ func (p *pebbleReadOnly) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 		iter = &p.prefixIter
 	}
 	if iter.inuse {
-		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability)
+		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability, p.SupportsRangeKeys())
 	}
 
 	if iter.iter != nil {
 		iter.setOptions(opts, p.durability)
 	} else {
-		iter.init(p.parent.db, p.iter, p.iterUnused, opts, p.durability)
+		iter.init(p.parent.db, p.iter, p.iterUnused, opts, p.durability, p.SupportsRangeKeys())
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
@@ -2024,19 +2101,22 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
 	}
+	if opts.KeyTypes != IterKeyTypePointsOnly {
+		panic("EngineIterator does not support range keys")
+	}
 
 	iter := &p.normalEngineIter
 	if opts.Prefix {
 		iter = &p.prefixEngineIter
 	}
 	if iter.inuse {
-		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability)
+		return newPebbleIterator(p.parent.db, p.iter, opts, p.durability, p.SupportsRangeKeys())
 	}
 
 	if iter.iter != nil {
 		iter.setOptions(opts, p.durability)
 	} else {
-		iter.init(p.parent.db, p.iter, p.iterUnused, opts, p.durability)
+		iter.init(p.parent.db, p.iter, p.iterUnused, opts, p.durability, p.SupportsRangeKeys())
 		if p.iter == nil {
 			// For future cloning.
 			p.iter = iter.iter
@@ -2052,6 +2132,11 @@ func (p *pebbleReadOnly) NewEngineIterator(opts IterOptions) EngineIterator {
 // ConsistentIterators implements the Engine interface.
 func (p *pebbleReadOnly) ConsistentIterators() bool {
 	return true
+}
+
+// SupportsRangeKeys implements the Engine interface.
+func (p *pebbleReadOnly) SupportsRangeKeys() bool {
+	return p.parent.SupportsRangeKeys()
 }
 
 // PinEngineStateForIterators implements the Engine interface.
@@ -2116,6 +2201,18 @@ func (p *pebbleReadOnly) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	panic("not implemented")
 }
 
+func (p *pebbleReadOnly) ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) ExperimentalClearAllMVCCRangeKeys(roachpb.Key, roachpb.Key) error {
+	panic("not implemented")
+}
+
 func (p *pebbleReadOnly) Merge(key MVCCKey, value []byte) error {
 	panic("not implemented")
 }
@@ -2157,7 +2254,7 @@ func (p *pebbleReadOnly) ShouldWriteLocalTimestamps(ctx context.Context) bool {
 // pebbleSnapshot represents a snapshot created using Pebble.NewSnapshot().
 type pebbleSnapshot struct {
 	snapshot *pebble.Snapshot
-	settings *cluster.Settings
+	parent   *Pebble
 	closed   bool
 }
 
@@ -2180,7 +2277,7 @@ func (p *pebbleSnapshot) ExportMVCCToSst(
 ) (roachpb.BulkOpSummary, roachpb.Key, hlc.Timestamp, error) {
 	r := wrapReader(p)
 	// Doing defer r.Free() does not inline.
-	summary, k, err := pebbleExportToSst(ctx, p.settings, r, exportOptions, dest)
+	summary, k, err := pebbleExportToSst(ctx, p.parent.settings, r, exportOptions, dest)
 	r.Free()
 	return summary, k.Key, k.Timestamp, err
 }
@@ -2244,7 +2341,9 @@ func (p *pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 		}
 		return iter
 	}
-	iter := MVCCIterator(newPebbleIterator(p.snapshot, nil, opts, StandardDurability))
+
+	iter := MVCCIterator(newPebbleIterator(
+		p.snapshot, nil, opts, StandardDurability, p.SupportsRangeKeys()))
 	if util.RaceEnabled {
 		iter = wrapInUnsafeIter(iter)
 	}
@@ -2253,12 +2352,20 @@ func (p *pebbleSnapshot) NewMVCCIterator(iterKind MVCCIterKind, opts IterOptions
 
 // NewEngineIterator implements the Reader interface.
 func (p pebbleSnapshot) NewEngineIterator(opts IterOptions) EngineIterator {
-	return newPebbleIterator(p.snapshot, nil, opts, StandardDurability)
+	if opts.KeyTypes != IterKeyTypePointsOnly {
+		panic("EngineIterator does not support range keys")
+	}
+	return newPebbleIterator(p.snapshot, nil, opts, StandardDurability, p.SupportsRangeKeys())
 }
 
 // ConsistentIterators implements the Reader interface.
 func (p pebbleSnapshot) ConsistentIterators() bool {
 	return true
+}
+
+// SupportsRangeKeys implements the Reader interface.
+func (p *pebbleSnapshot) SupportsRangeKeys() bool {
+	return p.parent.SupportsRangeKeys()
 }
 
 // PinEngineStateForIterators implements the Reader interface.

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -39,6 +39,10 @@ type pebbleIterator struct {
 	lowerBoundBuf []byte
 	upperBoundBuf []byte
 
+	// True if the iterator's underlying reader supports range keys.
+	//
+	// TODO(erikgrinaker): Remove after 22.2.
+	supportsRangeKeys bool
 	// Set to true to govern whether to call SeekPrefixGE or SeekGE. Skips
 	// SSTables based on MVCC/Engine key when true.
 	prefix bool
@@ -80,10 +84,11 @@ func newPebbleIterator(
 	iterToClone cloneableIter,
 	opts IterOptions,
 	durability DurabilityRequirement,
+	supportsRangeKeys bool,
 ) *pebbleIterator {
 	iter := pebbleIterPool.Get().(*pebbleIterator)
 	iter.reusable = false // defensive
-	iter.init(handle, iterToClone, false /* iterUnused */, opts, durability)
+	iter.init(handle, iterToClone, false /* iterUnused */, opts, durability, supportsRangeKeys)
 	return iter
 }
 
@@ -98,12 +103,14 @@ func (p *pebbleIterator) init(
 	iterUnused bool,
 	opts IterOptions,
 	durability DurabilityRequirement,
+	supportsRangeKeys bool, // TODO(erikgrinaker): remove after 22.2.
 ) {
 	*p = pebbleIterator{
-		keyBuf:        p.keyBuf,
-		lowerBoundBuf: p.lowerBoundBuf,
-		upperBoundBuf: p.upperBoundBuf,
-		reusable:      p.reusable,
+		keyBuf:            p.keyBuf,
+		lowerBoundBuf:     p.lowerBoundBuf,
+		upperBoundBuf:     p.upperBoundBuf,
+		reusable:          p.reusable,
+		supportsRangeKeys: supportsRangeKeys,
 	}
 
 	if iterToClone != nil {
@@ -138,9 +145,22 @@ func (p *pebbleIterator) setOptions(opts IterOptions, durability DurabilityRequi
 		panic("min timestamp hint set without max timestamp hint")
 	}
 
+	// If this Pebble database does not support range keys yet, fall back to
+	// only iterating over point keys to avoid panics. This is effectively the
+	// same, since a database without range key support contains no range keys,
+	// except in the case of RangesOnly where the iterator must always be empty.
+	if !p.supportsRangeKeys {
+		if opts.KeyTypes == IterKeyTypeRangesOnly {
+			opts.LowerBound = nil
+			opts.UpperBound = []byte{0}
+		}
+		opts.KeyTypes = IterKeyTypePointsOnly
+	}
+
 	// Generate new Pebble iterator options.
 	p.options = pebble.IterOptions{
 		OnlyReadGuaranteedDurable: durability == GuaranteedDurability,
+		KeyTypes:                  opts.KeyTypes,
 		UseL6Filters:              opts.useL6Filters,
 	}
 	p.prefix = opts.Prefix
@@ -372,10 +392,33 @@ func (p *pebbleIterator) NextKey() {
 	if !p.iter.Next() {
 		return
 	}
-	if bytes.Equal(p.keyBuf, p.UnsafeKey().Key) {
+
+	// If the Next() call above didn't move to a different key, seek to it.
+	if p.UnsafeKey().Key.Equal(p.keyBuf) {
 		// This is equivalent to:
 		// p.iter.SeekGE(EncodeKey(MVCCKey{p.UnsafeKey().Key.Next(), hlc.Timestamp{}}))
-		p.iter.SeekGE(append(p.keyBuf, 0, 0))
+		seekKey := append(p.keyBuf, 0, 0)
+		p.iter.SeekGE(seekKey)
+		// If there's a range key straddling the seek point (e.g. a-c when seeking
+		// to b), it will be surfaced first as a bare range key. However, unless it
+		// started exactly at the seek key then it has already been emitted, so we
+		// step past it to the next key, which may be either a point key or range
+		// key starting past the seek key.
+		//
+		// NB: We have to be careful to use p.iter methods below, rather than
+		// pebbleIterator methods, since seekKey is an already-encoded roachpb.Key
+		// in raw Pebble key form.
+		//
+		// TODO(erikgrinaker): It's possible for Pebble to return true from
+		// HasPointAndRange when Valid() returns false, so we check Valid first. We
+		// should make this part of the Pebble API contract.
+		if p.iter.Valid() {
+			if hasPoint, hasRange := p.iter.HasPointAndRange(); !hasPoint && hasRange {
+				if startKey, _ := p.iter.RangeBounds(); bytes.Compare(startKey, seekKey) < 0 {
+					p.iter.Next()
+				}
+			}
+		}
 	}
 }
 
@@ -531,6 +574,66 @@ func (p *pebbleIterator) ValueProto(msg protoutil.Message) error {
 	value := p.UnsafeValue()
 
 	return protoutil.Unmarshal(value, msg)
+}
+
+// HasPointAndRange implements the MVCCIterator interface.
+func (p *pebbleIterator) HasPointAndRange() (bool, bool) {
+	// TODO(erikgrinaker): The MVCCIterator contract mandates returning false for
+	// an invalid iterator. We should improve pebbleIterator validity and error
+	// checking by doing it once per iterator operation and propagating errors.
+	if ok, err := p.Valid(); !ok || err != nil {
+		return false, false
+	}
+	return p.iter.HasPointAndRange()
+}
+
+// RangeBounds implements the MVCCIterator interface.
+func (p *pebbleIterator) RangeBounds() roachpb.Span {
+	start, end := p.iter.RangeBounds()
+
+	// Avoid decoding empty keys: DecodeMVCCKey() will return errors for these,
+	// which are expensive to construct.
+	if len(start) == 0 && len(end) == 0 {
+		return roachpb.Span{}
+	}
+
+	// TODO(erikgrinaker): We should surface these errors somehow, but for now we
+	// follow UnsafeKey()'s example and silently return empty bounds.
+	startKey, err := DecodeMVCCKey(start)
+	if err != nil {
+		return roachpb.Span{}
+	}
+	endKey, err := DecodeMVCCKey(end)
+	if err != nil {
+		return roachpb.Span{}
+	}
+
+	return roachpb.Span{Key: startKey.Key, EndKey: endKey.Key}
+}
+
+// RangeKeys implements the MVCCIterator interface.
+func (p *pebbleIterator) RangeKeys() []MVCCRangeKeyValue {
+	bounds := p.RangeBounds()
+	rangeKeys := p.iter.RangeKeys()
+	rangeKVs := make([]MVCCRangeKeyValue, 0, len(rangeKeys))
+
+	for _, rangeKey := range rangeKeys {
+		timestamp, err := decodeMVCCTimestampSuffix(rangeKey.Suffix)
+		if err != nil {
+			// TODO(erikgrinaker): We should surface this error somehow, but for now
+			// we follow UnsafeKey()'s example and silently skip them.
+			continue
+		}
+		rangeKVs = append(rangeKVs, MVCCRangeKeyValue{
+			RangeKey: MVCCRangeKey{
+				StartKey:  bounds.Key,
+				EndKey:    bounds.EndKey,
+				Timestamp: timestamp,
+			},
+			Value: rangeKey.Value,
+		})
+	}
+	return rangeKVs
 }
 
 // ComputeStats implements the MVCCIterator interface.

--- a/pkg/storage/read_as_of_iterator.go
+++ b/pkg/storage/read_as_of_iterator.go
@@ -10,7 +10,10 @@
 
 package storage
 
-import "github.com/cockroachdb/cockroach/pkg/util/hlc"
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
 
 // ReadAsOfIterator wraps a SimpleMVCCIterator and only surfaces the latest
 // valid key of a given MVCC key that is also below the asOf timestamp, if set.
@@ -87,6 +90,21 @@ func (f *ReadAsOfIterator) UnsafeKey() MVCCKey {
 // invalidated on the next call to {NextKey,Seek}.
 func (f *ReadAsOfIterator) UnsafeValue() []byte {
 	return f.iter.UnsafeValue()
+}
+
+// HasPointAndRange implements SimpleMVCCIterator.
+func (f *ReadAsOfIterator) HasPointAndRange() (bool, bool) {
+	panic("not implemented")
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (f *ReadAsOfIterator) RangeBounds() roachpb.Span {
+	panic("not implemented")
+}
+
+// RangeKeys implements SimpleMVCCIterator.
+func (f *ReadAsOfIterator) RangeKeys() []MVCCRangeKeyValue {
+	panic("not implemented")
 }
 
 // advance moves past keys with timestamps later than f.asOf and skips MVCC keys

--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"bytes"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -169,4 +170,19 @@ func (r *sstIterator) verifyValue() {
 	} else {
 		r.err = mvccValue.Value.Verify(r.mvccKey.Key)
 	}
+}
+
+// HasPointAndRange implements SimpleMVCCIterator.
+func (r *sstIterator) HasPointAndRange() (bool, bool) {
+	panic("not implemented")
+}
+
+// RangeBounds implements SimpleMVCCIterator.
+func (r *sstIterator) RangeBounds() roachpb.Span {
+	panic("not implemented")
+}
+
+// RangeKeys implements SimpleMVCCIterator.
+func (r *sstIterator) RangeKeys() []MVCCRangeKeyValue {
+	panic("not implemented")
 }

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -142,6 +142,21 @@ func (fw *SSTWriter) ClearMVCCVersions(start, end MVCCKey) error {
 	return fw.clearRange(start, end)
 }
 
+// ExperimentalPutMVCCRangeKey implements the Writer interface.
+func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
+	panic("not implemented")
+}
+
+// ExperimentalClearMVCCRangeKey implements the Writer interface.
+func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
+	panic("not implemented")
+}
+
+// ExperimentalClearAllMVCCRangeKeys implements the Writer interface.
+func (fw *SSTWriter) ExperimentalClearAllMVCCRangeKeys(roachpb.Key, roachpb.Key) error {
+	panic("not implemented")
+}
+
 func (fw *SSTWriter) clearRange(start, end MVCCKey) error {
 	if fw.fw == nil {
 		return errors.New("cannot call ClearRange on a closed writer")

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter
@@ -1,0 +1,831 @@
+# Tests range key handling in MVCC iterators.
+#
+# Sets up the following dataset, where x is tombstone, o-o is range tombstone, [] is intent.
+#
+#  T
+#  7 [a7]        [d7]                    [j7]    [l7][m7]    [o7]
+#  6                      f6
+#  5          o---------------o               k5
+#  4  x   x       d4          g4  x
+#  3      o-------o   e3  o-------oh3                 o---o
+#  2  a2                      g2
+#  1  o---------------------------------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o
+#
+run ok
+put_rangekey k=a end=k ts=1
+put_rangekey k=m end=n ts=3 localTs=2
+put_rangekey k=b end=d ts=3
+put_rangekey k=f end=h ts=3
+put_rangekey k=c end=g ts=5
+put k=a ts=2 v=a2
+del k=a ts=4
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=6 v=f6
+put k=g ts=2 v=g2
+put k=g ts=4 v=g4
+put k=h ts=3 v=h3
+del k=h ts=4
+put k=k ts=5 v=k5
+with t=A
+  txn_begin ts=7
+  put k=a v=a7
+  put k=d v=d7
+  put k=j v=j7
+  put k=l v=l7
+  put k=m v=l7
+  put k=o v=n7
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/7.000000000,0 -> /BYTES/a7
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "d"/7.000000000,0 -> /BYTES/d7
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/h3
+meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "j"/7.000000000,0 -> /BYTES/j7
+data: "k"/5.000000000,0 -> /BYTES/k5
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/7.000000000,0 -> /BYTES/l7
+meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "m"/7.000000000,0 -> /BYTES/l7
+meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "o"/7.000000000,0 -> /BYTES/n7
+
+# Iterate across the entire span for all key types, and without intents.
+run ok
+iter_new types=pointsOnly
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "d"/7.000000000,0=/BYTES/d7
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/7.000000000,0=/BYTES/l7
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: .
+
+run ok
+iter_new types=rangesOnly
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: .
+
+run ok
+iter_new kind=keys types=pointsAndRanges
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: .
+
+# And do the same in reverse.
+run ok
+iter_new types=pointsOnly
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "o"/7.000000000,0=/BYTES/n7
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/7.000000000,0=/BYTES/l7
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "h"/3.000000000,0=/BYTES/h3
+iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "e"/3.000000000,0=/BYTES/e3
+iter_scan: "d"/4.000000000,0=/BYTES/d4
+iter_scan: "d"/7.000000000,0=/BYTES/d7
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "b"/4.000000000,0=/<empty>
+iter_scan: "a"/2.000000000,0=/BYTES/a2
+iter_scan: "a"/4.000000000,0=/<empty>
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "o"/7.000000000,0=/BYTES/n7
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+run ok
+iter_new types=rangesOnly
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+run ok
+iter_new kind=keys types=pointsAndRanges
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "o"/7.000000000,0=/BYTES/n7
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_scan: .
+
+# Bounded scans.
+run ok
+iter_new types=pointsAndRanges k=bbb end=fff
+iter_seek_ge k=a
+iter_scan
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_ge: {bbb-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {bbb-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: .
+iter_seek_lt: "f"/6.000000000,0=/BYTES/f6 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/6.000000000,0=/BYTES/f6 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {bbb-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: .
+
+# Seek to d, iterate a few times, then reverse direction and iterate beyond seek point.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=d
+iter_next
+iter_next
+iter_next
+iter_next
+iter_prev
+iter_prev
+iter_prev
+iter_prev
+iter_prev
+iter_prev
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Do a few seeks around an intent/point/range.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=d
+iter_next
+iter_seek_ge k=d ts=8
+iter_next
+iter_seek_ge k=d ts=7
+iter_seek_ge k=d ts=5
+iter_next
+iter_seek_ge k=d ts=4
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=e
+iter_seek_lt k=d ts=4
+iter_seek_lt k=d ts=7
+iter_prev
+iter_seek_lt k=d
+----
+iter_seek_lt: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Seeking to keys with an intent will hit the intent immediately, both when
+# it's at the start of a range key and in the middle of one.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=j
+iter_next
+iter_prev
+iter_prev
+iter_prev
+iter_seek_ge k=d
+iter_next
+iter_prev
+iter_prev
+----
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Do a few seeks and then switch direction immediately.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=d
+iter_prev
+iter_seek_ge k=d ts=8
+iter_prev
+iter_seek_ge k=d ts=7
+iter_prev
+iter_seek_ge k=d ts=5
+iter_prev
+iter_seek_ge k=d ts=4
+iter_prev
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=e
+iter_next
+iter_seek_lt k=d ts=4
+iter_next
+iter_seek_lt k=d ts=7
+iter_next
+iter_seek_lt k=d
+iter_next
+----
+iter_seek_lt: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Check that switching direction past an intent will yield the right range key.
+# We also reverse seek to the intent, which must surface the correct range key.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=d
+iter_prev
+iter_next
+iter_next
+iter_prev
+iter_prev
+----
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=d ts=7
+iter_prev
+iter_next
+iter_seek_lt k=d ts=7
+iter_next
+----
+iter_seek_lt: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_prev: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_lt: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/7.000000000,0=/BYTES/d7 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# We also try switching directions when the intent is at the start or end
+# of a range key, or when it's in the middle of one.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=m
+iter_prev
+iter_next
+iter_next
+iter_prev
+iter_prev
+iter_seek_ge k=m ts=8
+iter_prev
+iter_seek_ge k=m ts=7
+iter_prev
+iter_seek_ge k=m ts=6
+iter_prev
+iter_prev
+----
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "l"/7.000000000,0=/BYTES/l7
+iter_next: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "l"/7.000000000,0=/BYTES/l7
+iter_seek_ge: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=o
+iter_prev
+iter_next
+iter_next
+iter_prev
+iter_prev
+----
+iter_seek_ge: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next: "o"/7.000000000,0=/BYTES/n7
+iter_prev: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=j
+iter_prev
+iter_next
+iter_next
+iter_prev
+iter_prev
+iter_seek_ge k=j ts=8
+iter_prev
+iter_seek_ge k=j ts=7
+iter_prev
+iter_seek_ge k=j ts=6
+iter_prev
+iter_prev
+----
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_next: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_prev: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+
+# Try switching directions when the intents are by the edge of the iterator
+# bounds. This is a regression test for when incorrect limit handling may
+# prematurely exhaust intentInterleavingIter's intentIter.
+run ok
+iter_new types=pointsAndRanges k=l end=o
+iter_seek_ge k=m
+iter_scan reverse
+----
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges k=l end=p
+iter_seek_lt k=m ts=7
+iter_scan
+----
+iter_seek_lt: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/7.000000000,0=/BYTES/n7
+iter_scan: .
+
+# Exhaust iterators and then switch directions.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=a ts=4
+iter_prev
+iter_prev
+iter_prev
+iter_next
+iter_next
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_prev: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_prev: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_prev: .
+iter_next: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_next: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=m
+iter_next
+iter_next
+iter_next
+iter_next
+iter_prev
+iter_prev
+iter_prev
+iter_prev
+iter_prev
+----
+iter_seek_ge: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next: "o"/7.000000000,0=/BYTES/n7
+iter_next: .
+iter_prev: "o"/7.000000000,0=/BYTES/n7
+iter_prev: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_prev: "m"/7.000000000,0=/BYTES/l7 {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_prev: "l"/7.000000000,0=/BYTES/l7
+
+# Test NextKey() with and without intents/range keys, and with some seeks.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_next_key: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: "k"/5.000000000,0=/BYTES/k5
+iter_next_key: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next_key: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: .
+
+run ok
+iter_new kind=keys types=pointsAndRanges
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_next_key: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: "k"/5.000000000,0=/BYTES/k5
+iter_next_key: "l"/7.000000000,0=/BYTES/l7
+iter_next_key: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next_key: "o"/7.000000000,0=/BYTES/n7
+iter_next_key: .
+
+run ok
+iter_new types=pointsOnly
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "b"/4.000000000,0=/<empty>
+iter_next_key: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "e"/3.000000000,0=/BYTES/e3
+iter_next_key: "f"/6.000000000,0=/BYTES/f6
+iter_next_key: "g"/4.000000000,0=/BYTES/g4
+iter_next_key: "h"/4.000000000,0=/<empty>
+iter_next_key: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "k"/5.000000000,0=/BYTES/k5
+iter_next_key: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: .
+
+run ok
+iter_new types=rangesOnly
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
+iter_next_key: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]
+iter_next_key: .
+
+# Test NextKey() during seeks.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=g ts=2
+iter_next_key
+iter_seek_ge k=d
+iter_next_key
+----
+iter_seek_ge: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Test SeekIntentGE both with and without intents and range keys.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_intent_ge k=b txn=A
+iter_seek_intent_ge k=d txn=A
+iter_seek_intent_ge k=i txn=A
+iter_seek_intent_ge k=j txn=A
+iter_seek_intent_ge k=k txn=A
+----
+iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_intent_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_intent_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5
+
+run ok
+iter_new kind=keys types=pointsAndRanges
+iter_seek_intent_ge k=b txn=A
+iter_seek_intent_ge k=d txn=A
+iter_seek_intent_ge k=i txn=A
+iter_seek_intent_ge k=j txn=A
+iter_seek_intent_ge k=k txn=A
+----
+iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_intent_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5
+
+run ok
+iter_new types=pointsOnly
+iter_seek_intent_ge k=b txn=A
+iter_seek_intent_ge k=d txn=A
+iter_seek_intent_ge k=i txn=A
+iter_seek_intent_ge k=j txn=A
+iter_seek_intent_ge k=k txn=A
+----
+iter_seek_intent_ge: "b"/4.000000000,0=/<empty>
+iter_seek_intent_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: "k"/5.000000000,0=/BYTES/k5
+
+run ok
+iter_new types=rangesOnly
+iter_seek_intent_ge k=b txn=A
+iter_seek_intent_ge k=d txn=A
+iter_seek_intent_ge k=i txn=A
+iter_seek_intent_ge k=j txn=A
+iter_seek_intent_ge k=k txn=A
+----
+iter_seek_intent_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_intent_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_intent_ge: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_intent_ge: {m-n}/[3.000000000,0=vheader{ localTs=2.000000000,0 } /<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace
@@ -1,0 +1,120 @@
+# Set up a couple of intents around range keys, but clear their provisional
+# values. The initial setup will fail when it's scanning the data afterwards,
+# but the data is still written so that's fine.
+#
+# This test does not run under race, because the error behavior differs due
+# to additional (costly) assertions. We want to test that we are reasonably
+# resistant to invariant violations even when not under race.
+run error
+with t=A
+  txn_begin ts=5
+  put k=c v=c5
+  put k=e v=e5
+clear k=c ts=5
+clear k=e ts=5
+put k=f ts=1 v=f1
+put_rangekey k=b end=d ts=5
+put_rangekey k=e end=g ts=5
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+rangekey: {b-d}/[5.000000000,0=/<empty>]
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+error: (*withstack.withStack:) intentIter at intent, but iter not at provisional value
+
+# Forward and reverse scans should error eventually, and should never
+# show the wrong range key for the intent.
+run error
+iter_new types=pointsAndRanges
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {b-d}/[5.000000000,0=/<empty>]
+iter_scan: {b-d}/[5.000000000,0=/<empty>]
+iter_scan: err=iter ahead of provisional value for intent "c" (at "e"/0,0)
+error: (*withstack.withStack:) iter ahead of provisional value for intent "c" (at "e"/0,0)
+
+run error
+iter_new types=pointsAndRanges
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "f"/1.000000000,0=/BYTES/f1 {e-g}/[5.000000000,0=/<empty>]
+iter_scan: "f"/1.000000000,0=/BYTES/f1 {e-g}/[5.000000000,0=/<empty>]
+iter_scan: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
+iter_scan: err=intentIter should not be after iter
+error: (*withstack.withStack:) intentIter should not be after iter
+
+# Seeking to intent at c will error, due to best-effort checks for provisional
+# value.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=c
+----
+iter_seek_ge: err=iter not on provisional value for intent "c"
+
+# Seeking to e intent will not error immediately, because the best-effort checks
+# only look for a point key covered by a range key (which it finds at f@1). This
+# is fine, as long as we expose the correct range key. The next step will error.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=e
+iter_next
+----
+iter_seek_ge: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
+iter_next: err=intentIter at intent, but iter not at provisional value
+
+# With prefix iterators, both seeks immediately error.
+run ok
+iter_new prefix types=pointsAndRanges
+iter_seek_ge k=c
+iter_seek_ge k=e
+----
+iter_seek_ge: err=iter not on provisional value for intent "c"
+iter_seek_ge: err=iter not on provisional value for intent "e"
+
+# Reverse seek at f will land on intent at e, even though there was no
+# provisional value. This is fine, as long as we emit the correct range keys.
+# It eventually errors because 
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=f
+iter_prev
+----
+iter_seek_lt: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
+iter_prev: err=intentIter should not be after iter
+
+# Reverse seek at d ends up succeeding. This is also fine, as long as the
+# emitted range keys and values are correct.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=d
+iter_prev
+iter_prev
+----
+iter_seek_lt: "c"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {b-d}/[5.000000000,0=/<empty>]
+iter_prev: {b-d}/[5.000000000,0=/<empty>]
+iter_prev: .
+
+# Switching directions on these positions should also error if appropriate, and
+# never expose the wrong range key for an intent.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=e
+iter_prev
+----
+iter_seek_ge: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
+iter_prev: err=iter not at provisional value, cmp: -1
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=f
+iter_next
+iter_prev
+iter_next
+----
+iter_seek_lt: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
+iter_next: "f"/1.000000000,0=/BYTES/f1 {e-g}/[5.000000000,0=/<empty>]
+iter_prev: "e"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {e-g}/[5.000000000,0=/<empty>]
+iter_next: "f"/1.000000000,0=/BYTES/f1 {e-g}/[5.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_nextkey_null_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_nextkey_null_regression
@@ -1,0 +1,27 @@
+# This is a contrived scenario which makes sure NextKey() handles range keys
+# starting at key.Next() correctly.
+run ok
+put k=a ts=2 v=a2
+put k=a ts=3 v=a3
+put k=b ts=1 v=b1
+put_rangekey k=a end=+a ts=5
+put_rangekey k=+a end=b ts=4
+----
+>> at end:
+rangekey: a{-\x00}/[5.000000000,0=/<empty>]
+rangekey: {a\x00-b}/[4.000000000,0=/<empty>]
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/1.000000000,0 -> /BYTES/b1
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: a{-\x00}/[5.000000000,0=/<empty>]
+iter_next_key: {a\x00-b}/[4.000000000,0=/<empty>]
+iter_next_key: "b"/1.000000000,0=/BYTES/b1
+iter_next_key: .

--- a/pkg/storage/testdata/mvcc_histories/range_key_put
+++ b/pkg/storage/testdata/mvcc_histories/range_key_put
@@ -1,0 +1,68 @@
+# Test basic MVCC range key mutations.
+
+run trace
+# Write three range keys that extend each other on both sides.
+put_rangekey k=c end=e ts=1
+put_rangekey k=a end=c ts=1
+put_rangekey k=e end=f ts=1
+----
+>> put_rangekey k=c end=e ts=1
+rangekey: {c-e}/[1.000000000,0=/<empty>]
+>> put_rangekey k=a end=c ts=1
+rangekey: {a-e}/[1.000000000,0=/<empty>]
+>> put_rangekey k=e end=f ts=1
+rangekey: {a-f}/[1.000000000,0=/<empty>]
+
+# Write an overlapping range key above it causing fragmentation.
+run ok
+put_rangekey k=d end=k ts=2
+----
+>> at end:
+rangekey: {a-d}/[1.000000000,0=/<empty>]
+rangekey: {d-f}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-k}/[2.000000000,0=/<empty>]
+
+# Write a range key underneath the [f-k) fragment that fragments it in the middle.
+run ok
+put_rangekey k=g end=j ts=1
+----
+>> at end:
+rangekey: {a-d}/[1.000000000,0=/<empty>]
+rangekey: {d-f}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-g}/[2.000000000,0=/<empty>]
+rangekey: {g-j}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {j-k}/[2.000000000,0=/<empty>]
+
+# Merge the range keys at ts=1 again.
+run ok
+put_rangekey k=f end=g ts=1
+----
+>> at end:
+rangekey: {a-d}/[1.000000000,0=/<empty>]
+rangekey: {d-j}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {j-k}/[2.000000000,0=/<empty>]
+
+# Fill in the gaps to make a single fragment stack.
+run ok
+put_rangekey k=a end=d ts=2
+put_rangekey k=j end=k ts=1
+----
+>> at end:
+rangekey: {a-k}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+
+# Write a different value (localTs) at [c-e)@2 which should fragment it.
+run ok
+put_rangekey k=c end=e ts=2 localTs=1
+----
+>> at end:
+rangekey: {a-c}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-e}/[2.000000000,0=vheader{ localTs=1.000000000,0 } /<empty> 1.000000000,0=/<empty>]
+rangekey: {e-k}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+
+# Write the original value again to unfragment everything.
+run ok
+put_rangekey k=c end=e ts=2 localTs=0
+----
+>> at end:
+rangekey: {a-k}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]


### PR DESCRIPTION
This patch adds initial experimental primitives for MVCC range keys,
which will be the foundation for MVCC range tombstones. They are based
on experimental Pebble range keys.

* Data structures:
  * `MVCCRangeKey`
  * `MVCCRangeKeyValue`

* `Engine` methods for mutating range keys:
  * `ExperimentalClearMVCCRangeKey()`
  * `ExperimentalClearAllMVCCRangeKeys()`
  * `ExperimentalPutMVCCRangeKey()`
  * `SupportsRangeKeys()`

* `SimpleMVCCIterator` methods for accessing range keys:
  * `HasPointAndRange()`
  * `RangeBounds()`
  * `RangeKeys()`

Range keys do not have a distinct identity, and should instead be
considered a key continuum: they will merge with abutting keys of the
same value, can be partially cleared, can split or merge along with
ranges, and so on. Bounded scans will truncate them to the scan bounds.

Only MVCC range tombstones are currently supported, with an empty value.
Attempts to write a non-tombstone value will error, since these would
need additional logic throughout the MVCC APIs, and their semantics are
still unclear.

Range key support is implemented in `pebbleIterator` and
`intentInterleavingIter`, but not in the rest of the MVCC or KV APIs.
They are not persisted to disk either. Subsequent pull requests will
extend their functionality and integrate them with other components.

Touches #70412.

Release note: None