### PR TITLE
roachtest: update 21.2 version map to v21.1.16

### DIFF
--- a/pkg/cmd/roachtest/tests/predecessor_version.go
+++ b/pkg/cmd/roachtest/tests/predecessor_version.go
@@ -36,7 +36,7 @@ func PredecessorVersion(buildVersion version.Version) (string, error) {
 	// checkpoint option enabled to create the missing store directory
 	// fixture (see runVersionUpgrade).
 	verMap := map[string]string{
-		"21.2": "21.1.15",
+		"21.2": "21.1.16",
 		"21.1": "20.2.12",
 		"20.2": "20.1.16",
 		"20.1": "19.2.11",


### PR DESCRIPTION
Release note: None
Release justification: non-production code change.