### PR TITLE
release-21.2: ui: Remove stray parenthesis in Jobs page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/jobs/duration.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/duration.tsx
@@ -49,7 +49,6 @@ export class Duration extends React.PureComponent<{
         <span className={className}>
           {"Duration: " +
             formatDuration(moment.duration(finishedAt.diff(startedAt)))}
-          )
         </span>
       );
     }


### PR DESCRIPTION
Backport 1/1 commits from #77438.

/cc @cockroachdb/release

---

Addresses #77440.

This commit fixes the stray parenthesis at the end of the duration time for a
succeeded job. The parenthesis had been introduced in
https://github.com/cockroachdb/cockroach/pull/76691 and the 21.2 backport
https://github.com/cockroachdb/cockroach/pull/73624.

Before:
![image](https://user-images.githubusercontent.com/91907326/157065776-456c8f7d-1958-4192-b38d-dcb40432cf9d.png)

After:
![image](https://user-images.githubusercontent.com/91907326/157065785-e3f2db6a-67d1-4ae3-87cb-df71dccf0e5f.png)


Release note (ui): Remove stray parenthesis at the end of the duration time for
a succeeded job. It had been accidentally introduced to unreleased master and a
21.2 backport.

Release justification: Category 2, UI bug fix
