### PR TITLE
kvserver: maybe delay snapshot ingestion

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -496,6 +496,12 @@ var (
 		Measurement: "Snapshots",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRangeSnapshotsTotalDelay = metric.Metadata{
+		Name:        "range.snapshots.delay-total",
+		Help:        "Amount by which evaluation of snapshot requests was delayed",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaRangeRaftLeaderTransfers = metric.Metadata{
 		Name:        "range.raftleadertransfers",
 		Help:        "Number of raft leader transfers",
@@ -1392,6 +1398,7 @@ type StoreMetrics struct {
 	RangeSnapshotsAppliedByVoters                *metric.Counter
 	RangeSnapshotsAppliedForInitialUpreplication *metric.Counter
 	RangeSnapshotsAppliedByNonVoters             *metric.Counter
+	RangeSnapshotsProposalTotalDelay             *metric.Counter
 	RangeRaftLeaderTransfers                     *metric.Counter
 	RangeLossOfQuorumRecoveries                  *metric.Counter
 
@@ -1828,6 +1835,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RangeSnapshotsAppliedByVoters: metric.NewCounter(metaRangeSnapshotsAppliedByVoters),
 		RangeSnapshotsAppliedForInitialUpreplication: metric.NewCounter(metaRangeSnapshotsAppliedForInitialUpreplication),
 		RangeSnapshotsAppliedByNonVoters:             metric.NewCounter(metaRangeSnapshotsAppliedByNonVoter),
+		RangeSnapshotsProposalTotalDelay:             metric.NewCounter(metaRangeSnapshotsTotalDelay),
 		RangeRaftLeaderTransfers:                     metric.NewCounter(metaRangeRaftLeaderTransfers),
 		RangeLossOfQuorumRecoveries:                  metric.NewCounter(metaRangeLossOfQuorumRecoveries),
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -589,6 +589,12 @@ var charts = []sectionDescription{
 					"range.snapshots.applied-non-voter",
 				},
 			},
+			{
+				Title: "Snapshot Delays",
+				Metrics: []string{
+					"range.snapshots.delay-total",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Previously, upon receiving a snapshot the store would not check store
health before applying the snapshot. This can result in overload in the
case where the store is already unhealthy. This patch adds a
pre-ingestion check to avoid overloading the store.

The backpressure applied is configurable with
`rocksdb.ingest_backpressure.l0_file_count_threshold` and
`rocksdb.ingest_backpressure.max_delay`. To disable snapshot
backpressure, such that no delay is applied, the cluster settings can be
configured to:

`SET CLUSTER SETTING rocksdb.ingest_backpressure.l0_file_count_threshold = 99999999`
or
`SET CLUSTER SETTING rocksdb.ingest_backpressure.max_delay = 0`

touches: https://github.com/cockroachdb/cockroach/issues/74694

Release note ops change: Delay snapshot ingestion when the store is
unhealthy. The cumulative time that requests are delayed is tracked by
`range.snapshots.delay.total`. This backpressure is configurable with
`rocksdb.ingest_backpressure.l0_file_count_threshold` and
`rocksdb.ingest_backpressure.max_delay`.