### PR TITLE
sql: stop looping during auth cache lookups

### DIFF
--- a/pkg/sql/sessioninit/BUILD.bazel
+++ b/pkg/sql/sessioninit/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//pkg/security",
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/sem/tree",


### PR DESCRIPTION
This commit is meant to make it easier to read and maintain the caching
logic, perhaps at the cost of not using cached data in a small number of
edge cases where we might be able to. This is what the commit does:

- Stop using a loop to retry the data retrieval when the table version
  has changed. This was confusing, since it could mean that the txn
  would see data from a different table version.
- Change the initial staleness check to only clear the cache if the
  cached table version is older than the current txn table version. This
  might reduce some cache churn. Also, it seems more correct, since if the
  txn's table version is older, it is a bit silly to then store the data
  it fetches back to the cache.

Release justification: low risk, high benefit change to existing functionality.
Release note: None