### PR TITLE
sql: introduce special type for inverted index keys

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -161,7 +161,7 @@ TABLE t
  ├── j jsonb
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key bytes not null [inverted]
+ ├── j_inverted_key encodedkey not null [inverted]
  ├── FAMILY fam_0_pk_a_b_c_d_j (pk, a, b, c, d, j)
  ├── PRIMARY INDEX t_pkey
  │    ├── a int not null (implicit)
@@ -198,7 +198,7 @@ TABLE t
  │                   └── (4)
  ├── INVERTED INDEX t_j_idx
  │    ├── a int not null (implicit)
- │    ├── j_inverted_key bytes not null [inverted]
+ │    ├── j_inverted_key encodedkey not null [inverted]
  │    ├── pk int not null
  │    └── partitions
  │         └── j_implicit

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -39,7 +39,7 @@ TABLE regional_by_row_table
  ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@<enum_val>) [hidden]
  ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
  ├── tableoid oid [hidden] [system]
- ├── j_inverted_key bytes not null [inverted]
+ ├── j_inverted_key encodedkey not null [inverted]
  ├── FAMILY fam_0_pk_pk2_a_b_j_crdb_region (pk, pk2, a, b, j, crdb_region)
  ├── CHECK (crdb_region IN (x'40':::@<enum_val>, x'80':::@<enum_val>, x'c0':::@<enum_val>))
  ├── PRIMARY INDEX regional_by_row_table_pkey
@@ -169,7 +169,7 @@ TABLE regional_by_row_table
  │                   └── lease preference: [+region=us-east-1]
  ├── INVERTED INDEX regional_by_row_table_j_idx
  │    ├── crdb_region crdb_internal_region not null default (default_to_database_primary_region(gateway_region())::@<enum_val>) [hidden] (implicit)
- │    ├── j_inverted_key bytes not null [inverted]
+ │    ├── j_inverted_key encodedkey not null [inverted]
  │    ├── pk int not null
  │    ├── ZONE
  │    │    ├── replica constraints

--- a/pkg/col/typeconv/typeconv.go
+++ b/pkg/col/typeconv/typeconv.go
@@ -36,7 +36,7 @@ func TypeFamilyToCanonicalTypeFamily(family types.Family) types.Family {
 	switch family {
 	case types.BoolFamily:
 		return types.BoolFamily
-	case types.BytesFamily, types.StringFamily, types.UuidFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.EncodedKeyFamily:
 		return types.BytesFamily
 	case types.DecimalFamily:
 		return types.DecimalFamily

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -116,12 +116,12 @@ func (desc *IndexDescriptor) InvertedColumnName() string {
 }
 
 // InvertedColumnKeyType returns the type of the data element that is encoded
-// as the inverted index key. This is currently always Bytes.
+// as the inverted index key. This is currently always EncodedKey.
 //
 // Panics if the index is not inverted.
 func (desc *IndexDescriptor) InvertedColumnKeyType() *types.T {
 	if desc.Type != IndexDescriptor_INVERTED {
 		panic(errors.AssertionFailedf("index is not inverted"))
 	}
-	return types.Bytes
+	return types.EncodedKey
 }

--- a/pkg/sql/catalog/descpb/index_fetch.proto
+++ b/pkg/sql/catalog/descpb/index_fetch.proto
@@ -30,7 +30,7 @@ message IndexFetchSpec {
     optional string name = 2 [(gogoproto.nullable) = false];
 
     // Type of the column. If this is the key column of an inverted index, this
-    // is the actual type of whan the index encodes (usually Bytes), rather than
+    // is the type of the data element (currently always EncodedKey) and not
     // the table column type (e.g. JSON).
     optional sql.sem.types.T type = 3;
 
@@ -51,7 +51,7 @@ message IndexFetchSpec {
 
     // IsInverted is true if this column is the inverted key of an inverted index.
     // In this case, the type of this column is the type of the data element
-    // (currently always Bytes).
+    // (currently always EncodedKey).
     optional bool is_inverted = 4 [(gogoproto.nullable) = false];
   }
 

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -180,7 +180,7 @@ type Index interface {
 	InvertedColumnName() string
 
 	// InvertedColumnKeyType returns the type of the data element that is encoded
-	// as the inverted index key. This is currently always Bytes.
+	// as the inverted index key. This is currently always EncodedKey.
 	//
 	// Panics if the index is not inverted.
 	InvertedColumnKeyType() *types.T

--- a/pkg/sql/colconv/datum_to_vec.eg.go
+++ b/pkg/sql/colconv/datum_to_vec.eg.go
@@ -155,6 +155,15 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) interface{} {
 				return datum.(*tree.DJSON).JSON
 			}
 		}
+	case types.EncodedKeyFamily:
+		switch ct.Width() {
+		case -1:
+		default:
+			return func(datum tree.Datum) interface{} {
+
+				return encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DEncodedKey)))
+			}
+		}
 	case typeconv.DatumVecCanonicalTypeFamily:
 	default:
 		switch ct.Width() {

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -504,6 +504,32 @@ func ColVecToDatumAndDeselect(
 						converted[destIdx] = _converted
 					}
 				}
+			case types.EncodedKeyFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := typedCol.Get(srcIdx)
+						// Note that there is no need for a copy since DEncodedKey uses a string
+						// as underlying storage, which will perform the copy for us.
+						_converted := da.NewDEncodedKey(tree.DEncodedKey(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
+					}
+				}
 			case types.JsonFamily:
 				switch ct.Width() {
 				case -1:
@@ -870,6 +896,27 @@ func ColVecToDatumAndDeselect(
 						// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
 						_converted := da.NewDBytes(tree.DBytes(v))
+						//gcassert:bce
+						converted[destIdx] = _converted
+					}
+				}
+			case types.EncodedKeyFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := typedCol.Get(srcIdx)
+						// Note that there is no need for a copy since DEncodedKey uses a string
+						// as underlying storage, which will perform the copy for us.
+						_converted := da.NewDEncodedKey(tree.DEncodedKey(v))
 						//gcassert:bce
 						converted[destIdx] = _converted
 					}
@@ -1265,6 +1312,31 @@ func ColVecToDatum(
 							// Note that there is no need for a copy since DBytes uses a string
 							// as underlying storage, which will perform the copy for us.
 							_converted := da.NewDBytes(tree.DBytes(v))
+							converted[destIdx] = _converted
+						}
+					}
+				case types.EncodedKeyFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DEncodedKey uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDEncodedKey(tree.DEncodedKey(v))
 							converted[destIdx] = _converted
 						}
 					}
@@ -1685,6 +1757,31 @@ func ColVecToDatum(
 							converted[destIdx] = _converted
 						}
 					}
+				case types.EncodedKeyFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								//gcassert:bce
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DEncodedKey uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDEncodedKey(tree.DEncodedKey(v))
+							//gcassert:bce
+							converted[destIdx] = _converted
+						}
+					}
 				case types.JsonFamily:
 					switch ct.Width() {
 					case -1:
@@ -2056,6 +2153,27 @@ func ColVecToDatum(
 							converted[destIdx] = _converted
 						}
 					}
+				case types.EncodedKeyFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DEncodedKey uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDEncodedKey(tree.DEncodedKey(v))
+							converted[destIdx] = _converted
+						}
+					}
 				case types.JsonFamily:
 					switch ct.Width() {
 					case -1:
@@ -2395,6 +2513,26 @@ func ColVecToDatum(
 							// Note that there is no need for a copy since DBytes uses a string
 							// as underlying storage, which will perform the copy for us.
 							_converted := da.NewDBytes(tree.DBytes(v))
+							//gcassert:bce
+							converted[destIdx] = _converted
+						}
+					}
+				case types.EncodedKeyFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := typedCol.Get(srcIdx)
+							// Note that there is no need for a copy since DEncodedKey uses a string
+							// as underlying storage, which will perform the copy for us.
+							_converted := da.NewDEncodedKey(tree.DEncodedKey(v))
 							//gcassert:bce
 							converted[destIdx] = _converted
 						}

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowstovec_gen.go
@@ -85,6 +85,7 @@ var rowsToVecPreludeTmpls = map[familyWidthPair]string{
 var rowsToVecConversionTmpls = map[familyWidthPair]string{
 	{types.BoolFamily, anyWidth}:                     `bool(*%[1]s.(*tree.DBool))`,
 	{types.BytesFamily, anyWidth}:                    `encoding.UnsafeConvertStringToBytes(string(*%[1]s.(*tree.DBytes)))`,
+	{types.EncodedKeyFamily, anyWidth}:               `encoding.UnsafeConvertStringToBytes(string(*%[1]s.(*tree.DEncodedKey)))`,
 	{types.IntFamily, 16}:                            `int16(*%[1]s.(*tree.DInt))`,
 	{types.IntFamily, 32}:                            `int32(*%[1]s.(*tree.DInt))`,
 	{types.IntFamily, anyWidth}:                      `int64(*%[1]s.(*tree.DInt))`,

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -74,6 +74,9 @@ var vecToDatumConversionTmpls = map[types.Family]string{
 	types.BytesFamily: `// Note that there is no need for a copy since DBytes uses a string
 						// as underlying storage, which will perform the copy for us.
 						%[1]s := %[3]s.NewDBytes(tree.DBytes(%[2]s))`,
+	types.EncodedKeyFamily: `// Note that there is no need for a copy since DEncodedKey uses a string
+						// as underlying storage, which will perform the copy for us.
+						%[1]s := %[3]s.NewDEncodedKey(tree.DEncodedKey(%[2]s))`,
 	types.JsonFamily: `
             // The following operation deliberately copies the input JSON
             // bytes, since FromEncoding is lazy and keeps a handle on the bytes
@@ -124,8 +127,8 @@ func genVecToDatum(inputFileContents string, wr io.Writer) error {
 	// the template explicitly, so it is omitted from this slice.
 	optimizedTypeFamilies := []types.Family{
 		types.BoolFamily, types.IntFamily, types.FloatFamily, types.DecimalFamily,
-		types.DateFamily, types.BytesFamily, types.JsonFamily, types.UuidFamily,
-		types.TimestampFamily, types.TimestampTZFamily, types.IntervalFamily,
+		types.DateFamily, types.BytesFamily, types.EncodedKeyFamily, types.JsonFamily,
+		types.UuidFamily, types.TimestampFamily, types.TimestampTZFamily, types.IntervalFamily,
 	}
 	for _, typeFamily := range optimizedTypeFamilies {
 		canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(typeFamily)

--- a/pkg/sql/colexec/rowstovec.eg.go
+++ b/pkg/sql/colexec/rowstovec.eg.go
@@ -432,6 +432,33 @@ func EncDatumRowsToColVec(
 						}
 					}
 				}
+			case types.EncodedKeyFamily:
+				switch t.Width() {
+				case -1:
+				default:
+					col := vec.Bytes()
+					if len(rows) > 0 {
+						_ = col.Get(len(rows) - 1)
+						var v interface{}
+						for i := range rows {
+							row := rows[i]
+							if row[columnIdx].Datum == nil {
+								if err = row[columnIdx].EnsureDecoded(t, alloc); err != nil {
+									return
+								}
+							}
+							datum := row[columnIdx].Datum
+							if datum == tree.DNull {
+								vec.Nulls().SetNull(i)
+							} else {
+
+								v = encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DEncodedKey)))
+								castV := v.([]byte)
+								col.Set(i, castV)
+							}
+						}
+					}
+				}
 			case typeconv.DatumVecCanonicalTypeFamily:
 			default:
 				switch t.Width() {

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -64,17 +64,21 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 65
+const Version execinfrapb.DistSQLVersion = 66
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 65
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 66
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+- Version: 66 (MinAcceptedVersion: 66)
+  - Processor columns for inverted index keys now are presented as having
+    a new EncodedKey type.
 
 - Version: 65 (MinAcceptedVersion: 65)
   - adds the RestoreValidation field to the RestoreDataSpec and SplitAndScatterSpec

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -375,6 +375,8 @@ func (h *Histogram) InvertedFilter(spans inverted.Spans) *Histogram {
 
 func makeSpanFromInvertedSpan(invSpan inverted.Span) *constraint.Span {
 	var span constraint.Span
+	// The statistics use the Bytes type for the encoded key, so we use DBytes
+	// here.
 	span.Init(
 		constraint.MakeKey(tree.NewDBytes(tree.DBytes(invSpan.Start))),
 		constraint.IncludeBoundary,

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1444,8 +1444,8 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		}
 
 		// We treat the fixed values for JSON and Array as DBytes.
-		leftVal := tree.DBytes(vals[0])
-		rightVal := tree.DBytes(vals[1])
+		leftVal := tree.DEncodedKey(vals[0])
+		rightVal := tree.DEncodedKey(vals[1])
 
 		zigzagJoin := memo.ZigzagJoinExpr{
 			On: filters,

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -269,6 +269,15 @@ func Decode(
 			return nil, nil, err
 		}
 		return a.NewDEnum(tree.DEnum{EnumTyp: valType, PhysicalRep: phys, LogicalRep: log}), rkey, nil
+	case types.EncodedKeyFamily:
+		// We don't actually decode anything; we wrap the raw key bytes into a
+		// DEncodedKey.
+		len, err := encoding.PeekLength(key)
+		if err != nil {
+			return nil, nil, err
+		}
+		rkey := key[len:]
+		return a.NewDEncodedKey(tree.DEncodedKey(key[:len])), rkey, nil
 	default:
 		return nil, nil, errors.Errorf("unable to decode table key: %s", valType)
 	}

--- a/pkg/sql/rowenc/testdata/index-fetch
+++ b/pkg/sql/rowenc/testdata/index-fetch
@@ -757,7 +757,7 @@ columns:
       "column": {
         "column_id": 3,
         "name": "j",
-        "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
+        "type": "family: EncodedKeyFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 705\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
@@ -780,7 +780,7 @@ columns:
     {
       "column_id": 3,
       "name": "j",
-      "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
+      "type": "family: EncodedKeyFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 705\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {
@@ -830,7 +830,7 @@ columns:
       "column": {
         "column_id": 3,
         "name": "j",
-        "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
+        "type": "family: EncodedKeyFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 705\ntime_precision_is_set: false\n",
         "is_non_nullable": false
       },
       "direction": 0,
@@ -853,7 +853,7 @@ columns:
     {
       "column_id": 3,
       "name": "j",
-      "type": "family: BytesFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 17\ntime_precision_is_set: false\n",
+      "type": "family: EncodedKeyFamily\nwidth: 0\nprecision: 0\nlocale: \"\"\nvisible_type: 0\noid: 705\ntime_precision_is_set: false\n",
       "is_non_nullable": false
     },
     {

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -101,6 +101,12 @@ func DecodeUntaggedDatum(
 			return nil, b, err
 		}
 		return a.NewDBytes(tree.DBytes(data)), b, nil
+	case types.EncodedKeyFamily:
+		b, data, err := encoding.DecodeUntaggedBytesValue(buf)
+		if err != nil {
+			return nil, b, err
+		}
+		return a.NewDEncodedKey(tree.DEncodedKey(data)), b, nil
 	case types.DateFamily:
 		b, data, err := encoding.DecodeUntaggedIntValue(buf)
 		if err != nil {

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -50,6 +50,8 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(*t)), nil
 	case *tree.DBytes:
 		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(*t)), nil
+	case *tree.DEncodedKey:
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(*t)), nil
 	case *tree.DDate:
 		return encoding.EncodeIntValue(appendTo, uint32(colID), t.UnixEpochDaysWithOrig()), nil
 	case *tree.DBox2D:

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -226,11 +226,11 @@ func (ifr *invertedFilterer) readInput() (invertedFiltererState, *execinfrapb.Pr
 			ifr.MoveToDraining(errors.New("no datum found"))
 			return ifrStateUnknown, ifr.DrainHelper()
 		}
-		if row[ifr.invertedColIdx].Datum.ResolvedType().Family() != types.BytesFamily {
-			ifr.MoveToDraining(errors.New("inverted column should have type bytes"))
+		if row[ifr.invertedColIdx].Datum.ResolvedType().Family() != types.EncodedKeyFamily {
+			ifr.MoveToDraining(errors.New("inverted column should have type encodedkey"))
 			return ifrStateUnknown, ifr.DrainHelper()
 		}
-		enc = []byte(*row[ifr.invertedColIdx].Datum.(*tree.DBytes))
+		enc = []byte(*row[ifr.invertedColIdx].Datum.(*tree.DEncodedKey))
 	}
 	shouldAdd, err := ifr.invertedEval.prepareAddIndexRow(enc, nil /* encFull */)
 	if err != nil {

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -152,8 +152,9 @@ func newSampleAggregator(
 	)
 	for i := range spec.InvertedSketches {
 		var sr stats.SampleReservoir
-		// The datums are converted to their inverted index bytes and
-		// sent as a single DBytes column.
+		// The datums are converted to their inverted index bytes and sent as a
+		// single DBytes column. We do not use DEncodedKey here because it would
+		// introduce backward compatibility complications.
 		var srCols util.FastIntSet
 		srCols.Add(0)
 		sr.Init(int(spec.SampleSize), int(spec.MinSampleSize), bytesRowType, &s.memAcc, srCols)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1525,8 +1525,7 @@ func (d *DBytes) Max(_ *EvalContext) (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DBytes) AmbiguousFormat() bool { return true }
 
-func writeAsHexString(ctx *FmtCtx, d *DBytes) {
-	b := string(*d)
+func writeAsHexString(ctx *FmtCtx, b string) {
 	for i := 0; i < len(b); i++ {
 		ctx.Write(stringencoding.RawHexMap[b[i]])
 	}
@@ -1537,7 +1536,7 @@ func (d *DBytes) Format(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(fmtPgwireFormat) {
 		ctx.WriteString(`"\\x`)
-		writeAsHexString(ctx, d)
+		writeAsHexString(ctx, string(*d))
 		ctx.WriteString(`"`)
 	} else if f.HasFlags(fmtFormatByteLiterals) {
 		ctx.WriteByte('x')
@@ -1550,7 +1549,7 @@ func (d *DBytes) Format(ctx *FmtCtx) {
 			ctx.WriteByte('\'')
 		}
 		ctx.WriteString("\\x")
-		writeAsHexString(ctx, d)
+		writeAsHexString(ctx, string(*d))
 		if withQuotes {
 			ctx.WriteByte('\'')
 		}
@@ -1559,6 +1558,78 @@ func (d *DBytes) Format(ctx *FmtCtx) {
 
 // Size implements the Datum interface.
 func (d *DBytes) Size() uintptr {
+	return unsafe.Sizeof(*d) + uintptr(len(*d))
+}
+
+// DEncodedKey is a special Datum of types.EncodedKey type, used to pass through
+// encoded key data. It is similar to DBytes, except when it comes to
+// encoding/decoding. It is currently used to pass around inverted index keys,
+// which do not fully encode an object.
+type DEncodedKey string
+
+// NewDEncodedKey is a helper routine to create a *DEncodedKey initialized from its
+// argument.
+func NewDEncodedKey(d DEncodedKey) *DEncodedKey {
+	return &d
+}
+
+// ResolvedType implements the TypedExpr interface.
+func (*DEncodedKey) ResolvedType() *types.T {
+	return types.EncodedKey
+}
+
+// Compare implements the Datum interface.
+func (d *DEncodedKey) Compare(ctx *EvalContext, other Datum) int {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+// CompareError implements the Datum interface.
+func (d *DEncodedKey) CompareError(ctx *EvalContext, other Datum) (int, error) {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+// Prev implements the Datum interface.
+func (d *DEncodedKey) Prev(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// Next implements the Datum interface.
+func (d *DEncodedKey) Next(_ *EvalContext) (Datum, bool) {
+	return nil, true
+}
+
+// IsMax implements the Datum interface.
+func (*DEncodedKey) IsMax(_ *EvalContext) bool {
+	return false
+}
+
+// IsMin implements the Datum interface.
+func (d *DEncodedKey) IsMin(_ *EvalContext) bool {
+	return false
+}
+
+// Min implements the Datum interface.
+func (d *DEncodedKey) Min(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// Max implements the Datum interface.
+func (d *DEncodedKey) Max(_ *EvalContext) (Datum, bool) {
+	return nil, false
+}
+
+// AmbiguousFormat implements the Datum interface.
+func (*DEncodedKey) AmbiguousFormat() bool {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+// Format implements the NodeFormatter interface.
+func (d *DEncodedKey) Format(ctx *FmtCtx) {
+	(*DBytes)(d).Format(ctx)
+}
+
+// Size implements the Datum interface.
+func (d *DEncodedKey) Size() uintptr {
 	return unsafe.Sizeof(*d) + uintptr(len(*d))
 }
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -4680,6 +4680,11 @@ func (t *DBytes) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
+func (t *DEncodedKey) Eval(_ *EvalContext) (Datum, error) {
+	return t, nil
+}
+
+// Eval implements the TypedExpr interface.
 func (t *DUuid) Eval(_ *EvalContext) (Datum, error) {
 	return t, nil
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1643,6 +1643,7 @@ func (node *Datums) String() string           { return AsString(node) }
 func (node *DBitArray) String() string        { return AsString(node) }
 func (node *DBool) String() string            { return AsString(node) }
 func (node *DBytes) String() string           { return AsString(node) }
+func (node *DEncodedKey) String() string      { return AsString(node) }
 func (node *DDate) String() string            { return AsString(node) }
 func (node *DTime) String() string            { return AsString(node) }
 func (node *DTimeTZ) String() string          { return AsString(node) }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1697,6 +1697,12 @@ func (d *DBytes) TypeCheck(_ context.Context, _ *SemaContext, _ *types.T) (Typed
 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
+func (d *DEncodedKey) TypeCheck(_ context.Context, _ *SemaContext, _ *types.T) (TypedExpr, error) {
+	return d, nil
+}
+
+// TypeCheck implements the Expr interface. It is implemented as an idempotent
+// identity function for Datum.
 func (d *DUuid) TypeCheck(_ context.Context, _ *SemaContext, _ *types.T) (TypedExpr, error) {
 	return d, nil
 }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -726,6 +726,9 @@ func (expr *DBool) Walk(_ Visitor) Expr { return expr }
 func (expr *DBytes) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
+func (expr *DEncodedKey) Walk(_ Visitor) Expr { return expr }
+
+// Walk implements the Expr interface.
 func (expr *DDate) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -362,10 +362,7 @@ func (s *Builder) generateInvertedSpanKey(
 	keyLen := len(scratchRow) - 1
 	scratchRow = scratchRow[:keyLen]
 	if len(enc) > 0 {
-		// Pretend that the encoded inverted val is an EncDatum. This isn't always
-		// true, since JSON inverted columns use a custom encoding. But since we
-		// are providing an already encoded Datum, the following will eventually
-		// fall through to EncDatum.Encode() which will reuse the encoded bytes.
+		// The encoded inverted value will be passed through unchanged.
 		encDatum := rowenc.EncDatumFromEncoded(descpb.DatumEncoding_ASCENDING_KEY, enc)
 		scratchRow = append(scratchRow, encDatum)
 		keyLen++

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -463,6 +463,18 @@ var (
 		},
 	}
 
+	// EncodedKey is a special type used internally for passing encoded key data.
+	// It behaves similarly to Bytes in most circumstances, except
+	// encoding/decoding. It is currently used to pass around inverted index keys,
+	// which do not fully encode an object.
+	EncodedKey = &T{
+		InternalType: InternalType{
+			Family: EncodedKeyFamily,
+			Oid:    oid.T_unknown,
+			Locale: &emptyLocale,
+		},
+	}
+
 	// Scalar contains all types that meet this criteria:
 	//
 	//   1. Scalar type (no ArrayFamily or TupleFamily types).
@@ -1392,6 +1404,7 @@ var familyNames = map[Family]string{
 	UnknownFamily:        "unknown",
 	UuidFamily:           "uuid",
 	VoidFamily:           "void",
+	EncodedKeyFamily:     "encodedkey",
 }
 
 // Name returns a user-friendly word indicating the family type.

--- a/pkg/sql/types/types.proto
+++ b/pkg/sql/types/types.proto
@@ -374,6 +374,10 @@ enum Family {
     //   Void
     VoidFamily = 26;
 
+    // EncodedKeyFamily is a special type family used internally for inverted
+    // index keys, which do not fully encode an object.
+    EncodedKeyFamily = 27;
+
     // AnyFamily is a special type family used during static analysis as a
     // wildcard type that matches any other type, including scalar, array, and
     // tuple types. Execution-time values should never have this type. As an


### PR DESCRIPTION
Note: this is intended to merge to master after the 22.1 branch is cut.

Currently we pass around inverted index keys as having `Bytes` type,
but these datums behave in subtly different ways. The
encoding/decoding is special-cased to be a no-op. This leads to sharp
edges; for example, we put these keys in `EncodedDatum`s but if we
ever try to decode them (via `EnsureDecodedd`), we get obscure
decoding errors.

This commit cleans up this situation by adding a special `EncodedKey`
type and corresponding `DEncodedKey` datum. It behaves like
`Bytes/DBytes` in most cases, except key encoding and decoding.

Release note: None