### PR TITLE
sql: write all index entries for delete preserving indexes

### DIFF
--- a/pkg/sql/testdata/index_mutations/delete_preserving_update
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_update
@@ -61,13 +61,15 @@ Scan /Table/107/{1-2}
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
 Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
-# Update a row that matches the partial index before and after, but the index
-# entry doesn't change.
+# Update a row that matches the partial index before and after. While
+# the index entry doesn't change, it is still written to the delete
+# preserving index.
 kvtrace
 UPDATE tpi SET b = b - 1
 ----
 Scan /Table/107/{1-2}
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
+Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
 # Update a row that matches the partial index before and after, and the index
 # entry changes.
@@ -116,12 +118,14 @@ Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Put (delete) /Table/108/2/102/1/0
 Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
 
-# Update a row with different values without changing the index entry.
+# Update a row with different values without changing the expected index entry.
+# The index entry is still written for a delete preserving index
 kvtrace
 UPDATE tei SET a = a + 1, b = b - 1
 ----
 Scan /Table/108/{1-2}
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/199
+Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
 # Inverted Index With Delete Preserving Encoding

--- a/pkg/sql/testdata/index_mutations/delete_preserving_upsert
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_upsert
@@ -61,13 +61,15 @@ Scan /Table/107/1/3/0
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foo
 Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
-# Upsert a row that matches the partial index before and after, but the index
-# entry doesn't change.
+# Upsert a row that matches the partial index before and after, but
+# the index entry doesn't change. While the index entry doesn't
+# change, we still write it out to a delete preserving index.
 kvtrace
 UPSERT INTO tpi VALUES (3, 1, 'foo')
 ----
 Scan /Table/107/1/3/0
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
+Put /Table/107/2/"foo"/3/0 -> /BYTES/0x0a0103
 
 # Upsert a row that matches the partial index before and after, and the index
 # entry changes.
@@ -122,6 +124,7 @@ UPSERT INTO tei VALUES (1, 4, 499)
 ----
 Scan /Table/108/1/1/0
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/499
+Put /Table/108/2/503/1/0 -> /BYTES/0x0a0103
 
 # Upsert a row with a different primary key with the same index entry.
 kvtrace
@@ -228,3 +231,43 @@ Scan /Table/111/1/1/0
 Put /Table/111/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Put (delete) /Table/111/2/2/100/0
 Put /Table/111/2/3/200/0 -> /BYTES/0x0a020389
+
+# ---------------------------------------------------------------
+# Multi Column Family Table With Delete Preserving Encoding Index
+# ---------------------------------------------------------------
+statement
+CREATE TABLE mcf (
+    a INT PRIMARY KEY,
+    b INT,
+    c STRING,
+    FAMILY (a, b),
+    FAMILY (c),
+    INDEX multi_fam (b)
+);
+----
+
+mutate-index mcf multi_fam DELETE_AND_WRITE_ONLY use_delete_preserving_encoding=true
+----
+
+statement
+INSERT INTO mcf VALUES (1, 2, 'bar'), (2, 3, 'bar'), (3, 4, 'foo')
+----
+
+# Upsert a row that changes the first family but not the second
+kvtrace
+UPSERT INTO mcf VALUES (1, 1, 'baz')
+----
+Scan /Table/112/1/{1-2}
+Put /Table/112/1/1/0 -> /TUPLE/2:2:Int/1
+Put /Table/112/1/1/1/1 -> /BYTES/baz
+Put (delete) /Table/112/2/2/1/0
+Put /Table/112/2/1/1/0 -> /BYTES/0x0a0103
+
+# Upsert a row that changes the second family but not the first
+kvtrace
+UPSERT INTO mcf VALUES (1, 1, 'bat')
+----
+Scan /Table/112/1/{1-2}
+Put /Table/112/1/1/0 -> /TUPLE/2:2:Int/1
+Put /Table/112/1/1/1/1 -> /BYTES/bat
+Put /Table/112/2/1/1/0 -> /BYTES/0x0a0103


### PR DESCRIPTION
When updating a row, we calculate the index entries expected for a
given index using the old value and the new value of the row. To avoid
writing data unnecessarily, if an old and new index entry is the same,
we skip writing it.

This, however, is a problem for index additions. Consider the
following:

Assume we have a table with a schema such as

    CREATE TABLE t (
        pk INT PRIMARY KEY,
        a INT,
        b INT,
        c INT,
        FAMILY (pk, a),
        FAMILY (b),
        FAMILY (c)
    )

Then suppose we have the following series of events:

    t0: INSERT INTO t (pk, a, b, c) VALUES (1, 1, 1, 1)
    t1: CREATE INDEX t (a) STORING (b, c) // i2 added to table desc in BACKFILLING, i3 in DELETE_ONLY
    t2: i3 moves to DELETE_AND_WRITE_ONLY
    t3: AddSSTable based backfill of i2
    t4: i2 moves to DELETE_ONLY
    t5: UPDATE t SET b = 2 WHERE pk = 1;

Currently, the update at `t5` will produce the following KV
operations:

```
Put /Table/106/1/1/1/1 -> /INT/42               // Primary index entry for FAMILY (b)
Put /Table/106/3/1/1/1/1 -> /BYTES/0x0a030a3354 // Temporary index entry for FAMILY (b)
Del /Table/106/2/1/1/0
Del /Table/106/2/1/1/1/1
Del /Table/106/2/1/1/2/1
```

Note that we've deleted all entries from index 2 because it is in
DELETE_ONLY. And, in index 3, we only write out a value for the column
family that changed.  But, when we merge i3 into i2, the expected
index entries for the updated row will be incomplete as the expected
entry for the column family containing `c` will not be present.

To avoid this case, we write _all_ index entries for temporary
indexes. That is, in the new code, the update at t5 would produce the
following KV operations:

```
Put /Table/106/1/1/1/1 -> /INT/42               // Primary index entry for FAMILY (b)
Put /Table/106/3/1/1/0 -> /BYTES/0x0a0103
Put /Table/106/3/1/1/1/1 -> /BYTES/0x0a030a3354 // Temporary index entry for FAMILY (b)
Put /Table/106/3/1/1/2/1 -> /BYTES/0x0a030a4302 // Temporary index entry for FAMILY (c)
Del /Table/106/2/1/1/0
Del /Table/106/2/1/1/1/1
Del /Table/106/2/1/1/2/1
```

It's unfortunate that our index validation does not catch this case of
an invalid index creation.

Release justification: Critical correctness fix for create index
schema changes

Release note: None