### PR TITLE
cluster-ui: add active stmts and txns pages for CC

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.selectors.ts
@@ -1,0 +1,30 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { AppState } from "src";
+import { match, RouteComponentProps } from "react-router-dom";
+import { getMatchParamByName } from "src/util/query";
+import { executionIdAttr } from "../util/constants";
+import { getActiveStatementsFromSessions } from "../activeExecutions/activeStatementUtils";
+
+export const selectActiveStatement = createSelector(
+  (_: AppState, props: RouteComponentProps) => props.match,
+  (state: AppState) => state.adminUI.sessions,
+  (match: match, response) => {
+    if (!response.data) return null;
+
+    const executionID = getMatchParamByName(match, executionIdAttr);
+    return getActiveStatementsFromSessions(
+      response.data,
+      response.lastUpdated,
+    ).find(stmt => stmt.executionID === executionID);
+  },
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
@@ -1,0 +1,43 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import { actions as sessionsActions } from "src/store/sessions";
+import { AppState } from "../store";
+import {
+  ActiveStatementDetails,
+  ActiveStatementDetailsDispatchProps,
+} from "./activeStatementDetails";
+import { selectActiveStatement } from "./activeStatementDetails.selectors";
+import { ActiveStatementDetailsStateProps } from ".";
+
+// For tenant cases, we don't show information about node, regions and
+// diagnostics.
+const mapStateToProps = (
+  state: AppState,
+  props: RouteComponentProps,
+): ActiveStatementDetailsStateProps => {
+  return {
+    statement: selectActiveStatement(state, props),
+    match: props.match,
+  };
+};
+
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): ActiveStatementDetailsDispatchProps => ({
+  refreshSessions: () => dispatch(sessionsActions.refresh()),
+});
+
+export const ActiveStatementDetailsPageConnected = withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ActiveStatementDetails),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/index.ts
@@ -14,3 +14,4 @@ export * from "./diagnostics/diagnosticsUtils";
 export * from "./planView";
 export * from "./statementDetailsConnected";
 export * from "./activeStatementDetails";
+export * from "./activeStatementDetailsConnected";

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
@@ -1,0 +1,90 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { getActiveStatementsFromSessions } from "../activeExecutions/activeStatementUtils";
+import { localStorageSelector } from "./statementsPage.selectors";
+import {
+  ActiveStatementFilters,
+  ActiveStatementsViewDispatchProps,
+  ActiveStatementsViewStateProps,
+  AppState,
+  SortSetting,
+} from "src";
+import { actions as sessionsActions } from "src/store/sessions";
+import { actions as localStorageActions } from "src/store/localStorage";
+import { Dispatch } from "redux";
+
+export const selectActiveStatements = createSelector(
+  (state: AppState) => state.adminUI.sessions,
+  response => {
+    if (!response.data) return [];
+
+    return getActiveStatementsFromSessions(response.data, response.lastUpdated);
+  },
+);
+
+export const selectSortSetting = (state: AppState): SortSetting =>
+  localStorageSelector(state)["sortSetting/ActiveStatementsPage"];
+
+export const selectFilters = (state: AppState): ActiveStatementFilters =>
+  localStorageSelector(state)["filters/ActiveStatementsPage"];
+
+const selectLocalStorageColumns = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage["showColumns/ActiveStatementsPage"];
+};
+
+export const selectColumns = createSelector(
+  selectLocalStorageColumns,
+  value => {
+    if (value == null) return null;
+
+    return value.split(",").map(col => col.trim());
+  },
+);
+
+export const mapStateToActiveStatementsPageProps = (
+  state: AppState,
+): ActiveStatementsViewStateProps => ({
+  statements: selectActiveStatements(state),
+  sessionsError: state.adminUI.sessions.lastError,
+  selectedColumns: selectColumns(state),
+  sortSetting: selectSortSetting(state),
+  filters: selectFilters(state),
+});
+
+export const mapDispatchToActiveStatementsPageProps = (
+  dispatch: Dispatch,
+): ActiveStatementsViewDispatchProps => ({
+  refreshSessions: () => dispatch(sessionsActions.refresh()),
+  onColumnsSelect: columns => {
+    dispatch(
+      localStorageActions.update({
+        key: "showColumns/ActiveStatementsPage",
+        value: columns.join(","),
+      }),
+    );
+  },
+  onFiltersChange: (filters: ActiveStatementFilters) =>
+    dispatch(
+      localStorageActions.update({
+        key: "filters/ActiveStatementsPage",
+        value: filters,
+      }),
+    ),
+  onSortChange: (ss: SortSetting) =>
+    dispatch(
+      localStorageActions.update({
+        key: "sortSetting/ActiveStatementsPage",
+        value: ss,
+      }),
+    ),
+});

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -21,13 +21,19 @@ type SortSetting = {
 
 export type LocalStorageState = {
   "adminUi/showDiagnosticsModal": boolean;
+  "showColumns/ActiveStatementsPage": string;
+  "showColumns/ActiveTransactionsPage": string;
   "showColumns/StatementsPage": string;
   "showColumns/TransactionPage": string;
   "showColumns/SessionsPage": string;
   "timeScale/SQLActivity": TimeScale;
+  "sortSetting/ActiveStatementsPage": SortSetting;
+  "sortSetting/ActiveTransactionsPage": SortSetting;
   "sortSetting/StatementsPage": SortSetting;
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
+  "filters/ActiveStatementsPage": Filters;
+  "filters/ActiveTransactionsPage": Filters;
   "filters/StatementsPage": Filters;
   "filters/TransactionsPage": Filters;
   "filters/SessionsPage": Filters;
@@ -45,6 +51,15 @@ const defaultSortSetting: SortSetting = {
   columnTitle: "executionCount",
 };
 
+const defaultSortSettingActiveExecutions: SortSetting = {
+  ascending: false,
+  columnTitle: "startTime",
+};
+
+const defaultFiltersActiveExecutions = {
+  app: defaultFilters.app,
+};
+
 const defaultSessionsSortSetting: SortSetting = {
   ascending: false,
   columnTitle: "statementAge",
@@ -55,6 +70,12 @@ const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
     Boolean(JSON.parse(localStorage.getItem("adminUi/showDiagnosticsModal"))) ||
     false,
+  "showColumns/ActiveStatementsPage":
+    JSON.parse(localStorage.getItem("showColumns/ActiveStatementsPage")) ??
+    null,
+  "showColumns/ActiveTransactionsPage":
+    JSON.parse(localStorage.getItem("showColumns/ActiveTransactionsPage")) ??
+    null,
   "showColumns/StatementsPage":
     JSON.parse(localStorage.getItem("showColumns/StatementsPage")) || null,
   "showColumns/TransactionPage":
@@ -64,6 +85,12 @@ const initialState: LocalStorageState = {
   "timeScale/SQLActivity":
     JSON.parse(localStorage.getItem("timeScale/SQLActivity")) ||
     defaultTimeScaleSelected,
+  "sortSetting/ActiveStatementsPage":
+    JSON.parse(localStorage.getItem("sortSetting/ActiveStatementsPage")) ||
+    defaultSortSettingActiveExecutions,
+  "sortSetting/ActiveTransactionsPage":
+    JSON.parse(localStorage.getItem("sortSetting/ActiveTransactionsPage")) ||
+    defaultSortSettingActiveExecutions,
   "sortSetting/StatementsPage":
     JSON.parse(localStorage.getItem("sortSetting/StatementsPage")) ||
     defaultSortSetting,
@@ -73,6 +100,12 @@ const initialState: LocalStorageState = {
   "sortSetting/SessionsPage":
     JSON.parse(localStorage.getItem("sortSetting/SessionsPage")) ||
     defaultSessionsSortSetting,
+  "filters/ActiveStatementsPage":
+    JSON.parse(localStorage.getItem("filters/ActiveStatementsPage")) ||
+    defaultFiltersActiveExecutions,
+  "filters/ActiveTransactionsPage":
+    JSON.parse(localStorage.getItem("filters/ActiveTransactionsPage")) ||
+    defaultFiltersActiveExecutions,
   "filters/StatementsPage":
     JSON.parse(localStorage.getItem("filters/StatementsPage")) ||
     defaultFilters,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.reducer.ts
@@ -11,17 +11,20 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DOMAIN_NAME, noopReducer } from "../utils";
+import moment, { Moment } from "moment";
 
 type SessionsResponse = cockroach.server.serverpb.ListSessionsResponse;
 
 export type SessionsState = {
   data: SessionsResponse;
+  lastUpdated: Moment | null;
   lastError: Error;
   valid: boolean;
 };
 
 const initialState: SessionsState = {
   data: null,
+  lastUpdated: null,
   lastError: null,
   valid: true,
 };
@@ -34,6 +37,7 @@ const ssessionsSlice = createSlice({
       state.data = action.payload;
       state.valid = true;
       state.lastError = null;
+      state.lastUpdated = moment.utc();
     },
     failed: (state, action: PayloadAction<Error>) => {
       state.valid = false;

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
@@ -12,7 +12,7 @@ import { all, call, delay, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./sessions.reducer";
 import { getSessions } from "src/api/sessionsApi";
-import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
+import { throttleWithReset } from "../utils";
 import { rootActions } from "../reducers";
 
 export function* refreshSessionsSaga() {
@@ -33,9 +33,7 @@ export function* receivedStatementsSaga(delayMs: number) {
   yield put(actions.invalidated());
 }
 
-export function* sessionsSaga(
-  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
-) {
+export function* sessionsSaga(cacheInvalidationPeriod: number = 10 * 1000) {
   yield all([
     throttleWithReset(
       cacheInvalidationPeriod,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.selectors.tsx
@@ -1,0 +1,30 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { AppState } from "src";
+import { match, RouteComponentProps } from "react-router-dom";
+import { getMatchParamByName } from "src/util/query";
+import { executionIdAttr } from "../util/constants";
+import { getActiveTransactionsFromSessions } from "../activeExecutions/activeStatementUtils";
+
+export const selectActiveTransaction = createSelector(
+  (_: AppState, props: RouteComponentProps) => props.match,
+  (state: AppState) => state.adminUI.sessions,
+  (match: match, response) => {
+    if (!response.data) return null;
+
+    const executionID = getMatchParamByName(match, executionIdAttr);
+    return getActiveTransactionsFromSessions(
+      response.data,
+      response.lastUpdated,
+    ).find(stmt => stmt.executionID === executionID);
+  },
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetailsConnected.tsx
@@ -1,0 +1,43 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import { actions as sessionsActions } from "src/store/sessions";
+import { AppState } from "../store";
+import {
+  ActiveTransactionDetails,
+  ActiveTransactionDetailsDispatchProps,
+} from "./activeTransactionDetails";
+import { selectActiveTransaction } from "./activeTransactionDetails.selectors";
+import { ActiveTransactionDetailsStateProps } from ".";
+
+// For tenant cases, we don't show information about node, regions and
+// diagnostics.
+const mapStateToProps = (
+  state: AppState,
+  props: RouteComponentProps,
+): ActiveTransactionDetailsStateProps => {
+  return {
+    transaction: selectActiveTransaction(state, props),
+    match: props.match,
+  };
+};
+
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): ActiveTransactionDetailsDispatchProps => ({
+  refreshSessions: () => dispatch(sessionsActions.refresh()),
+});
+
+export const ActiveTransactionDetailsPageConnected = withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ActiveTransactionDetails),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/index.ts
@@ -11,3 +11,4 @@
 export * from "./transactionDetails";
 export * from "./transactionDetailsConnected";
 export * from "./activeTransactionDetails";
+export * from "./activeTransactionDetailsConnected";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
@@ -1,0 +1,92 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { getActiveTransactionsFromSessions } from "../activeExecutions/activeStatementUtils";
+import { localStorageSelector } from "src/statementsPage/statementsPage.selectors";
+import {
+  ActiveTransactionFilters,
+  ActiveTransactionsViewDispatchProps,
+  ActiveTransactionsViewStateProps,
+  AppState,
+  SortSetting,
+} from "src";
+import { actions as sessionsActions } from "src/store/sessions";
+import { actions as localStorageActions } from "src/store/localStorage";
+import { Dispatch } from "redux";
+
+export const selectActiveTransactions = createSelector(
+  (state: AppState) => state.adminUI.sessions,
+  response => {
+    if (!response.data) return [];
+
+    return getActiveTransactionsFromSessions(
+      response.data,
+      response.lastUpdated,
+    );
+  },
+);
+
+export const selectSortSetting = (state: AppState): SortSetting =>
+  localStorageSelector(state)["sortSetting/ActiveTransactionsPage"];
+
+export const selectFilters = (state: AppState): ActiveTransactionFilters =>
+  localStorageSelector(state)["filters/ActiveTransactionsPage"];
+
+const selectLocalStorageColumns = (state: AppState) => {
+  const localStorage = localStorageSelector(state);
+  return localStorage["showColumns/ActiveTransactionsPage"];
+};
+
+export const selectColumns = createSelector(
+  selectLocalStorageColumns,
+  value => {
+    if (value == null) return null;
+
+    return value.split(",").map(col => col.trim());
+  },
+);
+
+export const mapStateToActiveTransactionsPageProps = (
+  state: AppState,
+): ActiveTransactionsViewStateProps => ({
+  transactions: selectActiveTransactions(state),
+  sessionsError: state.adminUI.sessions.lastError,
+  selectedColumns: selectColumns(state),
+  sortSetting: selectSortSetting(state),
+  filters: selectFilters(state),
+});
+
+export const mapDispatchToActiveTransactionsPageProps = (
+  dispatch: Dispatch,
+): ActiveTransactionsViewDispatchProps => ({
+  refreshSessions: () => dispatch(sessionsActions.refresh()),
+  onColumnsSelect: columns =>
+    dispatch(
+      localStorageActions.update({
+        key: "showColumns/ActiveTransactionsPage",
+        value: columns ? columns.join(", ") : " ",
+      }),
+    ),
+  onFiltersChange: (filters: ActiveTransactionFilters) =>
+    dispatch(
+      localStorageActions.update({
+        key: "filters/ActiveTransactionsPage",
+        value: filters,
+      }),
+    ),
+  onSortChange: (ss: SortSetting) =>
+    dispatch(
+      localStorageActions.update({
+        key: "sortSetting/ActiveTransactionsPage",
+        value: ss,
+      }),
+    ),
+});

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -14,7 +14,6 @@ import { Dispatch } from "redux";
 
 import { AppState } from "src/store";
 import { actions as sqlStatsActions } from "src/store/sqlStats";
-import { TransactionsPage } from "./transactionsPage";
 import {
   TransactionsPageStateProps,
   TransactionsPageDispatchProps,
@@ -35,90 +34,130 @@ import { actions as localStorageActions } from "../store/localStorage";
 import { Filters } from "../queryFilter";
 import { actions as analyticsActions } from "../store/analytics";
 import { TimeScale } from "../timeScaleDropdown";
+import {
+  TransactionsPageRoot,
+  TransactionsPageRootProps,
+} from "./transactionsPageRoot";
+import {
+  mapStateToActiveTransactionsPageProps,
+  mapDispatchToActiveTransactionsPageProps,
+} from "./activeTransactionsPage.selectors";
+import {
+  ActiveTransactionsViewStateProps,
+  ActiveTransactionsViewDispatchProps,
+} from "./activeTransactionsView";
+
+type StateProps = {
+  fingerprintsPageProps: TransactionsPageStateProps & RouteComponentProps;
+  activePageProps: ActiveTransactionsViewStateProps;
+};
+
+type DispatchProps = {
+  fingerprintsPageProps: TransactionsPageDispatchProps;
+  activePageProps: ActiveTransactionsViewDispatchProps;
+};
 
 export const TransactionsPageConnected = withRouter(
   connect<
-    TransactionsPageStateProps,
-    TransactionsPageDispatchProps,
-    RouteComponentProps
+    StateProps,
+    DispatchProps,
+    RouteComponentProps,
+    TransactionsPageRootProps
   >(
-    (state: AppState) => ({
-      columns: selectTxnColumns(state),
-      data: selectTransactionsData(state),
-      timeScale: selectTimeScale(state),
-      error: selectTransactionsLastError(state),
-      filters: selectFilters(state),
-      isTenant: selectIsTenant(state),
-      nodeRegions: nodeRegionsByIDSelector(state),
-      search: selectSearch(state),
-      sortSetting: selectSortSetting(state),
+    (state: AppState, props) => ({
+      fingerprintsPageProps: {
+        ...props,
+        columns: selectTxnColumns(state),
+        data: selectTransactionsData(state),
+        timeScale: selectTimeScale(state),
+        error: selectTransactionsLastError(state),
+        filters: selectFilters(state),
+        isTenant: selectIsTenant(state),
+        nodeRegions: nodeRegionsByIDSelector(state),
+        search: selectSearch(state),
+        sortSetting: selectSortSetting(state),
+      },
+      activePageProps: mapStateToActiveTransactionsPageProps(state),
     }),
     (dispatch: Dispatch) => ({
-      refreshData: (req: StatementsRequest) =>
-        dispatch(sqlStatsActions.refresh(req)),
-      resetSQLStats: (req: StatementsRequest) =>
-        dispatch(sqlStatsActions.reset(req)),
-      onTimeScaleChange: (ts: TimeScale) => {
-        dispatch(
-          sqlStatsActions.updateTimeScale({
-            ts: ts,
-          }),
-        );
+      fingerprintsPageProps: {
+        refreshData: (req: StatementsRequest) =>
+          dispatch(sqlStatsActions.refresh(req)),
+        resetSQLStats: (req: StatementsRequest) =>
+          dispatch(sqlStatsActions.reset(req)),
+        onTimeScaleChange: (ts: TimeScale) => {
+          dispatch(
+            sqlStatsActions.updateTimeScale({
+              ts: ts,
+            }),
+          );
+        },
+        // We use `null` when the value was never set and it will show all columns.
+        // If the user modifies the selection and no columns are selected,
+        // the function will save the value as a blank space, otherwise
+        // it gets saved as `null`.
+        onColumnsChange: (selectedColumns: string[]) =>
+          dispatch(
+            localStorageActions.update({
+              key: "showColumns/TransactionPage",
+              value:
+                selectedColumns.length === 0 ? " " : selectedColumns.join(","),
+            }),
+          ),
+        onSortingChange: (
+          tableName: string,
+          columnName: string,
+          ascending: boolean,
+        ) => {
+          dispatch(
+            localStorageActions.update({
+              key: "sortSetting/TransactionsPage",
+              value: { columnTitle: columnName, ascending: ascending },
+            }),
+          );
+        },
+        onFilterChange: (value: Filters) => {
+          dispatch(
+            analyticsActions.track({
+              name: "Filter Clicked",
+              page: "Transactions",
+              filterName: "app",
+              value: value.toString(),
+            }),
+          );
+          dispatch(
+            localStorageActions.update({
+              key: "filters/TransactionsPage",
+              value: value,
+            }),
+          );
+        },
+        onSearchComplete: (query: string) => {
+          dispatch(
+            analyticsActions.track({
+              name: "Keyword Searched",
+              page: "Transactions",
+            }),
+          );
+          dispatch(
+            localStorageActions.update({
+              key: "search/TransactionsPage",
+              value: query,
+            }),
+          );
+        },
       },
-      // We use `null` when the value was never set and it will show all columns.
-      // If the user modifies the selection and no columns are selected,
-      // the function will save the value as a blank space, otherwise
-      // it gets saved as `null`.
-      onColumnsChange: (selectedColumns: string[]) =>
-        dispatch(
-          localStorageActions.update({
-            key: "showColumns/TransactionPage",
-            value:
-              selectedColumns.length === 0 ? " " : selectedColumns.join(","),
-          }),
-        ),
-      onSortingChange: (
-        tableName: string,
-        columnName: string,
-        ascending: boolean,
-      ) => {
-        dispatch(
-          localStorageActions.update({
-            key: "sortSetting/TransactionsPage",
-            value: { columnTitle: columnName, ascending: ascending },
-          }),
-        );
+      activePageProps: mapDispatchToActiveTransactionsPageProps(dispatch),
+    }),
+    (stateProps, dispatchProps) => ({
+      fingerprintsPageProps: {
+        ...stateProps.fingerprintsPageProps,
+        ...dispatchProps.fingerprintsPageProps,
       },
-      onFilterChange: (value: Filters) => {
-        dispatch(
-          analyticsActions.track({
-            name: "Filter Clicked",
-            page: "Transactions",
-            filterName: "app",
-            value: value.toString(),
-          }),
-        );
-        dispatch(
-          localStorageActions.update({
-            key: "filters/TransactionsPage",
-            value: value,
-          }),
-        );
-      },
-      onSearchComplete: (query: string) => {
-        dispatch(
-          analyticsActions.track({
-            name: "Keyword Searched",
-            page: "Transactions",
-          }),
-        );
-        dispatch(
-          localStorageActions.update({
-            key: "search/TransactionsPage",
-            value: query,
-          }),
-        );
+      activePageProps: {
+        ...stateProps.activePageProps,
+        ...dispatchProps.activePageProps,
       },
     }),
-  )(TransactionsPage),
+  )(TransactionsPageRoot),
 );


### PR DESCRIPTION
This commit adds the active statements and active transactions
pages required by cockroach cloud. The components created
in this commit are intended for use in `managed-service`.

Release note: None