### PR TITLE
backupccl: add proto fields for restore validation

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -136,6 +137,10 @@ func newRestoreDataProcessor(
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	sv := &flowCtx.Cfg.Settings.SV
+
+	if spec.Validation != jobspb.RestoreValidation_DefaultRestore {
+		return nil, errors.New("Restore Data Processor does not support validation yet")
+	}
 
 	rd := &restoreDataProcessor{
 		flowCtx:    flowCtx,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1214,6 +1214,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	p := execCtx.(sql.JobExecContext)
 	r.execCfg = p.ExecCfg()
 
+	if details.Validation != jobspb.RestoreValidation_DefaultRestore {
+		return errors.Errorf("No restore validation tools are supported")
+	}
+
 	mem := p.ExecCfg().RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1775,6 +1775,7 @@ func doRestorePlan(
 			DebugPauseOn:       debugPauseOn,
 			RestoreSystemUsers: restoreStmt.SystemUsers,
 			PreRewriteTenantId: oldTenantID,
+			Validation:         jobspb.RestoreValidation_DefaultRestore,
 		},
 		Progress: jobspb.RestoreProgress{},
 	}

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -94,6 +94,7 @@ func distRestore(
 		TableRekeys:  tableRekeys,
 		TenantRekeys: tenantRekeys,
 		PKIDs:        pkIDs,
+		Validation:   jobspb.RestoreValidation_DefaultRestore,
 	}
 
 	if len(splitAndScatterSpecs) == 0 {
@@ -258,6 +259,7 @@ func makeSplitAndScatterSpecs(
 				}},
 				TableRekeys:  tableRekeys,
 				TenantRekeys: tenantRekeys,
+				Validation:   jobspb.RestoreValidation_DefaultRestore,
 			}
 		}
 	}

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -209,6 +210,11 @@ func newSplitAndScatterProcessor(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
+
+	if spec.Validation != jobspb.RestoreValidation_DefaultRestore {
+		return nil, errors.New("Split and Scatter Processor does not support validation yet")
+	}
+
 	numEntries := 0
 	for _, chunk := range spec.Chunks {
 		numEntries += len(chunk.Entries)

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -246,6 +247,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			require.NoError(t, err)
 
 			post := execinfrapb.PostProcessSpec{}
+			c.procSpec.Validation = jobspb.RestoreValidation_DefaultRestore
 			proc, err := newSplitAndScatterProcessor(&flowCtx, 0 /* processorID */, c.procSpec, &post, out)
 			require.NoError(t, err)
 			ssp, ok := proc.(*splitAndScatterProcessor)

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -325,10 +325,22 @@ message RestoreDetails {
 
   // PreRewrittenTenantID is the ID of tenants[0] in the backup, aka its old ID;
   // it is only valid to set this if len(tenants) == 1.
-  roachpb.TenantID pre_rewrite_tenant_id = 23; 
+  roachpb.TenantID pre_rewrite_tenant_id = 23;
 
-  // NEXT ID: 24.
+  // RestoreValidation determines whether to skip certain parts of the restore
+  // job if its only purpose is to validate the user's restore command.
+  RestoreValidation validation = 24;
+
+  // NEXT ID: 25.
 }
+
+enum RestoreValidation {
+  DefaultRestore = 0;
+}
+
+
+
+
 
 message RestoreProgress {
   bytes high_water = 1;

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -64,17 +64,20 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 64
+const Version execinfrapb.DistSQLVersion = 65
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 63
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 65
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+- Version: 65 (MinAcceptedVersion: 65)
+  - adds the RestoreValidation field to the RestoreDataSpec and SplitAndScatterSpec
 
 - Version: 64 (MinAcceptedVersion: 63)
   - final_covar_samp, final_corr, and final_sqrdiff aggregate functions were

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -279,7 +279,9 @@ message RestoreDataSpec {
   // PKIDs is used to convert result from an ExportRequest into row count
   // information passed back to track progress in the backup job.
   map<uint64, bool> pk_ids = 4 [(gogoproto.customname) = "PKIDs"];
-  // NEXT ID: 7.
+  optional jobs.jobspb.RestoreValidation validation = 7 [(gogoproto.nullable) = false];
+
+  // NEXT ID: 8.
 }
 
 message SplitAndScatterSpec {
@@ -291,8 +293,9 @@ message SplitAndScatterSpec {
   repeated RestoreEntryChunk chunks = 1 [(gogoproto.nullable) = false];
   repeated TableRekey table_rekeys = 2 [(gogoproto.nullable) = false];
   repeated TenantRekey tenant_rekeys = 3 [(gogoproto.nullable) = false];
+  optional jobs.jobspb.RestoreValidation validation = 5 [(gogoproto.nullable) = false];
 
-  // NEXTID: 5.
+  // NEXTID: 6.
 }
 
 // ExporterSpec is the specification for a processor that consumes rows and


### PR DESCRIPTION
This PR adds a few proto fields before the branch cut in order to make
backports related to restore validation features safer.

Informs #67935

Release justification: low risk updates to existing functionality

Release note: None