### PR TITLE
sql: presplit temp hash sharded index

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
@@ -281,4 +281,4 @@ t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/3   /Tabl
 t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/4   /Table/116/2/"seattle"/5
 t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/5   /Table/116/2/"seattle"/6
 t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/6   /Table/116/2/"seattle"/7
-t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/7   /Max
+t_presplit  116       t_presplit_idx_member_id  /Table/116/2/"seattle"/7   /Table/116/3/"new york"/0

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -840,7 +840,7 @@ t_hash_pre_split  139       t_hash_pre_split_idx_b  /Table/139/2/3  /Table/139/2
 t_hash_pre_split  139       t_hash_pre_split_idx_b  /Table/139/2/4  /Table/139/2/5
 t_hash_pre_split  139       t_hash_pre_split_idx_b  /Table/139/2/5  /Table/139/2/6
 t_hash_pre_split  139       t_hash_pre_split_idx_b  /Table/139/2/6  /Table/139/2/7
-t_hash_pre_split  139       t_hash_pre_split_idx_b  /Table/139/2/7  /Max
+t_hash_pre_split  139       t_hash_pre_split_idx_b  /Table/139/2/7  /Table/139/3/0
 
 subtest test_default_bucket_count
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2985,9 +2985,9 @@ func (sc *SchemaChanger) shouldSplitAndScatter(
 		return false
 	}
 
-	if m.Adding() && idx.IsSharded() && !idx.IsTemporaryIndexForBackfill() {
+	if m.Adding() && idx.IsSharded() {
 		if sc.mvccCompliantAddIndex {
-			return m.Backfilling()
+			return m.Backfilling() || (idx.IsTemporaryIndexForBackfill() && m.DeleteOnly())
 		}
 		return m.DeleteOnly()
 	}


### PR DESCRIPTION
fixes #76686

we presplit hash sharded index before backflling it. but with the new
mvcc index backfiller, we also create a temp index to take care of write
traffic when the origin index is being backfilled. We need to presplit
the temp index as well.

Release note: None
Release justification: this needed by the mvcc index backfiller