### PR TITLE
storage,roachpb: expose pebble.InternalIteratorStats for scans

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//proto",
         "@com_github_golang_mock//gomock",  # keep
         "@io_etcd_go_etcd_raft_v3//raftpb",

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2912,4 +2912,12 @@ message ScanStats {
   uint64 num_internal_seeks = 2;
   uint64 num_interface_steps = 3;
   uint64 num_internal_steps = 4;
+  // Lower-level stats for the scan. See pebble.InternalIteratorStats for the
+  // meaning of these.
+  uint64 block_bytes = 5;
+  uint64 block_bytes_in_cache = 6;
+  uint64 key_bytes = 7;
+  uint64 value_bytes = 8;
+  uint64 point_count = 9;
+  uint64 points_covered_by_range_tombstones = 10;
 }

--- a/pkg/sql/execinfra/stats.go
+++ b/pkg/sql/execinfra/stats.go
@@ -56,6 +56,8 @@ func GetCumulativeContentionTime(ctx context.Context) time.Duration {
 // ScanStats contains statistics on the internal MVCC operators used to satisfy
 // a scan. See storage/engine.go for a more thorough discussion of the meaning
 // of each stat.
+// TODO(sql-observability): include other fields that are in roachpb.ScanStats,
+// here and in execinfrapb.KVStats.
 type ScanStats struct {
 	// NumInterfaceSteps is the number of times the MVCC step function was called
 	// to satisfy a scan.

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -964,6 +964,7 @@ func (i *intentInterleavingIter) Stats() IteratorStats {
 		stats.Stats.ForwardStepCount[i] += intentStats.Stats.ForwardStepCount[i]
 		stats.Stats.ReverseStepCount[i] += intentStats.Stats.ReverseStepCount[i]
 	}
+	stats.Stats.InternalStats.Merge(intentStats.Stats.InternalStats)
 	return stats
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2210,10 +2210,16 @@ func recordIteratorStats(traceSpan *tracing.Span, iteratorStats IteratorStats) {
 		internalSteps := stats.ReverseStepCount[pebble.InternalIterCall] + stats.ForwardStepCount[pebble.InternalIterCall]
 		internalSeeks := stats.ReverseSeekCount[pebble.InternalIterCall] + stats.ForwardSeekCount[pebble.InternalIterCall]
 		traceSpan.RecordStructured(&roachpb.ScanStats{
-			NumInterfaceSeeks: uint64(seeks),
-			NumInternalSeeks:  uint64(internalSeeks),
-			NumInterfaceSteps: uint64(steps),
-			NumInternalSteps:  uint64(internalSteps),
+			NumInterfaceSeeks:              uint64(seeks),
+			NumInternalSeeks:               uint64(internalSeeks),
+			NumInterfaceSteps:              uint64(steps),
+			NumInternalSteps:               uint64(internalSteps),
+			BlockBytes:                     stats.InternalStats.BlockBytes,
+			BlockBytesInCache:              stats.InternalStats.BlockBytesInCache,
+			KeyBytes:                       stats.InternalStats.KeyBytes,
+			ValueBytes:                     stats.InternalStats.ValueBytes,
+			PointCount:                     stats.InternalStats.PointCount,
+			PointsCoveredByRangeTombstones: stats.InternalStats.PointsCoveredByRangeTombstones,
 		})
 	}
 }


### PR DESCRIPTION
The current IteratorStats only include information from the top
of the tree (pebble.Iterator). The new InternalIteratorStats
includes block bytes loaded (and cached), and stats for points
iterated over when merging across levels in the log-structured
merge tree. The latter includes points that were ignored because
of range tombstones, but could not be cheaply skipped.

These stats can be used to make inferences about root causes
of slow scans.

This change exposes these in roachpb.ScanStats and the trace
span recorded when doing a mvcc get or scan. There are todos for
plumbing all or part of it through the higher layers via
roachpb.ScanStats and execinfrapb.KVStats.

Informs #59069
Informs https://github.com/cockroachdb/pebble/issues/1342

Release justification: low risk, and potentially high benefit
observability increase for existing functionality.

Release note: None