### PR TITLE
opt: index accelerate && (overlaps) expressions for array inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1492,3 +1492,107 @@ CREATE TABLE public.table_desc_inverted_index (
    FAMILY f1 (id, last_accessed),
    FAMILY f2 (testdata)
 )
+
+subtest overlaps_with_array
+
+statement ok
+DROP TABLE cb
+
+statement ok
+CREATE TABLE cb (
+  id INT PRIMARY KEY,
+  numbers INT[],
+  words STRING[],
+  primes INT[],
+  INVERTED INDEX n (numbers),
+  INVERTED INDEX w (words),
+  INVERTED INDEX p (primes)
+)
+
+statement ok
+INSERT INTO cb VALUES
+  (0, ARRAY[], ARRAY[], ARRAY[]),
+  (1, ARRAY[0], ARRAY[NULL, ''], ARRAY[2]),
+  (2, ARRAY[1], ARRAY['cat'], ARRAY[3]),
+  (3, ARRAY[0,1], ARRAY['mouse'], ARRAY[2,3]),
+  (4, ARRAY[NULL], ARRAY['cat', 'mouse'], ARRAY[2]),
+  (5, ARRAY[0,1,2], ARRAY['cat', NULL, 'mouse'], ARRAY[2,3,5]),
+  (6, ARRAY[3,4,5], ARRAY['rat'], ARRAY[2,3]),
+  (7, ARRAY[1,2,1], ARRAY['rat', NULL, ''], ARRAY[2,3]),
+  (8, ARRAY[0,1,NULL], ARRAY[''], ARRAY[7]),
+  (9, NULL, NULL, NULL)
+
+query T
+SELECT numbers FROM cb WHERE numbers && ARRAY[]::INT[] ORDER BY numbers
+----
+
+query T
+SELECT numbers FROM cb WHERE numbers && ARRAY[NULL]::INT[] ORDER BY numbers
+----
+
+query T
+SELECT numbers FROM cb@n WHERE numbers && ARRAY[1,NULL]::INT[] ORDER BY numbers
+----
+{0,1}
+{0,1,NULL}
+{0,1,2}
+{1}
+{1,2,1}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers && ARRAY[0,1,2] ORDER BY numbers
+----
+{0}
+{0,1}
+{0,1,NULL}
+{0,1,2}
+{1}
+{1,2,1}
+
+query T
+SELECT numbers FROM cb@n WHERE numbers && ARRAY[5,4,3] ORDER BY numbers
+----
+{3,4,5}
+
+query T
+SELECT words FROM cb WHERE words && ARRAY[]::STRING[] ORDER BY words
+----
+
+query T
+SELECT words FROM cb@w WHERE words && ARRAY['']::STRING[] ORDER BY words
+----
+{NULL,""}
+{""}
+{rat,NULL,""}
+
+query T
+SELECT words FROM cb WHERE words && ARRAY[NULL]::STRING[] ORDER BY words
+----
+
+query T
+SELECT words FROM cb@w WHERE words && ARRAY['cat'] ORDER BY words
+----
+{cat}
+{cat,NULL,mouse}
+{cat,mouse}
+
+query T
+SELECT words FROM cb@w WHERE words && ARRAY[NULL, 'cat', 'mouse'] ORDER BY words
+----
+{cat}
+{cat,NULL,mouse}
+{cat,mouse}
+{mouse}
+
+query T
+SELECT words FROM cb@w WHERE words && ARRAY[NULL, 'rat'] ORDER BY words
+----
+{rat}
+{rat,NULL,""}
+
+query T
+SELECT primes FROM cb WHERE primes && numbers ORDER BY primes
+----
+{2,3}
+{2,3}
+{2,3,5}

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -12,7 +12,7 @@ CREATE TABLE e (
   a INT PRIMARY KEY,
   b INT[],
   FAMILY (a,b),
-  INVERTED INDEX(b)
+  INVERTED INDEX bIdx (b)
 )
 
 statement ok
@@ -1049,7 +1049,7 @@ vectorized: true
 └── • scan
       columns: (a)
       estimated row count: 111 (missing stats)
-      table: e@e_b_idx
+      table: e@bidx
       spans: /1-/2
 
 query T
@@ -1134,10 +1134,10 @@ vectorized: true
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
-          left table: e@e_b_idx
+          left table: e@bidx
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
-          right table: e@e_b_idx
+          right table: e@bidx
           right columns: (a, b_inverted_key)
           right fixed values: 1 column
 
@@ -1161,10 +1161,10 @@ vectorized: true
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
-          left table: e@e_b_idx
+          left table: e@bidx
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
-          right table: e@e_b_idx
+          right table: e@bidx
           right columns: (a, b_inverted_key)
           right fixed values: 1 column
 
@@ -1189,7 +1189,7 @@ vectorized: true
     └── • scan
           columns: (a)
           estimated row count: 111 (missing stats)
-          table: e@e_b_idx
+          table: e@bidx
           spans: /[]-/"D"
 
 query T
@@ -1221,7 +1221,7 @@ vectorized: true
             └── • scan
                   columns: (a, b_inverted_key)
                   estimated row count: 111 (missing stats)
-                  table: e@e_b_idx
+                  table: e@bidx
                   spans: /[]-/"D" /0-/3
 
 query T
@@ -1244,7 +1244,7 @@ vectorized: true
     └── • scan
           columns: (a)
           estimated row count: 111 (missing stats)
-          table: e@e_b_idx
+          table: e@bidx
           spans: /[]-/"D"
 
 query T
@@ -1276,7 +1276,7 @@ vectorized: true
             └── • scan
                   columns: (a, b_inverted_key)
                   estimated row count: 111 (missing stats)
-                  table: e@e_b_idx
+                  table: e@bidx
                   spans: /[]-/"D" /0-/2
 
 query T
@@ -1421,6 +1421,100 @@ vectorized: true
                   estimated row count: 111 (missing stats)
                   table: d@foo_inv
                   spans: /"f"-/"f"/PrefixEnd /[]-/{} /Arr/"f"-/Arr/"f"/PrefixEnd /Arr/{}-/Arr/{}/PrefixEnd /Arr/"a"/"b"-/Arr/"a"/"b"/PrefixEnd /Arr/"c"/{}-/Arr/"c"/{}/PrefixEnd /Arr/"c"/"d"/[]-/Arr/"c"/"d"/{} /Arr/"c"/"d"/Arr/"e"-/Arr/"c"/"d"/Arr/"e"/PrefixEnd
+
+# Test that queries with overlaps && operator use the inverted index
+# for non-empty non-null array
+# TODO: Add normalization rule to convert to no-op since predicate
+# is a contradiction
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e WHERE b && ARRAY[]::INT[]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: b && ARRAY[]
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1,000 (missing stats)
+      table: e@e_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e@bIdx WHERE b && ARRAY[0,1,2]
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ table: e@e_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 1
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: e@bidx
+              spans: /0-/3
+
+# TODO: Add normalization rule to convert to no-op since predicate
+# is a contradiction
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e WHERE b && ARRAY[NULL]::INT[]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ filter: b && ARRAY[NULL]
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1,000 (missing stats)
+      table: e@e_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM e@bIdx WHERE b && ARRAY[0,1,NULL]
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b)
+│ estimated row count: 333 (missing stats)
+│ table: e@e_pkey
+│ key columns: a
+│
+└── • project
+    │ columns: (a)
+    │ estimated row count: 111 (missing stats)
+    │
+    └── • inverted filter
+        │ columns: (a, b_inverted_key)
+        │ inverted column: b_inverted_key
+        │ num spans: 1
+        │
+        └── • scan
+              columns: (a, b_inverted_key)
+              estimated row count: 111 (missing stats)
+              table: e@bidx
+              spans: /0-/2
 
 # Ensure that an inverted index with a composite primary key still encodes
 # the primary key data in the composite value.

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -3332,6 +3332,97 @@ select
       ├── a:2 <@ ARRAY[1] [outer=(2), immutable]
       └── a:2 <@ ARRAY[2] [outer=(2), immutable]
 
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c@a_inv_idx WHERE a && ARRAY[1]
+----
+index-join c
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── scan c@a_inv_idx
+      ├── columns: k:1!null
+      ├── inverted constraint: /6/1
+      │    └── spans: ["\x89", "\x89"]
+      ├── flags: force-index=a_inv_idx
+      └── key: (1)
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c@a_inv_idx WHERE a && ARRAY[1] OR a && ARRAY[2]
+----
+index-join c
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── inverted-filter
+      ├── columns: k:1!null
+      ├── inverted expression: /6
+      │    ├── tight: true, unique: false
+      │    └── union spans: ["\x89", "\x8b")
+      ├── key: (1)
+      └── scan c@a_inv_idx
+           ├── columns: k:1!null a_inverted_key:6!null
+           ├── inverted constraint: /6/1
+           │    └── spans: ["\x89", "\x8b")
+           ├── flags: force-index=a_inv_idx
+           ├── key: (1)
+           └── fd: (1)-->(6)
+
+opt expect=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a && ARRAY[1] AND a && ARRAY[2]
+----
+inner-join (lookup c)
+ ├── columns: k:1!null a:2 u:3
+ ├── key columns: [1] = [1]
+ ├── lookup columns are key
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── inner-join (zigzag c@a_inv_idx c@a_inv_idx)
+ │    ├── columns: k:1!null
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [6] = ['\x89']
+ │    ├── right fixed columns: [6] = ['\x8a']
+ │    └── filters (true)
+ └── filters
+      ├── a:2 && ARRAY[1] [outer=(2), immutable]
+      └── a:2 && ARRAY[2] [outer=(2), immutable]
+
+# TODO: Add normalization rule to convert to no-op since predicate
+# is a contradiction
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a && ARRAY[]::INT[]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── a:2 && ARRAY[] [outer=(2), immutable]
+
+# TODO: Add normalization rule to convert to no-op since predicate
+# is a contradiction
+opt expect-not=GenerateInvertedIndexScans
+SELECT * FROM c WHERE a && ARRAY[NULL]::INT[]
+----
+select
+ ├── columns: k:1!null a:2 u:3
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan c
+ │    ├── columns: k:1!null a:2 u:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── a:2 && ARRAY[NULL] [outer=(2), immutable]
+
 # Tests for indexes with older descriptor versions.
 
 exec-ddl

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -435,6 +435,26 @@ func ArrayContains(ctx *EvalContext, haystack *DArray, needles *DArray) (*DBool,
 	return DBoolTrue, nil
 }
 
+// ArrayOverlaps return true if there is even one element
+// common between the left and right arrays.
+func ArrayOverlaps(ctx *EvalContext, array, other *DArray) (*DBool, error) {
+	if !array.ParamTyp.Equivalent(other.ParamTyp) {
+		return nil, pgerror.New(pgcode.DatatypeMismatch, "cannot compare arrays with different element types")
+	}
+	for _, needle := range array.Array {
+		// Nulls don't compare to each other in && syntax.
+		if needle == DNull {
+			continue
+		}
+		for _, hay := range other.Array {
+			if needle.Compare(ctx, hay) == 0 {
+				return DBoolTrue, nil
+			}
+		}
+	}
+	return DBoolFalse, nil
+}
+
 // JSONExistsAny return true if any value in dArray is exist in the json
 func JSONExistsAny(_ *EvalContext, json DJSON, dArray *DArray) (*DBool, error) {
 	// TODO(justin): this can be optimized.
@@ -2602,21 +2622,7 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]cmpOpOverload{
 				Fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
 					array := MustBeDArray(left)
 					other := MustBeDArray(right)
-					if !array.ParamTyp.Equivalent(other.ParamTyp) {
-						return nil, pgerror.New(pgcode.DatatypeMismatch, "cannot compare arrays with different element types")
-					}
-					for _, needle := range array.Array {
-						// Nulls don't compare to each other in && syntax.
-						if needle == DNull {
-							continue
-						}
-						for _, hay := range other.Array {
-							if needle.Compare(ctx, hay) == 0 {
-								return DBoolTrue, nil
-							}
-						}
-					}
-					return DBoolFalse, nil
+					return ArrayOverlaps(ctx, array, other)
 				},
 				Volatility: VolatilityImmutable,
 			},


### PR DESCRIPTION
Previously, we did not support index acceleration for queries involving
array overlaps (&&).

This change adds support for using the inverted index with && expressions on
Array columns. When there is an inverted index available, a scan will be done on
the Array column using the spans found from the constant value.

Fixes: #75477

Release note (performance improvement): Expressions using the overlaps (&&)
operator for arrays now support index-acceleration for faster execution in
some cases.

Release justification: low risk, high benefit changes to existing
functionality.