### PR TITLE
server: precisely route cancel query/session requests for tenants

### DIFF
--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/spanconfig",
+        "//pkg/sql",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/sqlstats",

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -86,8 +87,16 @@ func TestTenantStatusAPI(t *testing.T) {
 		testTenantStatusCancelSession(t, testHelper)
 	})
 
+	t.Run("tenant_cancel_session_error_messages", func(t *testing.T) {
+		testTenantStatusCancelSessionErrorMessages(t, testHelper)
+	})
+
 	t.Run("tenant_cancel_query", func(t *testing.T) {
 		testTenantStatusCancelQuery(ctx, t, testHelper)
+	})
+
+	t.Run("tenant_cancel_query_error_messages", func(t *testing.T) {
+		testTenantStatusCancelQueryErrorMessages(t, testHelper)
 	})
 
 	t.Run("index_usage_stats", func(t *testing.T) {
@@ -405,7 +414,7 @@ func testResetIndexUsageStatsRPCForTenant(
 			name: "http",
 			resetFn: func(helper *tenantTestHelper) {
 				// Reset index usage stats over HTTP on tenant SQL pod 1.
-				httpPod1 := helper.testCluster().tenantHTTPClient(t, 1)
+				httpPod1 := helper.testCluster().tenantAdminHTTPClient(t, 1)
 				defer httpPod1.Close()
 				httpPod1.PostJSON("/_status/resetindexusagestats", &serverpb.ResetIndexUsageStatsRequest{}, &serverpb.ResetIndexUsageStatsResponse{})
 			},
@@ -728,7 +737,7 @@ SET TRACING=off;
 		resp := &serverpb.TransactionContentionEventsResponse{}
 		testHelper.
 			testCluster().
-			tenantHTTPClient(t, 1).
+			tenantAdminHTTPClient(t, 1).
 			GetJSON("/_status/transactioncontentionevents", resp)
 
 		if len(resp.Events) == 0 {
@@ -817,7 +826,7 @@ func testTenantStatusCancelSession(t *testing.T, helper *tenantTestHelper) {
 	sqlPod0.Exec(t, "SELECT 1")
 
 	// See the session over HTTP on tenant SQL pod 1.
-	httpPod1 := helper.testCluster().tenantHTTPClient(t, 1)
+	httpPod1 := helper.testCluster().tenantAdminHTTPClient(t, 1)
 	defer httpPod1.Close()
 	listSessionsResp := serverpb.ListSessionsResponse{}
 	httpPod1.GetJSON("/_status/sessions", &listSessionsResp)
@@ -854,6 +863,52 @@ func testTenantStatusCancelSession(t *testing.T, helper *tenantTestHelper) {
 	require.Equal(t, fmt.Sprintf("session ID %s not found", sessionID), cancelSessionResp.Error)
 }
 
+func testTenantStatusCancelSessionErrorMessages(t *testing.T, helper *tenantTestHelper) {
+	testCases := []struct {
+		sessionID     string
+		expectedError string
+	}{
+		{
+			sessionID:     "",
+			expectedError: "session ID 00000000000000000000000000000000 not found",
+		},
+		{
+			sessionID:     "01", // This query ID claims to have SQL instance ID 1, different from the one we're talking to.
+			expectedError: "session ID 00000000000000000000000000000001 not found",
+		},
+		{
+			sessionID:     "02", // This query ID claims to have SQL instance ID 2, the instance we're talking to.
+			expectedError: "session ID 00000000000000000000000000000002 not found",
+		},
+		{
+			sessionID:     "42", // This query ID claims to have SQL instance ID 42, which does not exist.
+			expectedError: "session ID 00000000000000000000000000000042 not found",
+		},
+	}
+
+	testutils.RunTrueAndFalse(t, "isAdmin", func(t *testing.T, isAdmin bool) {
+		client := helper.testCluster().tenantHTTPClient(t, 1, isAdmin)
+		defer client.Close()
+
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("sessionID-%s", testCase.sessionID), func(t *testing.T) {
+				sessionID, err := sql.StringToClusterWideID(testCase.sessionID)
+				require.NoError(t, err)
+				resp := serverpb.CancelSessionResponse{}
+				err = client.PostJSONChecked("/_status/cancel_session/0", &serverpb.CancelSessionRequest{
+					SessionID: sessionID.GetBytes(),
+				}, &resp)
+				if isAdmin {
+					require.NoError(t, err)
+					require.Equal(t, testCase.expectedError, resp.Error)
+				} else {
+					require.Error(t, err)
+				}
+			})
+		}
+	})
+}
+
 func selectClusterQueryIDs(t *testing.T, conn *sqlutils.SQLRunner) []string {
 	var queryIDs []string
 	rows := conn.QueryStr(t, "SELECT query_id FROM crdb_internal.cluster_queries")
@@ -879,7 +934,7 @@ func testTenantStatusCancelQuery(ctx context.Context, t *testing.T, helper *tena
 	}()
 
 	// See the query over HTTP on tenant SQL pod 1.
-	httpPod1 := helper.testCluster().tenantHTTPClient(t, 1)
+	httpPod1 := helper.testCluster().tenantAdminHTTPClient(t, 1)
 	defer httpPod1.Close()
 	var listSessionsResp serverpb.ListSessionsResponse
 	var query serverpb.ActiveQuery
@@ -925,6 +980,55 @@ func testTenantStatusCancelQuery(ctx context.Context, t *testing.T, helper *tena
 	httpPod1.PostJSON("/_status/cancel_query/0", &cancelQueryReq, &cancelQueryResp)
 	require.Equal(t, false, cancelQueryResp.Canceled)
 	require.Equal(t, fmt.Sprintf("query ID %s not found", query.ID), cancelQueryResp.Error)
+}
+
+func testTenantStatusCancelQueryErrorMessages(t *testing.T, helper *tenantTestHelper) {
+	testCases := []struct {
+		queryID       string
+		expectedError string
+	}{
+		{
+			queryID: "BOGUS_QUERY_ID",
+			expectedError: "query ID 00000000000000000000000000000000 malformed: " +
+				"could not decode BOGUS_QUERY_ID as hex: encoding/hex: invalid byte: U+004F 'O'",
+		},
+		{
+			queryID:       "",
+			expectedError: "query ID 00000000000000000000000000000000 not found",
+		},
+		{
+			queryID:       "01", // This query ID claims to have SQL instance ID 1, different from the one we're talking to.
+			expectedError: "query ID 00000000000000000000000000000001 not found",
+		},
+		{
+			queryID:       "02", // This query ID claims to have SQL instance ID 2, the instance we're talking to.
+			expectedError: "query ID 00000000000000000000000000000002 not found",
+		},
+		{
+			queryID:       "42", // This query ID claims to have SQL instance ID 42, which does not exist.
+			expectedError: "query ID 00000000000000000000000000000042 not found",
+		},
+	}
+
+	testutils.RunTrueAndFalse(t, "isAdmin", func(t *testing.T, isAdmin bool) {
+		client := helper.testCluster().tenantHTTPClient(t, 1, isAdmin)
+		defer client.Close()
+
+		for _, testCase := range testCases {
+			t.Run(fmt.Sprintf("queryID-%s", testCase.queryID), func(t *testing.T) {
+				resp := serverpb.CancelQueryResponse{}
+				err := client.PostJSONChecked("/_status/cancel_query/0", &serverpb.CancelQueryRequest{
+					QueryID: testCase.queryID,
+				}, &resp)
+				if isAdmin {
+					require.NoError(t, err)
+					require.Equal(t, testCase.expectedError, resp.Error)
+				} else {
+					require.Error(t, err)
+				}
+			})
+		}
+	})
 }
 
 // testTxnIDResolutionRPC tests the reachability of TxnIDResolution RPC. The

--- a/pkg/server/tenant_status.go
+++ b/pkg/server/tenant_status.go
@@ -17,11 +17,9 @@ package server
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -188,75 +186,52 @@ func (t *tenantStatusServer) ListLocalSessions(
 }
 
 func (t *tenantStatusServer) CancelQuery(
-	ctx context.Context, request *serverpb.CancelQueryRequest,
+	ctx context.Context, req *serverpb.CancelQueryRequest,
 ) (*serverpb.CancelQueryResponse, error) {
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = t.AnnotateCtx(ctx)
 
-	// Check permissions early to avoid fan-out to all nodes.
-	reqUsername := security.MakeSQLUsernameFromPreNormalizedString(request.Username)
-	if err := t.checkCancelPrivilege(ctx, reqUsername, findSessionByQueryID(request.QueryID)); err != nil {
-		// NB: not using serverError() here since the priv checker
-		// already returns a proper gRPC error status.
-		return nil, err
-	}
-	if t.sqlServer.SQLInstanceID() == 0 {
-		return nil, status.Errorf(codes.Unavailable, "instanceID not set")
-	}
-
-	response := serverpb.CancelQueryResponse{}
-	distinctErrorMessages := map[string]struct{}{}
-
-	if err := t.iteratePods(
-		ctx,
-		fmt.Sprintf("cancel query ID %s", request.QueryID),
-		t.dialCallback,
-		func(ctx context.Context, client interface{}, _ base.SQLInstanceID) (interface{}, error) {
-			return client.(serverpb.StatusClient).CancelLocalQuery(ctx, request)
-		},
-		func(_ base.SQLInstanceID, nodeResp interface{}) {
-			nodeCancelQueryResponse := nodeResp.(*serverpb.CancelQueryResponse)
-			if nodeCancelQueryResponse.Canceled {
-				response.Canceled = true
-			}
-			distinctErrorMessages[nodeCancelQueryResponse.Error] = struct{}{}
-		},
-		func(_ base.SQLInstanceID, err error) {
-			distinctErrorMessages[err.Error()] = struct{}{}
-		},
-	); err != nil {
-		return nil, serverError(ctx, err)
-	}
-
-	if !response.Canceled {
-		var errorMessages []string
-		for errorMessage := range distinctErrorMessages {
-			errorMessages = append(errorMessages, errorMessage)
-		}
-		response.Error = strings.Join(errorMessages, ", ")
-	}
-
-	return &response, nil
-}
-
-func (t *tenantStatusServer) CancelLocalQuery(
-	ctx context.Context, request *serverpb.CancelQueryRequest,
-) (*serverpb.CancelQueryResponse, error) {
-	reqUsername := security.MakeSQLUsernameFromPreNormalizedString(request.Username)
-	if err := t.checkCancelPrivilege(ctx, reqUsername, findSessionByQueryID(request.QueryID)); err != nil {
-		// NB: not using serverError() here since the priv checker
-		// already returns a proper gRPC error status.
-		return nil, err
-	}
-	var (
-		output = &serverpb.CancelQueryResponse{}
-		err    error
-	)
-	output.Canceled, err = t.sessionRegistry.CancelQuery(request.QueryID)
+	queryID, err := sql.StringToClusterWideID(req.QueryID)
 	if err != nil {
-		output.Error = err.Error()
+		return &serverpb.CancelQueryResponse{
+			Canceled: false,
+			Error:    errors.Wrapf(err, "query ID %s malformed", queryID).Error(),
+		}, nil
 	}
-	return output, nil
+	instanceID := base.SQLInstanceID(queryID.GetNodeID())
+
+	// This request needs to be forwarded to another instance.
+	if instanceID != t.sqlServer.SQLInstanceID() {
+		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)
+		if err != nil {
+			if errors.Is(err, sqlinstance.NonExistentInstanceError) {
+				return &serverpb.CancelQueryResponse{
+					Canceled: false,
+					Error:    fmt.Sprintf("query ID %s not found", queryID),
+				}, nil
+			}
+			return nil, serverError(ctx, err)
+		}
+		statusClient, err := t.dialPod(ctx, instanceID, instance.InstanceAddr)
+		if err != nil {
+			return nil, serverError(ctx, err)
+		}
+		return statusClient.CancelQuery(ctx, req)
+	}
+
+	reqUsername := security.MakeSQLUsernameFromPreNormalizedString(req.Username)
+	if err := t.checkCancelPrivilege(ctx, reqUsername, findSessionByQueryID(req.QueryID)); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
+		return nil, err
+	}
+	resp := &serverpb.CancelQueryResponse{}
+	resp.Canceled, err = t.sessionRegistry.CancelQuery(req.QueryID)
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	return resp, nil
+
 }
 
 // CancelQueryByKey responds to a pgwire query cancellation request, and cancels
@@ -318,68 +293,40 @@ func (t *tenantStatusServer) CancelQueryByKey(
 }
 
 func (t *tenantStatusServer) CancelSession(
-	ctx context.Context, request *serverpb.CancelSessionRequest,
+	ctx context.Context, req *serverpb.CancelSessionRequest,
 ) (*serverpb.CancelSessionResponse, error) {
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = t.AnnotateCtx(ctx)
 
-	// Check permissions early to avoid fan-out to all nodes.
-	reqUsername := security.MakeSQLUsernameFromPreNormalizedString(request.Username)
-	if err := t.checkCancelPrivilege(ctx, reqUsername, findSessionBySessionID(request.SessionID)); err != nil {
-		// NB: not using serverError() here since the priv checker
-		// already returns a proper gRPC error status.
-		return nil, err
-	}
+	sessionID := sql.BytesToClusterWideID(req.SessionID)
+	instanceID := base.SQLInstanceID(sessionID.GetNodeID())
 
-	if t.sqlServer.SQLInstanceID() == 0 {
-		return nil, status.Errorf(codes.Unavailable, "instanceID not set")
-	}
-
-	response := serverpb.CancelSessionResponse{}
-	distinctErrorMessages := map[string]struct{}{}
-
-	if err := t.iteratePods(
-		ctx,
-		fmt.Sprintf("cancel session ID %s", hex.EncodeToString(request.SessionID)),
-		t.dialCallback,
-		func(ctx context.Context, client interface{}, _ base.SQLInstanceID) (interface{}, error) {
-			return client.(serverpb.StatusClient).CancelLocalSession(ctx, request)
-		},
-		func(_ base.SQLInstanceID, nodeResp interface{}) {
-			nodeCancelSessionResp := nodeResp.(*serverpb.CancelSessionResponse)
-			if nodeCancelSessionResp.Canceled {
-				response.Canceled = true
+	// This request needs to be forwarded to another instance.
+	if instanceID != t.sqlServer.SQLInstanceID() {
+		instance, err := t.sqlServer.sqlInstanceProvider.GetInstance(ctx, instanceID)
+		if err != nil {
+			if errors.Is(err, sqlinstance.NonExistentInstanceError) {
+				return &serverpb.CancelSessionResponse{
+					Canceled: false,
+					Error:    fmt.Sprintf("session ID %s not found", sessionID),
+				}, nil
 			}
-			distinctErrorMessages[nodeCancelSessionResp.Error] = struct{}{}
-		},
-		func(_ base.SQLInstanceID, err error) {
-			distinctErrorMessages[err.Error()] = struct{}{}
-		},
-	); err != nil {
-		return nil, serverError(ctx, err)
-	}
-
-	if !response.Canceled {
-		var errorMessages []string
-		for errorMessage := range distinctErrorMessages {
-			errorMessages = append(errorMessages, errorMessage)
+			return nil, serverError(ctx, err)
 		}
-		response.Error = strings.Join(errorMessages, ", ")
+		statusClient, err := t.dialPod(ctx, instanceID, instance.InstanceAddr)
+		if err != nil {
+			return nil, serverError(ctx, err)
+		}
+		return statusClient.CancelSession(ctx, req)
 	}
 
-	return &response, nil
-}
-
-func (t *tenantStatusServer) CancelLocalSession(
-	ctx context.Context, request *serverpb.CancelSessionRequest,
-) (*serverpb.CancelSessionResponse, error) {
-	reqUsername := security.MakeSQLUsernameFromPreNormalizedString(request.Username)
-	if err := t.checkCancelPrivilege(ctx, reqUsername, findSessionBySessionID(request.SessionID)); err != nil {
+	reqUsername := security.MakeSQLUsernameFromPreNormalizedString(req.Username)
+	if err := t.checkCancelPrivilege(ctx, reqUsername, findSessionBySessionID(req.SessionID)); err != nil {
 		// NB: not using serverError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
 	}
-	return t.sessionRegistry.CancelSession(request.SessionID)
+	return t.sessionRegistry.CancelSession(req.SessionID)
 }
 
 func (t *tenantStatusServer) ListContentionEvents(


### PR DESCRIPTION
Fixes #75252.

Previously, these endpoints fanned out across all SQL instances, which
was unnecessary, because both the query ID and the session ID contain an
embedded node ID (which can be treated as a SQL instance ID).

In this change, we use that embedded ID to precisely route these
cancel requests.

Release justification: Category 2: Bug fixes and low-risk updates to new
functionality.

Release note: none