### PR TITLE
changefeedccl: resurrect manual protected timestamps

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1495,7 +1496,13 @@ func (cf *changeFrontier) checkpointJobProgress(
 		changefeedProgress.Checkpoint = &checkpoint
 
 		if shouldProtectTimestamps(cf.flowCtx.Codec()) {
-			if err := cf.manageProtectedTimestamps(cf.Ctx, txn, changefeedProgress); err != nil {
+			timestampManager := cf.manageProtectedTimestamps
+			// TODO(samiskin): Remove this conditional and the associated deprecated
+			// methods once we're confident in ActiveProtectedTimestampsEnabled
+			if !changefeedbase.ActiveProtectedTimestampsEnabled.Get(&cf.flowCtx.Cfg.Settings.SV) {
+				timestampManager = cf.deprecatedManageProtectedTimestamps
+			}
+			if err := timestampManager(cf.Ctx, txn, changefeedProgress); err != nil {
 				log.Warningf(cf.Ctx, "error managing protected timestamp record: %v", err)
 			}
 		}
@@ -1554,6 +1561,47 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 	return nil
 }
 
+// deprecatedManageProtectedTimestamps only sets a protected timestamp when the
+// changefeed is in a backfill or the highwater is lagging behind to a
+// sufficient degree after a backfill.  This was deprecated in favor of always
+// maintaining a timestamp record to avoid issues with a low gcttl setting.
+func (cf *changeFrontier) deprecatedManageProtectedTimestamps(
+	ctx context.Context, txn *kv.Txn, progress *jobspb.ChangefeedProgress,
+) error {
+	pts := cf.flowCtx.Cfg.ProtectedTimestampProvider
+	if err := cf.deprecatedMaybeReleaseProtectedTimestamp(ctx, progress, pts, txn); err != nil {
+		return err
+	}
+
+	schemaChangePolicy := changefeedbase.SchemaChangePolicy(cf.spec.Feed.Opts[changefeedbase.OptSchemaChangePolicy])
+	shouldProtectBoundaries := schemaChangePolicy == changefeedbase.OptSchemaChangePolicyBackfill
+	if cf.frontier.schemaChangeBoundaryReached() && shouldProtectBoundaries {
+		highWater := cf.frontier.Frontier()
+		ptr := createProtectedTimestampRecord(ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater, progress)
+		return pts.Protect(ctx, txn, ptr)
+	}
+	return nil
+}
+
+func (cf *changeFrontier) deprecatedMaybeReleaseProtectedTimestamp(
+	ctx context.Context, progress *jobspb.ChangefeedProgress, pts protectedts.Storage, txn *kv.Txn,
+) error {
+	if progress.ProtectedTimestampRecord == uuid.Nil {
+		return nil
+	}
+	if !cf.frontier.schemaChangeBoundaryReached() && cf.isBehind() {
+		log.VEventf(ctx, 2, "not releasing protected timestamp because changefeed is behind")
+		return nil
+	}
+	log.VEventf(ctx, 2, "releasing protected timestamp %v",
+		progress.ProtectedTimestampRecord)
+	if err := pts.Release(ctx, txn, progress.ProtectedTimestampRecord); err != nil {
+		return err
+	}
+	progress.ProtectedTimestampRecord = uuid.Nil
+	return nil
+}
+
 func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {
 	if cf.freqEmitResolved == emitNoResolved || newResolved.IsEmpty() {
 		return nil
@@ -1578,7 +1626,7 @@ func (cf *changeFrontier) isBehind() bool {
 		return true
 	}
 
-	return timeutil.Since(frontier.GoTime()) <= cf.slownessThreshold()
+	return timeutil.Since(frontier.GoTime()) > cf.slownessThreshold()
 }
 
 // Potentially log the most behind span in the frontier for debugging if the

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -186,3 +186,12 @@ var ProtectTimestampInterval = settings.RegisterDurationSetting(
 	10*time.Minute,
 	settings.PositiveDuration,
 )
+
+// ActiveProtectedTimestampsEnabled enables always having protected timestamps
+// laid down that are periodically advanced to the highwater mark.
+var ActiveProtectedTimestampsEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"changefeed.active_protected_timestamps.enabled",
+	"if set, rather than only protecting changefeed targets from garbage collection during backfills, data will always be protected up to the changefeed's frontier",
+	true,
+)


### PR DESCRIPTION
Resurrects the old 21.2 protected timestamp behaviour in order to increase stability and also make the backport easier

Release justification: Increases stability by allowing the disabling of
a new feature in favor of the old behavior

Release note: (None)