### PR TITLE
protectedts: flip knob to enable multi-tenant PTS in clusters

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6437,6 +6437,9 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 	conn := tc.ServerConn(0)
 	runner := sqlutils.MakeSQLRunner(conn)
 	runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES)")
+	runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms';")
+	runner.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'") // speeds up the test
+
 	close(allowRequest)
 
 	for _, testrun := range []struct {
@@ -6466,7 +6469,6 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 		baseBackupURI := "nodelocal://0/foo" + testrun.name
 		testrun.runBackup(t, fmt.Sprintf(`BACKUP TABLE FOO TO '%s'`, baseBackupURI), runner) // create a base backup.
 		allowRequest = make(chan struct{})
-		runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.poll_interval = '100ms';")
 		runner.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING gc.ttlseconds = 1;")
 		rRand, _ := randutil.NewTestRand()
 		writeGarbage := func(from, to int) {
@@ -6925,8 +6927,6 @@ func TestRestoreErrorPropagates(t *testing.T) {
 
 // TestProtectedTimestampsFailDueToLimits ensures that when creating a protected
 // timestamp record fails, we return the correct error.
-//
-// TODO(adityamaru): Remove in 22.2 once no records protect spans.
 func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -6942,12 +6942,32 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 	runner := sqlutils.MakeSQLRunner(db)
 	runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES)")
 	runner.Exec(t, "CREATE TABLE bar (k INT PRIMARY KEY, v BYTES)")
-	runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.max_spans = 1")
+	runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.max_bytes = 1")
 
 	// Creating the protected timestamp record should fail because there are too
 	// many spans. Ensure that we get the appropriate error.
 	_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo'`)
-	require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+2 > 1 spans")
+	require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+30 > 1 bytes")
+
+	// TODO(adityamaru): Remove in 22.2 once no records protect spans.
+	t.Run("deprecated-spans-limit", func(t *testing.T) {
+		params := base.TestClusterArgs{}
+		params.ServerArgs.ExternalIODir = dir
+		params.ServerArgs.Knobs.ProtectedTS = &protectedts.TestingKnobs{
+			DisableProtectedTimestampForMultiTenant: true}
+		tc := testcluster.StartTestCluster(t, 1, params)
+		defer tc.Stopper().Stop(ctx)
+		db := tc.ServerConn(0)
+		runner := sqlutils.MakeSQLRunner(db)
+		runner.Exec(t, "CREATE TABLE foo (k INT PRIMARY KEY, v BYTES)")
+		runner.Exec(t, "CREATE TABLE bar (k INT PRIMARY KEY, v BYTES)")
+		runner.Exec(t, "SET CLUSTER SETTING kv.protectedts.max_spans = 1")
+
+		// Creating the protected timestamp record should fail because there are too
+		// many spans. Ensure that we get the appropriate error.
+		_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo'`)
+		require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+2 > 1 spans")
+	})
 }
 
 func TestPaginatedBackupTenant(t *testing.T) {
@@ -9740,8 +9760,6 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 		DisableGCQueue:            true,
 		DisableLastProcessedCheck: true,
 	}
-	params.ServerArgs.Knobs.ProtectedTS = &protectedts.TestingKnobs{
-		EnableProtectedTimestampForMultiTenant: true}
 	params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	tc := testcluster.StartTestCluster(t, 1, params)
 	defer tc.Stopper().Stop(ctx)

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -182,6 +182,8 @@ go_test(
         "//pkg/server/status",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
+        "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigptsreader",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/descbuilder",

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -138,9 +138,6 @@ func TestJobsProtectedTimestamp(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
-				ProtectedTS: &protectedts.TestingKnobs{
-					EnableProtectedTimestampForMultiTenant: true,
-				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},
 		},
@@ -259,15 +256,7 @@ func TestSchedulesProtectedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				ProtectedTS: &protectedts.TestingKnobs{
-					EnableProtectedTimestampForMultiTenant: true,
-				},
-			},
-		},
-	})
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
 	// Now I want to create some artifacts that should get reconciled away and

--- a/pkg/ccl/spanconfigccl/spanconfigcomparedccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigcomparedccl/datadriven_test.go
@@ -110,7 +110,7 @@ func TestDataDriven(t *testing.T) {
 			tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '20ms'`)
 		}
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs, nil /* ptsKnobs */)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		kvSubscriber := tc.Server(0).SpanConfigKVSubscriber().(spanconfig.KVSubscriber)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/utilccl",
         "//pkg/jobs",
-        "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -19,7 +19,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
@@ -96,13 +95,11 @@ func TestDataDriven(t *testing.T) {
 			// Checkpoint noops frequently; speeds this test up.
 			SQLWatcherCheckpointNoopsEveryDurationOverride: 100 * time.Millisecond,
 		}
-		ptsKnobs := &protectedts.TestingKnobs{EnableProtectedTimestampForMultiTenant: true}
 		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speeds up test
 					SpanConfig:       scKnobs,
-					ProtectedTS:      ptsKnobs,
 				},
 			},
 		})
@@ -114,7 +111,7 @@ func TestDataDriven(t *testing.T) {
 			tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
 		}
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs, ptsKnobs)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		systemTenant := spanConfigTestCluster.InitializeTenant(ctx, roachpb.SystemTenantID)

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
@@ -75,7 +75,7 @@ func TestDataDriven(t *testing.T) {
 		})
 		defer tc.Stopper().Stop(ctx)
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs, nil)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		var tenant *spanconfigtestcluster.Tenant

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
         "//pkg/ccl/partitionccl",
         "//pkg/ccl/utilccl",
         "//pkg/config/zonepb",
-        "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -19,7 +19,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
@@ -87,23 +86,17 @@ func TestDataDriven(t *testing.T) {
 		// test cluster).
 		ManagerDisableJobCreation: true,
 	}
-	// TODO(adityamaru): Delete once the value for this knob defaults to true
-	// prior to release-22.1.
-	ptsKnobs := &protectedts.TestingKnobs{
-		EnableProtectedTimestampForMultiTenant: true,
-	}
 	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
 		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
-					SpanConfig:  scKnobs,
-					ProtectedTS: ptsKnobs,
+					SpanConfig: scKnobs,
 				},
 			},
 		})
 		defer tc.Stopper().Stop(ctx)
 
-		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs, ptsKnobs)
+		spanConfigTestCluster := spanconfigtestcluster.NewHandle(t, tc, scKnobs)
 		defer spanConfigTestCluster.Cleanup()
 
 		var tenant *spanconfigtestcluster.Tenant

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
@@ -16,7 +16,6 @@ go_test(
         "//pkg/jobs",
         "//pkg/keys",
         "//pkg/kv/kvclient/rangefeed",
-        "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/securitytest",

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
@@ -66,9 +65,6 @@ func TestSQLWatcherReactsToUpdates(t *testing.T) {
 					ManagerDisableJobCreation: true, // disable the automatic job creation.
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(), // speed up schema changes.
-				ProtectedTS: &protectedts.TestingKnobs{
-					EnableProtectedTimestampForMultiTenant: true,
-				},
 			},
 		},
 	})

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -317,6 +317,7 @@ go_test(
         "//pkg/kv",
         "//pkg/kv/kvclient",
         "//pkg/kv/kvclient/kvcoord",
+        "//pkg/kv/kvclient/rangefeed/rangefeedcache",
         "//pkg/kv/kvserver/abortspan",
         "//pkg/kv/kvserver/apply",
         "//pkg/kv/kvserver/batcheval",

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -41,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
@@ -3464,8 +3466,27 @@ func TestStrictGCEnforcement(t *testing.T) {
 	}
 	ctx := context.Background()
 
+	var mu struct {
+		syncutil.Mutex
+		blockOnTimestampUpdate func()
+	}
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					KVSubscriberRangeFeedKnobs: &rangefeedcache.TestingKnobs{
+						OnTimestampAdvance: func(timestamp hlc.Timestamp) {
+							mu.Lock()
+							defer mu.Unlock()
+							if mu.blockOnTimestampUpdate != nil {
+								mu.blockOnTimestampUpdate()
+							}
+						},
+					},
+				},
+			},
+		},
 	})
 	defer tc.Stopper().Stop(ctx)
 
@@ -3483,11 +3504,12 @@ func TestStrictGCEnforcement(t *testing.T) {
 		tenSecondsAgo hlc.Timestamp // written in setup
 		tableKey      = keys.SystemSQLCodec.TablePrefix(tableID)
 		tableSpan     = roachpb.Span{Key: tableKey, EndKey: tableKey.PrefixEnd()}
+		tableTarget   = ptpb.MakeSchemaObjectsTarget([]descpb.ID{descpb.ID(tableID)})
 		mkRecord      = func() ptpb.Record {
 			return ptpb.Record{
-				ID:              uuid.MakeV4().GetBytes(),
-				Timestamp:       tenSecondsAgo.Add(-10*time.Second.Nanoseconds(), 0),
-				DeprecatedSpans: []roachpb.Span{tableSpan},
+				ID:        uuid.MakeV4().GetBytes(),
+				Timestamp: tenSecondsAgo.Add(-10*time.Second.Nanoseconds(), 0),
+				Target:    tableTarget,
 			}
 		}
 		mkStaleTxn = func() *kv.Txn {
@@ -3511,24 +3533,6 @@ func TestStrictGCEnforcement(t *testing.T) {
 		assertScanOk = func(t *testing.T) {
 			t.Helper()
 			require.NoError(t, performScan())
-		}
-		// Make sure the cache has been updated. Once it has then we know it won't
-		// be for minutes. It should read on startup.
-		waitForCacheAfter = func(t *testing.T, min hlc.Timestamp) {
-			t.Helper()
-			testutils.SucceedsSoon(t, func() error {
-				for i := 0; i < tc.NumServers(); i++ {
-					ptsReader := tc.GetFirstStoreFromServer(t, 0).GetStoreConfig().ProtectedTimestampReader
-					_, asOf, err := ptsReader.GetProtectionTimestamps(ctx, tableSpan)
-					if err != nil {
-						return err
-					}
-					if asOf.Less(min) {
-						return errors.Errorf("not yet read")
-					}
-				}
-				return nil
-			})
 		}
 		setGCTTL = func(t *testing.T, object string, exp int) {
 			t.Helper()
@@ -3586,16 +3590,26 @@ func TestStrictGCEnforcement(t *testing.T) {
 				require.NoError(t, err)
 			}
 		}
-		refreshCacheAndUpdatePTSState = func(t *testing.T, nodeID roachpb.NodeID) {
+		// waitForProtectionAndReadProtectedTimestamps waits until the
+		// `protectionTimestamp` has been reconciled to KV, and then updates the
+		// replica's view of the protections that apply on it.
+		waitForProtectionAndReadProtectedTimestamps = func(t *testing.T, nodeID roachpb.NodeID,
+			protectionTimestamp hlc.Timestamp, span roachpb.Span) {
 			for i := 0; i < tc.NumServers(); i++ {
 				if tc.Server(i).NodeID() != nodeID {
 					continue
 				}
-				ptp := tc.Server(i).ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
-				require.NoError(t, ptp.Refresh(ctx, tc.Server(i).Clock().Now()))
+				ptsReader := tc.GetFirstStoreFromServer(t, i).GetStoreConfig().ProtectedTimestampReader
 				_, r := getFirstStoreReplica(t, tc.Server(i), tableKey)
-				err := r.ReadProtectedTimestamps(ctx)
-				require.NoError(t, err)
+				testutils.SucceedsSoon(t, func() error {
+					if err := verifyProtectionTimestampExistsOnSpans(ctx, t, tc, ptsReader, protectionTimestamp,
+						[]roachpb.Span{span}); err != nil {
+						return errors.Newf("protection timestamp %s does not exist on span %s",
+							protectionTimestamp, span)
+					}
+					return nil
+				})
+				require.NoError(t, r.ReadProtectedTimestamps(ctx))
 			}
 		}
 	)
@@ -3610,8 +3624,8 @@ func TestStrictGCEnforcement(t *testing.T) {
 		require.NoError(t, err)
 
 		setTableGCTTL(t, 1)
-		waitForCacheAfter(t, hlc.Timestamp{})
 
+		sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10 ms'")
 		defer sqlDB.Exec(t, `SET CLUSTER SETTING kv.gc_ttl.strict_enforcement.enabled = DEFAULT`)
 		setStrictGC(t, true)
 		tenSecondsAgo = tc.Server(0).Clock().Now().Add(-10*time.Second.Nanoseconds(), 0)
@@ -3640,22 +3654,41 @@ func TestStrictGCEnforcement(t *testing.T) {
 		require.NoError(t, err)
 	})
 	t.Run("protected timestamps are respected", func(t *testing.T) {
-		waitForCacheAfter(t, hlc.Timestamp{})
+		// Block the KVSubscriber rangefeed from progressing.
+		blockKVSubscriberCh := make(chan struct{})
+		var isBlocked bool
+		mu.Lock()
+		mu.blockOnTimestampUpdate = func() {
+			isBlocked = true
+			<-blockKVSubscriberCh
+		}
+		mu.Unlock()
+
+		// Ensure that the KVSubscriber has been blocked.
+		testutils.SucceedsSoon(t, func() error {
+			if !isBlocked {
+				return errors.New("kvsubscriber not blocked yet")
+			}
+			return nil
+		})
+
 		ptp := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
 		assertScanRejected(t)
-		// Create a protected timestamp, don't verify it, make sure it's not
-		// respected.
+		// Create a protected timestamp, and make sure it's not respected since the
+		// KVSubscriber is blocked.
 		rec := mkRecord()
 		require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			return ptp.Protect(ctx, txn, &rec)
 		}))
 		assertScanRejected(t)
 
+		// Unblock the KVSubscriber and wait for the PTS record to reach KV.
+		close(blockKVSubscriberCh)
 		desc, err := tc.LookupRange(tableKey)
 		require.NoError(t, err)
 		target, err := tc.FindRangeLeaseHolder(desc, nil)
 		require.NoError(t, err)
-		refreshCacheAndUpdatePTSState(t, target.NodeID)
+		waitForProtectionAndReadProtectedTimestamps(t, target.NodeID, rec.Timestamp, tableSpan)
 		assertScanOk(t)
 
 		// Transfer the lease and demonstrate that the query succeeds because we're

--- a/pkg/kv/kvserver/protectedts/ptcache/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptcache/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/sqlutil",
         "//pkg/testutils",

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler_test.go
@@ -37,75 +37,85 @@ func TestReconciler(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop(ctx)
-
-	// Now I want to create some artifacts that should get reconciled away and
-	// then make sure that they do and others which should not do not.
-	s0 := tc.Server(0)
-	ptp := s0.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
-
-	settings := cluster.MakeTestingClusterSettings()
-	const testTaskType = "foo"
-	var state = struct {
-		mu       syncutil.Mutex
-		toRemove map[string]struct{}
-	}{}
-	state.toRemove = map[string]struct{}{}
-	r := ptreconcile.New(settings, s0.DB(), ptp,
-		ptreconcile.StatusFuncs{
-			testTaskType: func(
-				ctx context.Context, txn *kv.Txn, meta []byte,
-			) (shouldRemove bool, err error) {
-				state.mu.Lock()
-				defer state.mu.Unlock()
-				_, shouldRemove = state.toRemove[string(meta)]
-				return shouldRemove, nil
+	testutils.RunTrueAndFalse(t, "reconciler", func(t *testing.T, withDeprecatedSpans bool) {
+		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					ProtectedTS: &protectedts.TestingKnobs{DisableProtectedTimestampForMultiTenant: withDeprecatedSpans},
+				},
 			},
 		})
-	require.NoError(t, r.StartReconciler(ctx, s0.Stopper()))
-	recMeta := "a"
-	rec1 := ptpb.Record{
-		ID:        uuid.MakeV4().GetBytes(),
-		Timestamp: s0.Clock().Now(),
-		Mode:      ptpb.PROTECT_AFTER,
-		MetaType:  testTaskType,
-		Meta:      []byte(recMeta),
-		DeprecatedSpans: []roachpb.Span{
-			{Key: keys.MinKey, EndKey: keys.MaxKey},
-		},
-	}
-	require.NoError(t, s0.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return ptp.Protect(ctx, txn, &rec1)
-	}))
+		defer tc.Stopper().Stop(ctx)
 
-	t.Run("update settings", func(t *testing.T) {
-		ptreconcile.ReconcileInterval.Override(ctx, &settings.SV, time.Millisecond)
-		testutils.SucceedsSoon(t, func() error {
-			require.Equal(t, int64(0), r.Metrics().RecordsRemoved.Count())
-			require.Equal(t, int64(0), r.Metrics().ReconciliationErrors.Count())
-			if processed := r.Metrics().RecordsProcessed.Count(); processed < 1 {
-				return errors.Errorf("expected processed to be at least 1, got %d", processed)
-			}
-			return nil
-		})
-	})
-	t.Run("reconcile", func(t *testing.T) {
-		state.mu.Lock()
-		state.toRemove[recMeta] = struct{}{}
-		state.mu.Unlock()
+		// Now I want to create some artifacts that should get reconciled away and
+		// then make sure that they do and others which should not do not.
+		s0 := tc.Server(0)
+		ptp := s0.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
 
-		ptreconcile.ReconcileInterval.Override(ctx, &settings.SV, time.Millisecond)
-		testutils.SucceedsSoon(t, func() error {
-			require.Equal(t, int64(0), r.Metrics().ReconciliationErrors.Count())
-			if removed := r.Metrics().RecordsRemoved.Count(); removed != 1 {
-				return errors.Errorf("expected processed to be 1, got %d", removed)
-			}
-			return nil
-		})
-		require.Regexp(t, protectedts.ErrNotExists, s0.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			_, err := ptp.GetRecord(ctx, txn, rec1.ID.GetUUID())
-			return err
+		settings := cluster.MakeTestingClusterSettings()
+		const testTaskType = "foo"
+		var state = struct {
+			mu       syncutil.Mutex
+			toRemove map[string]struct{}
+		}{}
+		state.toRemove = map[string]struct{}{}
+		r := ptreconcile.New(settings, s0.DB(), ptp,
+			ptreconcile.StatusFuncs{
+				testTaskType: func(
+					ctx context.Context, txn *kv.Txn, meta []byte,
+				) (shouldRemove bool, err error) {
+					state.mu.Lock()
+					defer state.mu.Unlock()
+					_, shouldRemove = state.toRemove[string(meta)]
+					return shouldRemove, nil
+				},
+			})
+		require.NoError(t, r.StartReconciler(ctx, s0.Stopper()))
+		recMeta := "a"
+		rec1 := ptpb.Record{
+			ID:        uuid.MakeV4().GetBytes(),
+			Timestamp: s0.Clock().Now(),
+			Mode:      ptpb.PROTECT_AFTER,
+			MetaType:  testTaskType,
+			Meta:      []byte(recMeta),
+		}
+		if withDeprecatedSpans {
+			rec1.DeprecatedSpans = []roachpb.Span{{Key: keys.MinKey, EndKey: keys.MaxKey}}
+		} else {
+			rec1.Target = ptpb.MakeClusterTarget()
+		}
+		require.NoError(t, s0.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			return ptp.Protect(ctx, txn, &rec1)
 		}))
+
+		t.Run("update settings", func(t *testing.T) {
+			ptreconcile.ReconcileInterval.Override(ctx, &settings.SV, time.Millisecond)
+			testutils.SucceedsSoon(t, func() error {
+				require.Equal(t, int64(0), r.Metrics().RecordsRemoved.Count())
+				require.Equal(t, int64(0), r.Metrics().ReconciliationErrors.Count())
+				if processed := r.Metrics().RecordsProcessed.Count(); processed < 1 {
+					return errors.Errorf("expected processed to be at least 1, got %d", processed)
+				}
+				return nil
+			})
+		})
+		t.Run("reconcile", func(t *testing.T) {
+			state.mu.Lock()
+			state.toRemove[recMeta] = struct{}{}
+			state.mu.Unlock()
+
+			ptreconcile.ReconcileInterval.Override(ctx, &settings.SV, time.Millisecond)
+			testutils.SucceedsSoon(t, func() error {
+				require.Equal(t, int64(0), r.Metrics().ReconciliationErrors.Count())
+				if removed := r.Metrics().RecordsRemoved.Count(); removed != 1 {
+					return errors.Errorf("expected processed to be 1, got %d", removed)
+				}
+				return nil
+			})
+			require.Regexp(t, protectedts.ErrNotExists, s0.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				_, err := ptp.GetRecord(ctx, txn, rec1.ID.GetUUID())
+				return err
+			}))
+		})
 	})
 }

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -52,11 +52,12 @@ type storage struct {
 
 var _ protectedts.Storage = (*storage)(nil)
 
+// TODO(adityamaru): Delete in 22.2.
 func useDeprecatedProtectedTSStorage(
 	ctx context.Context, st *cluster.Settings, knobs *protectedts.TestingKnobs,
 ) bool {
 	return !st.Version.IsActive(ctx, clusterversion.AlterSystemProtectedTimestampAddColumn) ||
-		!knobs.EnableProtectedTimestampForMultiTenant
+		knobs.DisableProtectedTimestampForMultiTenant
 }
 
 // New creates a new Storage.

--- a/pkg/kv/kvserver/protectedts/ptstorage/validate_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/validate_test.go
@@ -79,7 +79,7 @@ func TestValidateRecordForProtect(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
 			require.Equal(t, validateRecordForProtect(context.Background(), tc.r, st,
-				&protectedts.TestingKnobs{EnableProtectedTimestampForMultiTenant: true}), tc.err)
+				&protectedts.TestingKnobs{}), tc.err)
 		})
 
 		// Test that prior to the `AlterSystemProtectedTimestampAddColumn` migration
@@ -94,7 +94,7 @@ func TestValidateRecordForProtect(t *testing.T) {
 			}
 			st := cluster.MakeTestingClusterSettings()
 			require.Equal(t, validateRecordForProtect(context.Background(), r, st,
-				&protectedts.TestingKnobs{}), errEmptySpans)
+				&protectedts.TestingKnobs{DisableProtectedTimestampForMultiTenant: true}), errEmptySpans)
 		})
 	}
 }

--- a/pkg/kv/kvserver/protectedts/testing_knobs.go
+++ b/pkg/kv/kvserver/protectedts/testing_knobs.go
@@ -15,12 +15,12 @@ import "github.com/cockroachdb/cockroach/pkg/base"
 // TestingKnobs provide fine-grained control over the various span config
 // components for testing.
 type TestingKnobs struct {
-	// EnableProtectedTimestampForMultiTenant when set to true, runs the protected
-	// timestamp subsystem that depends on span configuration reconciliation.
+	// DisableProtectedTimestampForMultiTenant when set to true, runs the
+	// deprecated protected timestamp subsystem that does not work in a
+	// multi-tenant environment.
 	//
-	// TODO(adityamaru,arulajmani): Default this to true, or flip it to
-	// `DisableProtectedTimestampForMultiTenant` prior to release 22.1.
-	EnableProtectedTimestampForMultiTenant bool
+	// TODO(adityamaru): Delete in 22.2.
+	DisableProtectedTimestampForMultiTenant bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/spanconfig/spanconfigptsreader/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigptsreader/BUILD.bazel
@@ -6,12 +6,14 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
         "//pkg/spanconfig",
         "//pkg/testutils",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqlwatcher/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
         "//pkg/jobs/jobsprotectedts",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/security",

--- a/pkg/spanconfig/spanconfigsqlwatcher/protectedtsdecoder_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/protectedtsdecoder_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqlwatcher"
@@ -37,12 +36,7 @@ func TestProtectedTimestampDecoder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				ProtectedTS: &protectedts.TestingKnobs{EnableProtectedTimestampForMultiTenant: true}},
-		},
-	})
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
 	s0 := tc.Server(0)

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -33,26 +32,21 @@ import (
 // cluster while providing convenient, scoped access to each tenant's specific
 // span config primitives. It's not safe for concurrent use.
 type Handle struct {
-	t        *testing.T
-	tc       *testcluster.TestCluster
-	ts       map[roachpb.TenantID]*Tenant
-	scKnobs  *spanconfig.TestingKnobs
-	ptsKnobs *protectedts.TestingKnobs
+	t       *testing.T
+	tc      *testcluster.TestCluster
+	ts      map[roachpb.TenantID]*Tenant
+	scKnobs *spanconfig.TestingKnobs
 }
 
 // NewHandle returns a new Handle.
 func NewHandle(
-	t *testing.T,
-	tc *testcluster.TestCluster,
-	scKnobs *spanconfig.TestingKnobs,
-	ptsKnobs *protectedts.TestingKnobs,
+	t *testing.T, tc *testcluster.TestCluster, scKnobs *spanconfig.TestingKnobs,
 ) *Handle {
 	return &Handle{
-		t:        t,
-		tc:       tc,
-		ts:       make(map[roachpb.TenantID]*Tenant),
-		scKnobs:  scKnobs,
-		ptsKnobs: ptsKnobs,
+		t:       t,
+		tc:      tc,
+		ts:      make(map[roachpb.TenantID]*Tenant),
+		scKnobs: scKnobs,
 	}
 }
 
@@ -69,8 +63,7 @@ func (h *Handle) InitializeTenant(ctx context.Context, tenID roachpb.TenantID) *
 		tenantArgs := base.TestTenantArgs{
 			TenantID: tenID,
 			TestingKnobs: base.TestingKnobs{
-				SpanConfig:  h.scKnobs,
-				ProtectedTS: h.ptsKnobs,
+				SpanConfig: h.scKnobs,
 			},
 		}
 		var err error


### PR DESCRIPTION
This change switches the `EnableProtectedTimestampForMultiTenant`
testing knob to `DisableProtectedTimestampForMultiTenant`. This means
that all tests and clusters will now run with the ptpb.Target and spanconfig backed
protectedts infrastructure by default.



Informs: #73727

Release note: None

Release justification: high impact change to enable new functionality.