### PR TITLE
roachtest: update up-replication test helper

### DIFF
--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
 )
 
 func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -30,7 +31,8 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
 
-	WaitFor3XReplication(t, db)
+	err := WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 
 	lastWords := func(s string) []string {
 		var result []string

--- a/pkg/cmd/roachtest/tests/cluster_init.go
+++ b/pkg/cmd/roachtest/tests/cluster_init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/stretchr/testify/require"
 )
 
 func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -166,7 +167,8 @@ func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
 			fmt.Sprintf(`./cockroach init --insecure --port={pgport:%d}`, initNode))
 
 		// This will only succeed if 3 nodes joined the cluster.
-		WaitFor3XReplication(t, dbs[0])
+		err = WaitFor3XReplication(ctx, t, dbs[0])
+		require.NoError(t, err)
 
 		execCLI := func(runNode int, extraArgs ...string) (string, error) {
 			args := []string{"./cockroach"}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -135,31 +135,20 @@ func runDrainAndDecommission(
 		t.L().Printf("run: %s\n", stmt)
 	}
 
-	run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
-	run(fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
+	{
+		db := c.Conn(ctx, t.L(), pinnedNode)
+		defer db.Close()
 
-	// Speed up the decommissioning.
-	run(`SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='2GiB'`)
-	run(`SET CLUSTER SETTING kv.snapshot_recovery.max_rate='2GiB'`)
+		run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
+		run(fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, defaultReplicationFactor))
 
-	t.Status("waiting for initial up-replication")
-	db := c.Conn(ctx, t.L(), pinnedNode)
-	defer func() {
-		_ = db.Close()
-	}()
-	for {
-		fullReplicated := false
-		if err := db.QueryRow(
-			// Check if all ranges are fully replicated.
-			"SELECT min(array_length(replicas, 1)) >= $1 FROM crdb_internal.ranges",
-			defaultReplicationFactor,
-		).Scan(&fullReplicated); err != nil {
-			t.Fatal(err)
-		}
-		if fullReplicated {
-			break
-		}
-		time.Sleep(time.Second)
+		// Speed up the decommissioning.
+		run(`SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='2GiB'`)
+		run(`SET CLUSTER SETTING kv.snapshot_recovery.max_rate='2GiB'`)
+
+		// Wait for initial up-replication.
+		err := WaitFor3XReplication(ctx, t, db)
+		require.NoError(t, err)
 	}
 
 	var m *errgroup.Group
@@ -1044,7 +1033,8 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 		require.NoError(t, err)
 
 		// Wait for initial up-replication.
-		WaitFor3XReplication(t, db)
+		err := WaitFor3XReplication(ctx, t, db)
+		require.NoError(t, err)
 	}
 
 	// Connect to node 4 (the target node of the decommission).

--- a/pkg/cmd/roachtest/tests/event_log.go
+++ b/pkg/cmd/roachtest/tests/event_log.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/stretchr/testify/require"
 )
 
 func runEventLog(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -37,9 +38,10 @@ func runEventLog(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// a node starts and contacts the cluster.
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
-	WaitFor3XReplication(t, db)
+	err := WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 
-	err := retry.ForDuration(10*time.Second, func() error {
+	err = retry.ForDuration(10*time.Second, func() error {
 		rows, err := db.Query(
 			`SELECT "targetID", info FROM system.eventlog WHERE "eventType" = 'node_join'`,
 		)

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
 )
 
 func registerInconsistency(r registry.Registry) {
@@ -46,10 +47,9 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// inconsistency and wish for it to be detected when we've set up the test
 		// to expect it.
 		_, err := db.ExecContext(ctx, `SET CLUSTER SETTING server.consistency_check.interval = '0'`)
-		if err != nil {
-			t.Fatal(err)
-		}
-		WaitFor3XReplication(t, db)
+		require.NoError(t, err)
+		err = WaitFor3XReplication(ctx, t, db)
+		require.NoError(t, err)
 		_, db = db.Close(), nil
 	}
 

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 type jobStarter func(c cluster.Cluster, t test.Test) (string, error)
@@ -60,11 +61,12 @@ func jobSurvivesNodeShutdown(
 		// is in a healthy state before we start bringing any
 		// nodes down.
 		t.Status("waiting for cluster to be 3x replicated")
-		WaitFor3XReplication(t, watcherDB)
+		err := WaitFor3XReplication(ctx, t, watcherDB)
+		require.NoError(t, err)
 
 		t.Status("running job")
 		var jobID string
-		jobID, err := startJob(c, t)
+		jobID, err = startJob(c, t)
 		if err != nil {
 			return errors.Wrap(err, "starting the job")
 		}

--- a/pkg/cmd/roachtest/tests/many_splits.go
+++ b/pkg/cmd/roachtest/tests/many_splits.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
 )
 
 // runManySplits attempts to create 2000 tiny ranges on a 4-node cluster using
@@ -33,8 +34,9 @@ func runManySplits(ctx context.Context, t test.Test, c cluster.Cluster) {
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
 
-	// Wait for upreplication then create many ranges.
-	WaitFor3XReplication(t, db)
+	// Wait for up-replication then create many ranges.
+	err := WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 
 	m := c.NewMonitor(ctx, c.All())
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -48,7 +48,8 @@ func runNetworkSanity(ctx context.Context, t test.Test, origC cluster.Cluster, n
 
 	db := c.Conn(ctx, t.L(), 1) // unaffected by toxiproxy
 	defer db.Close()
-	WaitFor3XReplication(t, db)
+	err = WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 
 	// NB: we're generous with latency in this test because we're checking that
 	// the upstream connections aren't affected by latency below, but the fixed
@@ -173,7 +174,8 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 	defer db.Close()
 
 	// Wait for up-replication. This will also print a progress message.
-	WaitFor3XReplication(t, db)
+	err = WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 
 	t.L().Printf("creating test user...")
 	_, err = db.Exec(`CREATE USER testuser WITH PASSWORD 'password' VALID UNTIL '2060-01-01'`)
@@ -382,7 +384,8 @@ func runNetworkTPCC(ctx context.Context, t test.Test, origC cluster.Cluster, nod
 
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
-	WaitFor3XReplication(t, db)
+	err = WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 
 	duration := time.Hour
 	if c.IsLocal() {

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -12,7 +12,6 @@ package tests
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"regexp"
 	"time"
@@ -66,26 +65,6 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 		t.L().Printf("run: %s\n", stmt)
 	}
 
-	waitForReplication := func(db *gosql.DB) {
-		t.Status("waiting for initial up-replication")
-		for {
-			fullReplicated := false
-
-			err = db.QueryRow(
-				// Check if all ranges are fully replicated.
-				"SELECT min(array_length(replicas, 1)) >= $1 FROM crdb_internal.ranges",
-				replicationFactor,
-			).Scan(&fullReplicated)
-			require.NoError(t, err)
-
-			if fullReplicated {
-				break
-			}
-
-			time.Sleep(time.Second)
-		}
-	}
-
 	{
 		db := c.Conn(ctx, t.L(), pinnedNodeID)
 		defer db.Close()
@@ -95,7 +74,8 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 		run(fmt.Sprintf(`ALTER DATABASE system CONFIGURE ZONE USING num_replicas=%d`, replicationFactor))
 
 		// Wait for initial up-replication.
-		waitForReplication(db)
+		err := WaitForReplication(ctx, t, db, replicationFactor)
+		require.NoError(t, err)
 	}
 
 	// Drain the last 5 nodes from the cluster, resulting in immovable leases on

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
 )
 
 type sysbenchWorkload int
@@ -98,10 +99,11 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 	t.Status("installing cockroach")
 	c.Put(ctx, t.Cockroach(), "./cockroach", allNodes)
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
-	WaitFor3XReplication(t, c.Conn(ctx, t.L(), allNodes[0]))
+	err := WaitFor3XReplication(ctx, t, c.Conn(ctx, t.L(), allNodes[0]))
+	require.NoError(t, err)
 
 	t.Status("installing haproxy")
-	if err := c.Install(ctx, t.L(), loadNode, "haproxy"); err != nil {
+	if err = c.Install(ctx, t.L(), loadNode, "haproxy"); err != nil {
 		t.Fatal(err)
 	}
 	c.Run(ctx, loadNode, "./cockroach gen haproxy --insecure --url {pgurl:1}")

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -151,7 +151,8 @@ func setupTPCC(
 			_, err := db.Exec(`SET CLUSTER SETTING kv.replica_circuit_breaker.slow_replication_threshold = '15s'`)
 			require.NoError(t, err)
 		}
-		WaitFor3XReplication(t, c.Conn(ctx, t.L(), crdbNodes[0]))
+		err := WaitFor3XReplication(ctx, t, c.Conn(ctx, t.L(), crdbNodes[0]))
+		require.NoError(t, err)
 		switch opts.SetupType {
 		case usingExistingData:
 			// Do nothing.
@@ -982,9 +983,10 @@ func loadTPCCBench(
 
 	// Load the corresponding fixture.
 	t.L().Printf("restoring tpcc fixture\n")
-	WaitFor3XReplication(t, db)
+	err := WaitFor3XReplication(ctx, t, db)
+	require.NoError(t, err)
 	cmd := tpccImportCmd(b.LoadWarehouses, loadArgs)
-	if err := c.RunE(ctx, roachNodes[:1], cmd); err != nil {
+	if err = c.RunE(ctx, roachNodes[:1], cmd); err != nil {
 		return err
 	}
 	if rebalanceWait == 0 || len(roachNodes) <= 3 {
@@ -992,7 +994,7 @@ func loadTPCCBench(
 	}
 
 	t.L().Printf("waiting %v for rebalancing\n", rebalanceWait)
-	_, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='128MiB'`)
+	_, err = db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='128MiB'`)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcds"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func registerTPCDSVec(r registry.Registry) {
@@ -74,7 +75,8 @@ func registerTPCDSVec(r registry.Registry) {
 		}
 		scatterTables(t, clusterConn, tpcdsTables)
 		t.Status("waiting for full replication")
-		WaitFor3XReplication(t, clusterConn)
+		err := WaitFor3XReplication(ctx, t, clusterConn)
+		require.NoError(t, err)
 
 		// TODO(yuzefovich): it seems like if cmpconn.CompareConns hits a
 		// timeout, the query actually keeps on going and the connection

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
+	"github.com/stretchr/testify/require"
 )
 
 func registerTPCHConcurrency(r registry.Registry) {
@@ -80,7 +81,8 @@ func registerTPCHConcurrency(r registry.Registry) {
 			t.Fatal(err)
 		}
 		scatterTables(t, conn, tpchTables)
-		WaitFor3XReplication(t, conn)
+		err := WaitFor3XReplication(ctx, t, conn)
+		require.NoError(t, err)
 
 		// Populate the range cache on each node.
 		for node := 1; node < numNodes; node++ {

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpch"
+	"github.com/stretchr/testify/require"
 )
 
 const tpchVecPerfSlownessThreshold = 1.5
@@ -559,7 +560,8 @@ func runTPCHVec(
 	}
 	scatterTables(t, conn, tpchTables)
 	t.Status("waiting for full replication")
-	WaitFor3XReplication(t, conn)
+	err := WaitFor3XReplication(ctx, t, conn)
+	require.NoError(t, err)
 
 	testRun(ctx, t, c, conn, testCase)
 	testCase.postTestRunHook(ctx, t, c, conn)

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
 )
 
 const envYCSBFlags = "ROACHTEST_YCSB_FLAGS"
@@ -59,7 +60,8 @@ func registerYCSB(r registry.Registry) {
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(nodes+1))
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
-		WaitFor3XReplication(t, c.Conn(ctx, t.L(), 1))
+		err := WaitFor3XReplication(ctx, t, c.Conn(ctx, t.L(), 1))
+		require.NoError(t, err)
 
 		t.Status("running workload")
 		m := c.NewMonitor(ctx, c.Range(1, nodes))


### PR DESCRIPTION
This patch updates the "wait for up-replication" utility to be able to be
used in more general cases where the replication factor is changed.

Release justification: low risk change to existing functionality

Release note: None