### PR TITLE
build: allow disabling metamorphic constants with tag

### DIFF
--- a/pkg/roachpb/gen/BUILD.bazel
+++ b/pkg/roachpb/gen/BUILD.bazel
@@ -11,5 +11,6 @@ go_library(
 go_binary(
     name = "gen",
     embed = [":gen_lib"],
+    gotags = ["metamorphic_disable"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/sql/colexec/execgen/cmd/execgen/BUILD.bazel
+++ b/pkg/sql/colexec/execgen/cmd/execgen/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
 go_binary(
     name = "execgen",
     embed = [":execgen_lib"],
+    gotags = ["metamorphic_disable"],
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
     name = "util",
     srcs = [
         "constants.go",
+        "constants_metamorphic_disable.go",  # keep
+        "constants_metamorphic_enable.go",
         "every_n.go",
         "fast_int_map.go",
         "fast_int_set.go",  # keep

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,7 +16,6 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -84,15 +83,14 @@ var rng struct {
 	syncutil.Mutex
 }
 
-// DisableMetamorphicEnvVar can be used to disable metamorhpic tests for
+// DisableMetamorphicEnvVar can be used to disable metamorphic tests for
 // sub-processes. If it exists and is set to something truthy as defined by
 // strconv.ParseBool then metamorphic testing will not be enabled.
 const DisableMetamorphicEnvVar = "COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING"
 
 func init() {
 	if buildutil.CrdbTestBuild {
-		disabled := envutil.EnvOrDefaultBool(DisableMetamorphicEnvVar, false)
-		if !disabled {
+		if !disableMetamorphicTesting {
 			rng.r, _ = randutil.NewTestRand()
 			metamorphicBuild = rng.r.Float64() < metamorphicBuildProbability
 		}

--- a/pkg/util/constants_metamorphic_disable.go
+++ b/pkg/util/constants_metamorphic_disable.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build metamorphic_disable
+// +build metamorphic_disable
+
+package util
+
+// DisableMetamorphicTesting can be used to disable metamorphic tests. If it
+// is set to true then metamorphic testing will not be enabled.
+var disableMetamorphicTesting = true

--- a/pkg/util/constants_metamorphic_enable.go
+++ b/pkg/util/constants_metamorphic_enable.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build !metamorphic_disable
+// +build !metamorphic_disable
+
+package util
+
+import "github.com/cockroachdb/cockroach/pkg/util/envutil"
+
+// disableMetamorphicTesting can be used to disable metamorphic tests. If it
+// is set to true then metamorphic testing will not be enabled.
+var disableMetamorphicTesting = envutil.EnvOrDefaultBool(DisableMetamorphicEnvVar, false)


### PR DESCRIPTION
Previously #76309 added the ability to disable metamorphic constants
with env variable COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING which
disabled the metamorphic constants when set to true. For some tools
however (execgen, roachpb/gen) setting an evironment variable may not
be always possible. So this PR adds the ability to disable the
metamorphic testing through tag `metamorphic_disable`. It would seem
that similar thing could be achieved by using the crdb_test_off tag
instead. With bazel however this tag is ignored.

Fixes #76363

Release justification: Non-production code changes
Release note: None