### PR TITLE
release-21.2: changefeedccl: Augment kafka error messages.

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -360,6 +360,11 @@ func (s *kafkaSink) workerLoop() {
 			ackMsg = m
 		case err := <-s.producer.Errors():
 			ackMsg, ackError = err.Msg, err.Err
+			if ackError != nil {
+				ackError = errors.Wrapf(ackError,
+					"while sending message with key=%s, size=%d",
+					err.Msg.Key, err.Msg.Key.Length()+err.Msg.Value.Length())
+			}
 		}
 
 		if m, ok := ackMsg.Metadata.(messageMetadata); ok {


### PR DESCRIPTION
Backport 1/1 commits from #76997.

/cc @cockroachdb/release

---

Expand kafka error message to include message key as well
as message length for the rejected message.

Release Notes: None
Release Justification: Low impact; usability improvement.
