### PR TITLE
 ui: Fix Reset SQL stats in Statements and Transactions pages 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -27,13 +27,6 @@ export type ErrorWithKey = {
   key: string;
 };
 
-export const getStatements = (): Promise<cockroach.server.serverpb.StatementsResponse> => {
-  return fetchData(
-    cockroach.server.serverpb.StatementsResponse,
-    STATEMENTS_PATH,
-  );
-};
-
 export const getCombinedStatements = (
   req: StatementsRequest,
 ): Promise<cockroach.server.serverpb.StatementsResponse> => {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -87,10 +87,10 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 // provide convenient definitions for `mapDispatchToProps`, `mapStateToProps` and props that
 // have to be provided by parent component.
 export interface StatementsPageDispatchProps {
-  refreshStatements: (req?: StatementsRequest) => void;
+  refreshStatements: (req: StatementsRequest) => void;
   refreshStatementDiagnosticsRequests: () => void;
   refreshUserSQLRoles: () => void;
-  resetSQLStats: () => void;
+  resetSQLStats: (req: StatementsRequest) => void;
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (
     statement: string,
@@ -266,6 +266,10 @@ export class StatementsPage extends React.Component<
   refreshStatements = (): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.refreshStatements(req);
+  };
+  resetSQLStats = (): void => {
+    const req = statementsRequestFromProps(this.props);
+    this.props.resetSQLStats(req);
   };
 
   componentDidMount(): void {
@@ -596,7 +600,6 @@ export class StatementsPage extends React.Component<
       search,
       isTenant,
       nodeRegions,
-      resetSQLStats,
     } = this.props;
 
     const nodes = isTenant
@@ -649,7 +652,10 @@ export class StatementsPage extends React.Component<
             />
           </PageConfigItem>
           <PageConfigItem className={commonStyles("separator")}>
-            <ClearStats resetSQLStats={resetSQLStats} tooltipType="statement" />
+            <ClearStats
+              resetSQLStats={this.resetSQLStats}
+              tooltipType="statement"
+            />
           </PageConfigItem>
         </PageConfig>
         <Loading

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -77,7 +77,7 @@ export const ConnectedStatementsPage = withRouter(
       totalFingerprints: selectTotalFingerprints(state),
     }),
     (dispatch: Dispatch) => ({
-      refreshStatements: (req?: StatementsRequest) =>
+      refreshStatements: (req: StatementsRequest) =>
         dispatch(sqlStatsActions.refresh(req)),
       onTimeScaleChange: (ts: TimeScale) => {
         dispatch(
@@ -90,7 +90,8 @@ export const ConnectedStatementsPage = withRouter(
         dispatch(statementDiagnosticsActions.refresh()),
       refreshUserSQLRoles: () =>
         dispatch(uiConfigActions.refreshUserSQLRoles()),
-      resetSQLStats: () => dispatch(sqlStatsActions.reset()),
+      resetSQLStats: (req: StatementsRequest) =>
+        dispatch(sqlStatsActions.reset(req)),
       dismissAlertMessage: () =>
         dispatch(
           localStorageActions.update({

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -48,10 +48,10 @@ const sqlStatsSlice = createSlice({
     invalidated: state => {
       state.valid = false;
     },
-    refresh: (_, action?: PayloadAction<StatementsRequest>) => {},
-    request: (_, action?: PayloadAction<StatementsRequest>) => {},
+    refresh: (_, action: PayloadAction<StatementsRequest>) => {},
+    request: (_, action: PayloadAction<StatementsRequest>) => {},
     updateTimeScale: (_, action: PayloadAction<UpdateTimeScalePayload>) => {},
-    reset: _ => {},
+    reset: (_, action: PayloadAction<StatementsRequest>) => {},
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -20,7 +20,6 @@ import {
 import Long from "long";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import {
-  getStatements,
   getCombinedStatements,
   StatementsRequest,
 } from "src/api/statementsApi";
@@ -35,19 +34,15 @@ import { rootActions } from "../reducers";
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
 import { toDateRange } from "../../timeScaleDropdown";
 
-export function* refreshSQLStatsSaga(
-  action?: PayloadAction<StatementsRequest>,
-) {
-  yield put(sqlStatsActions.request(action?.payload));
+export function* refreshSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
+  yield put(sqlStatsActions.request(action.payload));
 }
 
 export function* requestSQLStatsSaga(
-  action?: PayloadAction<StatementsRequest>,
+  action: PayloadAction<StatementsRequest>,
 ): any {
   try {
-    const result = yield action?.payload?.combined
-      ? call(getCombinedStatements, action.payload)
-      : call(getStatements);
+    const result = yield call(getCombinedStatements, action.payload);
     yield put(sqlStatsActions.received(result));
   } catch (e) {
     yield put(sqlStatsActions.failed(e));
@@ -79,12 +74,12 @@ export function* updateSQLStatsTimeScaleSaga(
   yield put(sqlStatsActions.refresh(req));
 }
 
-export function* resetSQLStatsSaga() {
+export function* resetSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
   try {
     yield call(resetSQLStats);
     yield put(sqlStatsActions.invalidated());
-    yield put(sqlStatsActions.refresh());
     yield put(sqlDetailsStatsActions.invalidateAll());
+    yield put(sqlStatsActions.refresh(action.payload));
   } catch (e) {
     yield put(sqlStatsActions.failed(e));
   }

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
@@ -17,10 +17,6 @@
   position: relative;
 }
 
-.trigger-button {
-  width: 423px;
-  height: fit-content;
-}
 
 .trigger-container {
   width: 100%;
@@ -34,6 +30,11 @@
 
 .trigger-wrapper {
   width: 100%;
+
+  .trigger-button {
+    width: 423px;
+    height: fit-content;
+  }
 }
 
 .range-selector {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -91,8 +91,8 @@ export interface TransactionsPageStateProps {
 }
 
 export interface TransactionsPageDispatchProps {
-  refreshData: (req?: StatementsRequest) => void;
-  resetSQLStats: () => void;
+  refreshData: (req: StatementsRequest) => void;
+  resetSQLStats: (req: StatementsRequest) => void;
   onTimeScaleChange?: (ts: TimeScale) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
   onFilterChange?: (value: Filters) => void;
@@ -175,6 +175,10 @@ export class TransactionsPage extends React.Component<
   refreshData = (): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.refreshData(req);
+  };
+  resetSQLStats = (): void => {
+    const req = statementsRequestFromProps(this.props);
+    this.props.resetSQLStats(req);
   };
 
   componentDidMount(): void {
@@ -328,7 +332,6 @@ export class TransactionsPage extends React.Component<
   render(): React.ReactElement {
     const {
       data,
-      resetSQLStats,
       nodeRegions,
       isTenant,
       onColumnsChange,
@@ -409,7 +412,7 @@ export class TransactionsPage extends React.Component<
           </PageConfigItem>
           <PageConfigItem className={commonStyles("separator")}>
             <ClearStats
-              resetSQLStats={resetSQLStats}
+              resetSQLStats={this.resetSQLStats}
               tooltipType="transaction"
             />
           </PageConfigItem>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -54,9 +54,10 @@ export const TransactionsPageConnected = withRouter(
       sortSetting: selectSortSetting(state),
     }),
     (dispatch: Dispatch) => ({
-      refreshData: (req?: StatementsRequest) =>
+      refreshData: (req: StatementsRequest) =>
         dispatch(sqlStatsActions.refresh(req)),
-      resetSQLStats: () => dispatch(sqlStatsActions.reset()),
+      resetSQLStats: (req: StatementsRequest) =>
+        dispatch(sqlStatsActions.reset(req)),
       onTimeScaleChange: (ts: TimeScale) => {
         dispatch(
           sqlStatsActions.updateTimeScale({

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -308,7 +308,7 @@ const storesReducerObj = new KeyedCachedDataReducer(
 export const refreshStores = storesReducerObj.refresh;
 
 const queriesReducerObj = new CachedDataReducer(
-  api.getStatements,
+  api.getCombinedStatements,
   "statements",
   moment.duration(5, "m"),
   moment.duration(30, "m"),

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsActions.ts
@@ -9,6 +9,8 @@
 // licenses/APL.txt.
 
 import { Action } from "redux";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { cockroach } from "src/js/protos";
 
 export const RESET_SQL_STATS = "cockroachui/sqlStats/RESET_SQL_STATS";
 export const RESET_SQL_STATS_COMPLETE =
@@ -16,9 +18,14 @@ export const RESET_SQL_STATS_COMPLETE =
 export const RESET_SQL_STATS_FAILED =
   "cockroachui/sqlStats/RESET_SQL_STATS_FAILED";
 
-export function resetSQLStatsAction(): Action {
+import StatementsRequest = cockroach.server.serverpb.StatementsRequest;
+
+export function resetSQLStatsAction(
+  req: StatementsRequest,
+): PayloadAction<StatementsRequest> {
   return {
     type: RESET_SQL_STATS,
+    payload: req,
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
@@ -14,35 +14,44 @@ import { call } from "redux-saga-test-plan/matchers";
 import {
   resetSQLStatsFailedAction,
   resetSQLStatsCompleteAction,
+  resetSQLStatsAction,
 } from "./sqlStatsActions";
 import { resetSQLStatsSaga } from "./sqlStatsSagas";
 import { resetSQLStats } from "src/util/api";
 import {
   apiReducersReducer,
   invalidateStatements,
+  invalidateAllStatementDetails,
 } from "src/redux/apiReducers";
 import { throwError } from "redux-saga-test-plan/providers";
 
 import { cockroach } from "src/js/protos";
+import Long from "long";
 
 describe("SQL Stats sagas", () => {
   describe("resetSQLStatsSaga", () => {
+    const payload = new cockroach.server.serverpb.StatementsRequest({
+      start: Long.fromNumber(1596816675),
+      end: Long.fromNumber(1596820675),
+      combined: false,
+    });
     const resetSQLStatsResponse = new cockroach.server.serverpb.ResetSQLStatsResponse();
 
     it("successfully resets SQL stats", () => {
       // TODO(azhng): validate refreshStatement() actions once we can figure out
       //  how to get ThunkAction to work with sagas.
-      return expectSaga(resetSQLStatsSaga)
+      return expectSaga(resetSQLStatsSaga, resetSQLStatsAction(payload))
         .withReducer(apiReducersReducer)
         .provide([[call.fn(resetSQLStats), resetSQLStatsResponse]])
         .put(resetSQLStatsCompleteAction())
         .put(invalidateStatements())
+        .put(invalidateAllStatementDetails())
         .run();
     });
 
     it("returns error on failed reset", () => {
       const err = new Error("failed to reset");
-      return expectSaga(resetSQLStatsSaga)
+      return expectSaga(resetSQLStatsSaga, resetSQLStatsAction(payload))
         .provide([[call.fn(resetSQLStats), throwError(err)]])
         .put(resetSQLStatsFailedAction())
         .run();

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.ts
@@ -23,8 +23,10 @@ import {
 } from "src/redux/apiReducers";
 
 import ResetSQLStatsRequest = cockroach.server.serverpb.ResetSQLStatsRequest;
+import StatementsRequest = cockroach.server.serverpb.StatementsRequest;
+import { PayloadAction } from "@reduxjs/toolkit";
 
-export function* resetSQLStatsSaga() {
+export function* resetSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
   const resetSQLStatsRequest = new ResetSQLStatsRequest({
     // reset_persisted_stats is set to true in order to clear both
     // in-memory stats as well as persisted stats.
@@ -35,7 +37,7 @@ export function* resetSQLStatsSaga() {
     yield put(resetSQLStatsCompleteAction());
     yield put(invalidateStatements());
     yield put(invalidateAllStatementDetails());
-    yield put(refreshStatements() as any);
+    yield put(refreshStatements(action.payload) as any);
   } catch (e) {
     yield put(resetSQLStatsFailedAction());
   }

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -689,8 +689,8 @@ export function getStores(
   );
 }
 
-// getStatements returns statements the cluster has recently executed, and some stats about them.
-export function getStatements(
+// getCombinedStatements returns statements the cluster has recently executed, and some stats about them.
+export function getCombinedStatements(
   req: StatementsRequestMessage,
   timeout?: moment.Duration,
 ): Promise<StatementsResponseMessage> {


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/77546

Previously, the "Reset SQL stats" button on Statements and Transactions pages
was broken in different ways in DB Console and CC Console.

In DB Console, clicking the "Reset SQL stats" button on Statements or
Transactions pages causes the loading spinner to spin infinitely, and the table
does not reload. The stats are indeed reset in the backend, and so this can be
fixed by manually refreshing the page.

In CC Console, clicking the "Reset SQL stats" button on Statements or
Transactions pages causes the stats to correctly reset in the backend, and the
table to correctly reload. However, the table is reloaded without respecting
the currently selected time.

Both were ultimately caused because clicking the button did not pass a request
object specifying the currently selected start and end times. The bug
manifested differently in the two environments because of differing
implementations of their sagas.

Now, this has been fixed and the "Reset SQL stats" button works correctly. In DB
Console, the `requestSQLStatsSaga` saga previously called one of two API
functions, `getCombinedStatements` and `getStatements`, depending on whether a
request object was passed. We do not have a situation where we do not want to
pass the start and end times, so the `getStatements` path which did not take a
request object has been removed. Were possible, typing has been made stricter
to require the request object.

The change in `rangeSelector.module.scss` fixes a bug where equally specific CSS
selectors competed and won out differently depending on quirks of compilation.
The unrelated Javascript changes in this PR thus caused the height of
`timeScaleDropdown` to break, necessitating the changes in
`rangeSelector.module.scss`. To be clear, the height was not broken before this
commit; it was caused by the Javascript changes in this commit.

Release note (ui): Fixed a bug where the clicking the "Reset SQL stats" button
on Statements and Transactions pages caused, in DB Console, an infinite loading
spinner and, in CC Console, the statements/transactions table to be reloaded
without limiting to the time range that the user had selected. The button now
correctly reloads the table according to the selected time in both DB Console
and CC Console.

Release justification: Category 2, UI bug fix