### PR TITLE
admission: add support for tenant weights

### DIFF
--- a/pkg/util/admission/testdata/work_queue
+++ b/pkg/util/admission/testdata/work_queue
@@ -12,7 +12,7 @@ id 1: admit succeeded
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 1, fifo: -128
+ tenant-id: 53 used: 1, w: 1, fifo: -128
 
 # tryGet will return false, so work will queue up.
 set-try-get-return-value v=false
@@ -26,7 +26,7 @@ tryGet: returning false
 print
 ----
 closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
 
 admit id=3 tenant=53 priority=0 create-time-millis=2 bypass=false
 ----
@@ -36,7 +36,7 @@ admit id=3 tenant=53 priority=0 create-time-millis=2 bypass=false
 print
 ----
 closed epoch: 0 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 2, epoch: 0, qt: 100] [1: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 2, epoch: 0, qt: 100] [1: pri: 0, ct: 3, epoch: 0, qt: 100]
 
 # Request from tenant 71.
 admit id=4 tenant=71 priority=-128 create-time-millis=4 bypass=false
@@ -51,8 +51,8 @@ admit id=5 tenant=71 priority=0 create-time-millis=5 bypass=false
 print
 ----
 closed epoch: 0 tenantHeap len: 2 top tenant: 71
- tenant-id: 53 used: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 2, epoch: 0, qt: 100] [1: pri: 0, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 0, fifo: -128 waiting work heap: [0: pri: 0, ct: 5, epoch: 0, qt: 100] [1: pri: -128, ct: 4, epoch: 0, qt: 100]
+ tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 2, epoch: 0, qt: 100] [1: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 71 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 5, epoch: 0, qt: 100] [1: pri: -128, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -65,8 +65,8 @@ granted: returned true
 print
 ----
 closed epoch: 0 tenantHeap len: 2 top tenant: 71
- tenant-id: 53 used: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 2, epoch: 0, qt: 100] [1: pri: 0, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
+ tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 2, epoch: 0, qt: 100] [1: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
 
 # Cancel a request from tenant 53.
 cancel-work id=3
@@ -76,8 +76,8 @@ id 3: admit failed
 print
 ----
 closed epoch: 0 tenantHeap len: 2 top tenant: 71
- tenant-id: 53 used: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
+ tenant-id: 53 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
 
 # The work admitted for tenant 53 is done.
 work-done id=1
@@ -88,8 +88,8 @@ returnGrant
 print
 ----
 closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 53 used: 0, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
+ tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
 
 # A request from the system tenant bypasses admission control, but is
 # reflected in the WorkQueue state.
@@ -101,9 +101,9 @@ id 6: admit succeeded
 print
 ----
 closed epoch: 0 tenantHeap len: 2 top tenant: 53
- tenant-id: 1 used: 1, fifo: -128
- tenant-id: 53 used: 0, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
- tenant-id: 71 used: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
+ tenant-id: 1 used: 1, w: 1, fifo: -128
+ tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 3, epoch: 0, qt: 100]
+ tenant-id: 71 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: -128, ct: 4, epoch: 0, qt: 100]
 
 granted chain-id=7
 ----
@@ -121,9 +121,9 @@ granted: returned true
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 1, fifo: -128
- tenant-id: 53 used: 1, fifo: -128
- tenant-id: 71 used: 2, fifo: -128
+ tenant-id: 1 used: 1, w: 1, fifo: -128
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+ tenant-id: 71 used: 2, w: 1, fifo: -128
 
 # Granted returns false.
 granted chain-id=10
@@ -133,9 +133,9 @@ granted: returned false
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 1 used: 1, fifo: -128
- tenant-id: 53 used: 1, fifo: -128
- tenant-id: 71 used: 2, fifo: -128
+ tenant-id: 1 used: 1, w: 1, fifo: -128
+ tenant-id: 53 used: 1, w: 1, fifo: -128
+ tenant-id: 71 used: 2, w: 1, fifo: -128
 
 init
 ----
@@ -151,12 +151,12 @@ tryGet: returning false
 advance-time millis=205
 ----
 closed epoch: 2 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 0, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
 
 print
 ----
 closed epoch: 2 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 0, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 53 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
 
 granted chain-id=5
 ----
@@ -167,13 +167,13 @@ granted: returned true
 print
 ----
 closed epoch: 2 tenantHeap len: 0
- tenant-id: 53 used: 1, fifo: -128
+ tenant-id: 53 used: 1, w: 1, fifo: -128
 
 # Switch to LIFO since request waited for 205ms.
 advance-time millis=100
 ----
 closed epoch: 3 tenantHeap len: 0
- tenant-id: 53 used: 1, fifo: 1
+ tenant-id: 53 used: 1, w: 1, fifo: 1
 
 admit id=2 tenant=53 priority=0 create-time-millis=50 bypass=false
 ----
@@ -189,7 +189,7 @@ admit id=4 tenant=53 priority=0 create-time-millis=400 bypass=false
 print
 ----
 closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 399, epoch: 3, qt: 405, lifo-ordering] [1: pri: 0, ct: 50, epoch: 0, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405]
+ tenant-id: 53 used: 1, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 399, epoch: 3, qt: 405, lifo-ordering] [1: pri: 0, ct: 50, epoch: 0, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405]
 
 # Latest request in closed epoch is granted.
 granted chain-id=6
@@ -209,7 +209,7 @@ granted: returned true
 print
 ----
 closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, fifo: 1 open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405]
+ tenant-id: 53 used: 3, w: 1, fifo: 1 open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405]
 
 # Add request to closed epoch.
 admit id=5 tenant=53 priority=0 create-time-millis=300 bypass=false
@@ -224,7 +224,7 @@ admit id=6 tenant=53 priority=0 create-time-millis=500 bypass=false
 print
 ----
 closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, fifo: 1 waiting work heap: [0: pri: 0, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 # Add high priority request in open epoch 5.
 admit id=7 tenant=53 priority=127 create-time-millis=550 bypass=false
@@ -235,13 +235,13 @@ admit id=7 tenant=53 priority=127 create-time-millis=550 bypass=false
 print
 ----
 closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, fifo: 1 waiting work heap: [0: pri: 127, ct: 550, epoch: 5, qt: 405] [1: pri: 0, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: 127, ct: 550, epoch: 5, qt: 405] [1: pri: 0, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 # Make the request wait for 60ms so we don't switch back to fifo.
 advance-time millis=60
 ----
 closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 3, fifo: 1 waiting work heap: [0: pri: 127, ct: 550, epoch: 5, qt: 405] [1: pri: 0, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 3, w: 1, fifo: 1 waiting work heap: [0: pri: 127, ct: 550, epoch: 5, qt: 405] [1: pri: 0, ct: 300, epoch: 3, qt: 405, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=8
 ----
@@ -262,13 +262,13 @@ admit id=8 tenant=53 priority=0 create-time-millis=350 bypass=false
 print
 ----
 closed epoch: 3 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 5, fifo: 1 waiting work heap: [0: pri: 0, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405] [1: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 # One request moved from open to closed epoch heap.
 advance-time millis=40
 ----
 closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 5, fifo: 1 waiting work heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405, lifo-ordering] [1: pri: 0, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 5, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 400, epoch: 4, qt: 405, lifo-ordering] [1: pri: 0, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=10
 ----
@@ -279,7 +279,7 @@ granted: returned true
 print
 ----
 closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 6, fifo: 1 waiting work heap: [0: pri: 0, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 6, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 350, epoch: 3, qt: 465, lifo-ordering] open epochs heap: [0: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 granted chain-id=11
 ----
@@ -290,7 +290,7 @@ granted: returned true
 print
 ----
 closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 7, fifo: 1 open epochs heap: [0: pri: 0, ct: 500, epoch: 5, qt: 405]
+ tenant-id: 53 used: 7, w: 1, fifo: 1 open epochs heap: [0: pri: 0, ct: 500, epoch: 5, qt: 405]
 
 # Can dequeue from the open epochs heap if nothing else is remaining.
 granted chain-id=12
@@ -302,7 +302,7 @@ granted: returned true
 print
 ----
 closed epoch: 4 tenantHeap len: 0
- tenant-id: 53 used: 8, fifo: 1
+ tenant-id: 53 used: 8, w: 1, fifo: 1
 
 # Add a request for an already closed epoch.
 admit id=9 tenant=53 priority=0 create-time-millis=380 bypass=false
@@ -312,13 +312,13 @@ tryGet: returning false
 print
 ----
 closed epoch: 4 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 8, fifo: 1 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+ tenant-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This time advance means the previous request will see significant queueing.
 advance-time millis=100
 ----
 closed epoch: 5 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 8, fifo: 1 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+ tenant-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This request in an already closed epoch gets ahead because of higher
 # create-time-millis.
@@ -328,7 +328,7 @@ admit id=10 tenant=53 priority=0 create-time-millis=390 bypass=false
 print
 ----
 closed epoch: 5 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 8, fifo: 1 waiting work heap: [0: pri: 0, ct: 390, epoch: 3, qt: 605, lifo-ordering] [1: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+ tenant-id: 53 used: 8, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 390, epoch: 3, qt: 605, lifo-ordering] [1: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 granted chain-id=12
 ----
@@ -339,13 +339,13 @@ granted: returned true
 print
 ----
 closed epoch: 5 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 9, fifo: 1 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+ tenant-id: 53 used: 9, w: 1, fifo: 1 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 # This advance will switch all priorities back to FIFO.
 advance-time millis=100
 ----
 closed epoch: 6 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 9, fifo: -128 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
+ tenant-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering]
 
 admit id=11 tenant=53 priority=0 create-time-millis=610 bypass=false
 ----
@@ -359,7 +359,7 @@ admit id=12 tenant=53 priority=-128 create-time-millis=615 bypass=false
 print
 ----
 closed epoch: 6 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 9, fifo: -128 waiting work heap: [0: pri: 0, ct: 610, epoch: 6, qt: 705] [1: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering] [2: pri: -128, ct: 615, epoch: 6, qt: 705]
+ tenant-id: 53 used: 9, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 610, epoch: 6, qt: 705] [1: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering] [2: pri: -128, ct: 615, epoch: 6, qt: 705]
 
 granted chain-id=13
 ----
@@ -372,7 +372,7 @@ granted: returned true
 print
 ----
 closed epoch: 6 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 10, fifo: -128 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering] [1: pri: -128, ct: 615, epoch: 6, qt: 705]
+ tenant-id: 53 used: 10, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 380, epoch: 3, qt: 505, lifo-ordering] [1: pri: -128, ct: 615, epoch: 6, qt: 705]
 
 granted chain-id=14
 ----
@@ -391,7 +391,7 @@ granted: returned true
 advance-time millis=100
 ----
 closed epoch: 7 tenantHeap len: 0
- tenant-id: 53 used: 12, fifo: 1
+ tenant-id: 53 used: 12, w: 1, fifo: 1
 
 # Add a request whose epoch is not closed.
 admit id=13 tenant=53 priority=0 create-time-millis=810 bypass=false
@@ -401,7 +401,7 @@ tryGet: returning false
 print
 ----
 closed epoch: 7 tenantHeap len: 1 top tenant: 53
- tenant-id: 53 used: 12, fifo: 1 open epochs heap: [0: pri: 0, ct: 810, epoch: 8, qt: 805]
+ tenant-id: 53 used: 12, w: 1, fifo: 1 open epochs heap: [0: pri: 0, ct: 810, epoch: 8, qt: 805]
 
 # Cancel that request.
 cancel-work id=13
@@ -411,17 +411,296 @@ id 13: admit failed
 print
 ----
 closed epoch: 7 tenantHeap len: 0
- tenant-id: 53 used: 12, fifo: 1
+ tenant-id: 53 used: 12, w: 1, fifo: 1
 
 # Closed epoch advances. The FIFO threshold is not changed since the only
 # request was canceled.
 advance-time millis=100
 ----
 closed epoch: 8 tenantHeap len: 0
- tenant-id: 53 used: 12, fifo: 1
+ tenant-id: 53 used: 12, w: 1, fifo: 1
 
 # Closed epoch advances. All priorities are now subject to FIFO.
 advance-time millis=100
 ----
 closed epoch: 9 tenantHeap len: 0
- tenant-id: 53 used: 12, fifo: -128
+ tenant-id: 53 used: 12, w: 1, fifo: -128
+
+# Test tenant weights.
+init
+----
+
+set-try-get-return-value v=false
+----
+
+# Empty map is fine.
+set-tenant-weights weights=
+----
+closed epoch: 0 tenantHeap len: 0
+
+# Tenant 5 gets a weight of 1.
+admit id=1 tenant=5 priority=0 create-time-millis=1 bypass=false
+----
+tryGet: returning false
+
+print
+----
+closed epoch: 0 tenantHeap len: 1 top tenant: 5
+ tenant-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Weight is unchanged for tenant 5.
+set-tenant-weights weights=10:11
+----
+closed epoch: 0 tenantHeap len: 1 top tenant: 5
+ tenant-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Now tenant 5 has a new weight.
+set-tenant-weights weights=5:6,10:11
+----
+closed epoch: 0 tenantHeap len: 1 top tenant: 5
+ tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+admit id=2 tenant=10 priority=0 create-time-millis=1 bypass=false
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 5
+ tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 0, w: 11, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 1: admit succeeded
+granted: returned true
+
+granted chain-id=2
+----
+continueGrantChain 2
+id 2: admit succeeded
+granted: returned true
+
+# Both tenants are using 1 slot.
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 5 used: 1, w: 6, fifo: -128
+ tenant-id: 10 used: 1, w: 11, fifo: -128
+
+# Add additional requests for each tenant
+admit id=3 tenant=5 priority=0 create-time-millis=1 bypass=false
+----
+tryGet: returning false
+
+admit id=4 tenant=10 priority=0 create-time-millis=1 bypass=false
+----
+
+# The top of the heap is tenant 10 since it has a higher weight.
+print
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 10
+ tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 1, w: 11, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Grant to tenant 10 so it is using 2 slots.
+granted chain-id=3
+----
+continueGrantChain 3
+id 4: admit succeeded
+granted: returned true
+
+print
+----
+closed epoch: 0 tenantHeap len: 1 top tenant: 5
+ tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 2, w: 11, fifo: -128
+
+# Another request from tenant 10.
+admit id=5 tenant=10 priority=0 create-time-millis=1 bypass=false
+----
+
+# Tenant 10's weight is not high enough for it to be the top of the heap.
+print
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 5
+ tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 2, w: 11, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Increase tenant 10's weight so it becomes the top of the heap. Weight
+# scaling is also applied here to make the max weight 20, and reduce tenant
+# 5's weight to 4.
+set-tenant-weights weights=5:6,10:30
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 10
+ tenant-id: 5 used: 1, w: 4, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 2, w: 20, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Restore all weights to 1. Tenant 5 is now top of the heap.
+set-tenant-weights weights=5:1,10:1
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 5
+ tenant-id: 5 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 2, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Adjust weights to make tenant 10 just slightly preferable over tenant 5.
+set-tenant-weights weights=5:6,10:13
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 10
+ tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 2, w: 13, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Add another request for tenant 10.
+admit id=6 tenant=10 priority=0 create-time-millis=1 bypass=false
+----
+
+granted chain-id=4
+----
+continueGrantChain 4
+id 5: admit succeeded
+granted: returned true
+
+# Tenant 10 is using 3 slots and tenant 5 is using 1 slot. Tenant 5 is the top
+# of the heap.
+print
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 5
+ tenant-id: 5 used: 1, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 3, w: 13, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Bump up tenant 10's weight to a huge value. Tenant 5's weight is not scaled
+# down to 0, since the minimum weight is 1.
+set-tenant-weights weights=5:1,10:100000
+----
+closed epoch: 0 tenantHeap len: 2 top tenant: 10
+ tenant-id: 5 used: 1, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 10 used: 3, w: 20, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+granted chain-id=5
+----
+continueGrantChain 5
+id 6: admit succeeded
+granted: returned true
+
+granted chain-id=6
+----
+continueGrantChain 6
+id 3: admit succeeded
+granted: returned true
+
+# Test that batch update of tenant weights is working correctly.
+init
+----
+
+set-try-get-return-value v=false
+----
+
+admit id=1 tenant=1 priority=0 create-time-millis=1 bypass=false
+----
+tryGet: returning false
+
+admit id=2 tenant=2 priority=0 create-time-millis=1 bypass=false
+----
+
+admit id=3 tenant=3 priority=0 create-time-millis=1 bypass=false
+----
+
+admit id=4 tenant=4 priority=0 create-time-millis=1 bypass=false
+----
+
+admit id=5 tenant=5 priority=0 create-time-millis=1 bypass=false
+----
+
+admit id=6 tenant=6 priority=0 create-time-millis=1 bypass=false
+----
+
+admit id=7 tenant=7 priority=0 create-time-millis=1 bypass=false
+----
+
+admit id=8 tenant=8 priority=0 create-time-millis=1 bypass=false
+----
+
+print
+----
+closed epoch: 0 tenantHeap len: 8 top tenant: 1
+ tenant-id: 1 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 2 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 3 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 4 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 5 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 6 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 7 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 8 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+# Set weights for 7 out of the 8 tenants.
+set-tenant-weights weights=1:2,2:3,3:4,4:5,5:6,7:8,8:9
+----
+closed epoch: 0 tenantHeap len: 8 top tenant: 1
+ tenant-id: 1 used: 0, w: 2, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 2 used: 0, w: 3, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 3 used: 0, w: 4, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 4 used: 0, w: 5, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 5 used: 0, w: 6, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 6 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 7 used: 0, w: 8, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+ tenant-id: 8 used: 0, w: 9, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 100]
+
+granted chain-id=1
+----
+continueGrantChain 1
+id 1: admit succeeded
+granted: returned true
+
+granted chain-id=2
+----
+continueGrantChain 2
+id 8: admit succeeded
+granted: returned true
+
+granted chain-id=3
+----
+continueGrantChain 3
+id 7: admit succeeded
+granted: returned true
+
+granted chain-id=4
+----
+continueGrantChain 4
+id 6: admit succeeded
+granted: returned true
+
+granted chain-id=5
+----
+continueGrantChain 5
+id 5: admit succeeded
+granted: returned true
+
+granted chain-id=6
+----
+continueGrantChain 6
+id 4: admit succeeded
+granted: returned true
+
+granted chain-id=7
+----
+continueGrantChain 7
+id 3: admit succeeded
+granted: returned true
+
+granted chain-id=8
+----
+continueGrantChain 8
+id 2: admit succeeded
+granted: returned true
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 1 used: 1, w: 2, fifo: -128
+ tenant-id: 2 used: 1, w: 3, fifo: -128
+ tenant-id: 3 used: 1, w: 4, fifo: -128
+ tenant-id: 4 used: 1, w: 5, fifo: -128
+ tenant-id: 5 used: 1, w: 6, fifo: -128
+ tenant-id: 6 used: 1, w: 1, fifo: -128
+ tenant-id: 7 used: 1, w: 8, fifo: -128
+ tenant-id: 8 used: 1, w: 9, fifo: -128

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -236,7 +236,19 @@ type WorkQueue struct {
 		// Tenants with waiting work.
 		tenantHeap tenantHeap
 		// All tenants, including those without waiting work. Periodically cleaned.
-		tenants map[uint64]*tenantInfo
+		tenants       map[uint64]*tenantInfo
+		tenantWeights struct {
+			mu syncutil.Mutex
+			// active refers to the currently active weights. mu is held for updates
+			// to the inactive weights, to prevent concurrent updates. After
+			// updating the inactive weights, it is made active by swapping with
+			// active, while also holding WorkQueue.mu. Therefore, reading
+			// tenantWeights.active does not require tenantWeights.mu. For lock
+			// ordering, tenantWeights.mu precedes WorkQueue.mu.
+			//
+			// The maps are lazily allocated.
+			active, inactive map[uint64]uint32
+		}
 		// The highest epoch that is closed.
 		closedEpochThreshold int64
 		// Following values are copied from the cluster settings.
@@ -483,7 +495,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (enabled bool, err
 	q.mu.Lock()
 	tenant, ok := q.mu.tenants[tenantID]
 	if !ok {
-		tenant = newTenantInfo(tenantID)
+		tenant = newTenantInfo(tenantID, q.getTenantWeightLocked(tenantID))
 		q.mu.tenants[tenantID] = tenant
 	}
 	if info.BypassAdmission && roachpb.IsSystemTenantID(tenantID) && q.workKind == KVWork {
@@ -547,7 +559,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (enabled bool, err
 			tenant.used--
 		} else {
 			if !ok {
-				tenant = newTenantInfo(tenantID)
+				tenant = newTenantInfo(tenantID, q.getTenantWeightLocked(tenantID))
 				q.mu.tenants[tenantID] = tenant
 			}
 			// Don't want to overflow tenant.used if it is already 0 because of
@@ -767,8 +779,8 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, verb rune) {
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	for _, id := range ids {
 		tenant := q.mu.tenants[id]
-		s.Printf("\n tenant-id: %d used: %d, fifo: %d", tenant.id, tenant.used,
-			tenant.fifoPriorityThreshold)
+		s.Printf("\n tenant-id: %d used: %d, w: %d, fifo: %d", tenant.id, tenant.used,
+			tenant.weight, tenant.fifoPriorityThreshold)
 		if len(tenant.waitingWorkHeap) > 0 {
 			s.Printf(" waiting work heap:")
 			for i := range tenant.waitingWorkHeap {
@@ -793,6 +805,110 @@ func (q *WorkQueue) SafeFormat(s redact.SafePrinter, verb rune) {
 					tenant.openEpochsHeap[i].enqueueingTime.UnixNano()/int64(time.Millisecond))
 			}
 		}
+	}
+}
+
+// Weight for tenants that are not assigned a weight. This typically applies
+// to tenants which weren't on this node in the prior call to
+// SetTenantWeights. Additionally, it is also the minimum tenant weight.
+const defaultTenantWeight = 1
+
+// The current cap on the weight of a tenant. We don't allow a single tenant
+// to use more than cap times the number of resources of the smallest tenant.
+// For KV slots, we have seen a range of slot counts from 50-200 for 16 cpu
+// nodes, for a KV50 workload, depending on how we set
+// admission.kv_slot_adjuster.overload_threshold. We don't want to starve
+// small tenants, so the cap is currently set to 20. A more sophisticated fair
+// sharing scheme would not need such a cap.
+const tenantWeightCap = 20
+
+func (q *WorkQueue) getTenantWeightLocked(tenantID uint64) uint32 {
+	weight := uint32(defaultTenantWeight)
+	if q.mu.tenantWeights.active != nil {
+		w, ok := q.mu.tenantWeights.active[tenantID]
+		if ok {
+			weight = w
+		}
+	}
+	return weight
+}
+
+// SetTenantWeights sets the weight of tenants, using the provided tenant ID
+// => weight map.
+func (q *WorkQueue) SetTenantWeights(tenantWeights map[uint64]uint32) {
+	q.mu.tenantWeights.mu.Lock()
+	defer q.mu.tenantWeights.mu.Unlock()
+	if q.mu.tenantWeights.inactive == nil {
+		q.mu.tenantWeights.inactive = make(map[uint64]uint32)
+	}
+	// Remove all elements from the inactive map.
+	for k := range q.mu.tenantWeights.inactive {
+		delete(q.mu.tenantWeights.inactive, k)
+	}
+	// Compute the max weight in the new map, for enforcing the tenantWeightCap.
+	maxWeight := uint32(1)
+	for _, v := range tenantWeights {
+		if v > maxWeight {
+			maxWeight = v
+		}
+	}
+	scaling := float64(1)
+	if maxWeight > tenantWeightCap {
+		scaling = tenantWeightCap / float64(maxWeight)
+	}
+	// Populate the weights in the inactive map.
+	for k, v := range tenantWeights {
+		w := uint32(math.Ceil(float64(v) * scaling))
+		if w < defaultTenantWeight {
+			w = defaultTenantWeight
+		}
+		q.mu.tenantWeights.inactive[k] = w
+	}
+	q.mu.Lock()
+	// Establish the new active map.
+	q.mu.tenantWeights.active, q.mu.tenantWeights.inactive =
+		q.mu.tenantWeights.inactive, q.mu.tenantWeights.active
+	// Create a slice for storing all the tenantIDs. We use this to split the
+	// update to the data-structures that require holding q.mu, in case there
+	// are 1000s of tenants (we don't want to hold q.mu for long durations).
+	tenantIDs := make([]uint64, len(q.mu.tenants))
+	i := 0
+	for k := range q.mu.tenants {
+		tenantIDs[i] = k
+		i++
+	}
+	q.mu.Unlock()
+	// Any tenants not in tenantIDs will see the latest weight when their
+	// tenantInfo is created. The existing ones need their weights to be
+	// updated.
+
+	// tenantIDs[index] represents the next tenantID that needs to be updated.
+	var index int
+	n := len(tenantIDs)
+	// updateNextBatch acquires q.mu and updates a batch of tenants.
+	updateNextBatch := func() (repeat bool) {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		// Arbitrary batch size of 5.
+		const batchSize = 5
+		for i := 0; i < batchSize; i++ {
+			if index >= n {
+				return false
+			}
+			tenantID := tenantIDs[index]
+			tenantInfo := q.mu.tenants[tenantID]
+			weight := q.getTenantWeightLocked(tenantID)
+			if tenantInfo != nil && tenantInfo.weight != weight {
+				tenantInfo.weight = weight
+				if isInTenantHeap(tenantInfo) {
+					q.mu.tenantHeap.fix(tenantInfo)
+				}
+			}
+			index++
+		}
+		return true
+	}
+	for updateNextBatch() {
 	}
 }
 
@@ -945,6 +1061,8 @@ func (ps *priorityStates) getFIFOPriorityThresholdAndReset(
 // tenantInfo is the per-tenant information in the tenantHeap.
 type tenantInfo struct {
 	id uint64
+	// The weight assigned to the tenant. Must be > 0.
+	weight uint32
 	// used can be the currently used slots, or the tokens granted within the last
 	// interval.
 	//
@@ -996,10 +1114,11 @@ var tenantInfoPool = sync.Pool{
 	},
 }
 
-func newTenantInfo(id uint64) *tenantInfo {
+func newTenantInfo(id uint64, weight uint32) *tenantInfo {
 	ti := tenantInfoPool.Get().(*tenantInfo)
 	*ti = tenantInfo{
 		id:                    id,
+		weight:                weight,
 		waitingWorkHeap:       ti.waitingWorkHeap,
 		openEpochsHeap:        ti.openEpochsHeap,
 		priorityStates:        makePriorityStates(ti.priorityStates.ps),
@@ -1043,7 +1162,8 @@ func (th *tenantHeap) Len() int {
 }
 
 func (th *tenantHeap) Less(i, j int) bool {
-	return (*th)[i].used < (*th)[j].used
+	// used_i/weight_i < used_j/weight_j
+	return (*th)[i].used*uint64((*th)[j].weight) < (*th)[j].used*uint64((*th)[i].weight)
 }
 
 func (th *tenantHeap) Swap(i, j int) {


### PR DESCRIPTION
The weights are used in ordering tenants, such that tenant i is
preferred over tenant j if used_i/weight_i < used_j/weight_j,
where the used values represent usage of slots or tokens. This
allows for a form of weighted fair sharing. This fair sharing
is quite primitive, since there is no history for slots, and only
1s of history for token consumption (with a sharp reset, instead
of a rolling one).

The weighting can be useful when a node (or store) has
significantly different number of ranges for two tenants, so
giving them an equal share of resources (like CPU) would not be
reasonable.

The minimum weight is 1 and the maximum weight is currently
capped at 20. Note that a tenant using 0 slots/tokens will always
be preferred over one that is using a non-zero amount, regardless
of weight. This reduces the likelihood starvation, though with
a large enough number of waiting tenants, both the unweighted
(weight of 1) and weighted scheme can have starvation since
ties between tenants that are using 0 slots/tokens are broken
non-deterministically (and not by preferring the longer waiting
tenant).

This will be used for KV admission control, both for kv and
kv-stores queues, which use slots and tokens respectively. The
integration code that periodically sets the weights based on
the range count per tenant will be in a later PR.

Informs #77358

Release justification: Low-risk update to new functionality.
Even though inter-tenant isolation was included in v21.2,
it has only been used in CockroachDB serverless recently,
and there is consensus to include weighting for v22.1.
The integration code (in a later PR) will be gated on a
cluster setting, and will default to not using weights.

Release note: None