### PR TITLE
kv/bulk: split/scatter after range says it is full

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -430,6 +430,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	// non-overlapping ingestion into empty spans, that is just one seek.
 	disallowShadowingBelow := hlc.Timestamp{Logical: 1}
 	batcher, err := bulk.MakeSSTBatcher(ctx,
+		"restore",
 		db,
 		evalCtx.Settings,
 		disallowShadowingBelow,

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -49,13 +49,19 @@ type BufferingAdder struct {
 
 	initialSplits int
 
-	lastFlush   time.Time
+	lastFlush time.Time
+
+	// flushCounts accumulates performance and debug info for logging.
 	flushCounts struct {
-		total        int
-		bufferSize   int
+		total        int // number of flushes.
+		bufferSize   int // number of flushes due to buffer size.
 		totalSort    time.Duration
 		totalFlush   time.Duration
 		totalFilling time.Duration
+		// span tracks the total span into which this batcher has flushed. It is
+		// only maintained if log.V(1), so if vmodule is upped mid-ingest it may be
+		// incomplete.
+		span roachpb.Span
 	}
 
 	// name of the BufferingAdder for the purpose of logging only.
@@ -136,31 +142,37 @@ func (b *BufferingAdder) SetOnFlush(fn func(summary roachpb.BulkOpSummary)) {
 
 // Close closes the underlying SST builder.
 func (b *BufferingAdder) Close(ctx context.Context) {
-	log.VEventf(ctx, 1,
-		"%s adder ingested %s (%s); spent %s filling, %v sorting, %v flushing (%v sink, %v sending, %v splitting, %v scattering %v, %v commit-wait)",
-		b.name,
-		sz(b.sink.totalRows.DataSize),
-		sorted(b.sorted),
-		timing(b.flushCounts.totalFilling),
-		timing(b.flushCounts.totalSort),
-		timing(b.flushCounts.totalFlush),
-		timing(b.sink.flushCounts.flushWait),
-		timing(b.sink.flushCounts.sendWait),
-		timing(b.sink.flushCounts.splitWait),
-		timing(b.sink.flushCounts.scatterWait),
-		b.sink.flushCounts.scatterMoved,
-		timing(b.sink.flushCounts.commitWait),
-	)
-	log.VEventf(ctx, 2, "%s adder flushed %d times, %d due to buffer size (%s); flushing chunked into %d files (%d for ranges, %d for sst size, +%d after split-retries)",
-		b.name,
-		b.flushCounts.total,
-		b.flushCounts.bufferSize,
-		sz(b.memAcc.Used()),
-		b.sink.flushCounts.total,
-		b.sink.flushCounts.split,
-		b.sink.flushCounts.sstSize,
-		b.sink.flushCounts.files-b.sink.flushCounts.total,
-	)
+	if b.flushCounts.total > 0 {
+		log.VEventf(ctx, 1,
+			"%s adder closing; ingested %s (%s): %s filling, %v sorting, %v / %v flushing; %v sending, %v splitting / %d, %v scattering / %v, %v commit-wait",
+			b.name,
+			sz(b.sink.totalRows.DataSize),
+			sorted(b.sorted),
+			timing(b.flushCounts.totalFilling),
+			timing(b.flushCounts.totalSort),
+			timing(b.flushCounts.totalFlush),
+			timing(b.sink.flushCounts.flushWait),
+			timing(b.sink.flushCounts.sendWait),
+			timing(b.sink.flushCounts.splitWait),
+			b.sink.flushCounts.splitAndScatters,
+			timing(b.sink.flushCounts.scatterWait),
+			b.sink.flushCounts.scatterMoved,
+			timing(b.sink.flushCounts.commitWait),
+		)
+		log.VEventf(ctx, 2, "%s adder closing; flushed into %s %d times, %d due to buffer size (%s); flushing chunked into %d files (%d for ranges, %d for sst size, +%d after split-retries)",
+			b.name,
+			b.flushCounts.span,
+			b.flushCounts.total,
+			b.flushCounts.bufferSize,
+			sz(b.memAcc.Used()),
+			b.sink.flushCounts.total,
+			b.sink.flushCounts.dueToRange,
+			b.sink.flushCounts.dueToSize,
+			b.sink.flushCounts.files-b.sink.flushCounts.total,
+		)
+	} else {
+		log.VEventf(ctx, 3, "%s adder closing; ingested nothing", b.name)
+	}
 	b.sink.Close()
 
 	if b.bulkMon != nil {
@@ -272,6 +284,12 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 		b.initialSplits = 0
 	}
 
+	if log.V(1) {
+		if len(b.flushCounts.span.Key) == 0 || b.curBuf.Key(0).Compare(b.flushCounts.span.Key) < 0 {
+			b.flushCounts.span.Key = b.curBuf.Key(0).Clone()
+		}
+	}
+
 	for i := range b.curBuf.entries {
 		mvccKey.Key = b.curBuf.Key(i)
 		if err := b.sink.AddMVCCKey(ctx, mvccKey, b.curBuf.Value(i)); err != nil {
@@ -281,13 +299,20 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 	if err := b.sink.Flush(ctx); err != nil {
 		return err
 	}
+
+	if log.V(1) {
+		if b.flushCounts.span.EndKey.Compare(mvccKey.Key) < 0 {
+			b.flushCounts.span.EndKey = mvccKey.Key.Clone()
+		}
+	}
+
 	b.flushCounts.totalFlush += timeutil.Since(beforeFlush)
 
 	if log.V(3) {
 		written := b.sink.totalRows.DataSize - beforeSize
 		files := b.sink.flushCounts.total - before.total
-		dueToSplits := b.sink.flushCounts.split - before.split
-		dueToSize := b.sink.flushCounts.sstSize - before.sstSize
+		dueToSplits := b.sink.flushCounts.dueToRange - before.dueToRange
+		dueToSize := b.sink.flushCounts.dueToSize - before.dueToSize
 
 		log.Infof(ctx,
 			"%s adder flushing %s (%s buffered/%0.2gx) wrote %d SSTs (avg: %s) with %d for splits, %d for size, took %v",
@@ -305,7 +330,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 
 	if log.V(4) {
 		log.Infof(ctx,
-			"%s adder has ingested %s (%s); spent %s filling, %v sorting, %v flushing (%v sink, %v sending, %v splitting, %v scattering %v, %v commit-wait)",
+			"%s adder has ingested %s (%s): %s filling, %v sorting, %v / %v flushing; %v sending, %v splitting / %d, %v scattering / %v, %v commit-wait",
 			b.name,
 			sz(b.sink.totalRows.DataSize),
 			sorted(b.sorted),
@@ -315,6 +340,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 			timing(b.sink.flushCounts.flushWait),
 			timing(b.sink.flushCounts.sendWait),
 			timing(b.sink.flushCounts.splitWait),
+			b.sink.flushCounts.splitAndScatters,
 			timing(b.sink.flushCounts.scatterWait),
 			b.sink.flushCounts.scatterMoved,
 			timing(b.sink.flushCounts.commitWait),
@@ -323,13 +349,15 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 
 	if log.V(5) {
 		log.Infof(ctx,
-			"%s adder has flushed %d times due to buffer size (%s), chunked as %d files (%d for ranges, %d for sst size, +%d for split-retries)",
+			"%s adder has flushed into %s %d times, %d due to buffer size (%s), chunked as %d files (%d for ranges, %d for sst size, +%d for split-retries)",
 			b.name,
+			b.flushCounts.span,
+			b.flushCounts.total,
 			b.flushCounts.bufferSize,
 			sz(b.memAcc.Used()),
 			b.sink.flushCounts.total,
-			b.sink.flushCounts.split,
-			b.sink.flushCounts.sstSize,
+			b.sink.flushCounts.dueToRange,
+			b.sink.flushCounts.dueToSize,
 			b.sink.flushCounts.files-b.sink.flushCounts.total,
 		)
 	}
@@ -400,6 +428,7 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 			return err
 		}
 
+		b.sink.flushCounts.splitAndScatters++
 		b.sink.flushCounts.splitWait += resp.Timing.Split
 		b.sink.flushCounts.scatterWait += resp.Timing.Scatter
 		if resp.ScatteredStats != nil {

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -95,6 +95,7 @@ func MakeBulkAdder(
 	b := &BufferingAdder{
 		name: opts.Name,
 		sink: SSTBatcher{
+			name:                   opts.Name,
 			db:                     db,
 			rc:                     rangeCache,
 			settings:               settings,

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -417,8 +417,8 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 		}
 		predicateKey := b.curBuf.Key(predicateAt)
 		log.VEventf(ctx, 1, "pre-splitting span %d of %d at %s", i, b.initialSplits, splitKey)
-		resp, err := b.sink.db.SplitAndScatter(ctx, splitKey, expire, predicateKey)
-		if err != nil {
+		beforeSplit := timeutil.Now()
+		if err := b.sink.db.AdminSplit(ctx, splitKey, expire, predicateKey); err != nil {
 			// TODO(dt): a typed error would be nice here.
 			if strings.Contains(err.Error(), "predicate") {
 				log.VEventf(ctx, 1, "%s adder split at %s rejected, had previously split and no longer included %s",
@@ -427,16 +427,21 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 			}
 			return err
 		}
-
+		b.sink.flushCounts.splitWait += timeutil.Since(beforeSplit)
+		beforeScatter := timeutil.Now()
+		resp, err := b.sink.db.AdminScatter(ctx, splitKey, 0)
+		if err != nil {
+			log.Warningf(ctx, "failed to scatter: %v", err)
+			continue
+		}
 		b.sink.flushCounts.splitAndScatters++
-		b.sink.flushCounts.splitWait += resp.Timing.Split
-		b.sink.flushCounts.scatterWait += resp.Timing.Scatter
-		if resp.ScatteredStats != nil {
-			moved := sz(resp.ScatteredStats.Total())
+		b.sink.flushCounts.scatterWait += timeutil.Since(beforeScatter)
+		if resp.MVCCStats != nil {
+			moved := sz(resp.MVCCStats.Total())
 			b.sink.flushCounts.scatterMoved += moved
-			if resp.ScatteredStats.Total() > 0 {
+			if moved > 0 {
 				log.VEventf(ctx, 1, "pre-split scattered %s in non-empty range %s",
-					moved, resp.ScatteredSpan)
+					moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
 			}
 		}
 		created++

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -137,7 +137,7 @@ func (b *BufferingAdder) SetOnFlush(fn func(summary roachpb.BulkOpSummary)) {
 // Close closes the underlying SST builder.
 func (b *BufferingAdder) Close(ctx context.Context) {
 	log.VEventf(ctx, 1,
-		"%s adder ingested %s (%s); spent %s filling, %v sorting, %v flushing (%v sink, %v sending, %v splitting, %v scattering %v)",
+		"%s adder ingested %s (%s); spent %s filling, %v sorting, %v flushing (%v sink, %v sending, %v splitting, %v scattering %v, %v commit-wait)",
 		b.name,
 		sz(b.sink.totalRows.DataSize),
 		sorted(b.sorted),
@@ -149,6 +149,7 @@ func (b *BufferingAdder) Close(ctx context.Context) {
 		timing(b.sink.flushCounts.splitWait),
 		timing(b.sink.flushCounts.scatterWait),
 		b.sink.flushCounts.scatterMoved,
+		timing(b.sink.flushCounts.commitWait),
 	)
 	log.VEventf(ctx, 2, "%s adder flushed %d times, %d due to buffer size (%s); flushing chunked into %d files (%d for ranges, %d for sst size, +%d after split-retries)",
 		b.name,
@@ -304,7 +305,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 
 	if log.V(4) {
 		log.Infof(ctx,
-			"%s adder has ingested %s (%s); spent %s filling, %v sorting, %v flushing (%v sink, %v sending, %v splitting, %v scattering %v)",
+			"%s adder has ingested %s (%s); spent %s filling, %v sorting, %v flushing (%v sink, %v sending, %v splitting, %v scattering %v, %v commit-wait)",
 			b.name,
 			sz(b.sink.totalRows.DataSize),
 			sorted(b.sorted),
@@ -316,6 +317,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 			timing(b.sink.flushCounts.splitWait),
 			timing(b.sink.flushCounts.scatterWait),
 			b.sink.flushCounts.scatterMoved,
+			timing(b.sink.flushCounts.commitWait),
 		)
 	}
 

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -144,7 +144,7 @@ func (b *BufferingAdder) SetOnFlush(fn func(summary roachpb.BulkOpSummary)) {
 func (b *BufferingAdder) Close(ctx context.Context) {
 	if b.flushCounts.total > 0 {
 		log.VEventf(ctx, 1,
-			"%s adder closing; ingested %s (%s): %s filling, %v sorting, %v / %v flushing; %v sending, %v splitting / %d, %v scattering / %v, %v commit-wait",
+			"%s adder closing; ingested %s (%s): %s filling; %v sorting; %v / %v flushing; %v sending; %v splitting; %d; %v scattering, %d, %v; %v commit-wait",
 			b.name,
 			sz(b.sink.totalRows.DataSize),
 			sorted(b.sorted),
@@ -154,8 +154,9 @@ func (b *BufferingAdder) Close(ctx context.Context) {
 			timing(b.sink.flushCounts.flushWait),
 			timing(b.sink.flushCounts.sendWait),
 			timing(b.sink.flushCounts.splitWait),
-			b.sink.flushCounts.splitAndScatters,
+			b.sink.flushCounts.splits,
 			timing(b.sink.flushCounts.scatterWait),
+			b.sink.flushCounts.scatters,
 			b.sink.flushCounts.scatterMoved,
 			timing(b.sink.flushCounts.commitWait),
 		)
@@ -330,7 +331,7 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 
 	if log.V(4) {
 		log.Infof(ctx,
-			"%s adder has ingested %s (%s): %s filling, %v sorting, %v / %v flushing; %v sending, %v splitting / %d, %v scattering / %v, %v commit-wait",
+			"%s adder has ingested %s (%s): %s filling; %v sorting; %v / %v flushing; %v sending; %v splitting; %d; %v scattering, %d, %v; %v commit-wait",
 			b.name,
 			sz(b.sink.totalRows.DataSize),
 			sorted(b.sorted),
@@ -340,8 +341,9 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 			timing(b.sink.flushCounts.flushWait),
 			timing(b.sink.flushCounts.sendWait),
 			timing(b.sink.flushCounts.splitWait),
-			b.sink.flushCounts.splitAndScatters,
+			b.sink.flushCounts.splits,
 			timing(b.sink.flushCounts.scatterWait),
+			b.sink.flushCounts.scatters,
 			b.sink.flushCounts.scatterMoved,
 			timing(b.sink.flushCounts.commitWait),
 		)
@@ -374,11 +376,12 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 	log.Infof(ctx, "%s adder creating up to %d initial splits from %d KVs in %s buffer",
 		b.name, b.initialSplits, b.curBuf.Len(), b.curBuf.KVSize())
 
-	hour := hlc.Timestamp{WallTime: timeutil.Now().Add(time.Hour).UnixNano()}
-	before := timeutil.Now()
-
-	created := 0
+	// First make all the splits, then go back and scatter them, so that those
+	// scatters only move the narrower, post-split spans.
+	beforeSplits := timeutil.Now()
+	hour := hlc.Timestamp{WallTime: beforeSplits.Add(time.Hour).UnixNano()}
 	width := len(b.curBuf.entries) / b.initialSplits
+	var toScatter []roachpb.Key
 	for i := 0; i < b.initialSplits; i++ {
 		expire := hour
 		if i == 0 {
@@ -417,7 +420,6 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 		}
 		predicateKey := b.curBuf.Key(predicateAt)
 		log.VEventf(ctx, 1, "pre-splitting span %d of %d at %s", i, b.initialSplits, splitKey)
-		beforeSplit := timeutil.Now()
 		if err := b.sink.db.AdminSplit(ctx, splitKey, expire, predicateKey); err != nil {
 			// TODO(dt): a typed error would be nice here.
 			if strings.Contains(err.Error(), "predicate") {
@@ -427,15 +429,23 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 			}
 			return err
 		}
-		b.sink.flushCounts.splitWait += timeutil.Since(beforeSplit)
-		beforeScatter := timeutil.Now()
-		resp, err := b.sink.db.AdminScatter(ctx, splitKey, 0)
+		toScatter = append(toScatter, splitKey)
+	}
+
+	beforeScatters := timeutil.Now()
+	splitsWait := beforeScatters.Sub(beforeSplits)
+	log.Infof(ctx, "%s adder created %d initial splits in %v from %d keys in %s buffer",
+		b.name, len(toScatter), timing(splitsWait), b.curBuf.Len(), b.curBuf.MemSize())
+	b.sink.flushCounts.splits += len(toScatter)
+	b.sink.flushCounts.splitWait += splitsWait
+
+	for _, splitKey := range toScatter {
+		resp, err := b.sink.db.AdminScatter(ctx, splitKey, 0 /* maxSize */)
 		if err != nil {
 			log.Warningf(ctx, "failed to scatter: %v", err)
 			continue
 		}
-		b.sink.flushCounts.splitAndScatters++
-		b.sink.flushCounts.scatterWait += timeutil.Since(beforeScatter)
+		b.sink.flushCounts.scatters++
 		if resp.MVCCStats != nil {
 			moved := sz(resp.MVCCStats.Total())
 			b.sink.flushCounts.scatterMoved += moved
@@ -444,11 +454,11 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 					moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
 			}
 		}
-		created++
 	}
-
-	log.Infof(ctx, "%s adder created %d initial splits in %v from %d keys in %s buffer",
-		b.name, created, timing(timeutil.Since(before)), b.curBuf.Len(), b.curBuf.KVSize())
+	scattersWait := timeutil.Since(beforeScatters)
+	b.sink.flushCounts.scatterWait += scattersWait
+	log.Infof(ctx, "%s adder scattered %d initial split spans in %v",
+		b.name, len(toScatter), timing(scattersWait))
 
 	b.sink.initialSplitDone = true
 	return nil

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -39,13 +39,6 @@ var (
 		400*1<<10, // 400 Kib
 	)
 
-	splitAfter = settings.RegisterByteSizeSetting(
-		settings.TenantWritable,
-		"bulkio.ingest.scatter_after_size",
-		"amount of data added to any one range after which a new range should be split off and scattered",
-		48<<20,
-	)
-
 	ingestDelay = settings.RegisterDurationSetting(
 		settings.TenantWritable,
 		"bulkio.ingest.flush_delay",
@@ -121,12 +114,13 @@ type SSTBatcher struct {
 	// batches when Reset() is called.
 	totalRows   roachpb.BulkOpSummary
 	flushCounts struct {
-		total   int
-		split   int
-		sstSize int
-		files   int // a single flush might create multiple files.
+		total      int
+		dueToRange int
+		dueToSize  int
+		files      int // a single flush might create multiple files.
 
-		scatterMoved sz
+		splitAndScatters int
+		scatterMoved     sz
 
 		flushWait   time.Duration
 		sendWait    time.Duration
@@ -134,11 +128,9 @@ type SSTBatcher struct {
 		scatterWait time.Duration
 		commitWait  time.Duration
 	}
-	// Tracking for if we have "filled" a range in case we want to split/scatter.
-	disableSplits         bool
-	flushedToCurrentRange int64
-	lastFlushKey          []byte
-	maxWriteTS            hlc.Timestamp
+	disableSplits bool
+
+	maxWriteTS hlc.Timestamp
 
 	// The rest of the fields are per-batch and are reset via Reset() before each
 	// batch is started.
@@ -149,6 +141,12 @@ type SSTBatcher struct {
 	batchEndValue   []byte
 	flushKeyChecked bool
 	flushKey        roachpb.Key
+	// lastRange is the span and remaining capacity of the last range added to,
+	// for checking if the next addition would overfill it.
+	lastRange struct {
+		span      roachpb.Span
+		remaining sz
+	}
 	// stores on-the-fly stats for the SST if disallowShadowingBelow is set.
 	ms enginepb.MVCCStats
 	// rows written in the current batch.
@@ -305,14 +303,14 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 	}
 
 	if b.flushKey != nil && b.flushKey.Compare(nextKey) <= 0 {
-		if err := b.doFlush(ctx, rangeFlush, nil); err != nil {
+		if err := b.doFlush(ctx, rangeFlush); err != nil {
 			return err
 		}
 		return b.Reset(ctx)
 	}
 
 	if b.sstWriter.DataSize >= ingestFileSize(b.settings) {
-		if err := b.doFlush(ctx, sizeFlush, nextKey); err != nil {
+		if err := b.doFlush(ctx, sizeFlush); err != nil {
 			return err
 		}
 		return b.Reset(ctx)
@@ -322,7 +320,7 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 
 // Flush sends the current batch, if any.
 func (b *SSTBatcher) Flush(ctx context.Context) error {
-	if err := b.doFlush(ctx, manualFlush, nil); err != nil {
+	if err := b.doFlush(ctx, manualFlush); err != nil {
 		return err
 	}
 	if !b.maxWriteTS.IsEmpty() {
@@ -339,7 +337,7 @@ func (b *SSTBatcher) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Key) error {
+func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 	if b.sstWriter.DataSize == 0 {
 		return nil
 	}
@@ -358,60 +356,67 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		}
 	}
 
-	hour := hlc.Timestamp{WallTime: beforeFlush.Add(time.Hour).UnixNano()}
+	if err := b.sstWriter.Finish(); err != nil {
+		return errors.Wrapf(err, "finishing constructed sstable")
+	}
 
 	start := roachpb.Key(append([]byte(nil), b.batchStartKey...))
 	// The end key of the WriteBatch request is exclusive, but batchEndKey is
 	// currently the largest key in the batch. Increment it.
 	end := roachpb.Key(append([]byte(nil), b.batchEndKey...)).Next()
 
-	size := b.sstWriter.DataSize
-	if reason == sizeFlush {
-		log.VEventf(ctx, 3, "%s flushing %s SST due to size > %s", b.name, sz(size), sz(ingestFileSize(b.settings)))
-		b.flushCounts.sstSize++
+	size := sz(b.sstWriter.DataSize)
 
-		// On first flush, if it is due to size, we introduce one split at the start
-		// of our span, since size means we didn't already hit one. When adders have
-		// non-overlapping keyspace this split partitions off "our" target space for
-		// future splitting/scattering, while if they don't, doing this only once
-		// minimizes impact on other adders (e.g. causing extra SST splitting).
-		//
-		// We only do this splitting if the caller expects the sst_batcher to
-		// split and scatter the data as it ingests it i.e. splitAfter > 0.
-		if !b.disableSplits && !b.initialSplitDone && b.flushCounts.total == 1 && splitAfter.Get(&b.settings.SV) > 0 {
-			if splitAt, err := keys.EnsureSafeSplitKey(start); err != nil {
-				log.Warningf(ctx, "%s failed to generate split key to separate ingestion span: %v", b.name, err)
+	if reason == sizeFlush {
+		log.VEventf(ctx, 3, "%s flushing %s SST due to size > %s", b.name, size, sz(ingestFileSize(b.settings)))
+		b.flushCounts.dueToSize++
+	} else if reason == rangeFlush {
+		log.VEventf(ctx, 3, "%s flushing %s SST due to range boundary %s", b.name, size, b.flushKey)
+		b.flushCounts.dueToRange++
+	}
+
+	shouldSplit := false
+	if !b.disableSplits {
+		if b.lastRange.span.ContainsKey(start) && size >= b.lastRange.remaining {
+			// If this file is starting in the same span we last added to and is bigger
+			// than the size that range had when we last added to it, then we should
+			// split off the suffix of that range where this file starts and add it to
+			// that new range after scattering it.
+			log.VEventf(ctx, 2, "%s batcher splitting full range %s before adding file starting at %s",
+				b.name, b.lastRange.span, start)
+			shouldSplit = true
+		} else if reason == sizeFlush && !b.initialSplitDone && b.flushCounts.total == 1 {
+			// If we didn't make initial splits, and this is our first flush and is due
+			// to filling the buffer, then we may have our own span and should drop a
+			// split at the first key to separate it out.
+			log.VEventf(ctx, 1, "%s splitting on first flush to separate ingestion span using key %s",
+				b.name, start)
+			shouldSplit = true
+		}
+	}
+
+	if shouldSplit {
+		splitAt, err := keys.EnsureSafeSplitKey(start)
+		if err != nil {
+			log.Warningf(ctx, "%s failed to generate split key: %v", b.name, err)
+		} else {
+			hour := hlc.Timestamp{WallTime: beforeFlush.Add(time.Hour).UnixNano()}
+			reply, err := b.db.SplitAndScatter(ctx, splitAt, hour)
+			if err != nil {
+				log.Warningf(ctx, "%s failed to split: %v", b.name, err)
 			} else {
-				if log.V(1) {
-					log.Infof(ctx, "%s splitting on first flush to separate ingestion span using key %v", b.name, start)
-				}
-				// NB: Passing 'hour' here is technically illegal until 19.2 is
-				// active, but the value will be ignored before that, and we don't
-				// have access to the cluster version here.
-				reply, err := b.db.SplitAndScatter(ctx, splitAt, hour)
-				if err != nil {
-					log.Warningf(ctx, "%s failed to split at first key to separate ingestion span: %v", b.name, err)
-				} else {
-					b.flushCounts.splitWait += reply.Timing.Split
-					b.flushCounts.scatterWait += reply.Timing.Scatter
-					if reply.ScatteredStats != nil {
-						moved := sz(reply.ScatteredStats.Total())
-						b.flushCounts.scatterMoved += moved
-						if moved > 0 {
-							log.VEventf(ctx, 1, "%s starting split scattered %s in non-empty range %s", b.name, moved, reply.ScatteredSpan)
-						}
+				b.flushCounts.splitAndScatters++
+				b.flushCounts.splitWait += reply.Timing.Split
+				b.flushCounts.scatterWait += reply.Timing.Scatter
+				if reply.ScatteredStats != nil {
+					moved := sz(reply.ScatteredStats.Total())
+					b.flushCounts.scatterMoved += moved
+					if moved > 0 {
+						log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, reply.ScatteredSpan)
 					}
 				}
 			}
 		}
-	} else if reason == rangeFlush {
-		log.VEventf(ctx, 3, "%s flushing %s SST due to range boundary %s", b.name, sz(size), b.flushKey)
-		b.flushCounts.split++
-	}
-
-	err := b.sstWriter.Finish()
-	if err != nil {
-		return errors.Wrapf(err, "finishing constructed sstable")
 	}
 
 	// If the stats have been computed on-the-fly, set the last updated time
@@ -421,53 +426,19 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 	}
 
 	beforeSend := timeutil.Now()
-	writeTS, files, err := AddSSTable(ctx, b.db, start, end, b.sstFile.Data(), b.disallowShadowingBelow, b.ms, b.settings, b.batchTS, b.writeAtBatchTS)
+	writeTS, files, rangeSpan, rangeAvailable, err := AddSSTable(ctx, b.db, start, end, b.sstFile.Data(), b.disallowShadowingBelow, b.ms, b.settings, b.batchTS, b.writeAtBatchTS)
 	if err != nil {
 		return err
 	}
 	b.flushCounts.sendWait += timeutil.Since(beforeSend)
+	b.flushCounts.files += files
 	b.maxWriteTS.Forward(writeTS)
 
-	b.flushCounts.files += files
-	if b.flushKey != nil {
-		// If the flush-before key hasn't changed we know we don't think we passed
-		// a range boundary, and if the files-added count is 1 we didn't hit an
-		// unexpected split either, so assume we added to the same range.
-		if reason == sizeFlush && bytes.Equal(b.flushKey, b.lastFlushKey) && files == 1 {
-			b.flushedToCurrentRange += size
-		} else {
-			// Assume we started adding to new different range with this SST.
-			b.lastFlushKey = append(b.lastFlushKey[:0], b.flushKey...)
-			b.flushedToCurrentRange = size
-		}
-		if splitSize := splitAfter.Get(&b.settings.SV); !b.disableSplits && splitSize > 0 {
-			if b.flushedToCurrentRange > splitSize && nextKey != nil {
-				if splitAt, err := keys.EnsureSafeSplitKey(nextKey); err != nil {
-					log.Warningf(ctx, "%v", err)
-				} else {
-					log.VEventf(ctx, 2, "%s added since last split, splitting/scattering for next range at %v", sz(b.flushedToCurrentRange), end)
-					reply, err := b.db.SplitAndScatter(ctx, splitAt, hour)
-					if err != nil {
-						log.Warningf(ctx, "failed to split and scatter during ingest: %+v", err)
-					}
-					b.flushCounts.splitWait += reply.Timing.Split
-					b.flushCounts.scatterWait += reply.Timing.Scatter
-					if reply.ScatteredStats != nil {
-						moved := sz(reply.ScatteredStats.Total())
-						b.flushCounts.scatterMoved += moved
-						if moved > 0 {
-							// This is unexpected, since 'filling' a range without hitting a
-							// an existing split suggests non-overlapping input, so we expect
-							// our still-to-fill RHS to be empty and cheap to move.
-							log.VEventf(ctx, 1, "filled-range split scattered %s in non-empty range %s", moved, reply.ScatteredSpan)
-						}
-					}
-				}
-				b.flushedToCurrentRange = 0
-			}
-		}
+	b.lastRange.span = rangeSpan
+	if rangeSpan.Valid() {
+		b.flushKey = rangeSpan.EndKey
+		b.lastRange.remaining = sz(rangeAvailable)
 	}
-
 	b.rowCounter.DataSize += b.sstWriter.DataSize
 	b.totalRows.Add(b.rowCounter.BulkOpSummary)
 	b.flushCounts.flushWait += timeutil.Since(beforeFlush)
@@ -509,14 +480,20 @@ func AddSSTable(
 	settings *cluster.Settings,
 	batchTs hlc.Timestamp,
 	writeAtBatchTs bool,
-) (hlc.Timestamp, int, error) {
+) (
+	maxWriteTs hlc.Timestamp,
+	numFiles int,
+	maxRangeSpan roachpb.Span,
+	maxRangeRemaining int64,
+	_ error,
+) {
 	var files int
 	var maxTs hlc.Timestamp
 
 	now := timeutil.Now()
 	iter, err := storage.NewMemSSTIterator(sstBytes, true)
 	if err != nil {
-		return hlc.Timestamp{}, 0, err
+		return hlc.Timestamp{}, 0, roachpb.Span{}, 0, err
 	}
 	defer iter.Close()
 
@@ -524,7 +501,7 @@ func AddSSTable(
 	if (ms == enginepb.MVCCStats{}) {
 		stats, err = storage.ComputeStatsForRange(iter, start, end, now.UnixNano())
 		if err != nil {
-			return hlc.Timestamp{}, 0, errors.Wrapf(err, "computing stats for SST [%s, %s)", start, end)
+			return hlc.Timestamp{}, 0, roachpb.Span{}, 0, errors.Wrapf(err, "computing stats for SST [%s, %s)", start, end)
 		}
 	} else {
 		stats = ms
@@ -555,11 +532,13 @@ func AddSSTable(
 					log.VEventf(ctx, 3, "ingest data is too small (%d keys/%d bytes) for SSTable, adding via regular batch", item.stats.KeyCount, len(item.sstBytes))
 					ingestAsWriteBatch = true
 				}
+				var rangeSpan roachpb.Span
+				var rangeAvailable int64
 
 				if writeAtBatchTs {
 					var writeTs hlc.Timestamp
 					// This will fail if the range has split but we'll check for that below.
-					writeTs, err = db.AddSSTableAtBatchTimestamp(ctx, item.start, item.end, item.sstBytes,
+					writeTs, rangeSpan, rangeAvailable, err = db.AddSSTableAtBatchTimestamp(ctx, item.start, item.end, item.sstBytes,
 						false /* disallowConflicts */, !item.disallowShadowingBelow.IsEmpty(),
 						item.disallowShadowingBelow, &item.stats, ingestAsWriteBatch, batchTs)
 					if err == nil {
@@ -567,12 +546,16 @@ func AddSSTable(
 					}
 				} else {
 					// This will fail if the range has split but we'll check for that below.
-					err = db.AddSSTable(ctx, item.start, item.end, item.sstBytes, false, /* disallowConflicts */
+					rangeSpan, rangeAvailable, err = db.AddSSTable(ctx, item.start, item.end, item.sstBytes, false, /* disallowConflicts */
 						!item.disallowShadowingBelow.IsEmpty(), item.disallowShadowingBelow, &item.stats,
 						ingestAsWriteBatch, batchTs)
 				}
 				if err == nil {
 					log.VEventf(ctx, 3, "adding %s AddSSTable [%s,%s) took %v", sz(len(item.sstBytes)), item.start, item.end, timeutil.Since(before))
+					if maxRangeSpan.EndKey.Compare(rangeSpan.EndKey) < 0 {
+						maxRangeSpan = rangeSpan
+						maxRangeRemaining = rangeAvailable
+					}
 					return nil
 				}
 				// Retry on AmbiguousResult.
@@ -611,7 +594,7 @@ func AddSSTable(
 			}
 			return errors.Wrapf(err, "addsstable [%s,%s)", item.start, item.end)
 		}(); err != nil {
-			return maxTs, files, err
+			return maxTs, files, roachpb.Span{}, 0, err
 		}
 		files++
 		// explicitly deallocate SST. This will not deallocate the
@@ -619,7 +602,7 @@ func AddSSTable(
 		item.sstBytes = nil
 	}
 	log.VEventf(ctx, 3, "AddSSTable [%v, %v) added %d files and took %v", start, end, files, timeutil.Since(now))
-	return maxTs, files, nil
+	return maxTs, files, maxRangeSpan, maxRangeRemaining, nil
 }
 
 // createSplitSSTable is a helper for splitting up SSTs. The iterator

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -132,6 +132,7 @@ type SSTBatcher struct {
 		sendWait    time.Duration
 		splitWait   time.Duration
 		scatterWait time.Duration
+		commitWait  time.Duration
 	}
 	// Tracking for if we have "filled" a range in case we want to split/scatter.
 	disableSplits         bool
@@ -325,8 +326,15 @@ func (b *SSTBatcher) Flush(ctx context.Context) error {
 		return err
 	}
 	if !b.maxWriteTS.IsEmpty() {
-		log.VEventf(ctx, 1, "%s waiting until max write time %s", b.name, b.maxWriteTS)
-		return b.db.Clock().SleepUntil(ctx, b.maxWriteTS)
+		if now := b.db.Clock().Now(); now.Less(b.maxWriteTS) {
+			guess := timing(b.maxWriteTS.WallTime - now.WallTime)
+			log.VEventf(ctx, 1, "%s batcher waiting %s until max write time %s", b.name, guess, b.maxWriteTS)
+			if err := b.db.Clock().SleepUntil(ctx, b.maxWriteTS); err != nil {
+				return err
+			}
+			b.flushCounts.commitWait += timeutil.Since(now.GoTime())
+		}
+		b.maxWriteTS.Reset()
 	}
 	return nil
 }

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -13,6 +13,7 @@ package bulk
 import (
 	"bytes"
 	"context"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -30,6 +31,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
+
+// maxScatterSize is the size limit included in scatters sent for as-we-write
+// splits which expect to just move empty spans to balance ingestion, to avoid
+// them becoming expensive moves of existing data if sent to a non-empty range.
+const maxScatterSize = 4 << 20
 
 var (
 	tooSmallSSTSize = settings.RegisterByteSizeSetting(
@@ -401,18 +407,29 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 			log.Warningf(ctx, "%s failed to generate split key: %v", b.name, err)
 		} else {
 			hour := hlc.Timestamp{WallTime: beforeFlush.Add(time.Hour).UnixNano()}
-			reply, err := b.db.SplitAndScatter(ctx, splitAt, hour)
-			if err != nil {
+			beforeSplit := timeutil.Now()
+			if err := b.db.AdminSplit(ctx, splitAt, hour); err != nil {
 				log.Warningf(ctx, "%s failed to split: %v", b.name, err)
 			} else {
-				b.flushCounts.splitAndScatters++
-				b.flushCounts.splitWait += reply.Timing.Split
-				b.flushCounts.scatterWait += reply.Timing.Scatter
-				if reply.ScatteredStats != nil {
-					moved := sz(reply.ScatteredStats.Total())
-					b.flushCounts.scatterMoved += moved
-					if moved > 0 {
-						log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, reply.ScatteredSpan)
+				b.flushCounts.splitWait += timeutil.Since(beforeSplit)
+				beforeScatter := timeutil.Now()
+				resp, err := b.db.AdminScatter(ctx, splitAt, maxScatterSize)
+				b.flushCounts.scatterWait += timeutil.Since(beforeScatter)
+				if err != nil {
+					// TODO(dt): switch to a typed error.
+					if strings.Contains(err.Error(), "existing range size") {
+						log.VEventf(ctx, 1, "%s scattered non-empty range rejected: %v", b.name, err)
+					} else {
+						log.Warningf(ctx, "%s failed to scatter	: %v", b.name, err)
+					}
+				} else {
+					b.flushCounts.splitAndScatters++
+					if resp.MVCCStats != nil {
+						moved := sz(resp.MVCCStats.Total())
+						b.flushCounts.scatterMoved += moved
+						if moved > 0 {
+							log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
+						}
 					}
 				}
 			}

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -82,6 +82,7 @@ func (t sorted) SafeValue() {}
 // it to attempt to flush SSTs before they cross range boundaries to minimize
 // expensive on-split retries.
 type SSTBatcher struct {
+	name     string
 	db       *kv.DB
 	rc       *rangecache.RangeCache
 	settings *cluster.Settings
@@ -156,6 +157,7 @@ type SSTBatcher struct {
 // MakeSSTBatcher makes a ready-to-use SSTBatcher.
 func MakeSSTBatcher(
 	ctx context.Context,
+	name string,
 	db *kv.DB,
 	settings *cluster.Settings,
 	disallowShadowingBelow hlc.Timestamp,
@@ -163,6 +165,7 @@ func MakeSSTBatcher(
 	splitFilledRanges bool,
 ) (*SSTBatcher, error) {
 	b := &SSTBatcher{
+		name:                   name,
 		db:                     db,
 		settings:               settings,
 		disallowShadowingBelow: disallowShadowingBelow,
@@ -293,9 +296,9 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 			r := b.rc.GetCached(ctx, k, false /* inverted */)
 			if r != nil {
 				b.flushKey = r.Desc().EndKey.AsRawKey()
-				log.VEventf(ctx, 3, "building sstable that will flush before %v", b.flushKey)
+				log.VEventf(ctx, 3, "%s building sstable that will flush before %v", b.name, b.flushKey)
 			} else {
-				log.VEventf(ctx, 3, "no cached range desc available to determine sst flush key")
+				log.VEventf(ctx, 2, "%s no cached range desc available to determine sst flush key", b.name)
 			}
 		}
 	}
@@ -322,7 +325,7 @@ func (b *SSTBatcher) Flush(ctx context.Context) error {
 		return err
 	}
 	if !b.maxWriteTS.IsEmpty() {
-		log.VEventf(ctx, 1, "waiting until max write time %s", b.maxWriteTS)
+		log.VEventf(ctx, 1, "%s waiting until max write time %s", b.name, b.maxWriteTS)
 		return b.db.Clock().SleepUntil(ctx, b.maxWriteTS)
 	}
 	return nil
@@ -338,7 +341,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 
 	if delay := ingestDelay.Get(&b.settings.SV); delay != 0 {
 		if delay > time.Second || log.V(1) {
-			log.Infof(ctx, "delaying %s before flushing ingestion buffer...", delay)
+			log.Infof(ctx, "%s delaying %s before flushing ingestion buffer...", b.name, delay)
 		}
 		select {
 		case <-ctx.Done():
@@ -356,7 +359,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 
 	size := b.sstWriter.DataSize
 	if reason == sizeFlush {
-		log.VEventf(ctx, 3, "flushing %s SST due to size > %s", sz(size), sz(ingestFileSize(b.settings)))
+		log.VEventf(ctx, 3, "%s flushing %s SST due to size > %s", b.name, sz(size), sz(ingestFileSize(b.settings)))
 		b.flushCounts.sstSize++
 
 		// On first flush, if it is due to size, we introduce one split at the start
@@ -369,17 +372,17 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 		// split and scatter the data as it ingests it i.e. splitAfter > 0.
 		if !b.disableSplits && !b.initialSplitDone && b.flushCounts.total == 1 && splitAfter.Get(&b.settings.SV) > 0 {
 			if splitAt, err := keys.EnsureSafeSplitKey(start); err != nil {
-				log.Warningf(ctx, "failed to generate split key to separate ingestion span: %v", err)
+				log.Warningf(ctx, "%s failed to generate split key to separate ingestion span: %v", b.name, err)
 			} else {
 				if log.V(1) {
-					log.Infof(ctx, "splitting on first flush to separate ingestion span using key %v", start)
+					log.Infof(ctx, "%s splitting on first flush to separate ingestion span using key %v", b.name, start)
 				}
 				// NB: Passing 'hour' here is technically illegal until 19.2 is
 				// active, but the value will be ignored before that, and we don't
 				// have access to the cluster version here.
 				reply, err := b.db.SplitAndScatter(ctx, splitAt, hour)
 				if err != nil {
-					log.Warningf(ctx, "failed ot split at first key to separate ingestion span: %v", err)
+					log.Warningf(ctx, "%s failed to split at first key to separate ingestion span: %v", b.name, err)
 				} else {
 					b.flushCounts.splitWait += reply.Timing.Split
 					b.flushCounts.scatterWait += reply.Timing.Scatter
@@ -387,14 +390,14 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int, nextKey roachpb.Ke
 						moved := sz(reply.ScatteredStats.Total())
 						b.flushCounts.scatterMoved += moved
 						if moved > 0 {
-							log.VEventf(ctx, 1, "starting split scattered %s in non-empty range %s", moved, reply.ScatteredSpan)
+							log.VEventf(ctx, 1, "%s starting split scattered %s in non-empty range %s", b.name, moved, reply.ScatteredSpan)
 						}
 					}
 				}
 			}
 		}
 	} else if reason == rangeFlush {
-		log.VEventf(ctx, 3, "flushing %s SST due to range boundary %s", sz(size), b.flushKey)
+		log.VEventf(ctx, 3, "%s flushing %s SST due to range boundary %s", b.name, sz(size), b.flushKey)
 		b.flushCounts.split++
 	}
 
@@ -527,7 +530,7 @@ func AddSSTable(
 		if err := func() error {
 			var err error
 			for i := 0; i < maxAddSSTableRetries; i++ {
-				log.VEventf(ctx, 2, "sending %s AddSSTable [%s,%s)", sz(len(item.sstBytes)), item.start, item.end)
+				log.VEventf(ctx, 4, "sending %s AddSSTable [%s,%s)", sz(len(item.sstBytes)), item.start, item.end)
 				before := timeutil.Now()
 				// If this SST is "too small", the fixed costs associated with adding an
 				// SST – in terms of triggering flushes, extra compactions, etc – would
@@ -541,7 +544,7 @@ func AddSSTable(
 				// and just switch how it writes its result.
 				ingestAsWriteBatch := false
 				if settings != nil && int64(len(item.sstBytes)) < tooSmallSSTSize.Get(&settings.SV) {
-					log.VEventf(ctx, 2, "ingest data is too small (%d keys/%d bytes) for SSTable, adding via regular batch", item.stats.KeyCount, len(item.sstBytes))
+					log.VEventf(ctx, 3, "ingest data is too small (%d keys/%d bytes) for SSTable, adding via regular batch", item.stats.KeyCount, len(item.sstBytes))
 					ingestAsWriteBatch = true
 				}
 

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -26,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -585,55 +583,29 @@ func (db *DB) AdminSplit(
 	return getOneErr(db.Run(ctx, b), b)
 }
 
-// SplitAndScatterResult carries wraps information about the SplitAndScatter
-// call, including how long each step took or stats for range scattered.
-type SplitAndScatterResult struct {
-	// Timing indicates how long each step in this multi-step call took.
-	Timing struct {
-		Split   time.Duration
-		Scatter time.Duration
-	}
-	// Stats describe the scattered range, as returned by the AdminScatter call.
-	ScatteredStats *enginepb.MVCCStats
-	ScatteredSpan  roachpb.Span
-}
-
-// SplitAndScatter is a helper that wraps AdminSplit + AdminScatter.
-func (db *DB) SplitAndScatter(
-	ctx context.Context, key roachpb.Key, expirationTime hlc.Timestamp, predicateKeys ...roachpb.Key,
-) (SplitAndScatterResult, error) {
-	beforeSplit := timeutil.Now()
-	b := &Batch{}
-	b.adminSplit(key, expirationTime, predicateKeys)
-	if err := getOneErr(db.Run(ctx, b), b); err != nil {
-		return SplitAndScatterResult{}, err
-	}
-	beforeScatter := timeutil.Now()
-
+// AdminScatter scatters the range containing the specified key.
+//
+// maxSize greater than non-zero specified a maximum size of the range above
+// which it should reject the scatter request, allowing callers to send request
+// to scatter that is conditional on it not resulting in excessive data movement
+// if the range is large.
+func (db *DB) AdminScatter(
+	ctx context.Context, key roachpb.Key, maxSize int64,
+) (*roachpb.AdminScatterResponse, error) {
 	scatterReq := &roachpb.AdminScatterRequest{
 		RequestHeader:   roachpb.RequestHeaderFromSpan(roachpb.Span{Key: key, EndKey: key.Next()}),
 		RandomizeLeases: true,
+		MaxSize:         maxSize,
 	}
 	raw, pErr := SendWrapped(ctx, db.NonTransactionalSender(), scatterReq)
 	if pErr != nil {
-		return SplitAndScatterResult{}, pErr.GoError()
+		return nil, pErr.GoError()
 	}
-	reply := SplitAndScatterResult{}
-	reply.Timing.Split = beforeScatter.Sub(beforeSplit)
-	reply.Timing.Scatter = timeutil.Since(beforeScatter)
 	resp, ok := raw.(*roachpb.AdminScatterResponse)
 	if !ok {
-		return reply, errors.Errorf("unexpected response of type %T for AdminScatter", raw)
+		return nil, errors.Errorf("unexpected response of type %T for AdminScatter", raw)
 	}
-	reply.ScatteredStats = resp.MVCCStats
-	if len(resp.RangeInfos) > 0 {
-		reply.ScatteredSpan = roachpb.Span{
-			Key:    resp.RangeInfos[0].Desc.StartKey.AsRawKey(),
-			EndKey: resp.RangeInfos[0].Desc.EndKey.AsRawKey(),
-		}
-	}
-
-	return reply, nil
+	return resp, nil
 }
 
 // AdminUnsplit removes the sticky bit of the range specified by splitKey.

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -512,7 +512,7 @@ func TestWithOnSSTable(t *testing.T) {
 	ts := now.WallTime
 	sstKVs := []sstutil.KV{{"a", ts, "1"}, {"b", ts, "2"}, {"c", ts, "3"}, {"d", ts, "4"}, {"e", ts, "5"}}
 	sst, sstStart, sstEnd := sstutil.MakeSST(t, srv.ClusterSettings(), sstKVs)
-	_, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
 		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
 		false /* ingestAsWrites */, now)
 	require.Nil(t, pErr)
@@ -588,7 +588,7 @@ func TestWithOnSSTableCatchesUpIfNotSet(t *testing.T) {
 	sstKVs := []sstutil.KV{{"a", ts, "1"}, {"b", ts, "2"}, {"c", ts, "3"}, {"d", ts, "4"}, {"e", ts, "5"}}
 	expectKVs := []sstutil.KV{{"c", ts, "3"}, {"d", ts, "4"}}
 	sst, sstStart, sstEnd := sstutil.MakeSST(t, srv.ClusterSettings(), sstKVs)
-	_, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
 		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
 		false /* ingestAsWrites */, now)
 	require.Nil(t, pErr)

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -13,11 +13,13 @@ package batcheval
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -36,7 +38,19 @@ func init() {
 	// could instead iterate over the SST and take out point latches/locks, but
 	// the cost is likely not worth it since AddSSTable is often used with
 	// unpopulated spans.
-	RegisterReadWriteCommand(roachpb.AddSSTable, DefaultDeclareIsolatedKeys, EvalAddSSTable)
+	RegisterReadWriteCommand(roachpb.AddSSTable, declareKeysAddSSTable, EvalAddSSTable)
+}
+
+func declareKeysAddSSTable(
+	rs ImmutableRangeState,
+	header *roachpb.Header,
+	req roachpb.Request,
+	latchSpans, lockSpans *spanset.SpanSet,
+	maxOffset time.Duration,
+) {
+	DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
+	// We look up the range descriptor key to return its span.
+	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(rs.GetStartKey())})
 }
 
 // AddSSTableRewriteConcurrency sets the concurrency of a single SST rewrite.
@@ -63,7 +77,7 @@ var forceRewrite = util.ConstantWithMetamorphicTestBool("addsst-rewrite-forced",
 // EvalAddSSTable evaluates an AddSSTable command. For details, see doc comment
 // on AddSSTableRequest.
 func EvalAddSSTable(
-	ctx context.Context, readWriter storage.ReadWriter, cArgs CommandArgs, _ roachpb.Response,
+	ctx context.Context, readWriter storage.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.AddSSTableRequest)
 	h := cArgs.Header
@@ -249,6 +263,10 @@ func EvalAddSSTable(
 			Spans: []roachpb.Span{{Key: start.Key, EndKey: end.Key}},
 		}
 	}
+
+	reply := resp.(*roachpb.AddSSTableResponse)
+	reply.RangeSpan = cArgs.EvalCtx.Desc().KeySpan().AsRawSpanWithNoLocals()
+	reply.AvailableBytes = cArgs.EvalCtx.GetMaxBytes() - cArgs.EvalCtx.GetMVCCStats().Total() - stats.Total()
 
 	if args.IngestAsWrites {
 		span.RecordStructured(&types.StringValue{Value: fmt.Sprintf("ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(sst))})

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -695,7 +695,7 @@ func TestEvalAddSSTable(t *testing.T) {
 					sst, start, end := sstutil.MakeSST(t, st, tc.sst)
 					resp := &roachpb.AddSSTableResponse{}
 					result, err := batcheval.EvalAddSSTable(ctx, engine, batcheval.CommandArgs{
-						EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st, Desc: &roachpb.RangeDescriptor{}}).EvalContext(),
 						Stats:   stats,
 						Header: roachpb.Header{
 							Timestamp: hlc.Timestamp{WallTime: tc.reqTS},
@@ -863,7 +863,7 @@ func TestEvalAddSSTableRangefeed(t *testing.T) {
 			// Build and add SST.
 			sst, start, end := sstutil.MakeSST(t, st, tc.sst)
 			result, err := batcheval.EvalAddSSTable(ctx, opLogger, batcheval.CommandArgs{
-				EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext(),
+				EvalCtx: (&batcheval.MockEvalCtx{ClusterSettings: st, Desc: &roachpb.RangeDescriptor{}}).EvalContext(),
 				Header: roachpb.Header{
 					Timestamp: reqTS,
 				},
@@ -946,13 +946,13 @@ func runTestDBAddSSTable(
 		sst, start, end := sstutil.MakeSST(t, cs, []sstutil.KV{{"bb", 2, "1"}})
 
 		// Key is before the range in the request span.
-		err := db.AddSSTable(
+		_, _, err := db.AddSSTable(
 			ctx, "d", "e", sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not in request range")
 
 		// Key is after the range in the request span.
-		err = db.AddSSTable(
+		_, _, err = db.AddSSTable(
 			ctx, "a", "b", sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not in request range")
@@ -960,8 +960,9 @@ func runTestDBAddSSTable(
 		// Do an initial ingest.
 		ingestCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 		defer getRecAndFinish()
-		require.NoError(t, db.AddSSTable(
-			ingestCtx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS))
+		_, _, err = db.AddSSTable(
+			ingestCtx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS)
+		require.NoError(t, err)
 		trace := getRecAndFinish().String()
 		require.Contains(t, trace, "evaluating AddSSTable")
 		require.Contains(t, trace, "sideloadable proposal detected")
@@ -986,8 +987,9 @@ func runTestDBAddSSTable(
 	// the value returned by Get.
 	{
 		sst, start, end := sstutil.MakeSST(t, cs, []sstutil.KV{{"bb", 1, "2"}})
-		require.NoError(t, db.AddSSTable(
-			ctx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS))
+		_, _, err := db.AddSSTable(
+			ctx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS)
+		require.NoError(t, err)
 		r, err := db.Get(ctx, "bb")
 		require.NoError(t, err)
 		require.Equal(t, []byte("1"), r.ValueBytes())
@@ -1009,8 +1011,9 @@ func runTestDBAddSSTable(
 			ingestCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 			defer getRecAndFinish()
 
-			require.NoError(t, db.AddSSTable(
-				ingestCtx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS))
+			_, _, err := db.AddSSTable(
+				ingestCtx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS)
+			require.NoError(t, err)
 			trace := getRecAndFinish().String()
 			require.Contains(t, trace, "evaluating AddSSTable")
 			require.Contains(t, trace, "sideloadable proposal detected")
@@ -1045,8 +1048,9 @@ func runTestDBAddSSTable(
 			ingestCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 			defer getRecAndFinish()
 
-			require.NoError(t, db.AddSSTable(
-				ingestCtx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsWrites, noTS))
+			_, _, err := db.AddSSTable(
+				ingestCtx, start, end, sst, allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsWrites, noTS)
+			require.NoError(t, err)
 			trace := getRecAndFinish().String()
 			require.Contains(t, trace, "evaluating AddSSTable")
 			require.Contains(t, trace, "via regular write batch")
@@ -1076,7 +1080,7 @@ func runTestDBAddSSTable(
 		require.NoError(t, w.Put(key, value.RawBytes))
 		require.NoError(t, w.Finish())
 
-		err := db.AddSSTable(
+		_, _, err := db.AddSSTable(
 			ctx, "b", "c", sstFile.Data(), allowConflicts, allowShadowing, allowShadowingBelow, nilStats, ingestAsSST, noTS)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid checksum")
@@ -1088,9 +1092,14 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	const max = 1 << 10
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	evalCtx := (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext()
+	evalCtx := &batcheval.MockEvalCtx{
+		ClusterSettings: st,
+		MaxBytes:        max,
+		Desc:            &roachpb.RangeDescriptor{},
+	}
 
 	dir := t.TempDir()
 	engine, err := storage.Open(ctx, storage.Filesystem(filepath.Join(dir, "db")), storage.Settings(st))
@@ -1137,8 +1146,10 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	// applying the diff to the stats
 	statsBefore := engineStats(t, engine, 0)
 	ts := hlc.Timestamp{WallTime: 7}
+	evalCtx.Stats = *statsBefore
+
 	cArgs := batcheval.CommandArgs{
-		EvalCtx: evalCtx,
+		EvalCtx: evalCtx.EvalContext(),
 		Header: roachpb.Header{
 			Timestamp: ts,
 		},
@@ -1148,7 +1159,8 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		},
 		Stats: &enginepb.MVCCStats{},
 	}
-	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
+	var resp roachpb.AddSSTableResponse
+	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, &resp)
 	require.NoError(t, err)
 
 	sstPath := filepath.Join(dir, "sst")
@@ -1159,12 +1171,18 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	statsEvaled.Add(*cArgs.Stats)
 	statsEvaled.Add(statsDelta)
 	statsEvaled.ContainsEstimates = 0
-	require.Equal(t, engineStats(t, engine, statsEvaled.LastUpdateNanos), statsEvaled)
+
+	newStats := engineStats(t, engine, statsEvaled.LastUpdateNanos)
+	require.Equal(t, newStats, statsEvaled)
+
+	// Check that actual remaining bytes equals the returned remaining bytes once
+	// the delta for stats inaccuracy is applied.
+	require.Equal(t, max-newStats.Total(), resp.AvailableBytes-statsDelta.Total())
 
 	// Check stats for a single KV.
 	sst, start, end = sstutil.MakeSST(t, st, []sstutil.KV{{"zzzzzzz", ts.WallTime, "zzz"}})
 	cArgs = batcheval.CommandArgs{
-		EvalCtx: evalCtx,
+		EvalCtx: evalCtx.EvalContext(),
 		Header:  roachpb.Header{Timestamp: ts},
 		Args: &roachpb.AddSSTableRequest{
 			RequestHeader: roachpb.RequestHeader{Key: start, EndKey: end},
@@ -1172,7 +1190,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		},
 		Stats: &enginepb.MVCCStats{},
 	}
-	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
+	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, &roachpb.AddSSTableResponse{})
 	require.NoError(t, err)
 	require.Equal(t, enginepb.MVCCStats{
 		ContainsEstimates: 1,
@@ -1194,7 +1212,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	evalCtx := (&batcheval.MockEvalCtx{ClusterSettings: st}).EvalContext()
+	evalCtx := (&batcheval.MockEvalCtx{ClusterSettings: st, Desc: &roachpb.RangeDescriptor{}}).EvalContext()
 
 	engine := storage.NewDefaultInMemForTesting()
 	defer engine.Close()
@@ -1244,7 +1262,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 		},
 		Stats: &commandStats,
 	}
-	_, err := batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
+	_, err := batcheval.EvalAddSSTable(ctx, engine, cArgs, &roachpb.AddSSTableResponse{})
 	require.NoError(t, err)
 	firstSSTStats := commandStats
 
@@ -1268,7 +1286,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 		DisallowShadowing: true,
 		MVCCStats:         sstutil.ComputeStats(t, sst),
 	}
-	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
+	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, &roachpb.AddSSTableResponse{})
 	require.NoError(t, err)
 
 	// Check that there has been no double counting of stats. All keys in second SST are shadowing.
@@ -1288,7 +1306,7 @@ func TestAddSSTableMVCCStatsDisallowShadowing(t *testing.T) {
 		DisallowShadowing: true,
 		MVCCStats:         sstutil.ComputeStats(t, sst),
 	}
-	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, nil)
+	_, err = batcheval.EvalAddSSTable(ctx, engine, cArgs, &roachpb.AddSSTableResponse{})
 	require.NoError(t, err)
 
 	// This is the stats contribution of the KV {"e", 2, "ee"}. This should be

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -13,6 +13,7 @@ package batcheval
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
@@ -134,6 +135,8 @@ type EvalContext interface {
 	// non-nil on those paths (a nil account is safe to use since it functions
 	// as an unlimited account).
 	GetResponseMemoryAccount() *mon.BoundAccount
+
+	GetMaxBytes() int64
 }
 
 // MockEvalCtx is a dummy implementation of EvalContext for testing purposes.
@@ -153,6 +156,7 @@ type MockEvalCtx struct {
 	CurrentReadSummary rspb.ReadSummary
 	ClosedTimestamp    hlc.Timestamp
 	RevokedLeaseSeq    roachpb.LeaseSequence
+	MaxBytes           int64
 }
 
 // EvalContext returns the MockEvalCtx as an EvalContext. It will reflect future
@@ -269,4 +273,10 @@ func (m *mockEvalCtxImpl) WatchForMerge(ctx context.Context) error {
 func (m *mockEvalCtxImpl) GetResponseMemoryAccount() *mon.BoundAccount {
 	// No limits.
 	return nil
+}
+func (m *mockEvalCtxImpl) GetMaxBytes() int64 {
+	if m.MaxBytes != 0 {
+		return m.MaxBytes
+	}
+	return math.MaxInt64
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3321,6 +3321,11 @@ func (r *Replica) adminScatter(
 	maxAttempts := len(r.Desc().Replicas().Descriptors())
 	currentAttempt := 0
 
+	if args.MaxSize > 0 {
+		if existing, limit := r.GetMVCCStats().Total(), args.MaxSize; existing > limit {
+			return roachpb.AdminScatterResponse{}, errors.Errorf("existing range size %d exceeds specified limit %d", existing, limit)
+		}
+	}
 	// Loop until the replicate queue decides there is nothing left to do or until
 	// we hit `maxAttempts` for the range. Note that we disable lease transfers
 	// until the final step as transferring the lease prevents any further action

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -257,3 +257,8 @@ func (rec *SpanSetReplicaEvalContext) WatchForMerge(ctx context.Context) error {
 func (rec *SpanSetReplicaEvalContext) GetResponseMemoryAccount() *mon.BoundAccount {
 	return rec.i.GetResponseMemoryAccount()
 }
+
+// GetMaxBytes implements the batcheval.EvalContext interface.
+func (rec *SpanSetReplicaEvalContext) GetMaxBytes() int64 {
+	return rec.i.GetMaxBytes()
+}

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -350,7 +350,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	expSST := sstFile.Data()
 	expSSTSpan := roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("r")}
 
-	_, pErr = store1.DB().AddSSTableAtBatchTimestamp(ctx, roachpb.Key("b"), roachpb.Key("r"), sstFile.Data(),
+	_, _, _, pErr = store1.DB().AddSSTableAtBatchTimestamp(ctx, roachpb.Key("b"), roachpb.Key("r"), sstFile.Data(),
 		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
 		false /* ingestAsWrites */, ts6)
 	require.Nil(t, pErr)
@@ -377,7 +377,7 @@ func TestReplicaRangefeed(t *testing.T) {
 		expVal7q.RawBytes))
 	require.NoError(t, sstWriter.Finish())
 
-	_, pErr = store1.DB().AddSSTableAtBatchTimestamp(ctx, roachpb.Key("b"), roachpb.Key("r"), sstFile.Data(),
+	_, _, _, pErr = store1.DB().AddSSTableAtBatchTimestamp(ctx, roachpb.Key("b"), roachpb.Key("r"), sstFile.Data(),
 		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{}, nil, /* stats */
 		true /* ingestAsWrites */, ts7)
 	require.Nil(t, pErr)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1572,6 +1572,10 @@ message ExportResponse {
 message AdminScatterRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   bool randomize_leases = 2;
+
+  // max_size, if > 0, specifies a range's size above with it should reject
+  // this scatter request, allowing a "scatter-if-not-full" conditional request.
+  int64 max_size = 3;
 }
 
 // ScatterResponse is the response to a Scatter() operation.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1763,6 +1763,20 @@ message AddSSTableRequest {
 // AddSSTableResponse is the response to a AddSSTable() operation.
 message AddSSTableResponse {
   ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+
+  // RangeSpan is the span of the range which just added this sstable. It is 
+  // included in the reply along with AvailableBytes so that callers can tell if
+  // a file they are about to send would be sent to the same range as a file
+  // sent previously (i.e. if it intersects with this span as sent then), and if
+  // so, if its size would fit within the size remaining in this range.
+  Span range_span = 2 [(gogoproto.nullable) = false];
+
+  // AvailableBytes indicates how many bytes remain before the range into which
+  // this request added will be considered "full". This is for use by callers to
+  // check if they should keep sending additional SSTs to this range or if they
+  // should split first. Such callers can use RangeSpan to see if the file they
+  // would be sending would also add to this range.
+  int64 available_bytes = 3;
 }
 
 // RefreshRequest is arguments to the Refresh() method, which verifies that no


### PR DESCRIPTION
Previously we would split-and-scatter after adding "filling" a range so
that as we continued to fill, we would do so to a new range that was
first scattered to a new node. We did this once we had written 48MB to
one range, as determined by not hitting a split while sending that many
bytes during a single flush of the above buffer. 48MB was an OK default
when the default range size was 64MB, but has long since been far below
what we now consider full. This was a minor annoyance (causing merges)
but calling split-and-scatter so much more than is needed has recently
become a more severe issue now that ~every scatter call actually moves
a range and blocks on that snapshot.

Even when 48MB was a reasonable fraction of the 64MB default, this was
just a rough approximation for full that failed to account for the
actual range's configured size and only counted data flushed since the
last explicit Flush().

Instead, this change replaces this "split when i've sent enough" logic
with a new approach that lets the range itself reply to each SST with
its remaining capacity and end key. The caller can then use this to
determine if there is room to send another file to that range or if it
should consider it full, and split if/when another key that would be
added to that ranges span is added to the batch.

This significantly reduces how often ingestion stops to wait on scatter
of a split span with the recently updated scatter behavior, more than
doubling observed speeds of bulk ingestion.

Release justification: high impact fix to new/modified functionality.

Release note (performance improvement): Ranges are split and rebalanced during bulk ingestion only when they become full, reducing excessive splits and subsequent merging and associated rebalancing-related performance impact.
