### PR TITLE
kvserver: remove "not observed below raft" assertion

### DIFF
--- a/pkg/kv/kvserver/main_test.go
+++ b/pkg/kv/kvserver/main_test.go
@@ -87,7 +87,8 @@ func TestMain(m *testing.M) {
 		delete(notBelowRaftProtos, reflect.TypeOf(&roachpb.InternalTimeSeriesData{}))
 		delete(notBelowRaftProtos, reflect.TypeOf(&enginepb.MVCCMetadataSubsetForMergeSerialization{}))
 		for typ := range notBelowRaftProtos {
-			failed = true
+			// NB: don't set failed=true. In a bazel world, we may just end up sharding in a way that
+			// doesn't observe some of the protos below raft.
 			fmt.Printf("%s: not observed below raft!\n", typ)
 		}
 


### PR DESCRIPTION
This "meta test" intercepts all protos below raft and makes assertions
about them. In particular, it was injecting a nonzero exit code if one
of the tracked protos was *not* seen (so that we could stop tracking
it). But in a bazel world where sharding is the norm, you can't really
expect any given shard to see all of the protos. Take out this
particular assertion.

Release justification: testing-only fix
Release note: None
