### PR TITLE
deps: update cockroachdb/errors

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1252,10 +1252,10 @@ def go_deps():
         patches = [
             "@cockroach//build/patches:com_github_cockroachdb_errors.patch",
         ],
-        sha256 = "65cad26bfd3df564cfcbdc99f14b72b1a62d53d71956f60499a51801518e1fc3",
-        strip_prefix = "github.com/cockroachdb/errors@v1.8.9",
+        sha256 = "ff3814544271799c80da14dadfe408efc4f66e02cbdf17b73e81614ed9f7ae43",
+        strip_prefix = "github.com/cockroachdb/errors@v1.9.0",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/errors/com_github_cockroachdb_errors-v1.8.9.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/errors/com_github_cockroachdb_errors-v1.9.0.zip",
         ],
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/cockroachdb/cockroach-go/v2 v2.2.6
 	github.com/cockroachdb/crlfmt v0.0.0-20210128092314-b3eff0b87c79
 	github.com/cockroachdb/datadriven v1.0.1
-	github.com/cockroachdb/errors v1.8.9
+	github.com/cockroachdb/errors v1.9.0
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,9 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/errors v1.6.1/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=
 github.com/cockroachdb/errors v1.8.8/go.mod h1:z6VnEL3hZ/2ONZEvG7S5Ym0bU2AqPcEKnIiA1wbsSu0=
-github.com/cockroachdb/errors v1.8.9 h1:eqUxTOUOduHP4D3f3wJ0kiyoNjDf6wLCso/4n7rBA4U=
 github.com/cockroachdb/errors v1.8.9/go.mod h1:vaNcEYYqbIqB5JhKBhFV9CneUqeuEbB2OYJBK4GBNYQ=
+github.com/cockroachdb/errors v1.9.0 h1:B48dYem5SlAY7iU8AKsgedb4gH6mo+bDkbtLIvM/a88=
+github.com/cockroachdb/errors v1.9.0/go.mod h1:vaNcEYYqbIqB5JhKBhFV9CneUqeuEbB2OYJBK4GBNYQ=
 github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55 h1:YqzBA7tf8Gv8Oz0BbBsPenqkyjiohS7EUIwi7p1QJCU=
 github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55/go.mod h1:QqVqNIiRhLqJXif5C9wbM4JydBhrAF2WDMxkv5xkyxQ=
 github.com/cockroachdb/gostdlib v1.13.0 h1:TzSEPYgkKDNei3gbLc0rrHu4iHyBp7/+NxPOFmcXGaw=

--- a/pkg/util/log/logcrash/crash_reporting_packet_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_packet_test.go
@@ -105,15 +105,11 @@ func TestCrashReportingPacket(t *testing.T) {
 
 	const prefix = "crash_reporting_packet_test.go:"
 
-	type extraPair struct {
-		key   string
-		reVal string
-	}
 	expectations := []struct {
 		serverID *regexp.Regexp
 		tagCount int
-		message  string
-		extra    []extraPair
+		title    string
+		message  *regexp.Regexp
 	}{
 		{regexp.MustCompile(`^$`), 7, func() string {
 			message := prefix
@@ -125,9 +121,9 @@ func TestCrashReportingPacket(t *testing.T) {
 			}
 			message += " (TestCrashReportingPacket)"
 			return message
-		}(), []extraPair{
-			{"1: details", "panic: " + panicPre},
-		}},
+		}(),
+			regexp.MustCompile(`crash_reporting_packet_test.go:\d+: panic: boom`),
+		},
 		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 12, func() string {
 			message := prefix
 			// gccgo stack traces are different in the presence of function literals.
@@ -138,9 +134,9 @@ func TestCrashReportingPacket(t *testing.T) {
 			}
 			message += " (TestCrashReportingPacket)"
 			return message
-		}(), []extraPair{
-			{"1: details", "panic: " + panicPost},
-		}},
+		}(),
+			regexp.MustCompile(`crash_reporting_packet_test.go:\d+: panic: baam`),
+		},
 	}
 
 	if e, a := len(expectations), len(packets); e != a {
@@ -151,6 +147,8 @@ func TestCrashReportingPacket(t *testing.T) {
 		p := packets[0]
 		packets = packets[1:]
 		t.Run("", func(t *testing.T) {
+			t.Logf("message: %q", p.Message)
+
 			if !logcrash.ReportSensitiveDetails {
 				e, a := "<redacted>", p.ServerName
 				if e != a {
@@ -167,12 +165,14 @@ func TestCrashReportingPacket(t *testing.T) {
 				t.Errorf("expected server_id '%s' to match %s", serverID, exp.serverID)
 			}
 
+			assert.Regexp(t, exp.message, p.Message)
+
 			if len(p.Exception) < 1 {
 				t.Error("expected some exception in packet, got none")
 			} else {
-				if p.Exception[0].Type != exp.message {
+				if p.Exception[0].Type != exp.title {
 					t.Errorf("expected %q in exception type, got %q",
-						exp.message, p.Exception[0].Type)
+						exp.title, p.Exception[0].Type)
 				}
 
 				lastFrame := p.Exception[0].Stacktrace.Frames[len(p.Exception[0].Stacktrace.Frames)-1]
@@ -182,20 +182,6 @@ func TestCrashReportingPacket(t *testing.T) {
 				if !strings.HasSuffix(lastFrame.Filename, "crash_reporting_packet_test.go") {
 					t.Errorf("last frame filename: expected crash_reporting_packet_test.go, got %q", lastFrame.Filename)
 				}
-			}
-
-			for _, ex := range exp.extra {
-				data, ok := p.Extra[ex.key]
-				if !ok {
-					t.Errorf("expected detail %q in extras, was not found", ex.key)
-					continue
-				}
-				sdata, ok := data.(string)
-				if !ok {
-					t.Errorf("expected detail %q of type string, found %T (%q)", ex.key, data, data)
-					continue
-				}
-				assert.Regexp(t, ex.reVal, sdata)
 			}
 		})
 	}
@@ -248,41 +234,37 @@ func TestInternalErrorReporting(t *testing.T) {
 	// the redaction markers are removed.
 	rm := string(redact.RedactableBytes(redact.RedactedMarker()).StripMarkers())
 
-	assert.Regexp(t, `builtins\.go:\d+: crdb_internal.force_assertion_error\(\): `+rm+`\n`+
-		`--\n`+
-		`\*errutil.leafError: `+rm+` \(1\)\n`+
-		`builtins.go:\d+: \*withstack.withStack \(top exception\)\n`+
-		`\*assert.withAssertionFailure\n`+
-		`\*errutil.withPrefix: crdb_internal.force_assertion_error\(\) \(2\)\n`+
-		`eval.go:\d+: \*withstack.withStack \(3\)\n`+
-		`\*telemetrykeys.withTelemetry: crdb_internal.force_assertion_error\(\) \(4\)\n`+
-		`\*colexecerror.notInternalError\n`+
-		`\(check the extra data payloads\)`, p.Message)
-
-	expectedExtra := []struct {
-		key   string
-		reVal string
-	}{
-		{"1: details", rm},
-		{"2: details", `crdb_internal\.force_assertion_error\(\)`},
-		{"4: details", `crdb_internal\.force_assertion_error\(\)`},
-	}
-	for _, ex := range expectedExtra {
-		data, ok := p.Extra[ex.key]
-		if !ok {
-			t.Errorf("expected detail %q in extras, was not found", ex.key)
-			continue
-		}
-		sdata, ok := data.(string)
-		if !ok {
-			t.Errorf("expected detail %q of type string, found %T (%q)", ex.key, data, data)
-			continue
-		}
-		assert.Regexp(t, ex.reVal, sdata)
+	assert.Regexp(t, `builtins\.go:\d+: crdb_internal.force_assertion_error\(\): `+rm+`\n`, p.Message)
+	idx := strings.Index(p.Message, "-- report composition:\n")
+	assert.GreaterOrEqual(t, idx, 1)
+	if idx > 0 {
+		assert.Regexp(t,
+			`-- report composition:\n`+
+				`\*errutil.leafError: `+rm+`\n`+
+				`builtins.go:\d+: \*withstack.withStack \(top exception\)\n`+
+				`\*assert.withAssertionFailure\n`+
+				`\*errutil.withPrefix: crdb_internal.force_assertion_error\(\)\n`+
+				`eval.go:\d+: \*withstack.withStack \(1\)\n`+
+				`\*telemetrykeys.withTelemetry: crdb_internal.force_assertion_error\(\)\n`+
+				`\*colexecerror.notInternalError\n`+
+				`\(check the extra data payloads\)`, p.Message[idx:])
 	}
 
 	if len(p.Exception) < 2 {
 		t.Fatalf("expected 2 stacktraces, got %d", len(p.Exception))
+	}
+
+	extra, ok := p.Extra["error types"]
+	assert.True(t, ok)
+	if ok {
+		assert.Equal(t, "github.com/cockroachdb/errors/errutil/*errutil.leafError (*::)\n"+
+			"github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)\n"+
+			"github.com/cockroachdb/errors/assert/*assert.withAssertionFailure (*::)\n"+
+			"github.com/cockroachdb/errors/errutil/*errutil.withPrefix (*::)\n"+
+			"github.com/cockroachdb/errors/withstack/*withstack.withStack (*::)\n"+
+			"github.com/cockroachdb/errors/telemetrykeys/*telemetrykeys.withTelemetry (*::)\n"+
+			"github.com/cockroachdb/cockroach/pkg/sql/colexecerror/*colexecerror.notInternalError (*::)\n",
+			extra)
 	}
 
 	// The innermost stack trace (and main exception object) is the last
@@ -293,7 +275,7 @@ func TestInternalErrorReporting(t *testing.T) {
 	assert.Regexp(t, `.*/builtins.go`, fr[len(fr)-1].Filename)
 	assert.Regexp(t, `.*/eval.go`, fr[len(fr)-2].Filename)
 
-	assert.Regexp(t, `^\(3\) eval.go:\d+ \(MaybeWrapError\)$`, p.Exception[0].Type)
+	assert.Regexp(t, `^\(1\) eval.go:\d+ \(MaybeWrapError\)$`, p.Exception[0].Type)
 	assert.Regexp(t, `^\*withstack\.withStack$`, p.Exception[0].Value)
 	fr = p.Exception[0].Stacktrace.Frames
 	assert.Regexp(t, `.*/eval.go`, fr[len(fr)-1].Filename)


### PR DESCRIPTION
Fixes  #76571

This upgrades to v1.9.0 and enhances Sentry reports as requested by
the SQL queries team.

Release justification: low risk, high benefit changes to existing functionality

Release note: None