### PR TITLE
dashboards: switch flushes/compactions graphs to bytes written

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -182,21 +182,38 @@ export default function(props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Compactions/Flushes"
+      title="Flushes"
       sources={storeSources}
-      tooltip={`The number of compactions and memtable flushes per second ${tooltipSelection}.`}
+      tooltip={`Bytes written by memtable flushes ${tooltipSelection}.`}
     >
-      <Axis label="count">
-        <Metric
-          name="cr.store.rocksdb.compactions"
-          title="Compactions"
-          nonNegativeRate
-        />
-        <Metric
-          name="cr.store.rocksdb.flushes"
-          title="Flushes"
-          nonNegativeRate
-        />
+      <Axis units={AxisUnits.Bytes} label="written bytes">
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.rocksdb.flushed-bytes"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Compactions"
+      sources={storeSources}
+      tooltip={`Bytes written by compactions ${tooltipSelection}.`}
+    >
+      <Axis units={AxisUnits.Bytes} label="written bytes">
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.rocksdb.compacted-bytes-written"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+            nonNegativeRate
+          />
+        ))}
       </Axis>
     </LineGraph>,
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -218,6 +218,24 @@ export default function(props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Ingestions"
+      sources={storeSources}
+      tooltip={`Bytes written by sstable ingestions ${tooltipSelection}.`}
+    >
+      <Axis units={AxisUnits.Bytes} label="written bytes">
+        {_.map(nodeIDs, nid => (
+          <Metric
+            key={nid}
+            name="cr.store.rocksdb.ingested-bytes"
+            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(nodesSummary, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Write Stalls"
       sources={storeSources}
       tooltip={`The number of intentional write stalls per second ${tooltipSelection}. Write stalls


### PR DESCRIPTION
Release note (ui change): The Flushes/Compactions graph on the Storage metrics Dashboard now shows bytes written by these operations, and has been split into separate graphs which are each per-node.

<img width="1377" alt="Screen Shot 2022-03-09 at 1 46 29 PM" src="https://user-images.githubusercontent.com/15615/157511632-b3bc0279-d17f-48ff-8192-9a112a2a9b9d.png">


Release justification: low risk, seems useful (we've frequently wished we had it in escalations from prior versions)