### PR TITLE
dev: update `doctor` stamp variable check

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=20
+DEV_VERSION=21
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -198,8 +198,8 @@ Please perform the following steps:
 		if err != nil {
 			return err
 		}
-		if !strings.Contains(fileContents, "STABLE_BUILD_GIT_BUILD_TYPE") {
-			failedStampTestMsg = fmt.Sprintf("Could not find STABLE_BUILD_GIT_TYPE in %s\n", testStampingTxt)
+		if !strings.Contains(fileContents, "STABLE_BUILD_TYPE") {
+			failedStampTestMsg = fmt.Sprintf("Could not find STABLE_BUILD_TYPE in %s\n", testStampingTxt)
 		}
 	}
 	if failedStampTestMsg != "" {


### PR DESCRIPTION
This was renamed from `STABLE_BUILD_GIT_BUILD_TYPE` in #76897 and I
forgot to update it here.

Release justification: Non-production code changes
Release note: None