### PR TITLE
schemachanger: reduce unnecessary validation for complex schemas

### DIFF
--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -555,6 +555,7 @@ func (r *incrementalReconciler) filterForMissingTableIDs(
 					IncludeDropped: true,
 					IncludeOffline: true,
 					AvoidLeased:    true, // we want consistent reads
+					SkipValidation: true, // we only care about existence, so don't validate.
 				})
 
 				considerAsMissing := false

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -150,6 +150,8 @@ var descLookupFlags = tree.CommonLookupFlags{
 	IncludeOffline: true,
 	// We want consistent reads.
 	AvoidLeased: true,
+	// Skip validation due to the overhead in complex schemas.
+	SkipValidation: true,
 }
 
 // generateSystemSpanConfigRecords is responsible for generating all the SpanConfigs

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -139,7 +139,7 @@ func (tc *Collection) getDescriptorsByID(
 		return descs, nil
 	}
 	kvDescs, err := tc.withReadFromStore(flags.RequireMutable, func() ([]catalog.MutableDescriptor, error) {
-		return tc.kv.getByIDs(ctx, txn, tc.version, kvIDs)
+		return tc.kv.getByIDs(ctx, txn, tc.version, !flags.SkipValidation, kvIDs)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -305,7 +305,7 @@ func (t *descriptorState) startLeaseRenewal(
 	log.VEventf(ctx, 1,
 		"background lease renewal beginning for id=%d name=%q",
 		id, name)
-	if _, err := acquireNodeLease(ctx, m, id); err != nil {
+	if _, err := acquireNodeLease(ctx, m, id, false /*validate descriptor */); err != nil {
 		log.Errorf(ctx,
 			"background lease renewal for id=%d name=%q failed: %s",
 			id, name, err)

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -550,7 +550,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 	tracker := removalTracker.TrackRemoval(lease.Descriptor)
 
 	// Acquire another lease.
-	if _, err := acquireNodeLease(context.Background(), leaseManager, tableDesc.GetID()); err != nil {
+	if _, err := acquireNodeLease(context.Background(), leaseManager, tableDesc.GetID(), true /*validate desc*/); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -235,6 +235,10 @@ type CommonLookupFlags struct {
 	IncludeDropped bool
 	// AvoidSynthetic specifies if the any synthetic descriptors will be ignored.
 	AvoidSynthetic bool
+	// SkipValidation returns a descriptor without validating its contents. This
+	// should only be used by callers that do not care about the validity of the
+	// descriptor contents.
+	SkipValidation bool
 }
 
 // SchemaLookupFlags is the flag struct suitable for GetSchemaByName().


### PR DESCRIPTION
We noticed scenarios with complex schemas where validation can lead to high CPU usage and poor drop performance, so to help with these issues:
1.  Disable validation during lease renewal
2. Disable validation for the spanconfig reconciler
3. Disable validation for operations during WaitForOneVersion

Release justification: low risk and disables unnecessary validation checks that can lead to high CPU usage

These issues also exist in the previous release, so it's not much of a release blocker and more of an enhancement.

Jira issue: CRDB-14854