### PR TITLE
sql: add support for date_trunc(string, interval)

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -486,6 +486,11 @@ significant than <code>element</code> to zero (or one, for day and month)</p>
 <p>Compatible elements: millennium, century, decade, year, quarter, month,
 week, day, hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
+<tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
+significant than <code>element</code> to zero (or one, for day and month)</p>
+<p>Compatible elements: millennium, century, decade, year, quarter, month,
+week, day, hour, minute, second, millisecond, microsecond.</p>
+</span></td></tr>
 <tr><td><a name="date_trunc"></a><code>date_trunc(element: <a href="string.html">string</a>, input: <a href="time.html">time</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Truncates <code>input</code> to precision <code>element</code>.  Sets all fields that are less
 significant than <code>element</code> to zero.</p>
 <p>Compatible elements: hour, minute, second, millisecond, microsecond.</p>

--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -650,3 +650,66 @@ WHERE tablename = 'intervalstyle_in_index'
 AND indexname = 'idx'
 ----
 idx  CREATE INDEX idx ON test.public.intervalstyle_in_index USING btree (b ASC) WHERE (b > 'P3Y'::INTERVAL)
+
+# date_trunc
+statement ok
+SET intervalstyle = 'postgres'
+
+statement error pgcode 22023 interval units "invalid" not recognized
+SELECT date_trunc('invalid', interval '1 month')
+
+statement error pgcode 0A000 interval units "week" not supported because months usually have fractional weeks
+SELECT date_trunc('week', interval '1 month')
+
+statement error pgcode 0A000 interval units "weeks" not supported because months usually have fractional weeks
+SELECT date_trunc('weeks', interval '1 month')
+
+query TT
+SELECT timespan, date_trunc(timespan, '1111 year 4 month 1 day 1 hour 1 minute 1 second 1 millisecond 1 microsecond')
+FROM (VALUES
+  ('millennia'),
+  ('millennium'),
+  ('millenniums'),
+  ('century'),
+  ('centuries'),
+  ('decade'),
+  ('decades'),
+  ('quarter'),
+  ('month'),
+  ('months'),
+  ('day'),
+  ('days'),
+  ('hour'),
+  ('hours'),
+  ('minute'),
+  ('minutes'),
+  ('second'),
+  ('seconds'),
+  ('millisecond'),
+  ('milliseconds'),
+  ('microsecond'),
+  ('microseconds'))
+AS t(timespan)
+----
+millennia     1000 years
+millennium    1000 years
+millenniums   1000 years
+century       1100 years
+centuries     1100 years
+decade        1110 years
+decades       1110 years
+quarter       1111 years 3 mons
+month         1111 years 4 mons
+months        1111 years 4 mons
+day           1111 years 4 mons 1 day
+days          1111 years 4 mons 1 day
+hour          1111 years 4 mons 1 day 01:00:00
+hours         1111 years 4 mons 1 day 01:00:00
+minute        1111 years 4 mons 1 day 01:01:00
+minutes       1111 years 4 mons 1 day 01:01:00
+second        1111 years 4 mons 1 day 01:01:01
+seconds       1111 years 4 mons 1 day 01:01:01
+millisecond   1111 years 4 mons 1 day 01:01:01.001
+milliseconds  1111 years 4 mons 1 day 01:01:01.001
+microsecond   1111 years 4 mons 1 day 01:01:01.001001
+microseconds  1111 years 4 mons 1 day 01:01:01.001001


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/76960

Release justification: Adds new date_trunc interval support that does not affect
existing functionality.

Release note (sql change): Add support for date_trunc(string, interval).