### PR TITLE
sql/contention: expose metrics for contention event store

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -663,7 +663,14 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	if hasNodeLiveness {
 		traceCollector = collector.New(cfg.nodeDialer, nodeLiveness, cfg.Tracer)
 	}
-	contentionRegistry := contention.NewRegistry(cfg.Settings, cfg.sqlStatusServer.TxnIDResolution)
+	contentionMetrics := contention.NewMetrics()
+	cfg.registry.AddMetricStruct(contentionMetrics)
+
+	contentionRegistry := contention.NewRegistry(
+		cfg.Settings,
+		cfg.sqlStatusServer.TxnIDResolution,
+		&contentionMetrics,
+	)
 	contentionRegistry.Start(ctx, cfg.stopper)
 
 	*execCfg = sql.ExecutorConfig{

--- a/pkg/sql/contention/BUILD.bazel
+++ b/pkg/sql/contention/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cluster_settings.go",
         "event_store.go",
+        "metrics.go",
         "registry.go",
         "resolver.go",
         "test_utils.go",
@@ -22,6 +23,7 @@ go_library(
         "//pkg/sql/contentionpb",
         "//pkg/util/cache",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/sql/contention/event_store.go
+++ b/pkg/sql/contention/event_store.go
@@ -123,11 +123,11 @@ var (
 )
 
 func newEventStore(
-	st *cluster.Settings, endpoint ResolverEndpoint, timeSrc timeSource,
+	st *cluster.Settings, endpoint ResolverEndpoint, timeSrc timeSource, metrics *Metrics,
 ) *eventStore {
 	s := &eventStore{
 		st:             st,
-		resolver:       newResolver(endpoint, eventBatchSize /* sizeHint */),
+		resolver:       newResolver(endpoint, metrics, eventBatchSize /* sizeHint */),
 		eventBatchChan: make(chan *eventBatch, eventChannelSize),
 		closeCh:        make(chan struct{}),
 		timeSrc:        timeSrc,

--- a/pkg/sql/contention/metrics.go
+++ b/pkg/sql/contention/metrics.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package contention
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics is a struct that include all metrics related to contention event
+// store.
+type Metrics struct {
+	ResolverQueueSize *metric.Gauge
+	ResolverRetries   *metric.Counter
+	ResolverFailed    *metric.Counter
+}
+
+var _ metric.Struct = Metrics{}
+
+// MetricStruct returns a new instance of Metrics.
+func (Metrics) MetricStruct() {}
+
+// NewMetrics returns a new instance of Metrics.
+func NewMetrics() Metrics {
+	return Metrics{
+		ResolverQueueSize: metric.NewGauge(metric.Metadata{
+			Name:        "sql.contention.resolver.queue_size",
+			Help:        "Length of queued unresolved contention events",
+			Measurement: "Queue length",
+			Unit:        metric.Unit_COUNT,
+		}),
+		ResolverRetries: metric.NewCounter(metric.Metadata{
+			Name:        "sql.contention.resolver.retries",
+			Help:        "Number of times transaction id resolution has been retried",
+			Measurement: "Retry count",
+			Unit:        metric.Unit_COUNT,
+		}),
+		ResolverFailed: metric.NewCounter(metric.Metadata{
+			Name:        "sql.contention.resolver.failed_resolutions",
+			Help:        "Number of failed transaction ID resolution attempts",
+			Measurement: "Failed transaction ID resolution count",
+			Unit:        metric.Unit_COUNT,
+		}),
+	}
+}

--- a/pkg/sql/contention/registry.go
+++ b/pkg/sql/contention/registry.go
@@ -243,11 +243,11 @@ func newNonSQLKeysMap() *nonSQLKeysMap {
 }
 
 // NewRegistry creates a new Registry.
-func NewRegistry(st *cluster.Settings, endpoint ResolverEndpoint) *Registry {
+func NewRegistry(st *cluster.Settings, endpoint ResolverEndpoint, metrics *Metrics) *Registry {
 	return &Registry{
 		indexMap:      newIndexMap(),
 		nonSQLKeysMap: newNonSQLKeysMap(),
-		eventStore:    newEventStore(st, endpoint, timeutil.Now),
+		eventStore:    newEventStore(st, endpoint, timeutil.Now, metrics),
 	}
 }
 

--- a/pkg/sql/contention/registry_test.go
+++ b/pkg/sql/contention/registry_test.go
@@ -82,7 +82,8 @@ func TestRegistry(t *testing.T) {
 			var ok bool
 			registry, ok = registryMap[registryKey]
 			if !ok {
-				registry = contention.NewRegistry(st, nil /* status */)
+				m := contention.NewMetrics()
+				registry = contention.NewRegistry(st, nil /* status */, &m)
 				registryMap[registryKey] = registry
 			}
 			return d.Expected
@@ -176,7 +177,8 @@ func TestRegistryConcurrentAdds(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	// Disable the event store.
 	contention.TxnIDResolutionInterval.Override(context.Background(), &st.SV, 0)
-	registry := contention.NewRegistry(st, nil /* status */)
+	m := contention.NewMetrics()
+	registry := contention.NewRegistry(st, nil /* status */, &m)
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			defer wg.Done()
@@ -311,7 +313,8 @@ func TestSerializedRegistryInvariants(t *testing.T) {
 	// Disable the event store.
 	contention.TxnIDResolutionInterval.Override(context.Background(), &st.SV, 0)
 	createNewSerializedRegistry := func() contentionpb.SerializedRegistry {
-		r := contention.NewRegistry(st, nil /* status */)
+		m := contention.NewMetrics()
+		r := contention.NewRegistry(st, nil /* status */, &m)
 		populateRegistry(r)
 		s := r.Serialize()
 		checkSerializedRegistryInvariants(s)

--- a/pkg/sql/contention/resolver.go
+++ b/pkg/sql/contention/resolver.go
@@ -109,13 +109,16 @@ type resolverQueueImpl struct {
 	}
 
 	resolverEndpoint ResolverEndpoint
+
+	metrics *Metrics
 }
 
 var _ resolverQueue = &resolverQueueImpl{}
 
-func newResolver(endpoint ResolverEndpoint, sizeHint int) *resolverQueueImpl {
+func newResolver(endpoint ResolverEndpoint, metrics *Metrics, sizeHint int) *resolverQueueImpl {
 	s := &resolverQueueImpl{
 		resolverEndpoint: endpoint,
+		metrics:          metrics,
 	}
 
 	s.mu.unresolvedEvents = make([]contentionpb.ExtendedContentionEvent, 0, sizeHint)
@@ -131,6 +134,7 @@ func (q *resolverQueueImpl) enqueue(block []contentionpb.ExtendedContentionEvent
 	defer q.mu.Unlock()
 
 	q.mu.unresolvedEvents = append(q.mu.unresolvedEvents, block...)
+	q.metrics.ResolverQueueSize.Inc(int64(len(block)))
 }
 
 // dequeue implements the resolverQueue interface.
@@ -143,6 +147,8 @@ func (q *resolverQueueImpl) dequeue(
 	err := q.resolveLocked(ctx)
 	result := q.mu.resolvedEvents
 	q.mu.resolvedEvents = q.mu.resolvedEvents[:0]
+
+	q.metrics.ResolverQueueSize.Dec(int64(len(result)))
 
 	return result, err
 }
@@ -288,11 +294,14 @@ func (q *resolverQueueImpl) maybeRequeueEventForRetryLocked(
 
 		if remainingRetryBudget == 0 {
 			delete(q.mu.remainingRetries, event.Hash())
+			q.metrics.ResolverFailed.Inc(1)
+			q.metrics.ResolverQueueSize.Dec(1)
 			return false /* requeued */
 		}
 	}
 
 	q.mu.unresolvedEvents = append(q.mu.unresolvedEvents, event)
+	q.metrics.ResolverRetries.Inc(1)
 	return true /* requeued */
 }
 

--- a/pkg/sql/contention/resolver_test.go
+++ b/pkg/sql/contention/resolver_test.go
@@ -33,7 +33,8 @@ type testData struct {
 
 func TestResolver(t *testing.T) {
 	statusServer := newFakeStatusServerCluster()
-	resolver := newResolver(statusServer.txnIDResolution, 0 /* sizeHint */)
+	metrics := NewMetrics()
+	resolver := newResolver(statusServer.txnIDResolution, &metrics, 0 /* sizeHint */)
 	ctx := context.Background()
 
 	t.Run("normal_resolution", func(t *testing.T) {

--- a/pkg/sql/contention/txnidcache/metrics.go
+++ b/pkg/sql/contention/txnidcache/metrics.go
@@ -12,8 +12,7 @@ package txnidcache
 
 import "github.com/cockroachdb/cockroach/pkg/util/metric"
 
-// Metrics is a structs that include all metrics related to contention
-// subsystem.
+// Metrics is a struct that include all metrics related to txn id cache.
 type Metrics struct {
 	CacheMissCounter *metric.Counter
 	CacheReadCounter *metric.Counter

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1934,6 +1934,18 @@ var charts = []sectionDescription{
 				Title:   "Transaction ID Cache Read",
 				Metrics: []string{"sql.contention.txn_id_cache.read"},
 			},
+			{
+				Title:   "Resolver Queue Size",
+				Metrics: []string{"sql.contention.resolver.queue_size"},
+			},
+			{
+				Title:   "Resolver Retries",
+				Metrics: []string{"sql.contention.resolver.retries"},
+			},
+			{
+				Title:   "Resolver Failures",
+				Metrics: []string{"sql.contention.resolver.failed_resolutions"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This commit introduces three new metrics for contention event store.
* sql.contention.resolver.queue_size: shows the current size of the of
the contention resolver queue. This metric is useful to assess the level
of backlog unresolved contention events.
* sql.contention.resolver.retries: shows the number of retries performed
by the resolver. Any spike in this metric could indicate possible
anomaly in the transaction id resolution protocol.
* sql.contention.resolver.failed_resolution: shows the number of failed
transaction ID resolution. A spike in this metric indicates likely severe
failure in transaction ID resolution protocol. Human intervention might
be needed in this case to disable the contention event store + txn id
cache until root cause is found.

Release justification: low risk and potentially high benefit
observability increase for existing functionality.

Release note (sql change): introduce sql.contention.resolver.queue_size
metric. This is a gauge metric reflecting the current size of the queued
contention events waiting to have its transaction ID to be translated
into transaction fingerprint ID.

Release note (sql change): introduce sql.contention.resolver.retries
metric. This is a counter metric reflecting the number of retries
performed by the contention event store attempting to translate the
transaction ID of the contention event into transaction fingerprint ID.

Release note (sql change): introduce sql.contention.resolver.failed_resolution
metric. This is a counter metric number of failed attempt to translate
transaciton ID in the contention events into transaction fingerprint ID.