### PR TITLE
release-21.2: jobs: Set a timeout when executing schedules.

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/sql/sqlutil",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/contextutil",
         "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/jobs/job_scheduler_test.go
+++ b/pkg/jobs/job_scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -285,10 +286,10 @@ func (n *recordScheduleExecutor) GetCreateScheduleStatement(
 var _ ScheduledJobExecutor = &recordScheduleExecutor{}
 
 func fastDaemonKnobs(scanDelay func() time.Duration) *TestingKnobs {
-	return &TestingKnobs{
-		SchedulerDaemonInitialScanDelay: func() time.Duration { return 0 },
-		SchedulerDaemonScanDelay:        scanDelay,
-	}
+	knobs := NewTestingKnobsWithShortIntervals()
+	knobs.SchedulerDaemonInitialScanDelay = func() time.Duration { return 0 }
+	knobs.SchedulerDaemonScanDelay = scanDelay
+	return knobs
 }
 
 func TestJobSchedulerCanBeDisabledWhileSleeping(t *testing.T) {
@@ -766,6 +767,7 @@ INSERT INTO defaultdb.foo VALUES(1, 1)
 }
 
 type blockUntilCancelledExecutor struct {
+	once          sync.Once
 	started, done chan struct{}
 }
 
@@ -778,8 +780,12 @@ func (e *blockUntilCancelledExecutor) ExecuteJob(
 	schedule *ScheduledJob,
 	txn *kv.Txn,
 ) error {
-	defer close(e.done)
-	close(e.started)
+	done := func() {}
+	e.once.Do(func() {
+		close(e.started)
+		done = func() { close(e.done) }
+	})
+	defer done()
 	<-ctx.Done()
 	return ctx.Err()
 }
@@ -811,6 +817,15 @@ func (e *blockUntilCancelledExecutor) GetCreateScheduleStatement(
 	return "", errors.AssertionFailedf("unexpected GetCreateScheduleStatement call")
 }
 
+func readWithTimeout(t *testing.T, ch chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
 func TestDisablingSchedulerCancelsSchedules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -840,8 +855,44 @@ func TestDisablingSchedulerCancelsSchedules(t *testing.T) {
 	require.NoError(t, schedule.Create(
 		context.Background(), ts.InternalExecutor().(sqlutil.InternalExecutor), nil))
 
-	<-ex.started
+	readWithTimeout(t, ex.started)
 	// Disable scheduler and verify all running schedules were canceled.
 	schedulerEnabledSetting.Override(context.Background(), &ts.ClusterSettings().SV, false)
-	<-ex.done
+	readWithTimeout(t, ex.done)
+}
+
+func TestSchedulePlanningRespectsTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const executorName = "block-until-canceled-executor"
+	ex := &blockUntilCancelledExecutor{
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	defer registerScopedScheduledJobExecutor(executorName, ex)()
+
+	knobs := base.TestingKnobs{
+		JobsTestingKnobs: fastDaemonKnobs(overridePaceSetting(10 * time.Millisecond)),
+	}
+	ts, _, _ := serverutils.StartServer(t, base.TestServerArgs{Knobs: knobs})
+	defer ts.Stopper().Stop(context.Background())
+
+	// timeout must be long enough to work when running under stress.
+	schedulerScheduleExecutionTimeout.Override(
+		context.Background(), &ts.ClusterSettings().SV, 100*time.Millisecond)
+	// Create schedule which blocks until its context canceled due to timeout.
+	// We only need to create one schedule.  This is because
+	// scheduler executes its batch of schedules sequentially, and so, creating more
+	// than one doesn't change anything since we block.
+	schedule := NewScheduledJob(scheduledjobs.ProdJobSchedulerEnv)
+	schedule.SetScheduleLabel("test schedule")
+	schedule.SetOwner(security.TestUserName())
+	schedule.SetNextRun(timeutil.Now())
+	schedule.SetExecutionDetails(executorName, jobspb.ExecutionArguments{})
+	require.NoError(t, schedule.Create(
+		context.Background(), ts.InternalExecutor().(sqlutil.InternalExecutor), nil))
+
+	readWithTimeout(t, ex.started)
+	readWithTimeout(t, ex.done)
 }


### PR DESCRIPTION
Backport 1/1 commits from #77372.

/cc @cockroachdb/release

---

Improve jobs system resilience to misbehaving schedules, which take
unreasonable time to execute.

Job scheduler now sets a timeout when executing each schedule.
Scheduled jobs must ensure that they complete their execution within
specified timeout.  This does not imply that you cannot have long running
scheduled jobs.

Failed execution due to timeout are handled based on schedule policy.
The timeout is controlled via the `jobs.scheduler.schedule_execution.timeout` setting,
and can be disabled by setting timeout value to 0.

Release Notes: Improve jobs system resilience to scheduled jobs that
may lock up jobs/scheduled job table for long periods of time.  Each schedule
now has a limited amount of time to complete its execution.  The timeout
is controlled via  `jobs.scheduler.schedule_execution.timeout` setting.

Release Justification: System stability improvement.
