### PR TITLE
ui: create new invalidate for cache with keys

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -84,7 +84,7 @@ export function* resetSQLStatsSaga() {
     yield call(resetSQLStats);
     yield put(sqlStatsActions.invalidated());
     yield put(sqlStatsActions.refresh());
-    yield put(sqlDetailsStatsActions.invalidated());
+    yield put(sqlDetailsStatsActions.invalidateAll());
   } catch (e) {
     yield put(sqlStatsActions.failed(e));
   }

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.reducer.ts
@@ -51,13 +51,12 @@ const sqlDetailsStatsSlice = createSlice({
       };
     },
     invalidated: (state, action: PayloadAction<{ key: string }>) => {
-      if (action.payload.key) {
-        delete state[action.payload.key];
-      } else {
-        const keys = Object.keys(state);
-        for (const key in keys) {
-          delete state[key];
-        }
+      delete state[action.payload.key];
+    },
+    invalidateAll: state => {
+      const keys = Object.keys(state);
+      for (const key in keys) {
+        delete state[key];
       }
     },
     refresh: (_, action: PayloadAction<StatementDetailsRequest>) => {},

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -357,6 +357,8 @@ const queryReducerObj = new KeyedCachedDataReducer(
 
 export const invalidateStatementDetails =
   queryReducerObj.cachedDataReducer.invalidateData;
+export const invalidateAllStatementDetails =
+  queryReducerObj.cachedDataReducer.invalidateAllData;
 export const refreshStatementDetails = queryReducerObj.refresh;
 
 const userSQLRolesReducerObj = new CachedDataReducer(

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -89,6 +89,7 @@ export class CachedDataReducer<
   RECEIVE: string; // receive new data
   ERROR: string; // request encountered an error
   INVALIDATE: string; // invalidate data
+  INVALIDATE_ALL: string; // invalidate all data on keyed cache
 
   /**
    * apiEndpoint - The API endpoint used to refresh data.
@@ -117,6 +118,7 @@ export class CachedDataReducer<
     this.RECEIVE = `cockroachui/CachedDataReducer/${actionNamespace}/RECEIVE`;
     this.ERROR = `cockroachui/CachedDataReducer/${actionNamespace}/ERROR`;
     this.INVALIDATE = `cockroachui/CachedDataReducer/${actionNamespace}/INVALIDATE`;
+    this.INVALIDATE_ALL = `cockroachui/CachedDataReducer/${actionNamespace}/INVALIDATE_ALL`;
   }
 
   /**
@@ -217,6 +219,16 @@ export class CachedDataReducer<
   ): PayloadAction<WithRequest<void, TRequest>> => {
     return {
       type: this.INVALIDATE,
+      payload: { request },
+    };
+  };
+
+  // invalidateAllData is the INVALIDATE_ALL action creator.
+  invalidateAllData = (
+    request?: TRequest,
+  ): PayloadAction<WithRequest<void, TRequest>> => {
+    return {
+      type: this.INVALIDATE_ALL,
       payload: { request },
     };
   };
@@ -385,6 +397,14 @@ export class KeyedCachedDataReducer<
         const id = this.requestToID(request);
         state = _.clone(state);
         state[id] = this.cachedDataReducer.reducer(state[id], action);
+        return state;
+      }
+      case this.cachedDataReducer.INVALIDATE_ALL: {
+        state = _.clone(state);
+        const keys = Object.keys(state);
+        for (const key in keys) {
+          state[key] = this.cachedDataReducer.reducer(state[key], action);
+        }
         return state;
       }
       default:

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.ts
@@ -17,7 +17,7 @@ import {
   resetSQLStatsFailedAction,
 } from "./sqlStatsActions";
 import {
-  invalidateStatementDetails,
+  invalidateAllStatementDetails,
   invalidateStatements,
   refreshStatements,
 } from "src/redux/apiReducers";
@@ -34,7 +34,7 @@ export function* resetSQLStatsSaga() {
     yield call(resetSQLStats, resetSQLStatsRequest);
     yield put(resetSQLStatsCompleteAction());
     yield put(invalidateStatements());
-    yield put(invalidateStatementDetails());
+    yield put(invalidateAllStatementDetails());
     yield put(refreshStatements() as any);
   } catch (e) {
     yield put(resetSQLStatsFailedAction());


### PR DESCRIPTION
Previously, the invalidate on keye cached values were not working
properly. This commit adds a new invalidate all to invalidate
all data with keys.

Release justification: Bug fix
Release note: None