### PR TITLE
kv/bulk: bump split-after default to 448mb

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -43,7 +43,7 @@ var (
 		settings.TenantWritable,
 		"bulkio.ingest.scatter_after_size",
 		"amount of data added to any one range after which a new range should be split off and scattered",
-		48<<20,
+		448<<20,
 	)
 
 	ingestDelay = settings.RegisterDurationSetting(


### PR DESCRIPTION
This change caused imbalance before, even though it was (incorrectly) splitting at well below
the actual range size (48 vs 512MB), but that over-calling Scatter likely was compensating for
Scatter's relative insensitivity. We have since sensitized AdminScatter so this over-split now
manifests as spending more time waiting for the extra scatters (now that they all actually scatter)
than anything else during a bulk ingestion.

Release note: none.

Release justification: high impact fix based on new changes to functionality.