### PR TITLE
ccl/sqlproxyccl: allow backend/frontend interceptors to act as net.Conn

### DIFF
--- a/pkg/ccl/sqlproxyccl/authentication.go
+++ b/pkg/ccl/sqlproxyccl/authentication.go
@@ -153,19 +153,19 @@ var authenticate = func(clientConn, crdbConn net.Conn, throttleHook func(throttl
 // we should merge them back in the future. Instead of having the writer as the
 // other end, the writer should be the same connection. That way, a
 // sqlproxyccl.Conn can be used to read-from, or write-to the same component.
-var readTokenAuthResult = func(serverConn net.Conn) error {
+var readTokenAuthResult = func(conn net.Conn) error {
 	// This interceptor is discarded once this function returns. Just like
-	// pgproto3.NewFrontend, this interceptor has an internal buffer.
+	// pgproto3.NewFrontend, this serverConn object has an internal buffer.
 	// Discarding the buffer is fine since there won't be any other messages
 	// from the server once we receive the ReadyForQuery message because the
 	// caller (i.e. proxy) does not forward client messages until then.
-	serverInterceptor := interceptor.NewFrontendInterceptor(serverConn)
+	serverConn := interceptor.NewFrontendConn(conn)
 
 	// The auth step should require only a few back and forths so 20 iterations
 	// should be enough.
 	var i int
 	for ; i < 20; i++ {
-		backendMsg, err := serverInterceptor.ReadMsg()
+		backendMsg, err := serverConn.ReadMsg()
 		if err != nil {
 			return newErrorf(codeBackendReadFailed, "unable to receive message from backend: %v", err)
 		}

--- a/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
@@ -3,10 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "interceptor",
     srcs = [
-        "backend_interceptor.go",
+        "backend_conn.go",
         "base.go",
         "chunkreader.go",
-        "frontend_interceptor.go",
+        "frontend_conn.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor",
     visibility = ["//visibility:public"],
@@ -21,10 +21,10 @@ go_library(
 go_test(
     name = "interceptor_test",
     srcs = [
-        "backend_interceptor_test.go",
+        "backend_conn_test.go",
         "base_test.go",
         "chunkreader_test.go",
-        "frontend_interceptor_test.go",
+        "frontend_conn_test.go",
         "interceptor_test.go",
     ],
     embed = [":interceptor"],

--- a/pkg/ccl/sqlproxyccl/interceptor/backend_conn.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/backend_conn.go
@@ -10,46 +10,53 @@ package interceptor
 
 import (
 	"io"
+	"net"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/jackc/pgproto3/v2"
 )
 
-// FrontendInterceptor is a client interceptor for the Postgres frontend protocol.
-type FrontendInterceptor pgInterceptor
+// BackendConn is a server interceptor for the Postgres backend protocol.
+// This will be used for the connection between client and proxy.
+type BackendConn struct {
+	net.Conn
+	interceptor *pgInterceptor
+}
 
-// NewFrontendInterceptor creates a FrontendInterceptor using the default buffer
-// size of 8K bytes.
-func NewFrontendInterceptor(src io.Reader) *FrontendInterceptor {
-	return (*FrontendInterceptor)(newPgInterceptor(src, defaultBufferSize))
+// NewBackendConn creates a BackendConn using the default buffer size of 8KB.
+func NewBackendConn(conn net.Conn) *BackendConn {
+	return &BackendConn{
+		Conn:        conn,
+		interceptor: newPgInterceptor(conn, defaultBufferSize),
+	}
 }
 
 // PeekMsg returns the header of the current pgwire message without advancing
 // the interceptor.
 //
 // See pgInterceptor.PeekMsg for more information.
-func (fi *FrontendInterceptor) PeekMsg() (typ pgwirebase.ServerMessageType, size int, err error) {
-	byteType, size, err := (*pgInterceptor)(fi).PeekMsg()
-	return pgwirebase.ServerMessageType(byteType), size, err
+func (c *BackendConn) PeekMsg() (typ pgwirebase.ClientMessageType, size int, err error) {
+	byteType, size, err := c.interceptor.PeekMsg()
+	return pgwirebase.ClientMessageType(byteType), size, err
 }
 
-// ReadMsg decodes the current pgwire message and returns a BackendMessage.
+// ReadMsg decodes the current pgwire message and returns a FrontendMessage.
 // This also advances the interceptor to the next message.
 //
 // See pgInterceptor.ReadMsg for more information.
-func (fi *FrontendInterceptor) ReadMsg() (msg pgproto3.BackendMessage, err error) {
-	msgBytes, err := (*pgInterceptor)(fi).ReadMsg()
+func (c *BackendConn) ReadMsg() (msg pgproto3.FrontendMessage, err error) {
+	msgBytes, err := c.interceptor.ReadMsg()
 	if err != nil {
 		return nil, err
 	}
 	// errWriter is used here because Receive must not Write.
-	return pgproto3.NewFrontend(newChunkReader(msgBytes), &errWriter{}).Receive()
+	return pgproto3.NewBackend(newChunkReader(msgBytes), &errWriter{}).Receive()
 }
 
 // ForwardMsg sends the current pgwire message to the destination without any
 // decoding, and advances the interceptor to the next message.
 //
 // See pgInterceptor.ForwardMsg for more information.
-func (fi *FrontendInterceptor) ForwardMsg(dst io.Writer) (n int, err error) {
-	return (*pgInterceptor)(fi).ForwardMsg(dst)
+func (c *BackendConn) ForwardMsg(dst io.Writer) (n int, err error) {
+	return c.interceptor.ForwardMsg(dst)
 }

--- a/pkg/ccl/sqlproxyccl/interceptor/backend_conn_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/backend_conn_test.go
@@ -10,6 +10,8 @@ package interceptor_test
 
 import (
 	"bytes"
+	"io"
+	"net"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
@@ -19,38 +21,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBackendInterceptor tests the BackendInterceptor. Note that the tests
-// here are shallow. For detailed ones, see the tests for the internal
-// interceptor in base_test.go.
-func TestBackendInterceptor(t *testing.T) {
+// TestBackendConn tests the BackendConn. Note that the tests here are shallow.
+// For detailed ones, see the tests for the internal interceptor in base_test.go.
+func TestBackendConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	q := (&pgproto3.Query{String: "SELECT 1"}).Encode(nil)
 
-	buildSrc := func(t *testing.T, count int) *bytes.Buffer {
+	writeAsync := func(t *testing.T, w io.Writer) <-chan error {
 		t.Helper()
-		src := new(bytes.Buffer)
-		_, err := src.Write(q)
-		require.NoError(t, err)
-		return src
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := w.Write(q)
+			errCh <- err
+		}()
+		return errCh
 	}
 
 	t.Run("PeekMsg returns the right message type", func(t *testing.T) {
-		src := buildSrc(t, 1)
+		w, r := net.Pipe()
+		errCh := writeAsync(t, w)
 
-		bi := interceptor.NewBackendInterceptor(src)
+		bi := interceptor.NewBackendConn(r)
 		require.NotNil(t, bi)
 
 		typ, size, err := bi.PeekMsg()
 		require.NoError(t, err)
 		require.Equal(t, pgwirebase.ClientMsgSimpleQuery, typ)
 		require.Equal(t, 14, size)
+
+		err = <-errCh
+		require.Nil(t, err)
 	})
 
 	t.Run("ReadMsg decodes the message correctly", func(t *testing.T) {
-		src := buildSrc(t, 1)
+		w, r := net.Pipe()
+		errCh := writeAsync(t, w)
 
-		bi := interceptor.NewBackendInterceptor(src)
+		bi := interceptor.NewBackendConn(r)
 		require.NotNil(t, bi)
 
 		msg, err := bi.ReadMsg()
@@ -58,18 +66,25 @@ func TestBackendInterceptor(t *testing.T) {
 		rmsg, ok := msg.(*pgproto3.Query)
 		require.True(t, ok)
 		require.Equal(t, "SELECT 1", rmsg.String)
+
+		err = <-errCh
+		require.Nil(t, err)
 	})
 
 	t.Run("ForwardMsg forwards data to dst", func(t *testing.T) {
-		src := buildSrc(t, 1)
+		w, r := net.Pipe()
+		errCh := writeAsync(t, w)
 		dst := new(bytes.Buffer)
 
-		bi := interceptor.NewBackendInterceptor(src)
+		bi := interceptor.NewBackendConn(r)
 		require.NotNil(t, bi)
 
 		n, err := bi.ForwardMsg(dst)
 		require.NoError(t, err)
 		require.Equal(t, 14, n)
 		require.Equal(t, 14, dst.Len())
+
+		err = <-errCh
+		require.Nil(t, err)
 	})
 }

--- a/pkg/ccl/sqlproxyccl/interceptor/frontend_conn.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/frontend_conn.go
@@ -10,46 +10,53 @@ package interceptor
 
 import (
 	"io"
+	"net"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/jackc/pgproto3/v2"
 )
 
-// BackendInterceptor is a server int/erceptor for the Postgres backend protocol.
-type BackendInterceptor pgInterceptor
+// FrontendConn is a client interceptor for the Postgres frontend protocol.
+// This will be used for the connection between proxy and server.
+type FrontendConn struct {
+	net.Conn
+	interceptor *pgInterceptor
+}
 
-// NewBackendInterceptor creates a BackendInterceptor using the default buffer
-// size of 8K bytes.
-func NewBackendInterceptor(src io.Reader) *BackendInterceptor {
-	return (*BackendInterceptor)(newPgInterceptor(src, defaultBufferSize))
+// NewFrontendConn creates a FrontendConn using the default buffer size of 8KB.
+func NewFrontendConn(conn net.Conn) *FrontendConn {
+	return &FrontendConn{
+		Conn:        conn,
+		interceptor: newPgInterceptor(conn, defaultBufferSize),
+	}
 }
 
 // PeekMsg returns the header of the current pgwire message without advancing
 // the interceptor.
 //
 // See pgInterceptor.PeekMsg for more information.
-func (bi *BackendInterceptor) PeekMsg() (typ pgwirebase.ClientMessageType, size int, err error) {
-	byteType, size, err := (*pgInterceptor)(bi).PeekMsg()
-	return pgwirebase.ClientMessageType(byteType), size, err
+func (c *FrontendConn) PeekMsg() (typ pgwirebase.ServerMessageType, size int, err error) {
+	byteType, size, err := c.interceptor.PeekMsg()
+	return pgwirebase.ServerMessageType(byteType), size, err
 }
 
-// ReadMsg decodes the current pgwire message and returns a FrontendMessage.
+// ReadMsg decodes the current pgwire message and returns a BackendMessage.
 // This also advances the interceptor to the next message.
 //
 // See pgInterceptor.ReadMsg for more information.
-func (bi *BackendInterceptor) ReadMsg() (msg pgproto3.FrontendMessage, err error) {
-	msgBytes, err := (*pgInterceptor)(bi).ReadMsg()
+func (c *FrontendConn) ReadMsg() (msg pgproto3.BackendMessage, err error) {
+	msgBytes, err := c.interceptor.ReadMsg()
 	if err != nil {
 		return nil, err
 	}
 	// errWriter is used here because Receive must not Write.
-	return pgproto3.NewBackend(newChunkReader(msgBytes), &errWriter{}).Receive()
+	return pgproto3.NewFrontend(newChunkReader(msgBytes), &errWriter{}).Receive()
 }
 
 // ForwardMsg sends the current pgwire message to the destination without any
 // decoding, and advances the interceptor to the next message.
 //
 // See pgInterceptor.ForwardMsg for more information.
-func (bi *BackendInterceptor) ForwardMsg(dst io.Writer) (n int, err error) {
-	return (*pgInterceptor)(bi).ForwardMsg(dst)
+func (c *FrontendConn) ForwardMsg(dst io.Writer) (n int, err error) {
+	return c.interceptor.ForwardMsg(dst)
 }

--- a/pkg/ccl/sqlproxyccl/interceptor/interceptor_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/interceptor_test.go
@@ -9,7 +9,8 @@
 package interceptor_test
 
 import (
-	"bytes"
+	"encoding/json"
+	"net"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
@@ -19,60 +20,100 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSimpleProxy illustrates how the frontend and backend interceptors can be
+// TestSimpleProxy illustrates how the frontend and backend connections can be
 // used as a proxy.
 func TestSimpleProxy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// These represents connections for client<->proxy and proxy<->server.
-	fromClient := new(bytes.Buffer)
-	toClient := new(bytes.Buffer)
-	fromServer := new(bytes.Buffer)
-	toServer := new(bytes.Buffer)
-
-	// Create client and server interceptors.
-	clientInt := interceptor.NewBackendInterceptor(fromClient)
-	serverInt := interceptor.NewFrontendInterceptor(fromServer)
-
 	t.Run("client to server", func(t *testing.T) {
+		// These represents connections for client<->proxy and proxy<->server.
+		clientProxy, client := net.Pipe()
+		serverProxy, server := net.Pipe()
+		defer clientProxy.Close()
+		defer client.Close()
+		defer serverProxy.Close()
+		defer server.Close()
+
+		// Create client and server interceptors.
+		clientConn := interceptor.NewBackendConn(clientProxy)
+		serverConn := interceptor.NewFrontendConn(serverProxy)
+
 		// Client sends a list of SQL queries.
 		queries := []pgproto3.FrontendMessage{
 			&pgproto3.Query{String: "SELECT 1"},
-			&pgproto3.Query{String: "SELECT * FROM foo.bar"},
+			&pgproto3.Query{String: "SELECT 2 FROM foobar"},
 			&pgproto3.Query{String: "UPDATE foo SET x = 42"},
 			&pgproto3.Sync{},
 			&pgproto3.Terminate{},
 		}
-		for _, msg := range queries {
-			_, err := fromClient.Write(msg.Encode(nil))
-			require.NoError(t, err)
-		}
-		totalBytes := fromClient.Len()
+		errCh := make(chan error, len(queries))
+		go func() {
+			for _, msg := range queries {
+				_, err := client.Write(msg.Encode(nil))
+				errCh <- err
+			}
+		}()
+		msgCh := make(chan pgproto3.FrontendMessage, 10)
+		go func() {
+			backend := interceptor.NewBackendConn(server)
+			for {
+				msg, err := backend.ReadMsg()
+				if err != nil {
+					return
+				}
+				msgCh <- msg
+			}
+		}()
 
 		customQuery := &pgproto3.Query{
 			String: "SELECT * FROM crdb_internal.serialize_session()"}
 
 		for {
-			typ, _, err := clientInt.PeekMsg()
+			typ, _, err := clientConn.PeekMsg()
 			require.NoError(t, err)
 
 			// Forward message to server.
-			_, err = clientInt.ForwardMsg(toServer)
+			_, err = clientConn.ForwardMsg(serverConn)
 			require.NoError(t, err)
 
 			if typ == pgwirebase.ClientMsgTerminate {
 				// Right before we terminate, we could also craft a custom
 				// message, and send it to the server.
-				_, err := toServer.Write(customQuery.Encode(nil))
+				_, err := serverConn.Write(customQuery.Encode(nil))
 				require.NoError(t, err)
 				break
 			}
 		}
-		require.Equal(t, 0, fromClient.Len())
-		require.Equal(t, totalBytes+len(customQuery.Encode(nil)), toServer.Len())
+
+		expectedMsg := []string{
+			`"Type":"Query","String":"SELECT 1"`,
+			`"Type":"Query","String":"SELECT 2 FROM foobar"`,
+			`"Type":"Query","String":"UPDATE foo SET x = 42"`,
+			`"Type":"Sync"`,
+			`"Type":"Terminate"`,
+			`"Type":"Query","String":"SELECT \* FROM crdb_internal.serialize_session\(\)"`,
+		}
+		var m1 []byte
+		for _, m2 := range expectedMsg {
+			msg := <-msgCh
+			m1, _ = json.Marshal(msg)
+			require.Regexp(t, m2, string(m1))
+		}
 	})
 
 	t.Run("server to client", func(t *testing.T) {
+		// These represents connections for client<->proxy and proxy<->server.
+		clientProxy, client := net.Pipe()
+		serverProxy, server := net.Pipe()
+		defer clientProxy.Close()
+		defer client.Close()
+		defer serverProxy.Close()
+		defer server.Close()
+
+		// Create client and server interceptors.
+		clientConn := interceptor.NewBackendConn(clientProxy)
+		serverConn := interceptor.NewFrontendConn(serverProxy)
+
 		// Server sends back responses.
 		queries := []pgproto3.BackendMessage{
 			// Forward these back to the client.
@@ -83,15 +124,27 @@ func TestSimpleProxy(t *testing.T) {
 			// Terminator.
 			&pgproto3.ReadyForQuery{},
 		}
-		for _, msg := range queries {
-			_, err := fromServer.Write(msg.Encode(nil))
-			require.NoError(t, err)
-		}
-		// Exclude bytes from second message.
-		totalBytes := fromServer.Len() - len(queries[2].Encode(nil))
+		errCh := make(chan error, len(queries))
+		go func() {
+			for _, msg := range queries {
+				_, err := server.Write(msg.Encode(nil))
+				errCh <- err
+			}
+		}()
+		msgCh := make(chan pgproto3.BackendMessage, 10)
+		go func() {
+			frontend := interceptor.NewFrontendConn(client)
+			for {
+				msg, err := frontend.ReadMsg()
+				if err != nil {
+					return
+				}
+				msgCh <- msg
+			}
+		}()
 
 		for {
-			typ, size, err := serverInt.PeekMsg()
+			typ, size, err := serverConn.PeekMsg()
 			require.NoError(t, err)
 
 			switch typ {
@@ -99,13 +152,13 @@ func TestSimpleProxy(t *testing.T) {
 				// Assuming that we're only interested in small messages, then
 				// we could skip all the large ones.
 				if size > 12 {
-					_, err := serverInt.ForwardMsg(toClient)
+					_, err := serverConn.ForwardMsg(clientConn)
 					require.NoError(t, err)
 					continue
 				}
 
 				// Decode message.
-				msg, err := serverInt.ReadMsg()
+				msg, err := serverConn.ReadMsg()
 				require.NoError(t, err)
 
 				// Once we've decoded the message, we could store the message
@@ -114,7 +167,7 @@ func TestSimpleProxy(t *testing.T) {
 				require.True(t, ok)
 				require.Equal(t, "short", string(dmsg.CommandTag))
 			case pgwirebase.ServerMsgBackendKeyData:
-				msg, err := serverInt.ReadMsg()
+				msg, err := serverConn.ReadMsg()
 				require.NoError(t, err)
 
 				dmsg, ok := msg.(*pgproto3.BackendKeyData)
@@ -124,11 +177,11 @@ func TestSimpleProxy(t *testing.T) {
 				// the client.
 				dmsg.SecretKey = 100
 
-				_, err = toClient.Write(dmsg.Encode(nil))
+				_, err = clientConn.Write(dmsg.Encode(nil))
 				require.NoError(t, err)
 			default:
 				// Forward message that we're not interested to the client.
-				_, err := serverInt.ForwardMsg(toClient)
+				_, err := serverConn.ForwardMsg(clientConn)
 				require.NoError(t, err)
 			}
 
@@ -136,7 +189,17 @@ func TestSimpleProxy(t *testing.T) {
 				break
 			}
 		}
-		require.Equal(t, 0, fromServer.Len())
-		require.Equal(t, totalBytes, toClient.Len())
+
+		expectedMsg := []string{
+			`"Type":"CommandComplete","CommandTag":"averylongstring"`,
+			`"Type":"BackendKeyData","ProcessID":100,"SecretKey":100`,
+			`"Type":"ReadyForQuery"`,
+		}
+		var m1 []byte
+		for _, m2 := range expectedMsg {
+			msg := <-msgCh
+			m1, _ = json.Marshal(msg)
+			require.Regexp(t, m2, string(m1))
+		}
 	})
 }


### PR DESCRIPTION
Previously, interceptors were separated from their net.Conn objects causing
additional work in the caller to ensure that they both match. This commit
updates the pg-specific interceptors so that they can now act as net.Conn
objects, reducing the additional bookkeeping work in the caller.

Release justification: sqlproxy-only change.

Release note: None