### PR TITLE
dev: don't throw away so much log output in `dev doctor`

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=19
+DEV_VERSION=20
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/cache.go
+++ b/pkg/cmd/dev/cache.go
@@ -75,8 +75,14 @@ func (d *dev) cache(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	_, err = d.checkPresenceInBazelRc(bazelRcLine)
-	return err
+	errStr, err := d.checkPresenceInBazelRc(bazelRcLine)
+	if err != nil {
+		return err
+	}
+	if errStr != "" {
+		return fmt.Errorf("%s", errStr)
+	}
+	return nil
 }
 
 func bazelRemoteCacheDir() (string, error) {
@@ -130,6 +136,10 @@ func (d *dev) setUpCache(ctx context.Context) (string, error) {
 
 	log.Printf("Configuring cache...\n")
 
+	err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", "build", bazelRemoteTarget)
+	if err != nil {
+		return "", err
+	}
 	bazelRemoteLoc, err := d.exec.CommandContextSilent(ctx, "bazel", "run", bazelRemoteTarget, "--run_under=//build/bazelutil/whereis")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
We keep the `stderr` for commands and have `doctor` log it along with
the `stdout`. Also reword some of the error output to make it clearer --
for example, the `stamp` test can fail for reasons besides stamping not
being enabled in your `.bazelrc.user`, so the error message should make
that clear.

Closes #77355.

Release justification: Non-production code changes
Release note: None