### PR TITLE
ui: add locality field to Hot ranges page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/localities.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/localities.ts
@@ -66,3 +66,19 @@ export interface LocalityTree {
   };
   nodes: INodeStatus[];
 }
+
+// selectNodeLocalities returns a map of node ID to stringified version
+// of locality values (i.e. "region=us-east1, az=2").
+export const selectNodeLocalities = createSelector(
+  selectCommissionedNodeStatuses,
+  nodes => {
+    return new Map(
+      nodes.map(n => {
+        const locality = (n.desc?.locality?.tiers || [])
+          .map(t => `${t.key}=${t.value}`)
+          .join(", ");
+        return [n.desc.node_id, locality];
+      }),
+    );
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -29,9 +29,13 @@ const cx = classNames.bind(styles);
 interface HotRangesTableProps {
   hotRangesList: cockroach.server.serverpb.HotRangesResponseV2.IHotRange[];
   lastUpdate?: string;
+  nodeIdToLocalityMap: Map<number, string>;
 }
 
-const HotRangesTable = ({ hotRangesList }: HotRangesTableProps) => {
+const HotRangesTable = ({
+  hotRangesList,
+  nodeIdToLocalityMap,
+}: HotRangesTableProps) => {
   const [pagination, setPagination] = useState({
     pageSize: PAGE_SIZE,
     current: 1,
@@ -146,6 +150,16 @@ const HotRangesTable = ({ hotRangesList }: HotRangesTableProps) => {
       ),
       cell: val => <>{val.index_name}</>,
       sort: val => val.index_name,
+    },
+    {
+      name: "locality",
+      title: (
+        <Tooltip placement="bottom" title="Locality">
+          Locality
+        </Tooltip>
+      ),
+      cell: val => <>{nodeIdToLocalityMap.get(val.node_id)}</>,
+      sort: val => nodeIdToLocalityMap.get(val.node_id),
     },
   ];
 

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
@@ -26,6 +26,7 @@ import {
   lastErrorSelector,
   lastSetAtSelector,
 } from "src/redux/hotRanges";
+import { selectNodeLocalities } from "src/redux/localities";
 
 const cx = classNames.bind(styles);
 const HotRangesRequest = cockroach.server.serverpb.HotRangesRequest;
@@ -37,6 +38,7 @@ const HotRangesPage = () => {
   const lastError = useSelector(lastErrorSelector);
   const lastSetAt = useSelector(lastSetAtSelector);
   const isLoading = useSelector(isLoadingSelector);
+  const nodeIdToLocalityMap = useSelector(selectNodeLocalities);
 
   useEffect(() => {
     if (!isValid) {
@@ -86,6 +88,7 @@ const HotRangesPage = () => {
             <HotRangesTable
               hotRangesList={hotRanges}
               lastUpdate={lastSetAt && formatCurrentDateTime(lastSetAt?.utc())}
+              nodeIdToLocalityMap={nodeIdToLocalityMap}
             />
           )}
           page={undefined}


### PR DESCRIPTION
Before, Hot Ranges page provided a list of hot ranges
info without localities of nodes where range is stored.
This information is very useful during investigation of
hot ranges.

Current change, adds one more column to hot ranges table
with localities represented in human-readable way.

Release note: None

Release justification: bug fixes and low-risk updates to new functionality

<img width="1557" alt="Screen Shot 2022-03-08 at 16 58 19" src="https://user-images.githubusercontent.com/3106437/157265104-766c7045-9a38-4f39-a504-4cf9a3e4fd7d.png">
