### PR TITLE
release-21.2: changefeedccl: Reduce log spam when memory tight.

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
@@ -47,8 +48,10 @@ type blockingBuffer struct {
 func NewMemBuffer(
 	acc mon.BoundAccount, sv *settings.Values, metrics *Metrics, opts ...quotapool.Option,
 ) Buffer {
+	const slowAcquisitionThreshold = 5 * time.Second
+
 	opts = append(opts,
-		quotapool.OnSlowAcquisition(5*time.Second, quotapool.LogSlowAcquisition),
+		quotapool.OnSlowAcquisition(slowAcquisitionThreshold, logSlowAcquisition(slowAcquisitionThreshold)),
 		quotapool.OnWaitFinish(
 			func(ctx context.Context, poolName string, r quotapool.Request, start time.Time) {
 				metrics.BufferPushbackNanos.Inc(timeutil.Since(start).Nanoseconds())
@@ -424,4 +427,25 @@ func (ap allocPool) Release(ctx context.Context, bytes, entries int64) {
 		ap.metrics.BufferEntriesReleased.Inc(entries)
 		return true
 	})
+}
+
+// logSlowAcquisition is a function returning a quotapool.SlowAcquisitionFunction.
+// It differs from the quotapool.LogSlowAcquisition in that only some of slow acquisition
+// events are logged to reduce log spam.
+func logSlowAcquisition(slowAcquisitionThreshold time.Duration) quotapool.SlowAcquisitionFunc {
+	logSlowAcquire := log.Every(slowAcquisitionThreshold)
+
+	return func(ctx context.Context, poolName string, r quotapool.Request, start time.Time) func() {
+		shouldLog := logSlowAcquire.ShouldLog()
+		if shouldLog {
+			log.Warningf(ctx, "have been waiting %s attempting to acquire changefeed quota",
+				timeutil.Since(start))
+		}
+
+		return func() {
+			if shouldLog {
+				log.Infof(ctx, "acquired changefeed quota after %s", timeutil.Since(start))
+			}
+		}
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #74165.

/cc @cockroachdb/release

---

Blocking buffer logs events every time a request is blocked for too
long (5 seconds).  However, when we acquire the resource, we also log
how long that resource waited for.  Because blocking allows concurrent
ingestion of events, this resulted in substantial number of log
messages generated in short burts when running under high concurrency
settings.  Reduce the number of these log messages by only logging periodically.

Release Notes: None

Release Justification: Low impact logging change.