### PR TITLE
ccl/sqlproxyccl: implement suspend/resume for request/response processors 

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/ccl/sqlproxyccl/throttler",
         "//pkg/roachpb",
         "//pkg/security/certmgr",
-        "//pkg/sql/pgwire",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/util/contextutil",

--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -26,10 +26,8 @@ import (
 // waitForShowTransferState.
 //
 // Unlike runAndWaitForDeserializeSession, we split the SHOW TRANSFER STATE
-// operation into `run` and `wait` since they both will be invoked in different
-// goroutines. If we combined them, we'll have to wait for at least one of the
-// goroutines to pause, which can introduce a latency of about 1-2s per transfer
-// while waiting for Read in readTimeoutConn to be unblocked.
+// operation into `run` and `wait` since doing so allows us to send the query
+// ahead of time.
 func runShowTransferState(w io.Writer, transferKey string) error {
 	return writeQuery(w, "SHOW TRANSFER STATE WITH '%s'", transferKey)
 }

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -11,23 +11,24 @@ package sqlproxyccl
 import (
 	"context"
 	"net"
+	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
 // forwarder is used to forward pgwire messages from the client to the server,
-// and vice-versa. At the moment, this does a direct proxying, and there is
-// no intercepting. Once https://github.com/cockroachdb/cockroach/issues/76000
-// has been addressed, we will start intercepting pgwire messages at their
-// boundaries here.
-//
-// The forwarder instance should always be constructed through the forward
-// function, which also starts the forwarder.
+// and vice-versa. The forwarder instance should always be constructed through
+// the forward function, which also starts the forwarder.
 type forwarder struct {
 	// ctx is a single context used to control all goroutines spawned by the
-	// forwarder.
+	// forwarder. An exception to this is that if the goroutines are blocked
+	// due to IO on clientConn or serverConn, cancelling the context does not
+	// unblock them. Due to this, it is important to invoke Close() on the
+	// forwarder whenever ctx has been cancelled to prevent leaks.
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
@@ -37,115 +38,104 @@ type forwarder struct {
 	// clientConn is set once during initialization, and stays the same
 	// throughout the lifetime of the forwarder.
 	//
-	// serverConn is only set after the authentication phase for the initial
-	// connection. In the context of a connection migration, serverConn is only
-	// replaced once the session has successfully been deserialized, and the old
-	// connection will be closed. Whenever serverConn gets updated, both
-	// clientMessageTypeSent and isServerMsgReadyReceived fields have to reset
-	// to their initial values.
+	// serverConn is set during initialization, which happens after the
+	// authentication phase, and will be replaced if a connection migration
+	// occurs. During a connection migration, serverConn is only replaced once
+	// the session has successfully been deserialized, and the old connection
+	// will be closed.
 	//
-	// All reads from these connections must go through the interceptors. It is
-	// not safe to call Read directly as the interceptors may have buffered data.
-	clientConn *interceptor.BackendConn  // client <-> proxy
-	serverConn *interceptor.FrontendConn // proxy <-> server
+	// All reads from these connections must go through the PG interceptors.
+	// It is not safe to call Read directly as the interceptors may have
+	// buffered data.
+	clientConn *interceptor.PGConn // client <-> proxy
+	serverConn *interceptor.PGConn // proxy <-> server
 
-	// errChan is a buffered channel that contains the first forwarder error.
-	// This channel may receive nil errors.
-	errChan chan error
+	// request and response both represent the processors used to handle
+	// client-to-server and server-to-client messages.
+	request  *processor // client -> server
+	response *processor // server -> client
+
+	// errCh is a buffered channel that contains the first forwarder error.
+	// This channel may receive nil errors. When an error is written to this
+	// channel, it is guaranteed that the forwarder and all connections will
+	// be closed.
+	errCh chan error
 }
 
 // forward returns a new instance of forwarder, and starts forwarding messages
-// from clientConn to serverConn. When this is called, it is expected that the
-// caller passes ownership of serverConn to the forwarder, which implies that
-// the forwarder will clean up serverConn. clientConn and serverConn must not
-// be nil in all cases except for testing.
+// from clientConn to serverConn (and vice-versa). When this is called, it is
+// expected that the caller passes ownership of both clientConn and serverConn
+// to the forwarder, which implies that the forwarder will clean them up.
+// clientConn and serverConn must not be nil in all cases except for testing.
 //
-// Note that callers MUST call Close in all cases, even if ctx was cancelled.
+// Note that callers MUST call Close in all cases, even if ctx was cancelled,
+// and callers will need to detect that.
 func forward(ctx context.Context, clientConn, serverConn net.Conn) *forwarder {
 	ctx, cancelFn := context.WithCancel(ctx)
-
 	f := &forwarder{
-		ctx:       ctx,
-		ctxCancel: cancelFn,
-		errChan:   make(chan error, 1),
+		ctx:        ctx,
+		ctxCancel:  cancelFn,
+		errCh:      make(chan error, 1),
+		clientConn: interceptor.NewPGConn(clientConn),
+		serverConn: interceptor.NewPGConn(serverConn),
 	}
-
-	// The net.Conn object for the client is switched to a net.Conn that
-	// unblocks Read every second on idle to check for exit conditions.
-	// This is mainly used to unblock the request processor whenever the
-	// forwarder has stopped, or a transfer has been requested.
-	clientConn = pgwire.NewReadTimeoutConn(clientConn, func() error {
-		// Context was cancelled.
-		if f.ctx.Err() != nil {
-			return f.ctx.Err()
-		}
-		// TODO(jaylim-crl): Check for transfer state here.
-		return nil
-	})
-	f.clientConn = interceptor.NewBackendConn(clientConn)
-	f.serverConn = interceptor.NewFrontendConn(serverConn)
-
-	// Start request (client to server) and response (server to client)
-	// processors. We will copy all pgwire messages/ from client to server
-	// (and vice-versa) until we encounter an error or a shutdown signal
-	// (i.e. context cancellation).
-	go func() {
-		defer f.Close()
-
-		err := wrapClientToServerError(f.handleClientToServer())
-		select {
-		case f.errChan <- err: /* error reported */
-		default: /* the channel already contains an error */
-		}
-	}()
-	go func() {
-		defer f.Close()
-
-		err := wrapServerToClientError(f.handleServerToClient())
-		select {
-		case f.errChan <- err: /* error reported */
-		default: /* the channel already contains an error */
-		}
-	}()
-
+	f.request = newProcessor(f.clientConn, f.serverConn)  // client -> server
+	f.response = newProcessor(f.serverConn, f.clientConn) // server -> client
+	f.resumeProcessors()
 	return f
 }
 
-// Close closes the forwarder, and stops the forwarding process. This is
-// idempotent.
+// Close closes the forwarder and all connections. This is idempotent.
 func (f *forwarder) Close() {
 	f.ctxCancel()
 
-	// Since Close is idempotent, we'll ignore the error from Close in case it
-	// has already been closed.
+	// Whenever Close is called while both of the processors are suspended, the
+	// main goroutine will be stuck waiting for a reponse from the forwarder.
+	// Send an error to unblock that. If an error has been sent, this error will
+	// be ignored.
+	//
+	// We don't use tryReportError here since that will call Close, leading to
+	// a recursive call.
+	select {
+	case f.errCh <- errors.New("forwarder closed"): /* error reported */
+	default: /* the channel already contains an error */
+	}
+
+	// Since Close is idempotent, we'll ignore the error from Close calls in
+	// case they have already been closed.
+	f.clientConn.Close()
 	f.serverConn.Close()
 }
 
-// handleClientToServer handles the communication from the client to the server.
-// This returns a context cancellation error whenever the forwarder's context
-// is cancelled, or whenever forwarding fails. When ForwardMsg gets blocked on
-// Read, we will unblock that through our custom readTimeoutConn wrapper, which
-// gets triggered when context is cancelled.
-func (f *forwarder) handleClientToServer() error {
-	for f.ctx.Err() == nil {
-		if _, err := f.clientConn.ForwardMsg(f.serverConn); err != nil {
-			return err
+// resumeProcessors starts both the request and response processors
+// asynchronously. The forwarder will be closed if any of the processors
+// return an error while resuming. This is idempotent as resume() will return
+// nil if the processor has already been started.
+func (f *forwarder) resumeProcessors() {
+	go func() {
+		if err := f.request.resume(f.ctx); err != nil {
+			f.tryReportError(wrapClientToServerError(err))
 		}
-	}
-	return f.ctx.Err()
+	}()
+	go func() {
+		if err := f.response.resume(f.ctx); err != nil {
+			f.tryReportError(wrapServerToClientError(err))
+		}
+	}()
 }
 
-// handleServerToClient handles the communication from the server to the client.
-// This returns a context cancellation error whenever the forwarder's context
-// is cancelled, or whenever forwarding fails. When ForwardMsg gets blocked on
-// Read, we will unblock that by closing serverConn through f.Close().
-func (f *forwarder) handleServerToClient() error {
-	for f.ctx.Err() == nil {
-		if _, err := f.serverConn.ForwardMsg(f.clientConn); err != nil {
-			return err
-		}
+// tryReportError tries to send err to errCh, and closes the forwarder if
+// it succeeds. If an error has already been reported, err will be dropped.
+func (f *forwarder) tryReportError(err error) {
+	select {
+	case f.errCh <- err: /* error reported */
+		// Whenever an error has been reported, all processors must terminate to
+		// stop processing on either sides, and the easiest way to do so is to
+		// close the forwarder, which closes all connections. Doing this also
+		// ensures that resuming a processor again will return an error.
+		f.Close()
+	default: /* the channel already contains an error */
 	}
-	return f.ctx.Err()
 }
 
 // wrapClientToServerError overrides client to server errors for external
@@ -176,4 +166,147 @@ func wrapServerToClientError(err error) error {
 		return nil
 	}
 	return newErrorf(codeBackendDisconnected, "copying from target server to client: %s", err)
+}
+
+// aLongTimeAgo is a non-zero time, far in the past, used for immediate
+// cancellation of dials.
+var aLongTimeAgo = timeutil.Unix(1, 0)
+
+var (
+	errProcessorResumed  = errors.New("processor has already been resumed")
+	errSuspendInProgress = errors.New("suspension is already in progress")
+)
+
+// processor must always be constructed through newProcessor.
+type processor struct {
+	// src and dst are immutable fields. A new processor should be created if
+	// any of those fields need to be updated. When that happens, all existing
+	// processors must be terminated first to prevent concurrent reads on src.
+	src *interceptor.PGConn
+	dst *interceptor.PGConn
+
+	mu struct {
+		syncutil.Mutex
+		cond       *sync.Cond
+		resumed    bool
+		inPeek     bool
+		suspendReq bool // Indicates that a suspend has been requested.
+	}
+}
+
+func newProcessor(src *interceptor.PGConn, dst *interceptor.PGConn) *processor {
+	p := &processor{src: src, dst: dst}
+	p.mu.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+// resume starts the processor and blocks during the processing. When the
+// processing has been terminated, this returns nil if the processor can be
+// resumed again in the future. If an error (except errProcessorResumed) was
+// returned, the processor should not be resumed again, and the forwarder should
+// be closed.
+func (p *processor) resume(ctx context.Context) error {
+	enterResume := func() error {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.mu.resumed {
+			return errProcessorResumed
+		}
+		p.mu.resumed = true
+		return nil
+	}
+	exitResume := func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.mu.resumed = false
+		p.mu.cond.Broadcast()
+	}
+	enterPeek := func() (terminate bool) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		// Suspend has been requested. Suspend now before blocking.
+		if p.mu.suspendReq {
+			return true
+		}
+		p.mu.inPeek = true
+		return false
+	}
+	exitPeek := func() (suspendReq bool) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.mu.inPeek = false
+		return p.mu.suspendReq
+	}
+
+	if err := enterResume(); err != nil {
+		return err
+	}
+	defer exitResume()
+
+	for ctx.Err() == nil {
+		// If suspend was requested, we terminate to avoid blocking on PeekMsg
+		// as an optimization.
+		if terminate := enterPeek(); terminate {
+			return nil
+		}
+
+		// Always peek the message to ensure that we're blocked on reading the
+		// header, rather than when forwarding during idle periods.
+		_, _, peekErr := p.src.PeekMsg()
+
+		suspendReq := exitPeek()
+
+		// If suspend was requested, there are two cases where we terminate:
+		//   1. peekErr == nil, where we read a header. In that case, suspension
+		//      gets priority.
+		//   2. peekErr != nil, where the error was due to a timeout. Connection
+		//      was likely idle here.
+		if peekErr != nil {
+			if netErr := (net.Error)(nil); errors.As(peekErr, &netErr) && suspendReq && netErr.Timeout() {
+				// Return nil so that the processor can be resumed in the future.
+				peekErr = nil
+			} else {
+				peekErr = errors.Wrap(peekErr, "peeking message")
+			}
+		}
+		if peekErr != nil || suspendReq {
+			return peekErr
+		}
+
+		if _, err := p.src.ForwardMsg(p.dst); err != nil {
+			return errors.Wrap(err, "forwarding message")
+		}
+	}
+	return ctx.Err()
+}
+
+// suspend requests for the processor to be suspended if it is in a safe state,
+// and blocks until the processor has been terminated. If the suspend request
+// failed, suspend returns an error, and the caller is safe to retry again.
+func (p *processor) suspend(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.mu.suspendReq {
+		return errSuspendInProgress
+	}
+
+	p.mu.suspendReq = true
+	defer func() {
+		p.mu.suspendReq = false
+		_ = p.src.SetReadDeadline(time.Time{})
+	}()
+
+	for p.mu.resumed {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if p.mu.inPeek {
+			if err := p.src.SetReadDeadline(aLongTimeAgo); err != nil {
+				return err
+			}
+		}
+		p.mu.cond.Wait()
+	}
+	return nil
 }

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -9,11 +9,16 @@
 package sqlproxyccl
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"math/rand"
 	"net"
 	"testing"
+	"testing/iotest"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -28,7 +33,8 @@ func TestForward(t *testing.T) {
 
 	t.Run("closed_when_processors_error", func(t *testing.T) {
 		p1, p2 := net.Pipe()
-		// Close the connection right away. p2 is owned by the forwarder.
+
+		// Close the connection right away to simulate processor error.
 		p1.Close()
 
 		f := forward(bgCtx, p1, p2)
@@ -48,12 +54,10 @@ func TestForward(t *testing.T) {
 		ctx, cancel := context.WithTimeout(bgCtx, 5*time.Second)
 		defer cancel()
 
+		// We don't close clientW and serverR here since we have no control
+		// over those. The rest are handled by the forwarder.
 		clientW, clientR := net.Pipe()
 		serverW, serverR := net.Pipe()
-		// We don't close clientW and serverR here since we have no control
-		// over those. serverW is not closed since the forwarder is responsible
-		// for that.
-		defer clientR.Close()
 
 		f := forward(ctx, clientR, serverW)
 		defer f.Close()
@@ -119,12 +123,10 @@ func TestForward(t *testing.T) {
 		ctx, cancel := context.WithTimeout(bgCtx, 5*time.Second)
 		defer cancel()
 
+		// We don't close clientW and serverR here since we have no control
+		// over those. The rest are handled by the forwarder.
 		clientW, clientR := net.Pipe()
 		serverW, serverR := net.Pipe()
-		// We don't close clientW and serverR here since we have no control
-		// over those. serverW is not closed since the forwarder is responsible
-		// for that.
-		defer clientR.Close()
 
 		f := forward(ctx, clientR, serverW)
 		defer f.Close()
@@ -177,13 +179,43 @@ func TestForwarder_Close(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	p1, p2 := net.Pipe()
-	defer p1.Close() // p2 is owned by the forwarder.
 
 	f := forward(context.Background(), p1, p2)
 	defer f.Close()
 	require.Nil(t, f.ctx.Err())
 
 	f.Close()
+	require.EqualError(t, f.ctx.Err(), context.Canceled.Error())
+}
+
+func TestForwarder_tryReportError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	p1, p2 := net.Pipe()
+
+	f := forward(context.Background(), p1, p2)
+	defer f.Close()
+
+	select {
+	case err := <-f.errCh:
+		t.Fatalf("expected no error, but got %v", err)
+	default:
+		// We are good.
+	}
+
+	// Report an error.
+	f.tryReportError(errors.New("foo"))
+
+	select {
+	case err := <-f.errCh:
+		require.EqualError(t, err, "foo")
+	default:
+		t.Fatal("expected error, but got none")
+	}
+
+	// Forwarder should be closed.
+	_, err := p1.Write([]byte("foobarbaz"))
+	require.Regexp(t, "closed pipe", err)
 	require.EqualError(t, f.ctx.Err(), context.Canceled.Error())
 }
 
@@ -241,4 +273,211 @@ func TestWrapServerToClientError(t *testing.T) {
 			require.EqualError(t, err, tc.output.Error())
 		}
 	}
+}
+
+func TestSuspendResumeProcessor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		clientProxy, serverProxy := net.Pipe()
+		defer clientProxy.Close()
+		defer serverProxy.Close()
+
+		p := newProcessor(
+			interceptor.NewPGConn(clientProxy),
+			interceptor.NewPGConn(serverProxy),
+		)
+		require.EqualError(t, p.resume(ctx), context.Canceled.Error())
+
+		// Set resumed to true to simulate suspend loop.
+		p.mu.Lock()
+		p.mu.resumed = true
+		p.mu.Unlock()
+		require.EqualError(t, p.suspend(ctx), context.Canceled.Error())
+	})
+
+	// This tests that resume() and suspend() can be called multiple times.
+	// As an aside, we also check that we can suspend when blocked on PeekMsg
+	// because there are no messages.
+	t.Run("already_resumed_or_suspended", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		clientProxy, serverProxy := net.Pipe()
+		defer clientProxy.Close()
+		defer serverProxy.Close()
+
+		p := newProcessor(
+			interceptor.NewPGConn(clientProxy),
+			interceptor.NewPGConn(serverProxy),
+		)
+
+		// Ensure that everything will return a resumed error except 1.
+		errCh := make(chan error, 2)
+		go func() { errCh <- p.resume(ctx) }()
+		go func() { errCh <- p.resume(ctx) }()
+		go func() { errCh <- p.resume(ctx) }()
+		err := <-errCh
+		require.EqualError(t, err, errProcessorResumed.Error())
+		err = <-errCh
+		require.EqualError(t, err, errProcessorResumed.Error())
+
+		// Suspend the last goroutine.
+		err = p.suspend(ctx)
+		require.NoError(t, err)
+
+		// Validate suspension.
+		err = <-errCh
+		require.Nil(t, err)
+		p.mu.Lock()
+		require.False(t, p.mu.resumed)
+		require.False(t, p.mu.inPeek)
+		require.False(t, p.mu.suspendReq)
+		p.mu.Unlock()
+
+		// Suspend a second time.
+		err = p.suspend(ctx)
+		require.NoError(t, err)
+
+		// If already suspended, do nothing.
+		p.mu.Lock()
+		require.False(t, p.mu.resumed)
+		require.False(t, p.mu.inPeek)
+		require.False(t, p.mu.suspendReq)
+		p.mu.Unlock()
+	})
+
+	// Multiple suspend/resumes calls should not cause issues. ForwardMsg should
+	// not be interrupted.
+	t.Run("multiple_resume_suspend_race", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		clientProxy, client := net.Pipe()
+		defer clientProxy.Close()
+		defer client.Close()
+		serverProxy, server := net.Pipe()
+		defer serverProxy.Close()
+		defer server.Close()
+
+		p := newProcessor(
+			interceptor.NewPGConn(clientProxy),
+			interceptor.NewPGConn(serverProxy),
+		)
+
+		const (
+			queryCount  = 100
+			concurrency = 200
+		)
+
+		// Client writes messages to be forwarded.
+		buf := new(bytes.Buffer)
+		q := (&pgproto3.Query{String: "SELECT 1"}).Encode(nil)
+		for i := 0; i < queryCount; i++ {
+			// Alternate between SELECT 1 and 2 to ensure correctness.
+			if i%2 == 0 {
+				q[12] = '1'
+			} else {
+				q[12] = '2'
+			}
+			_, _ = buf.Write(q)
+		}
+		go func() {
+			// Simulate slow writes by writing byte by byte.
+			_, _ = io.Copy(client, iotest.OneByteReader(buf))
+		}()
+
+		// Server reads messages that are forwarded.
+		msgCh := make(chan pgproto3.FrontendMessage, queryCount)
+		go func() {
+			backend := interceptor.NewBackendConn(server)
+			for {
+				msg, err := backend.ReadMsg()
+				if err != nil {
+					return
+				}
+				msgCh <- msg
+			}
+		}()
+
+		// Start the suspend/resume calls.
+		errResumeCh := make(chan error, concurrency)
+		errSuspendCh := make(chan error, concurrency)
+		for i := 1; i <= concurrency; i++ {
+			go func(p *processor, i int) {
+				time.Sleep(jitteredInterval(time.Duration((i*2)+500) * time.Millisecond))
+				errResumeCh <- p.resume(ctx)
+			}(p, i)
+			go func(p *processor, i int) {
+				time.Sleep(jitteredInterval(time.Duration((i*2)+500) * time.Millisecond))
+				errSuspendCh <- p.suspend(ctx)
+			}(p, i)
+		}
+
+		// Wait until all resume calls except 1 have returned.
+		for i := 0; i < concurrency-1; i++ {
+			err := <-errResumeCh
+			// If error is not nil, it has to be an already resumed error.
+			if err != nil {
+				require.EqualError(t, err, errProcessorResumed.Error())
+			}
+		}
+
+		// Wait until the last one returns. We can guarantee that this is for
+		// the last resume because all the other resume calls have returned.
+		var lastErr error
+		require.Eventually(t, func() bool {
+			select {
+			case lastErr = <-errResumeCh:
+				return true
+			default:
+				_ = p.suspend(ctx)
+				return false
+			}
+		}, 10*time.Second, 100*time.Millisecond)
+		// If error is not nil, it has to be an already resumed error. This
+		// would happen if suspend was the last to be called within all those
+		// suspend/resume calls.
+		if lastErr != nil {
+			require.EqualError(t, lastErr, errProcessorResumed.Error())
+		}
+
+		// Wait until all initial suspend calls have returned.
+		for i := 0; i < concurrency; i++ {
+			err := <-errSuspendCh
+			// If error is not nil, it has to be a suspend in-progress error.
+			if err != nil {
+				require.EqualError(t, err, errSuspendInProgress.Error())
+			}
+		}
+
+		// At this point, we know that all pending resume and suspend calls
+		// have returned. Run the final resumption to make sure all packets
+		// have been forwarded.
+		go func(p *processor) { _ = p.resume(ctx) }(p)
+
+		// Now read all the messages on the server for correctness.
+		for i := 0; i < queryCount; i++ {
+			msg := <-msgCh
+			q := msg.(*pgproto3.Query)
+
+			expectedStr := "SELECT 1"
+			if i%2 == 1 {
+				expectedStr = "SELECT 2"
+			}
+			require.Equal(t, expectedStr, q.String)
+		}
+
+		// Suspend the final goroutine.
+		err := p.suspend(ctx)
+		require.NoError(t, err)
+	})
+}
+
+// jitteredInterval returns a randomly jittered (+/-50%) duration from interval.
+func jitteredInterval(interval time.Duration) time.Duration {
+	return time.Duration(float64(interval) * (0.5 + 0.5*rand.Float64()))
 }

--- a/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "base.go",
         "chunkreader.go",
         "frontend_conn.go",
+        "pg_conn.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor",
     visibility = ["//visibility:public"],
@@ -26,6 +27,7 @@ go_test(
         "chunkreader_test.go",
         "frontend_conn_test.go",
         "interceptor_test.go",
+        "pg_conn_test.go",
     ],
     embed = [":interceptor"],
     deps = [

--- a/pkg/ccl/sqlproxyccl/interceptor/pg_conn.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/pg_conn.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package interceptor
+
+import "net"
+
+// PGConn wraps both net.Conn and pgInterceptor as one object. This is the
+// net.Conn version for pgInterceptor.
+type PGConn struct {
+	net.Conn
+	*pgInterceptor
+}
+
+// NewPGConn creates a PGConn using a default buffer size of 8KB.
+func NewPGConn(conn net.Conn) *PGConn {
+	return &PGConn{
+		Conn:          conn,
+		pgInterceptor: newPgInterceptor(conn, defaultBufferSize),
+	}
+}

--- a/pkg/ccl/sqlproxyccl/interceptor/pg_conn_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/pg_conn_test.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package interceptor_test
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// Note that the tests here are shallow. For detailed ones, see the tests for
+// the internal interceptor in base_test.go.
+func TestPGConn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	q := (&pgproto3.Query{String: "SELECT 1"}).Encode(nil)
+
+	writeAsync := func(t *testing.T, w io.Writer) <-chan error {
+		t.Helper()
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := w.Write(q)
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	t.Run("net.Conn/Write", func(t *testing.T) {
+		external, proxy := net.Pipe()
+
+		c := interceptor.NewPGConn(proxy)
+		errCh := writeAsync(t, c)
+
+		bc := interceptor.NewBackendConn(external)
+		msg, err := bc.ReadMsg()
+		require.NoError(t, err)
+		rmsg, ok := msg.(*pgproto3.Query)
+		require.True(t, ok)
+		require.Equal(t, "SELECT 1", rmsg.String)
+
+		err = <-errCh
+		require.Nil(t, err)
+	})
+
+	t.Run("pgInterceptor/ForwardMsg", func(t *testing.T) {
+		external, proxy := net.Pipe()
+		errCh := writeAsync(t, external)
+		dst := new(bytes.Buffer)
+
+		c := interceptor.NewPGConn(proxy)
+
+		n, err := c.ForwardMsg(dst)
+		require.NoError(t, err)
+		require.Equal(t, 14, n)
+		require.Equal(t, 14, dst.Len())
+
+		err = <-errCh
+		require.Nil(t, err)
+	})
+}


### PR DESCRIPTION
Previously, we were treating request/response processors as forwarder methods,
and the original intention was to perform a connection migration inline with
the forwarding. However, this has proved to cause confusions and complications.
The new connection migration design uses a different approach by performing
the connection migration out-of-band with the forwarding processors. For this
to work, we would need to be able to suspend and resume those processors.
This commit implements support for that.

Release justification: sqlproxy-only change, and only used within
CockroachCloud.

Release note: None