### PR TITLE
sql: make session_revival_token.enabled tenant-ro

### DIFF
--- a/pkg/ccl/testccl/sqlccl/session_revival_test.go
+++ b/pkg/ccl/testccl/sqlccl/session_revival_test.go
@@ -43,7 +43,9 @@ func TestAuthenticateWithSessionRevivalToken(t *testing.T) {
 
 	_, err := tenantDB.Exec("CREATE USER testuser WITH PASSWORD 'hunter2'")
 	require.NoError(t, err)
-	_, err = tenantDB.Exec("SET CLUSTER SETTING server.user_login.session_revival_token.enabled = true")
+	// TODO(rafi): use ALTER TENANT ALL when available.
+	_, err = mainDB.Exec(`INSERT INTO system.tenant_settings (tenant_id, name, value, value_type) VALUES
+		(0, 'server.user_login.session_revival_token.enabled', 'true', 'b')`)
 	require.NoError(t, err)
 
 	var token string

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3136,8 +3136,16 @@ SELECT hmac('dog', 'key', 'made up alg')
 
 subtest session_revival_token
 
+user host-cluster-root
+
+# TODO(rafi): use ALTER TENANT ALL when available.
 statement ok
-SET CLUSTER SETTING server.user_login.session_revival_token.enabled = true;
+INSERT INTO system.tenant_settings (tenant_id, name, value, value_type) VALUES
+		(0, 'server.user_login.session_revival_token.enabled', 'true', 'b');
+
+user root
+
+statement ok
 CREATE USER parentuser;
 GRANT parentuser TO testuser
 
@@ -3196,7 +3204,11 @@ FROM
 ----
 Ed25519  testuser  true  true  true  true
 
-user root
+user host-cluster-root
 
+# TODO(rafi): use ALTER TENANT ALL when available.
 statement ok
-SET CLUSTER SETTING server.user_login.session_revival_token.enabled = false
+UPSERT INTO system.tenant_settings (tenant_id, name, value, value_type) VALUES
+		(0, 'server.user_login.session_revival_token.enabled', 'false', 'b')
+
+user root

--- a/pkg/sql/session_revival_token.go
+++ b/pkg/sql/session_revival_token.go
@@ -25,7 +25,7 @@ import (
 // setting since this is only intended to be used by CockroachDB-serverless
 // at the time of this writing.
 var AllowSessionRevival = settings.RegisterBoolSetting(
-	settings.TenantWritable,
+	settings.TenantReadOnly,
 	"server.user_login.session_revival_token.enabled",
 	"if set, the cluster is able to create session revival tokens and use them "+
 		"to authenticate a new session",


### PR DESCRIPTION
I was hoping to wait for the new cluster setting syntax to be completed,
but since it's getting close to the branch cut time I'd rather merge
this now so we don't forget at the last minute.

Release justification: low risk change to new functionality.

Release note: None