### PR TITLE
release-21.1: sql: do no collect multi-column stats for indexes with only virtual columns

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -441,6 +441,12 @@ func createStatsDefaultColumns(
 				colIDs = append(colIDs, col.GetID())
 			}
 
+			// Do not attempt to create multi-column stats with no columns. This
+			// can happen when an index contains only virtual computed columns.
+			if len(colIDs) == 0 {
+				continue
+			}
+
 			// Check for existing stats and remember the requested stats.
 			if !trackStatsIfNotExists(colIDs) {
 				continue

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1156,3 +1156,16 @@ CREATE STATISTICS s ON b FROM t71080;
 
 statement error cannot create statistics on virtual column \"b\"
 CREATE STATISTICS s ON a, b FROM t71080;
+
+# Regression test for #76867. Do not attempt to collect empty multi-column stats
+# when there are indexes on columns that are all virtual.
+statement ok
+CREATE TABLE t76867 (
+  a INT,
+  b INT AS (a + 1) VIRTUAL,
+  c INT AS (a + 2) VIRTUAL,
+  INDEX (b, c)
+)
+
+statement ok
+ANALYZE t76867


### PR DESCRIPTION
Backport 1/1 commits from #77507.

/cc @cockroachdb/release

---

Fixes #76867

Release justification: This is a low-risk fix for a minor bug.

Release note (bug fix): A bug has been fixed that caused errors when
attempting to create table statistics (with CREATE STATISTICS or
ANALYZE) for a table containing an index which indexed only virtual
computed columns. This bug has been present since version 21.1.0.
