### PR TITLE
server,kvserver: set tenant weights for admission control

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -6,6 +6,8 @@
 <tr><td><code>admission.epoch_lifo.epoch_duration</code></td><td>duration</td><td><code>100ms</code></td><td>the duration of an epoch, for epoch-LIFO admission control ordering</td></tr>
 <tr><td><code>admission.epoch_lifo.queue_delay_threshold_to_switch_to_lifo</code></td><td>duration</td><td><code>105ms</code></td><td>the queue delay encountered by a (tenant,priority) for switching to epoch-LIFO ordering</td></tr>
 <tr><td><code>admission.kv.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the KV layer is subject to admission control</td></tr>
+<tr><td><code>admission.kv.stores.tenant_weights.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, tenant weights are enabled for KV-stores admission control</td></tr>
+<tr><td><code>admission.kv.tenant_weights.enabled</code></td><td>boolean</td><td><code>false</code></td><td>when true, tenant weights are enabled for KV admission control</td></tr>
 <tr><td><code>admission.sql_kv_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a KV response is subject to admission control</td></tr>
 <tr><td><code>admission.sql_sql_response.enabled</code></td><td>boolean</td><td><code>true</code></td><td>when true, work performed by the SQL layer when receiving a DistSQL response is subject to admission control</td></tr>
 <tr><td><code>bulkio.backup.file_size</code></td><td>byte size</td><td><code>128 MiB</code></td><td>target size for individual data files produced during BACKUP</td></tr>

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -365,15 +365,16 @@ func NewNode(
 		sqlExec = execCfg.InternalExecutor
 	}
 	n := &Node{
-		storeCfg:              cfg,
-		stopper:               stopper,
-		recorder:              recorder,
-		metrics:               makeNodeMetrics(reg, cfg.HistogramWindowInterval),
-		stores:                stores,
-		txnMetrics:            txnMetrics,
-		sqlExec:               sqlExec,
-		clusterID:             clusterID,
-		admissionController:   kvserver.MakeKVAdmissionController(kvAdmissionQ, storeGrantCoords),
+		storeCfg:   cfg,
+		stopper:    stopper,
+		recorder:   recorder,
+		metrics:    makeNodeMetrics(reg, cfg.HistogramWindowInterval),
+		stores:     stores,
+		txnMetrics: txnMetrics,
+		sqlExec:    sqlExec,
+		clusterID:  clusterID,
+		admissionController: kvserver.MakeKVAdmissionController(
+			kvAdmissionQ, storeGrantCoords, cfg.Settings),
 		tenantUsage:           tenantUsage,
 		tenantSettingsWatcher: tenantSettingsWatcher,
 		spanConfigAccessor:    spanConfigAccessor,
@@ -529,6 +530,8 @@ func (n *Node) start(
 	}
 
 	n.startComputePeriodicMetrics(n.stopper, base.DefaultMetricsSampleInterval)
+	// Stores have been created, so can start providing tenant weights.
+	n.admissionController.SetTenantWeightProvider(n, n.stopper)
 
 	// Be careful about moving this line above where we start stores; store
 	// migrations rely on the fact that the cluster version has not been updated
@@ -774,6 +777,30 @@ func (n *Node) GetPebbleMetrics() []admission.StoreMetrics {
 		return nil
 	})
 	return metrics
+}
+
+// GetTenantWeights implements kvserver.TenantWeightProvider.
+func (n *Node) GetTenantWeights() kvserver.TenantWeights {
+	weights := kvserver.TenantWeights{
+		Node: make(map[uint64]uint32),
+	}
+	_ = n.stores.VisitStores(func(store *kvserver.Store) error {
+		sw := make(map[uint64]uint32)
+		weights.Stores = append(weights.Stores, kvserver.TenantWeightsForStore{
+			StoreID: store.StoreID(),
+			Weights: sw,
+		})
+		store.VisitReplicas(func(r *kvserver.Replica) bool {
+			tid, valid := r.TenantID()
+			if valid {
+				weights.Node[tid.ToUint64()]++
+				sw[tid.ToUint64()]++
+			}
+			return true
+		})
+		return nil
+	})
+	return weights
 }
 
 func (n *Node) startGraphiteStatsExporter(st *cluster.Settings) {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -680,3 +680,70 @@ func TestNodeBatchRequestMetricsInc(t *testing.T) {
 	require.GreaterOrEqual(t, n.metrics.MethodCounts[roachpb.Get].Count(), getCurr)
 	require.GreaterOrEqual(t, n.metrics.MethodCounts[roachpb.Put].Count(), putCurr)
 }
+
+func TestGetTenantWeights(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	specs := []base.StoreSpec{
+		{InMemory: true},
+		{InMemory: true},
+	}
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		StoreSpecs: specs,
+	})
+	defer s.Stopper().Stop(ctx)
+	// Wait until both stores are started properly.
+	testutils.SucceedsSoon(t, func() error {
+		var n int
+		err := s.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+			if !s.IsStarted() {
+				return fmt.Errorf("not started: %s", s)
+			}
+			n++
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		if exp := len(specs); exp != n {
+			return fmt.Errorf("found only %d of %d stores", n, exp)
+		}
+		return nil
+	})
+	// At this point, all ranges have the SystemTenantID. Create a split using
+	// another tenant, which will cause that tenant to have a weight of 1 in the
+	// relevant store(s).
+	const otherTenantID = 5
+	prefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(otherTenantID))
+	require.NoError(t, s.DB().AdminSplit(ctx, prefix, hlc.MaxTimestamp))
+	// The range can have replicas on multiple stores, so wait for the split to
+	// be applied everywhere.
+	stores := s.GetStores().(*kvserver.Stores)
+	testutils.SucceedsSoon(t, func() error {
+		return stores.VisitStores(func(s *kvserver.Store) error {
+			r := s.LookupReplica(roachpb.RKey(prefix))
+			if r != nil && !r.Desc().StartKey.Equal(prefix) {
+				return errors.Errorf("waiting for split")
+			}
+			return nil
+		})
+	})
+	// Unfortunately, the non-determinism of replica distribution can make this
+	// test more complicated than the code it is trying to test, if we were to
+	// validate exact counts. So we do some simple validation instead.
+	weights := s.Node().(*Node).GetTenantWeights()
+	// Both tenants have overall non-zero counts.
+	require.Less(t, uint32(0), weights.Node[roachpb.SystemTenantID.ToUint64()])
+	require.Less(t, uint32(0), weights.Node[otherTenantID])
+	// There are two stores.
+	require.Equal(t, 2, len(weights.Stores))
+	// The sum of the values in the stores is equal to the node-level value.
+	checkSum := func(tenantID uint64) {
+		require.Equal(t, weights.Node[tenantID], weights.Stores[0].Weights[tenantID]+
+			weights.Stores[1].Weights[tenantID])
+	}
+	checkSum(roachpb.SystemTenantID.ToUint64())
+	checkSum(otherTenantID)
+}


### PR DESCRIPTION
The weights are used in ordering tenants, such that tenant i is
preferred over tenant j if used_i/weight_i < used_j/weight_j,
where the used values represent usage of slots or tokens. It
allows for a primitive form of weighted fair sharing. This
was added in a preceding PR.

This PR integrates this existing support for weighting, by
- making Node provide these weights by counting the number
  of ranges for each tenant, both per store and across the
  whole node.
- making KVAdmissionControllerImpl periodically poll for these
  weights (at a 10min interval) and provide these to the
  single KV WorkQueue and each of the kv-stores WorkQueues.

An alternative would be to put the polling logic inside the
admission control package. The difficulty there is that we
want to synchronize the computaton across the whole node,
instead of doing it once per WorkQueue.
KVAdmissionControllerImpl provides a convenient place to place
this synchronized computation.

The cluster settings for using weights are set to a default
that disables weights.

Informs #77358

Release justification: Low-risk update to new functionality.
Even though inter-tenant isolation was included in v21.2,
it has only been used in CockroachDB serverless recently,
and there is consensus to include weighting for v22.1.
Additionally, weights are disabled by default.

Release note (ops change): The cluster settings
admission.kv.tenant_weights.enabled and
admission.kv.stores.tenant_weights.enabled can be used to
enable tenant weights in multi-tenant storage servers. The
default is disabled.