### PR TITLE
vendor: bump Pebble to e2b7bb844759

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1297,10 +1297,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "5b306806fca1c0defafe031c4cd842934aec44394bc44dc24bc805bc3fd609b8",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220301234049-69a82fe41c31",
+        sha256 = "cc3201e4197273c3ddc0adf72ab1f800d7b09e2b9d50422cab619a854d8e4e80",
+        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20220307192532-e2b7bb844759",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220301234049-69a82fe41c31.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20220307192532-e2b7bb844759.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220301234049-69a82fe41c31
+	github.com/cockroachdb/pebble v0.0.0-20220307192532-e2b7bb844759
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20220217190341-94cf65c2a29f

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0n
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e h1:FrERdkPlRj+v7fc+PGpey3GUiDGuTR5CsmLCA54YJ8I=
 github.com/cockroachdb/panicparse/v2 v2.0.0-20211103220158-604c82a44f1e/go.mod h1:pMxsKyCewnV3xPaFvvT9NfwvDTcIx2Xqg0qL5Gq0SjM=
-github.com/cockroachdb/pebble v0.0.0-20220301234049-69a82fe41c31 h1:hkBQIZdAeGQzF3pVbL1lrPJNx/Hvwiy5HHpRf0Nz6y8=
-github.com/cockroachdb/pebble v0.0.0-20220301234049-69a82fe41c31/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20220307192532-e2b7bb844759 h1:PKDkU1nARLt2TL99CCEukKJIEUo2cgt9AEVlrdtzfuM=
+github.com/cockroachdb/pebble v0.0.0-20220307192532-e2b7bb844759/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
e2b7bb84 db: clear range key count during Batch Reset
9d0c3914 db: use L0 target file size, grandparent limit for intra L0 compactions
e6b9afd6 sstable: fix bug with overall bound setting
dc74f53e internal/manifest: refactor TestCheckOrdering to use ParseVersionDebug
02363a55 tool/logs: add ingested events, reorganize output
e0cf288f tool/logs: fix single memtable flushes
cd3d4bd4 ci: mark and close stale issues
b4f1f653 base: fix InternalIteratorStats.Merge
e7ea208e db: remove obsolete pickIntraL0 function
3515304a db: fix flaky TestOpenWALReplayReadOnlySeqNums
```

Release note: None

Release justification: non-production code changes (3515304a, e7ea208e,
cd3d4bd4, e0cf288f, 02363a55, dc74f53e), bug fixes (e2b7bb84, 9d0c3914,
e6b9afd6, b4f1f653)