### PR TITLE
sql/schemachanger: various fixes to improve runtime

### DIFF
--- a/pkg/sql/schemachanger/rel/database.go
+++ b/pkg/sql/schemachanger/rel/database.go
@@ -55,7 +55,7 @@ func NewDatabase(sc *Schema, indexes [][]Attr) (*Database, error) {
 	{
 		var primaryIndex index
 		primaryIndex.s = sc
-		primaryIndex.tree = btree.NewWithFreeList(8, fl)
+		primaryIndex.tree = btree.NewWithFreeList(degree, fl)
 		t.indexes[0] = primaryIndex
 	}
 	secondaryIndexes := t.indexes[1:]

--- a/pkg/sql/schemachanger/rel/database.go
+++ b/pkg/sql/schemachanger/rel/database.go
@@ -60,9 +60,15 @@ func NewDatabase(sc *Schema, indexes [][]Attr) (*Database, error) {
 	}
 	secondaryIndexes := t.indexes[1:]
 	for i, attrs := range indexes {
-		ords, set, err := sc.attributesToOrdinals(attrs)
-		if err != nil {
-			return nil, err
+		var set ordinalSet
+		ords := make([]ordinal, len(attrs))
+		for i, a := range attrs {
+			ord, err := sc.getOrdinal(a)
+			if err != nil {
+				return nil, err
+			}
+			set = set.add(ord)
+			ords[i] = ord
 		}
 		spec := indexSpec{mask: set, attrs: ords, s: sc}
 		secondaryIndexes[i] = index{

--- a/pkg/sql/schemachanger/rel/entity.go
+++ b/pkg/sql/schemachanger/rel/entity.go
@@ -33,10 +33,6 @@ func (sc *Schema) EqualOn(attrs []Attr, a, b interface{}) (eq bool) {
 // CompareOn compares two entities. Note that it will panic if either variable
 // is malformed.
 func (sc *Schema) CompareOn(attrs []Attr, a, b interface{}) (less, eq bool) {
-	ords, _, err := sc.attributesToOrdinals(attrs)
-	if err != nil {
-		panic(err)
-	}
 	ae, err := toEntity(sc, a)
 	if err != nil {
 		panic(err)
@@ -47,8 +43,12 @@ func (sc *Schema) CompareOn(attrs []Attr, a, b interface{}) (less, eq bool) {
 	}
 	defer putValues((*valuesMap)(ae))
 	defer putValues((*valuesMap)(be))
-	for _, a := range ords {
-		if less, eq = compareOn(a, (*valuesMap)(ae), (*valuesMap)(be)); !eq {
+	for _, a := range attrs {
+		ord, err := sc.getOrdinal(a)
+		if err != nil {
+			panic(err)
+		}
+		if less, eq = compareOn(ord, (*valuesMap)(ae), (*valuesMap)(be)); !eq {
 			return less, eq
 		}
 	}

--- a/pkg/sql/schemachanger/rel/ordinal_set.go
+++ b/pkg/sql/schemachanger/rel/ordinal_set.go
@@ -16,22 +16,6 @@ import "math/bits"
 // It enables use of the ordinalSet.
 type ordinal uint64
 
-// attributesToOrdinals constructs a slice of ordinals and the corresponding
-// ordinalSet from a slice of Attr.
-func (sc *Schema) attributesToOrdinals(attrs []Attr) ([]ordinal, ordinalSet, error) {
-	var set ordinalSet
-	ret := make([]ordinal, len(attrs))
-	for i, a := range attrs {
-		ord, err := sc.getOrdinal(a)
-		if err != nil {
-			return nil, 0, err
-		}
-		set = set.add(ord)
-		ret[i] = ord
-	}
-	return ret, set, nil
-}
-
 // ordinalSet represents A bitmask over ordinals.
 // Note that it cannot contain attributes with ordinals greater than 64.
 type ordinalSet uint64

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -39,6 +39,8 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -31,6 +33,13 @@ import (
 func Build(
 	ctx context.Context, dependencies Dependencies, initial scpb.CurrentState, n tree.Statement,
 ) (_ scpb.CurrentState, err error) {
+	start := timeutil.Now()
+	defer func() {
+		if err != nil || !log.ExpensiveLogEnabled(ctx, 2) {
+			return
+		}
+		log.Infof(ctx, "build for %s took %v", n.StatementTag(), timeutil.Since(start))
+	}()
 	initial = initial.DeepCopy()
 	bs := newBuilderState(ctx, dependencies, initial)
 	els := newEventLogState(dependencies, initial, n)

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -122,6 +122,16 @@ type cachedDesc struct {
 	ers          *elementResultSet
 	privileges   map[privilege.Kind]error
 	hasOwnership bool
+
+	// elementIndexMap maps from the string serialization of the element
+	// to the index of the element in the builder state. Note that this
+	// works as a key because the string is derived from the same set of
+	// attributes used to define equality. If we were to change that, we'd
+	// need to derive a new cache key.
+	//
+	// This map ends up being very important to make sure that Ensure does
+	// not become O(N) where N is the number of elements in the descriptor.
+	elementIndexMap map[string]int
 }
 
 // newBuilderState constructs a builderState.

--- a/pkg/sql/schemachanger/scplan/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/BUILD.bazel
@@ -14,6 +14,8 @@ go_library(
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/scplan/internal/scgraphviz",
         "//pkg/sql/schemachanger/scplan/internal/scstage",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
@@ -62,7 +62,9 @@ go_library(
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/sem/catid",
+        "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
@@ -20,25 +20,56 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func newLogEventOp(e scpb.Element, ts scpb.TargetState) *scop.LogEvent {
-	for _, t := range ts.Targets {
-		if t.Element() == e {
-			return &scop.LogEvent{
-				TargetMetadata: *protoutil.Clone(&t.Metadata).(*scpb.TargetMetadata),
-				Authorization:  *protoutil.Clone(&ts.Authorization).(*scpb.Authorization),
-				Statement:      ts.Statements[t.Metadata.StatementID].RedactedStatement,
-				StatementTag:   ts.Statements[t.Metadata.StatementID].StatementTag,
-				Element:        *protoutil.Clone(&t.ElementProto).(*scpb.ElementProto),
-				TargetStatus:   t.TargetStatus,
-			}
-		}
+func newLogEventOp(e scpb.Element, md targetsWithElementMap) *scop.LogEvent {
+	idx, ok := md.elementToTarget[e]
+	if !ok {
+		panic(errors.AssertionFailedf(
+			"could not find element %s in target state", screl.ElementString(e),
+		))
 	}
-	panic(errors.AssertionFailedf("could not find element %s in target state", screl.ElementString(e)))
+	t := md.Targets[idx]
+	return &scop.LogEvent{
+		TargetMetadata: *protoutil.Clone(&t.Metadata).(*scpb.TargetMetadata),
+		Authorization:  *protoutil.Clone(&md.Authorization).(*scpb.Authorization),
+		Statement:      md.Statements[t.Metadata.StatementID].RedactedStatement,
+		StatementTag:   md.Statements[t.Metadata.StatementID].StatementTag,
+		Element:        *protoutil.Clone(&t.ElementProto).(*scpb.ElementProto),
+		TargetStatus:   t.TargetStatus,
+	}
+}
+
+// targetsWithElementMap is one of the available arguments to an opgen
+// function. It allows access to the fields of the TargetState and, via
+// a lookup map, the fields of the element itself.
+//
+// This map allows opgen functions to find their target without an O(N)
+// lookup.
+type targetsWithElementMap struct {
+	scpb.TargetState
+	elementToTarget map[scpb.Element]int
+}
+
+func makeTargetsWithElementMap(cs scpb.CurrentState) targetsWithElementMap {
+	md := targetsWithElementMap{
+		TargetState:     cs.TargetState,
+		elementToTarget: make(map[scpb.Element]int),
+	}
+	for i := range cs.Targets {
+		e := cs.Targets[i].Element()
+		if prev, exists := md.elementToTarget[e]; exists {
+			panic(errors.AssertionFailedf(
+				"duplicate targets for %s: %v and %v", screl.ElementString(e),
+				cs.Targets[i].TargetStatus, cs.Targets[prev].TargetStatus,
+			))
+		}
+		md.elementToTarget[e] = i
+	}
+	return md
 }
 
 // opsFunc are a fully-compiled and checked set of functions to emit operations
 // given an element value.
-type opsFunc func(element scpb.Element, targetState scpb.TargetState) []scop.Op
+type opsFunc func(element scpb.Element, md targetsWithElementMap) []scop.Op
 
 func makeOpsFunc(el scpb.Element, fns []interface{}) (opsFunc, error) {
 	var funcValues []reflect.Value
@@ -48,10 +79,10 @@ func makeOpsFunc(el scpb.Element, fns []interface{}) (opsFunc, error) {
 		}
 		funcValues = append(funcValues, reflect.ValueOf(fn))
 	}
-	return func(element scpb.Element, targetState scpb.TargetState) []scop.Op {
+	return func(element scpb.Element, md targetsWithElementMap) []scop.Op {
 		ret := make([]scop.Op, 0, len(funcValues))
 		in := []reflect.Value{reflect.ValueOf(element)}
-		inWithMeta := []reflect.Value{reflect.ValueOf(element), reflect.ValueOf(targetState)}
+		inWithMeta := []reflect.Value{reflect.ValueOf(element), reflect.ValueOf(md)}
 		for _, fn := range funcValues {
 			var out []reflect.Value
 			if fn.Type().NumIn() == 1 {
@@ -80,7 +111,7 @@ func checkOpFunc(el scpb.Element, fn interface{}) error {
 	elType := reflect.TypeOf(el)
 	if !(fnT.NumIn() == 1 && fnT.In(0) == elType) &&
 		!(fnT.NumIn() == 2 && fnT.In(0) == elType &&
-			fnT.In(1) == reflect.TypeOf(scpb.TargetState{})) {
+			fnT.In(1) == reflect.TypeOf(targetsWithElementMap{})) {
 		return errors.Errorf(
 			"expected %v to be a func with one argument of type %s", fnT, elType,
 		)

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
@@ -42,6 +42,7 @@ func (r *registry) buildGraph(cs scpb.CurrentState) (*scgraph.Graph, error) {
 		n *screl.Node
 	}
 	var edgesToAdd []toAdd
+	md := makeTargetsWithElementMap(cs)
 	for _, t := range r.targets {
 		edgesToAdd = edgesToAdd[:0]
 		if err := t.iterateFunc(g.Database(), func(n *screl.Node) error {
@@ -62,7 +63,7 @@ func (r *registry) buildGraph(cs scpb.CurrentState) (*scgraph.Graph, error) {
 		for _, e := range edgesToAdd {
 			var ops []scop.Op
 			if e.ops != nil {
-				ops = e.ops(e.n.Element(), cs.TargetState)
+				ops = e.ops(e.n.Element(), md)
 			}
 			if err := g.AddOpEdges(
 				e.n.Target, e.from, e.to, e.revertible, e.minPhase, ops...,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_alias_type.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_alias_type.go
@@ -47,8 +47,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.AliasType, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.AliasType, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.AliasType) scop.Op {
 					return &scop.DeleteDescriptor{

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column.go
@@ -27,8 +27,8 @@ func init() {
 						Column: *protoutil.Clone(this).(*scpb.Column),
 					}
 				}),
-				emit(func(this *scpb.Column, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.Column, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 			),
 			to(scpb.Status_WRITE_ONLY,
@@ -59,8 +59,8 @@ func init() {
 						ColumnID: this.ColumnID,
 					}
 				}),
-				emit(func(this *scpb.Column, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.Column, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 			),
 			to(scpb.Status_DELETE_ONLY,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database.go
@@ -47,8 +47,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Database, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.Database, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.Database) scop.Op {
 					return &scop.CreateGcJobForDatabase{

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_enum_type.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_enum_type.go
@@ -47,8 +47,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.EnumType, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.EnumType, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.EnumType) scop.Op {
 					return &scop.DeleteDescriptor{

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_schema.go
@@ -46,8 +46,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Schema, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.Schema, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.Schema) scop.Op {
 					return &scop.DeleteDescriptor{

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
@@ -47,8 +47,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Sequence, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.Sequence, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.Sequence) scop.Op {
 					return &scop.CreateGcJobForTable{

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
@@ -47,8 +47,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.Table, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.Table, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.Table) scop.Op {
 					return &scop.CreateGcJobForTable{

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
@@ -65,8 +65,8 @@ func init() {
 			),
 			to(scpb.Status_ABSENT,
 				minPhase(scop.PostCommitPhase),
-				emit(func(this *scpb.View, ts scpb.TargetState) scop.Op {
-					return newLogEventOp(this, ts)
+				emit(func(this *scpb.View, md targetsWithElementMap) scop.Op {
+					return newLogEventOp(this, md)
 				}),
 				emit(func(this *scpb.View) scop.Op {
 					return &scop.CreateGcJobForTable{

--- a/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
@@ -17,6 +17,8 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -93,9 +93,8 @@ func (d depRuleSpec) register() {
 	}
 	c := rel.Clauses{
 		from.Type(d.from.types[0], d.from.types[1:]...),
-		to.Type(d.to.types[0], d.to.types[1:]...),
-
 		fromTarget.AttrEq(screl.TargetStatus, d.targetStatus),
+		to.Type(d.to.types[0], d.to.types[1:]...),
 		toTarget.AttrEq(screl.TargetStatus, d.targetStatus),
 
 		fromNode.AttrEq(screl.CurrentStatus, d.from.status),

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -6,8 +6,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.View'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.View', '*scpb.Table']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.View', '*scpb.Table']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = DROPPED
     - $to-node[CurrentStatus] = DROPPED
@@ -26,8 +26,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.AliasType'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = DROPPED
     - $to-node[CurrentStatus] = DROPPED
@@ -46,8 +46,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.AliasType'
-    - $to[Type] = '*scpb.EnumType'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.EnumType'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = DROPPED
     - $to-node[CurrentStatus] = DROPPED
@@ -66,8 +66,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.SchemaParent'
-    - $to[Type] = '*scpb.Database'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.Database'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -87,8 +87,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ObjectParent'
-    - $to[Type] = '*scpb.Schema'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.Schema'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -108,8 +108,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.TableLocalitySecondaryRegion'
-    - $to[Type] = '*scpb.EnumType'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.EnumType'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -129,8 +129,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.CheckConstraint'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -149,8 +149,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ForeignKeyConstraint'
-    - $to[Type] = '*scpb.Table'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.Table'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -170,8 +170,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.SecondaryIndexPartial'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -190,8 +190,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ColumnType'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -210,8 +210,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ColumnDefaultExpression'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -230,8 +230,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ColumnOnUpdateExpression'
-    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.AliasType', '*scpb.EnumType', '*scpb.Sequence']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -250,8 +250,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.SequenceOwner'
-    - $to[Type] = '*scpb.Sequence'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.Sequence'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -271,8 +271,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.DatabaseRegionConfig'
-    - $to[Type] = '*scpb.EnumType'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.EnumType'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -292,8 +292,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnComment', '*scpb.SequenceOwner', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexComment', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent']
-    - $to[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.AliasType', '*scpb.EnumType']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.AliasType', '*scpb.EnumType']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = DROPPED
@@ -313,8 +313,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.Table', '*scpb.View']
-    - $to[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.RowLevelTTL']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.RowLevelTTL']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = ABSENT
@@ -356,8 +356,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $to[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexComment']
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexComment']
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = DELETE_ONLY
     - $to-node[CurrentStatus] = PUBLIC
@@ -379,8 +379,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.SecondaryIndex'
-    - $to[Type] = '*scpb.SecondaryIndexPartial'
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] = '*scpb.SecondaryIndexPartial'
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = DELETE_ONLY
     - $to-node[CurrentStatus] = PUBLIC
@@ -402,8 +402,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.IndexPartitioning', '*scpb.IndexComment']
-    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = PUBLIC
     - $to-node[CurrentStatus] = WRITE_ONLY
@@ -425,8 +425,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.IndexName'
-    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = PUBLIC
     - $to-node[CurrentStatus] = PUBLIC
@@ -448,8 +448,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $to[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = VALIDATED
     - $to-node[CurrentStatus] = ABSENT
@@ -471,8 +471,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment']
-    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = ABSENT
@@ -494,8 +494,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.Column'
-    - $to[Type] = '*scpb.ColumnType'
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] = '*scpb.ColumnType'
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = DELETE_ONLY
     - $to-node[CurrentStatus] = PUBLIC
@@ -517,8 +517,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.Column'
-    - $to[Type] IN ['*scpb.ColumnName', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnComment']
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] IN ['*scpb.ColumnName', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnComment']
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = DELETE_ONLY
     - $to-node[CurrentStatus] = PUBLIC
@@ -540,8 +540,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression']
-    - $to[Type] = '*scpb.Column'
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] = '*scpb.Column'
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = PUBLIC
     - $to-node[CurrentStatus] = WRITE_ONLY
@@ -563,8 +563,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ColumnName'
-    - $to[Type] = '*scpb.Column'
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] = '*scpb.Column'
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = PUBLIC
     - $to-node[CurrentStatus] = PUBLIC
@@ -586,8 +586,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ColumnComment'
-    - $to[Type] = '*scpb.Column'
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] = '*scpb.Column'
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = PUBLIC
     - $to-node[CurrentStatus] = PUBLIC
@@ -609,8 +609,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.Column'
-    - $to[Type] IN ['*scpb.ColumnType', '*scpb.ColumnName', '*scpb.ColumnComment']
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] IN ['*scpb.ColumnType', '*scpb.ColumnName', '*scpb.ColumnComment']
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = WRITE_ONLY
     - $to-node[CurrentStatus] = ABSENT
@@ -632,8 +632,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.SequenceOwner', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression']
-    - $to[Type] = '*scpb.ColumnType'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.ColumnType'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = ABSENT
@@ -655,8 +655,8 @@ deprules
   to: to-node
   query:
     - $from[Type] IN ['*scpb.ColumnName', '*scpb.ColumnComment', '*scpb.ColumnType']
-    - $to[Type] = '*scpb.Column'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.Column'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = ABSENT
@@ -678,8 +678,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.ColumnType'
-    - $to[Type] = '*scpb.Column'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.Column'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = ABSENT
@@ -702,8 +702,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.SecondaryIndexPartial'
-    - $to[Type] = '*scpb.SecondaryIndex'
     - $from-target[TargetStatus] = ABSENT
+    - $to[Type] = '*scpb.SecondaryIndex'
     - $to-target[TargetStatus] = ABSENT
     - $from-node[CurrentStatus] = ABSENT
     - $to-node[CurrentStatus] = ABSENT
@@ -750,8 +750,8 @@ deprules
   to: to-node
   query:
     - $from[Type] = '*scpb.Column'
-    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $from-target[TargetStatus] = PUBLIC
+    - $to[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $to-target[TargetStatus] = PUBLIC
     - $from-node[CurrentStatus] = DELETE_ONLY
     - $to-node[CurrentStatus] = DELETE_ONLY

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
@@ -64,11 +64,10 @@ func (g *Graph) Database() *rel.Database {
 // targets. If they do not, an error will be returned.
 func New(cs scpb.CurrentState) (*Graph, error) {
 	db, err := rel.NewDatabase(screl.Schema, [][]rel.Attr{
-		{rel.Type, screl.DescID},
-		{screl.DescID, rel.Type},
-		{screl.Element},
-		{screl.Target},
-		// TODO(ajwerner): Decide what more predicates are needed
+		{screl.DescID, rel.Type, screl.ColumnID},
+		{screl.ReferencedDescID, rel.Type},
+		{rel.Type, screl.Element, screl.CurrentStatus},
+		{rel.Type, screl.Target, screl.TargetStatus},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
These commits improve the runtime in very large graphs. Mostly they address quadratic behavior. Some of them just optimize things internally or do minor cleanup. See the individual commits. There still remains one bad point in stage construction to be sorted. 

Release justification: bug fixes and low-risk updates to new functionality